### PR TITLE
Add query answer to EvalInt and EvalInterval in the poly analysis

### DIFF
--- a/src/analyses/poly.ml
+++ b/src/analyses/poly.ml
@@ -106,11 +106,22 @@ struct
     let open Queries in
     let d = ctx.local in
     match q with
-    | EvalInt e
-    | EvalIntSet e
-    | EvalInterval e
-    | ExpEq (e1, e2)
-      -> Result.top () (* TODO *)
+    | EvalInt e ->
+      begin
+        match D.get_int_val_for_cil_exp d e with
+        | Some i -> `Int i
+        | _ -> `Top
+      end
+    | EvalIntSet _ -> Result.top ()  (* TODO *)
+    | EvalInterval e ->
+      begin
+        match D.get_int_interval_for_cil_exp d e with
+        | Some i, Some s -> `Interval (IntDomain.Interval.of_interval i s)
+        | Some i, _ ->  `Interval (IntDomain.Interval.starting i)
+        | _, Some s -> `Interval (IntDomain.Interval.ending s)
+        | _ -> `Top
+      end
+    | ExpEq (_, _) -> Result.top () (* TODO *)
     | _ -> Result.top ()
 end
 

--- a/src/analyses/poly.ml
+++ b/src/analyses/poly.ml
@@ -116,7 +116,7 @@ struct
     | EvalInterval e ->
       begin
         match D.get_int_interval_for_cil_exp d e with
-        | Some i, Some s -> `Interval (IntDomain.Interval.of_interval i s)
+        | Some i, Some s -> `Interval (IntDomain.Interval.of_interval (i,s))
         | Some i, _ ->  `Interval (IntDomain.Interval.starting i)
         | _, Some s -> `Interval (IntDomain.Interval.ending s)
         | _ -> `Top

--- a/src/cdomains/apronDomain.ml
+++ b/src/cdomains/apronDomain.ml
@@ -90,7 +90,7 @@ struct
     in
     List.fold_left f ([],[])
 
-  let rec exptoexpr =
+  let rec cil_exp_to_cil_lhost =
     function
     | Lval (Var v,NoOffset) when isArithmeticType v.vtype && (not v.vglob) ->
       Var (Var.of_string v.vname)
@@ -99,22 +99,22 @@ struct
     | Const (CReal (f,_,_)) ->
       Cst (Coeff.s_of_float f)
     | UnOp  (Neg ,e,_) ->
-      Unop (Neg,exptoexpr e,Int,Near)
+      Unop (Neg,cil_exp_to_cil_lhost e,Int,Near)
     | BinOp (PlusA,e1,e2,_) ->
-      Binop (Add,exptoexpr e1,exptoexpr e2,Int,Near)
+      Binop (Add,cil_exp_to_cil_lhost e1,cil_exp_to_cil_lhost e2,Int,Near)
     | BinOp (MinusA,e1,e2,_) ->
-      Binop (Sub,exptoexpr e1,exptoexpr e2,Int,Near)
+      Binop (Sub,cil_exp_to_cil_lhost e1,cil_exp_to_cil_lhost e2,Int,Near)
     | BinOp (Mult,e1,e2,_) ->
-      Binop (Mul,exptoexpr e1,exptoexpr e2,Int,Near)
+      Binop (Mul,cil_exp_to_cil_lhost e1,cil_exp_to_cil_lhost e2,Int,Near)
     | BinOp (Div,e1,e2,_) ->
-      Binop (Div,exptoexpr e1,exptoexpr e2,Int,Zero)
+      Binop (Div,cil_exp_to_cil_lhost e1,cil_exp_to_cil_lhost e2,Int,Zero)
     | BinOp (Mod,e1,e2,_) ->
-      Binop (Mod,exptoexpr e1,exptoexpr e2,Int,Near)
-    | CastE (TFloat (FFloat,_),e) -> Unop(Cast,exptoexpr e,Texpr0.Single,Zero)
-    | CastE (TFloat (FDouble,_),e) -> Unop(Cast,exptoexpr e,Texpr0.Double,Zero)
-    | CastE (TFloat (FLongDouble,_),e) -> Unop(Cast,exptoexpr e,Texpr0.Extended,Zero)
-    | CastE (TInt _,e) -> Unop(Cast,exptoexpr e,Int,Zero)
-    | _ -> raise (Invalid_argument "exptotexpr1")
+      Binop (Mod,cil_exp_to_cil_lhost e1,cil_exp_to_cil_lhost e2,Int,Near)
+    | CastE (TFloat (FFloat,_),e) -> Unop(Cast,cil_exp_to_cil_lhost e,Texpr0.Single,Zero)
+    | CastE (TFloat (FDouble,_),e) -> Unop(Cast,cil_exp_to_cil_lhost e,Texpr0.Double,Zero)
+    | CastE (TFloat (FLongDouble,_),e) -> Unop(Cast,cil_exp_to_cil_lhost e,Texpr0.Extended,Zero)
+    | CastE (TInt _,e) -> Unop(Cast,cil_exp_to_cil_lhost e,Int,Zero)
+    | _ -> raise (Invalid_argument "cil_exp_to_apron_texpr1")
 
 
   let add_t x y =
@@ -139,7 +139,7 @@ struct
 
   type lexpr = (string * [`int of int | `float of float]) list
 
-  let rec exptolinexp =
+  let rec cil_exp_to_lexp =
     let add ((xs:lexpr),x,r) ((ys:lexpr),y,r') =
       let add_one xs (var_name, var_coefficient) =
         let found_var_in_list var_name var_coeff_list =
@@ -151,7 +151,7 @@ struct
         else (var_name, var_coefficient)::xs in
       match r, r' with
       | EQ, EQ -> List.fold_left add_one xs ys, add_t' x y, EQ
-      | _ -> raise (Invalid_argument "exptolinexp")
+      | _ -> raise (Invalid_argument "cil_exp_to_lexp")
     in
     function
     | Lval (Var v,NoOffset) when isArithmeticType v.vtype && (not v.vglob) ->
@@ -161,55 +161,60 @@ struct
     | Const (CReal (f,_,_)) ->
       [], `float f, EQ
     | UnOp  (Neg ,e,_) ->
