### PR TITLE
Fix missing accesses

### DIFF
--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -375,7 +375,7 @@ let invalidate_actions = ref [
     "dev_driver_string", readsAll;
     "__spin_lock_init", writes [1];
     "kmem_cache_create", readsAll;
-    "pthread_create", writes [1];
+    "pthread_create", onlyWrites [1];
     "__builtin_prefetch", readsAll;
     "idr_pre_get", readsAll;
     "zil_replay", writes [1;2;3;5]

--- a/src/analyses/mutex.ml
+++ b/src/analyses/mutex.ml
@@ -254,6 +254,9 @@ struct
       in
       List.iter (access_one_top ctx false true) (arg_acc `Read);
       List.iter (access_one_top ctx true  true ) (arg_acc `Write);
+      (match lv with
+      | Some x -> access_one_top ctx true false (AddrOf x)
+      | None -> ());
       ctx.local
 
   let enter ctx lv f args : (D.t * D.t) list =
@@ -263,7 +266,7 @@ struct
     access_one_top ctx false false fexp;
     begin match lv with
       | None      -> ()
-      | Some lval -> access_one_top ctx true false (Lval lval)
+      | Some lval -> access_one_top ctx true false (AddrOf lval)
     end;
     List.iter (access_one_top ctx false false) args;
     al

--- a/src/analyses/mutex.ml
+++ b/src/analyses/mutex.ml
@@ -252,7 +252,7 @@ struct
         | Some fnc -> (fnc act arglist)
         | _ -> arglist
       in
-      List.iter (access_one_top ctx false false) (arg_acc `Read);
+      List.iter (access_one_top ctx false true) (arg_acc `Read);
       List.iter (access_one_top ctx true  true ) (arg_acc `Write);
       ctx.local
 


### PR DESCRIPTION
Found some missing races on Andrés test suite. This should fix it.
However, the first commit breaks [tests/regression/05-lval_ls/17-per_elem_simp.c](https://github.com/goblint/analyzer/blob/master/tests/regression/05-lval_ls/17-per_elem_simp.c).
