### PR TITLE
Fix setup via vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "ubuntu/bionic64"
 
   config.vm.provision :shell, :path => "scripts/travis-ci.sh"
 

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -15,7 +15,9 @@ else
         }
         # update repositories to prevent errors caused by missing packages
         sudo apt-get update -qq
-        apt python-software-properties # needed for ppa
+        apt gcc
+        apt libgmp-ocaml-dev
+        apt software-properties-common # needed for ppa
         apt make m4  # needed for compiling ocamlfind
         apt patch    # needed for compiling xml-light
         apt autoconf # needed for compiling cil


### PR DESCRIPTION
If I read the content of the vagrant file correctly, it creates a VM based on Ubuntu precise (12.04):

https://github.com/goblint/analyzer/blob/af29b913edf23930e759590ce4b19378c6d8bb23/Vagrantfile#L5

This seems to not be a security problem, since the VM is not given network access by default. Still, I guess it won't hurt to update this, users might enable network access anyway.

In next line seems to be unnecessary here (since `config.vm.box` already points into the Vagrant Cloud[1]), uses unsafe http (but the server fortunately redirects to https), and the link is broken anyway:
https://github.com/goblint/analyzer/blob/af29b913edf23930e759590ce4b19378c6d8bb23/Vagrantfile#L6

It is therefore no surprise that `vagrant up` also fails currently with this error:
```
Failed to connect to hashicorp-files.hashicorp.com port 443: Connection refused
```


[1] https://www.vagrantup.com/docs/vagrantfile/machine_settings.html#config-vm-box_url

This PR will make vagrant use Ubuntu 18.04 (20.04 is not yet supported by ppa avsm/ppa needed for ocaml).

The VM is setup via running scripts/travis-ci.sh, but I found that additional packages are needed in order to run `vagrant up`
successfully with the new base image. Also one package has been renamed in newer Ubuntu versions (and now also comes preinstalled).