### PR TITLE
Improve int domain values via query system

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -559,6 +559,61 @@ struct
    * Auxilliary functions
    **************************************************************************)
 
+  let refine_answer (ask: Q.ask) question prior_value =
+    let refine_to_interval answer_interval_inferior answer_interval_superior =
+      match prior_value with
+      | `Int prior_value  -> (
+          if not(ID.is_top prior_value) then (
+            match ID.minimal prior_value, ID.maximal prior_value with
+            | Some prior_inferior, Some prior_superior ->
+              `Int (ID.meet (ID.of_interval (prior_inferior, prior_superior)) (ID.of_interval (answer_interval_inferior, answer_interval_superior)))
+            | _ -> `Int (ID.of_interval (answer_interval_inferior, answer_interval_superior)))
+          else `Int (ID.of_interval (answer_interval_inferior, answer_interval_superior))
+        )
+      | `Bot -> `Bot
+      | _ -> `Int (ID.of_interval (answer_interval_inferior, answer_interval_superior))
+    in
+    let refine_to_set excl_list =
+      match prior_value with
+      | `Int prior_value  -> (
+          match ID.to_excl_list prior_value with
+          | Some prior_excl_list -> `Int (ID.meet (ID.of_excl_list prior_excl_list) (ID.of_excl_list excl_list))
+          | _ -> `Int (ID.of_excl_list excl_list)
+        )
+      | `Bot -> `Bot
+      | _ -> `Int (ID.of_excl_list excl_list)
+    in
+    match ask question with
+    | `Int x -> (
+        match prior_value with
+        | `Int prior_value  -> `Int (ID.meet (ID.of_int x) prior_value)
+        | `Bot -> `Bot
+        | _ -> `Int (ID.of_int x)
+      )
+    | `Interval x -> (
+        if IntDomain.Interval.is_top x then prior_value else
+          match IntDomain.Interval.minimal x, IntDomain.Interval.maximal x with
+          | Some x, Some y -> refine_to_interval x y
+          | _ -> prior_value
+      )
+    | `IntSet x -> (
+        if IntDomain.Enums.is_top x then prior_value else
+          match IntDomain.Enums.to_excl_list x with
+          | Some excl_list -> refine_to_set excl_list
+          | _ -> prior_value
+      )
+    | _ -> prior_value
+
+  let improve_abstract_value_with_queries ask exp base_value =
+    try
+      match refine_answer ask (Queries.EvalInt exp) base_value with
+      | `Top -> base_value
+      | x -> x
+    with Not_found -> base_value
+
+  let eval_rv_with_query (a: Q.ask) (gs:glob_fun) (st: store) (exp:exp) =
+    improve_abstract_value_with_queries a exp (eval_rv a gs st exp)
+
   let rec bot_value a (gs:glob_fun) (st: store) (t: typ): value =
     let rec bot_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
@@ -573,7 +628,7 @@ struct
     | TArray (_, None, _) -> `Array (ValueDomain.CArrays.bot ())
     | TArray (ai, Some exp, _) -> begin
         let default = `Array (ValueDomain.CArrays.bot ()) in
-        match eval_rv a gs st exp with
+        match eval_rv_with_query a gs st exp with
         | `Int n -> begin
             match ID.to_int n with
             | Some n -> `Array (ValueDomain.CArrays.make (Int64.to_int n) (bot_value a gs st ai))
@@ -736,6 +791,7 @@ struct
       else
         let oldval = get a gs st addr in
         let new_val = apply_invariant oldval value in
+        let new_val = improve_abstract_value_with_queries a (Lval lval) new_val in
         if M.tracing then M.traceu "invariant" "New value is %a\n" VD.pretty new_val;
         (* make that address meet the invariant, i.e exclusion sets will be joined *)
         if is_some_bot new_val then (
@@ -814,7 +870,7 @@ struct
           (`List (ValueDomain.Lists.bot ()))
       end
     | _ ->
-      let rval_val = eval_rv ctx.ask ctx.global ctx.local rval in
+      let rval_val = eval_rv_with_query ctx.ask ctx.global ctx.local rval in
       let lval_val = eval_lv ctx.ask ctx.global ctx.local lval in
       (* let sofa = AD.short 80 lval_val^" = "^VD.short 80 rval_val in *)
       (* M.debug @@ sprint ~width:80 @@ dprintf "%a = %a\n%s" d_plainlval lval d_plainexp rval sofa; *)
@@ -849,7 +905,7 @@ struct
 
   let branch ctx (exp:exp) (tv:bool) : store =
     Locmap.replace Deadcode.dead_branches_cond !Tracing.next_loc exp;
-    let valu = eval_rv ctx.ask ctx.global ctx.local exp in
+    let valu = eval_rv_with_query ctx.ask ctx.global ctx.local exp in
     if M.tracing then M.traceli "branch" ~subsys:["invariant"] "Evaluating branch for expression %a with value %a\n" d_exp exp VD.pretty valu;
     if M.tracing then M.tracel "branchosek" "Evaluating branch for expression %a with value %a\n" d_exp exp VD.pretty valu;
     (* First we want to see, if we can determine a dead branch: *)
@@ -911,7 +967,7 @@ struct
     | _ -> let nst = rem_many ctx.local (fundec.sformals @ fundec.slocals) in
       match exp with
       | None -> nst
-      | Some exp -> set ctx.ask ctx.global nst (return_var ()) (eval_rv ctx.ask ctx.global ctx.local exp)
+      | Some exp -> set ctx.ask ctx.global nst (return_var ()) (eval_rv_with_query ctx.ask ctx.global ctx.local exp)
 
 
   (**************************************************************************
@@ -1010,7 +1066,7 @@ struct
     (* We define the function that invalidates all the values that an address
      * expression e may point to *)
     let invalidate_exp e =
-      match eval_rv ask gs st e with
+      match eval_rv_with_query ask gs st e with
       (*a null pointer is invalid by nature*)
       | `Address a when AD.equal a (AD.null_ptr()) -> []
       | `Address a when not (AD.is_top a) ->
@@ -1031,7 +1087,7 @@ struct
   (* Variation of the above for yet another purpose, uhm, code reuse? *)
   let collect_funargs ask (gs:glob_fun) (st:store) (exps: exp list) =
     let do_exp e =
-      match eval_rv ask gs st e with
+      match eval_rv_with_query ask gs st e with
       | `Address a when AD.equal a (AD.null_ptr ()) -> []
       | `Address a when not (AD.is_top a) ->
         let rble = reachable_vars ask [a] gs st in
@@ -1292,7 +1348,7 @@ struct
   let make_entry ctx ?nfl:(nfl=(snd ctx.local)) fn args: D.t =
     let cpa,fl as st = ctx.local in
     (* Evaluate the arguments. *)
-    let vals = List.map (eval_rv ctx.ask ctx.global st) args in
+    let vals = List.map (eval_rv_with_query ctx.ask ctx.global st) args in
     (* generate the entry states *)
     let fundec = Cilfacade.getdec fn in
     (* If we need the globals, add them *)
@@ -1526,7 +1582,7 @@ struct
       cpa, Flag.make_main fl
     (* handling thread joins... sort of *)
     | `ThreadJoin (id,ret_var) ->
-      begin match (eval_rv ctx.ask gs st ret_var) with
+      begin match (eval_rv_with_query ctx.ask gs st ret_var) with
         | `Int n when n = ID.of_int 0L -> cpa,fl
         | _      -> invalidate ctx.ask gs st [ret_var]
       end

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -606,9 +606,11 @@ struct
 
   let improve_abstract_value_with_queries ask exp base_value =
     try
-      match refine_answer ask (Queries.EvalInt exp) base_value with
-      | `Top -> base_value
-      | x -> x
+      if (get_bool "ana.int.queries") then
+        match refine_answer ask (Queries.EvalInt exp) base_value with
+        | `Top -> base_value
+        | x -> x
+      else base_value
     with Not_found -> base_value
 
   let eval_rv_with_query (a: Q.ask) (gs:glob_fun) (st: store) (exp:exp) =

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1200,6 +1200,26 @@ struct
         | `Bot   -> `Bot
         | _      -> `Top
       end
+    | Q.EvalInterval e -> begin
+        match eval_rv ctx.ask ctx.global ctx.local e with
+        | `Int e -> (
+              match ID.is_top e with
+                | true -> `Top
+                | false -> (
+                    match ID.minimal e, ID.maximal e with
+                      Some i, Some s -> `Interval (IntDomain.Interval.of_interval (i,s))
+                    | _ -> `Top
+                  )
+          )
+        | `Bot   -> `Bot
+        | _      -> `Top
+      end
+    | Q.EvalIntSet e -> begin
+        match eval_rv ctx.ask ctx.global ctx.local e with
+        | `Int e -> (match ID.to_excl_list e with Some l -> `IntSet (IntDomain.Enums.of_excl_list l) | _ -> `Top)
+        | `Bot   -> `Bot
+        | _      -> `Top
+      end
     | Q.MayPointTo e -> begin
         match eval_rv ctx.ask ctx.global ctx.local e with
         | `Address a when AD.is_top a -> `LvalSet (Q.LS.top ())

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -442,7 +442,19 @@ struct
         ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in query context.")
         }
       in
-      Queries.Result.meet a @@ S.query ctx' q
+      let answer = ref (Queries.Result.meet a @@ S.query ctx' q) in
+      let q = ref q in
+      let break = ref false in
+      while not(!break) && (!answer = `Top) do
+        let next_q = (Queries.Query.get_next_query_in_hierarchy !q) in
+        match next_q with
+        | Some x -> (
+            q := x;
+            answer := (Queries.Result.meet a @@ S.query ctx' !q);
+          )
+        | _ -> break := true;
+       done;
+      !answer
     in
     match q with
     | Queries.PrintFullState ->

--- a/src/analyses/poly.ml
+++ b/src/analyses/poly.ml
@@ -115,13 +115,19 @@ struct
     | EvalIntSet e ->
       begin
         match D.get_int_interval_for_cil_exp d e with
-        | Some i, Some s -> `IntSet (IntDomain.Enums.of_interval (i,s))
+        | Some i, Some s ->
+          if (Int64.compare i s) <= 0 then
+            `IntSet (IntDomain.Enums.of_interval (i,s))
+          else Result.bot ()
         | _ -> Result.top ()
       end
     | EvalInterval e ->
       begin
         match D.get_int_interval_for_cil_exp d e with
-        | Some i, Some s -> `Interval (IntDomain.Interval.of_interval (i,s))
+        | Some i, Some s ->
+          if (Int64.compare i s) <= 0 then
+             `Interval (IntDomain.Interval.of_interval (i,s))
+          else Result.bot ()
         | Some i, _ ->  `Interval (IntDomain.Interval.starting i)
         | _, Some s -> `Interval (IntDomain.Interval.ending s)
         | _ -> `Top

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2578,8 +2578,8 @@ module Enums : S = struct
 
   let of_interval (x,y) =
     let rec build_set set start_num end_num =
-      if start_num >= end_num then set
-      else (build_set ([start_num] @ set) (Int64.add start_num (Int64.of_int 1)) end_num) in
+      if start_num > end_num then set
+      else (build_set (set @ [start_num]) (Int64.add start_num (Int64.of_int 1)) end_num) in
     Pos (build_set [] x y)
 
   let rec merge_cup a b = match a,b with

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -69,6 +69,16 @@ type result = [
 
 type ask = t -> result
 
+module Query =
+struct
+  let get_next_query_in_hierarchy (query: t) =
+    match query with
+    | EvalInt x -> Some (EvalInterval x)
+    | EvalInterval x -> Some (EvalIntSet x)
+    | _ -> None
+end
+
+
 module Result: Lattice.S with type t = result =
 struct
   include Printable.Std

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -115,6 +115,7 @@ let _ = ()
       ; reg Analyses "ana.int.cdebug"      "false" "Debugging output for wrapped interval analysis."
       ; reg Analyses "ana.int.cwiden"      "'basic'" "Widing variant to use for wrapped interval analysis ('basic', 'double')"
       ; reg Analyses "ana.int.cnarrow"     "'basic'" "Widing variant to use for wrapped interval analysis ('basic', 'half')"
+      ; reg Analyses "ana.int.queries"     "false"  "Use queries in the base analysis to improve abstract values using EvalInt in other domains"
       ; reg Analyses "ana.file.optimistic" "false" "Assume fopen never fails."
       ; reg Analyses "ana.spec.file"       ""      "Path to the specification file."
       ; reg Analyses "ana.arinc.assume_success" "true"    "Assume that all ARINC functions succeed (sets return code to NO_ERROR, otherwise invalidates it)."


### PR DESCRIPTION
###  Summary:
If 'ana.int.queries' is set to true, the query system is used to improve the abstract values of different int domains from each other.

### Details:
- EvalInterval and EvalInt is now answered in the base analysis
- Query hierarchy: Int -> Interval -> Set: A single int can be improved by intervals and sets, an int set can improve an interval. If one of the queries returns Top, the other queries in this hierarchy are called. 
- Small fixes to make it work properly: fix of_interval in enums, fixes of answering in poly

### How to test: 
`goblint --html -o ../results/ tests/regression/01-cpa/03-loops.c --set ana.activated "['poly','base']" --set ana.int.trier true --set ana.int.interval true --set ana.int.queries true`
After assert(k) you see improved values for k than without the query system. (just one example)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/goblint/analyzer/pull/46?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/goblint/analyzer/pull/46'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/goblint/analyzer/46)
<!-- Reviewable:end -->
