### PR TITLE
Implemented EvalIntSet and ExpEq

### DIFF
--- a/src/analyses/poly.ml
+++ b/src/analyses/poly.ml
@@ -64,7 +64,7 @@ struct
     if D.is_bot ctx.local then D.bot () else
       begin
         match LibraryFunctions.classify f.vname args with
-        | `Assert expression -> D.assert_inv ctx.local expression true
+        | `Assert expression -> D.assert_inv ctx.local expression false
         | `Unknown "printf" -> ctx.local
         | _ -> D.topE (A.env ctx.local)
       end
@@ -112,7 +112,12 @@ struct
         | Some i -> `Int i
         | _ -> `Top
       end
-    | EvalIntSet _ -> Result.top ()  (* TODO *)
+    | EvalIntSet e ->
+      begin
+        match D.get_int_interval_for_cil_exp d e with
+        | Some i, Some s -> `IntSet (IntDomain.Enums.of_interval (i,s))
+        | _ -> Result.top ()
+      end
     | EvalInterval e ->
       begin
         match D.get_int_interval_for_cil_exp d e with
@@ -121,7 +126,9 @@ struct
         | _, Some s -> `Interval (IntDomain.Interval.ending s)
         | _ -> `Top
       end
-    | ExpEq (_, _) -> Result.top () (* TODO *)
+    | ExpEq (e1, e2) ->
+      if D.cil_exp_equals d e1 e2 then `Bool (Queries.BD.of_bool true)
+      else Result.top ()
     | _ -> Result.top ()
 end
 


### PR DESCRIPTION
Implemented EvalIntSet and ExpEq

While doing so, I saw that I named the signature of cil_exp_to_apron_linexpr1 misleadingly, therefore, I changed  the params in assert_inv.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/goblint/analyzer/pull/44?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/goblint/analyzer/pull/44'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/goblint/analyzer/44)
<!-- Reviewable:end -->