-      negate (exptolinexp e)
+      negate (cil_exp_to_lexp e)
     | BinOp (PlusA,e1,e2,_) ->
-      add (exptolinexp e1) (exptolinexp e2)
+      add (cil_exp_to_lexp e1) (cil_exp_to_lexp e2)
     | BinOp (MinusA,e1,e2,_) ->
-      add (exptolinexp e1) (negate (exptolinexp e2))
+      add (cil_exp_to_lexp e1) (negate (cil_exp_to_lexp e2))
     | BinOp (Mult,e1,e2,_) ->
-      begin match exptolinexp e1, exptolinexp e2 with
+      begin match cil_exp_to_lexp e1, cil_exp_to_lexp e2 with
         | ([], `int x, EQ), ([], `int y, EQ) -> ([], `int (x*y), EQ)
         | ([], `float x, EQ), ([], `float y, EQ) -> ([], `float (x*.y), EQ)
         | (xs, `none, EQ), ([], `int y, EQ) | ([], `int y, EQ), (xs, `none, EQ) ->
           (List.map (function (n,`int x) -> n, `int (x*y) | (n,`float x) -> n, `float (x*.float_of_int y)) xs, `none, EQ)
         | (xs, `none, EQ), ([], `float y, EQ) | ([], `float y, EQ), (xs, `none, EQ) ->
           (List.map (function (n,`float x) -> n, `float (x*.y) | (n,`int x) -> (n,`float (float_of_int x*.y))) xs, `none, EQ)
-        | _ -> raise (Invalid_argument "exptolinexp")
+        | _ -> raise (Invalid_argument "cil_exp_to_lexp")
       end
     | BinOp (r,e1,e2,_) ->
       let comb r = function
         | (xs,y,EQ) -> (xs,y,r)
-        | _ -> raise (Invalid_argument "exptolinexp")
+        | _ -> raise (Invalid_argument "cil_exp_to_lexp")
       in
       begin match r with
-        | Lt -> comb SUP   (add (exptolinexp e2) (negate (exptolinexp e1)))
-        | Gt -> comb SUP   (add (exptolinexp e1) (negate (exptolinexp e2)))
-        | Le -> comb SUPEQ (add (exptolinexp e2) (negate (exptolinexp e1)))
-        | Ge -> comb SUPEQ (add (exptolinexp e1) (negate (exptolinexp e2)))
-        | Eq -> comb EQ    (add (exptolinexp e1) (negate (exptolinexp e2)))
-        | Ne -> comb DISEQ (add (exptolinexp e1) (negate (exptolinexp e2)))
-        | _ -> raise (Invalid_argument "exptolinexp")
+        | Lt -> comb SUP   (add (cil_exp_to_lexp e2) (negate (cil_exp_to_lexp e1)))
+        | Gt -> comb SUP   (add (cil_exp_to_lexp e1) (negate (cil_exp_to_lexp e2)))
+        | Le -> comb SUPEQ (add (cil_exp_to_lexp e2) (negate (cil_exp_to_lexp e1)))
+        | Ge -> comb SUPEQ (add (cil_exp_to_lexp e1) (negate (cil_exp_to_lexp e2)))
+        | Eq -> comb EQ    (add (cil_exp_to_lexp e1) (negate (cil_exp_to_lexp e2)))
+        | Ne -> comb DISEQ (add (cil_exp_to_lexp e1) (negate (cil_exp_to_lexp e2)))
+        | _ -> raise (Invalid_argument "cil_exp_to_lexp")
       end
-    | CastE (_,e) -> exptolinexp e
+    | CastE (_,e) -> cil_exp_to_lexp e
     | _ ->
-      raise (Invalid_argument "exptolinexp")
+      raise (Invalid_argument "cil_exp_to_lexp")
 
-  let exptolinecons env x b =
+  let inverse_comparator comparator =
+    match comparator with
+    | EQ -> DISEQ
+    | DISEQ -> EQ
+    | SUPEQ -> SUP
+    | SUP -> SUPEQ
+    | EQMOD x -> EQMOD x
+
+  let cil_exp_to_apron_linexpr1 environment cil_exp should_negate =
+    let var_name_coeff_pairs, constant, comparator = cil_exp_to_lexp (Cil.constFold false cil_exp) in
+    let var_name_coeff_pairs, constant, comparator = if should_negate then var_name_coeff_pairs, constant, comparator else negate (var_name_coeff_pairs, constant, (inverse_comparator comparator)) in
+    let apron_var_coeff_pairs = List.map (function (x,`int y) -> Coeff.s_of_int y, Var.of_string x | (x,`float f) -> Coeff.s_of_float f, Var.of_string x) var_name_coeff_pairs in
+    let apron_constant = match constant with `int x -> Some (Coeff.s_of_int x) | `float f -> Some (Coeff.s_of_float f) | `none -> None in
+    let linexpr1 = Linexpr1.make environment in
+    Linexpr1.set_list linexpr1 apron_var_coeff_pairs apron_constant;
+    linexpr1, comparator
+
+  let cil_exp_to_apron_linecons environment cil_exp should_negate =
     (* ignore (Pretty.printf "exptolinecons '%a'\n" d_plainexp x); *)
-    let inverse = function
-      | EQ -> DISEQ
-      | DISEQ -> EQ
-      | SUPEQ -> SUP
-      | SUP -> SUPEQ
-      | EQMOD x -> EQMOD x
-    in
-    let cs, c, r = exptolinexp (Cil.constFold false x) in
-    let cs, c, r = if b then cs, c, r else negate (cs,c,inverse r) in
-    let cs = List.map (function (x,`int y) -> Coeff.s_of_int y, Var.of_string x | (x,`float f) ->Coeff.s_of_float f, Var.of_string x) cs in
-    let c = match c with `int x -> Some (Coeff.s_of_int x) | `float f -> Some (Coeff.s_of_float f) | `none -> None in
-    let le = Linexpr1.make env in
-    Linexpr1.set_list le cs c;
-    Lincons1.make le r
+    let linexpr1, comparator = cil_exp_to_apron_linexpr1 environment cil_exp should_negate in
+    Lincons1.make linexpr1 comparator
 
   let assert_inv d x b =
     try
@@ -218,16 +223,16 @@ struct
         | Lval (Var v,NoOffset) when isArithmeticType v.vtype ->
           UnOp(LNot, (BinOp (Eq, x, (Const (CInt64(Int64.of_int 0, IInt, None))), intType)), intType)
         | _ -> x in
-      let ea = { lincons0_array = [|Lincons1.get_lincons0 (exptolinecons (A.env d) x b) |]
+      let ea = { lincons0_array = [|Lincons1.get_lincons0 (cil_exp_to_apron_linecons (A.env d) x b) |]
                ; array_env = A.env d
                }
       in
       A.meet_lincons_array Man.mgr d ea
-    with Invalid_argument "exptolinexp" -> d
+    with Invalid_argument "cil_exp_to_lexp" -> d
 
-  let exptotexpr1 env x =
+  let cil_exp_to_apron_texpr1 env exp =
     (* ignore (Pretty.printf "exptotexpr1 '%a'\n" d_plainexp x); *)
-    Texpr1.of_expr env (exptoexpr x)
+    Texpr1.of_expr env (cil_exp_to_cil_lhost exp)
 
   let assign_var_eq_with d v v' =
     A.assign_texpr_with Man.mgr d (Var.of_string v)
@@ -242,8 +247,8 @@ struct
     (* ignore (Pretty.printf "assign_var_with %a %s %a\n" pretty d v d_plainexp e); *)
     begin try
         A.assign_texpr_with Man.mgr d (Var.of_string v)
-          (exptotexpr1 (A.env d) (Cil.constFold false e)) None
-      with Invalid_argument "exptotexpr1" ->
+          (cil_exp_to_apron_texpr1 (A.env d) (Cil.constFold false e)) None
+      with Invalid_argument "cil_exp_to_apron_texpr1" ->
         A.forget_array_with Man.mgr d [|Var.of_string v|] false
         (* | Manager.Error q -> *)
         (* ignore (Pretty.printf "Manager.Error: %s\n" q.msg); *)
@@ -268,8 +273,8 @@ struct
     (* ignore (Pretty.printf "substitute_var_with %a %s %a\n" pretty d v d_plainexp e); *)
     begin try
         A.substitute_texpr_with Man.mgr d (Var.of_string v)
-          (exptotexpr1 (A.env d) (Cil.constFold false e)) None
-      with Invalid_argument "exptotexpr1" ->
+          (cil_exp_to_apron_texpr1 (A.env d) (Cil.constFold false e)) None
+      with Invalid_argument "cil_exp_to_apron_texpr1" ->
         A.forget_array_with Man.mgr d [|Var.of_string v|] false
         (* | Manager.Error q ->
            ignore (Pretty.printf "Manager.Error: %s\n" q.msg);

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -21,7 +21,7 @@ sig
   val to_excl_list: t -> int64 list option
   val of_excl_list: int64 list -> t
   val is_excl_list: t -> bool
-  (*  val of_interval: int64 -> int64 -> t*)
+  val of_interval: int64 -> int64 -> t
   val starting   : int64 -> t
   val ending     : int64 -> t
   val maximal    : t -> int64 option
@@ -118,6 +118,8 @@ struct
   let is_int = function Some (x,y) when Int64.compare x y = 0 -> true | _ -> false
   let of_int x = norm @@ Some (x,x)
   let to_int = function Some (x,y) when Int64.compare x y = 0 -> Some x | _ -> None
+
+  let of_interval x y = norm @@ Some (x,y)
 
   let of_bool = function true -> Some (Int64.one,Int64.one) | false -> Some (Int64.zero,Int64.zero)
   let is_bool = function None -> false | Some (x,y) ->
@@ -903,6 +905,9 @@ struct
     match x with
     | Int(_,a,b) -> C.eq a b
     | _ -> false
+
+  let of_interval x y =
+    I.of_int64 max_width x y
 
   (* Bool Conversion *)
   let to_bool x =
@@ -1978,6 +1983,8 @@ struct
     (I1.of_int x
     ,I2.of_int x)
 
+  let of_interval x y = top ()
+
   let compare (x1,x2) (y1,y2) =
     match I1.compare x1 y1 with
     | 0 -> I2.compare x2 y2
@@ -2103,6 +2110,8 @@ struct
       [("trier"   ,fun () -> Trier    (I1.of_int x))
       ;("interval",fun () -> Interval (I2.of_int x))
       ;("cinterval",fun () -> CInterval (I3.of_int x))]
+
+  let of_interval x y = top ()
 
   (* element functions *)
 
@@ -2568,6 +2577,12 @@ module Enums : S = struct
   let of_int x = Pos [x]
   let cast_to_width w = function Pos xs -> Pos (List.map (I.cast_to_width w) xs) | Neg _ -> top ()
 
+  let of_interval x y =
+    let rec build_set set start_num end_num =
+      if start_num >= end_num then set
+      else (build_set ([start_num] @ set) (Int64.add start_num (Int64.of_int 1)) end_num) in
+    Pos (build_set [] x y)
+
   let rec merge_cup a b = match a,b with
     | [],x | x,[] -> x
     | x::xs, y::ys -> (match compare x y with
@@ -2712,7 +2727,6 @@ module Enums : S = struct
   let to_excl_list = function Neg x when x<>[] -> Some x | _ -> None
   let of_excl_list x = Neg x
   let is_excl_list = Option.is_some % to_excl_list
-  (* let of_interval  x y = Pos (List.of_enum (x--y)) *)
   let starting     x = top ()
   let ending       x = top ()
   let maximal = function Pos xs when xs<>[] -> Some (List.last xs) | _ -> None
@@ -2730,6 +2744,7 @@ module IntDomTuple : S = struct (* the above IntDomList has too much boilerplate
   type 'a m = (module S with type t = 'a)
   (* only first-order polymorphism on functions -> use records to get around monomorphism restriction on arguments *)
   type 'b poly_in  = { fi  : 'a. 'a m -> 'b -> 'a } (* inject *)
+  type 'b poly2_in  = { f2i  : 'a. 'a m -> 'b -> 'b -> 'a }
   type 'b poly_pr  = { fp  : 'a. 'a m -> 'a -> 'b } (* project *)
   type 'b poly2_pr  = { f2p  : 'a. 'a m -> 'a -> 'a -> 'b }
   type poly1 = { f1 : 'a. 'a m -> 'a -> 'a } (* needed b/c above 'b must be different from 'a *)
@@ -2737,6 +2752,9 @@ module IntDomTuple : S = struct (* the above IntDomList has too much boilerplate
   let create r x = (* use where values are introduced *)
     let f n g = if get_bool ("ana.int."^n) then Some (g x) else None in
     f "trier" @@ r.fi (module I1), f "interval" @@ r.fi (module I2), f "cinterval" @@ r.fi (module I3), f "enums" @@ r.fi (module I4)
+  let createTwoParams r x y = (* use where values are introduced *)
+    let f n g = if get_bool ("ana.int."^n) then Some (g x y) else None in
+    f "trier" @@ r.f2i (module I1), f "interval" @@ r.f2i (module I2), f "cinterval" @@ r.f2i (module I3), f "enums" @@ r.f2i (module I4)
   let mapp r (a,b,c,d) = Option.(map (r.fp (module I1)) a, map (r.fp (module I2)) b, map (r.fp (module I3)) c, map (r.fp (module I4)) d)
   let map  r (a,b,c,d) = Option.(map (r.f1 (module I1)) a, map (r.f1 (module I2)) b, map (r.f1 (module I3)) c, map (r.f1 (module I4)) d)
   let opt_map2 f = curry @@ function | Some x, Some y -> Some (f x y) | _ -> None
@@ -2758,6 +2776,7 @@ module IntDomTuple : S = struct (* the above IntDomList has too much boilerplate
   let of_int = create { fi = fun (type a) (module I:S with type t = a) -> I.of_int }
   let starting = create { fi = fun (type a) (module I:S with type t = a) -> I.starting }
   let ending = create { fi = fun (type a) (module I:S with type t = a) -> I.ending }
+  let of_interval = createTwoParams { f2i = fun (type a) (module I:S with type t = a) -> I.of_interval }
 
   (* f1: unary ops *)
   let neg = map { f1 = fun (type a) (module I:S with type t = a) -> I.neg }

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -31,7 +31,7 @@ sig
   (* Creates a exclusion set from a given list of integers. *)
   val is_excl_list: t -> bool
   (* Checks if the element is an exclusion set. *)
-  val of_interval: int64 -> int64 -> t
+  val of_interval: int64 * int64 -> t
   val starting   : int64 -> t
   val ending     : int64 -> t
   val maximal    : t -> int64 option

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -31,7 +31,7 @@ sig
   (* Creates a exclusion set from a given list of integers. *)
   val is_excl_list: t -> bool
   (* Checks if the element is an exclusion set. *)
-  (*  val of_interval: int64 -> int64 -> t*)
+  val of_interval: int64 -> int64 -> t
   val starting   : int64 -> t
   val ending     : int64 -> t
   val maximal    : t -> int64 option


### PR DESCRIPTION
- added the function of_interval to the signature of the int domains (commit bc7268b)
- refactored the apronDomain such that the functions transforming cil expressions to apron expressions have names that can be distinguished easier (commit 0fa9ee7)
- added functions to answer EvalInt and EvalInterval (commit b8b9475)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/goblint/analyzer/pull/43%23issuecomment-171952782%22%2C%20%22https%3A//github.com/goblint/analyzer/pull/43%23issuecomment-172764747%22%2C%20%22https%3A//github.com/goblint/analyzer/pull/43%23issuecomment-172772091%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/goblint/analyzer/pull/43%23issuecomment-171952782%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20change%20%60val%20of_interval%3A%20int64%20-%3E%20int64%20-%3E%20t%60%20to%20%60val%20of_interval%3A%20int64%20%2A%20int64%20-%3E%20t%60%3F%20Then%20there%27s%20no%20need%20for%20%60poly2_in/createTwoParams%60.%22%2C%20%22created_at%22%3A%20%222016-01-15T12%3A54%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/493741%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/vogler%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%20we%20merge%20it%3F%22%2C%20%22created_at%22%3A%20%222016-01-19T07%3A36%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8916408%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/isabelmax%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%2C%20didn%27t%20see%20the%20commit.%22%2C%20%22created_at%22%3A%20%222016-01-19T08%3A17%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/493741%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/vogler%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/goblint/analyzer/pull/43#issuecomment-171952782'>General Comment</a></b>
- <a href='https://github.com/vogler'><img border=0 src='https://avatars.githubusercontent.com/u/493741?v=3' height=16 width=16'></a> Could you change `val of_interval: int64 -> int64 -> t` to `val of_interval: int64 * int64 -> t`? Then there's no need for `poly2_in/createTwoParams`.
- <a href='https://github.com/isabelmax'><img border=0 src='https://avatars.githubusercontent.com/u/8916408?v=3' height=16 width=16'></a> Can we merge it?
- <a href='https://github.com/vogler'><img border=0 src='https://avatars.githubusercontent.com/u/493741?v=3' height=16 width=16'></a> Sorry, didn't see the commit.


<a href='https://www.codereviewhub.com/goblint/analyzer/pull/43?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/goblint/analyzer/pull/43?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/goblint/analyzer/pull/43'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/goblint/analyzer/43)
<!-- Reviewable:end -->
***
***
***