### PR TITLE
Fix def_exc

### DIFF
--- a/regtest.sh
+++ b/regtest.sh
@@ -9,7 +9,7 @@ if [ ! -e $file ]; then
   exit 1
 fi
 params="`grep -oP "PARAM: \K.*" $file`"
-cmd="./goblint --enable dbg.fail_on_different_ikind --enable dbg.debug --sets warnstyle \"legacy\" --enable colors --enable dbg.showtemps --enable dbg.regression --html $params ${@:3} $file" #  --enable dbg.verbose --enable printstats
+cmd="./goblint --enable dbg.debug --sets warnstyle \"legacy\" --enable colors --enable dbg.showtemps --enable dbg.regression --html $params ${@:3} $file" #  --enable dbg.verbose --enable printstats
 cmd=`echo "$cmd" | sed "s:ana.osek.oil :ana.osek.oil $(dirname $file)/:"` # regression tests are run inside the test's directory which is why we either also need to cd there or instead prepend the path to the test directory for file parameters like these .oil files
 echo "$cmd"
 eval $cmd

--- a/regtest.sh
+++ b/regtest.sh
@@ -9,7 +9,7 @@ if [ ! -e $file ]; then
   exit 1
 fi
 params="`grep -oP "PARAM: \K.*" $file`"
-cmd="./goblint --enable dbg.debug --sets warnstyle \"legacy\" --enable colors --enable dbg.showtemps --enable dbg.regression --html $params ${@:3} $file" #  --enable dbg.verbose --enable printstats
+cmd="./goblint --enable dbg.fail_on_different_ikind --enable dbg.debug --sets warnstyle \"legacy\" --enable colors --enable dbg.showtemps --enable dbg.regression --html $params ${@:3} $file" #  --enable dbg.verbose --enable printstats
 cmd=`echo "$cmd" | sed "s:ana.osek.oil :ana.osek.oil $(dirname $file)/:"` # regression tests are run inside the test's directory which is why we either also need to cd there or instead prepend the path to the test directory for file parameters like these .oil files
 echo "$cmd"
 eval $cmd

--- a/scripts/update_suite.rb
+++ b/scripts/update_suite.rb
@@ -166,7 +166,6 @@ regs.sort.each do |d|
       tests[-1] = "term"
       debug = true
     end
-    params << " --enable dbg.fail_on_different_ikind"
     params << " --set dbg.debug true" if debug
     p = Project.new(id, testname, 0, groupname, path, params, tests, tests_line, true)
     projects << p

--- a/scripts/update_suite.rb
+++ b/scripts/update_suite.rb
@@ -166,6 +166,7 @@ regs.sort.each do |d|
       tests[-1] = "term"
       debug = true
     end
+    params << " --enable dbg.fail_on_different_ikind"
     params << " --set dbg.debug true" if debug
     p = Project.new(id, testname, 0, groupname, path, params, tests, tests_line, true)
     projects << p

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1400,7 +1400,7 @@ struct
       | PlusA  -> meet_com ID.sub
       | Mult   -> meet_com ID.div (* Div is ok here, c must be divisible by a and b *)
       | MinusA -> meet_non ID.add ID.sub
-      (* | Div    -> be careful when adding Div, it is division with remainder this is not easy to inverse *)
+      | Div    -> meet_bin (ID.add (ID.mul b c) (ID.rem a b)) (ID.div (ID.sub a (ID.rem a b)) c)
       | Mod    -> meet_bin (ID.add c (ID.mul b (ID.div a b))) (ID.div (ID.sub a c) (ID.div a b))
       | Eq | Ne ->
         let both x = x, x in
@@ -1487,7 +1487,7 @@ struct
         | v -> fallback ("CastE: e did not evaluate to `Int, but " ^ sprint VD.pretty v))
       | e -> fallback (sprint d_plainexp e ^ " not implemented")
     in
-    if eval_bool exp = Some (not tv) then raise Deadcode (* we already know that the branch is dead *) (*TODO: Negation? *)
+    if eval_bool exp = Some (not tv) then raise Deadcode (* we already know that the branch is dead *)
     else
       let is_cmp = function
         | BinOp ((Lt | Gt | Le | Ge | Eq | Ne), _, _, t) -> true

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1474,26 +1474,12 @@ struct
           | _ -> `Int c
         in
         let oldv = eval (Lval x) in
-        let skip = if Cil.isVoidPtrType t then
-            match oldv with
-            | `Address _ -> false
-            | _ -> true (* We do not change type on a cast to void*, so we can not meet here without type errors*)
-          else
-            false
-        in
-        let v =
-          if skip then
-            (if M.tracing then M.tracel "inv" "lval %a = %a has type void*, but we want to improve it with %a (from %a) -> skipping\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c ;
-            oldv)
-          else
-            let v = VD.meet oldv c' in
-            if is_some_bot v then
-              raise Deadcode
-            else
-              (if M.tracing then M.tracel "inv" "improve lval %a = %a with %a (from %a), meet = %a\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c VD.pretty v;
-              v)
-        in
-          set' x v
+        let v = VD.meet oldv c' in
+        if is_some_bot v then
+          raise Deadcode
+        else
+          (if M.tracing then M.tracel "inv" "improve lval %a = %a with %a (from %a), meet = %a\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c VD.pretty v;
+          set' x v)
       | Const _ -> Tuple3.first st (* nothing to do *)
       | CastE ((TInt (ik, _)) as t, e) -> (* Can only meet the t part of an Lval in e with c (unless we meet with all overflow possibilities)! Since there is no good way to do this, we only continue if e has no values outside of t. *)
         (match eval e with

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -100,7 +100,7 @@ struct
     | 0 -> Flag.compare x2 y2
     | x -> x
 
-  let get_ikind t = match Cil.unrollType t with TInt (ik,_) -> ik | _ ->
+  let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
     (* important to unroll the type here, otherwise problems with typedefs *)
     M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
 
@@ -1469,7 +1469,8 @@ struct
         let t = Cil.unrollType (typeOfLval x) in  (* unroll type to deal with TNamed *)
         let c' = match t with
           | TPtr _ -> `Address (AD.of_int (module ID) c)
-          | TInt (ik, _) -> `Int (ID.cast_to ik c )
+          | TInt (ik, _)
+          | TEnum ({ekind = ik; _}, _) -> `Int (ID.cast_to ik c )
           | _ -> `Int c
         in
         let oldv = eval (Lval x) in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1407,12 +1407,14 @@ struct
         let m = ID.meet a b in
         (match op, ID.to_bool c with
         | Eq, Some true
-        | Ne, Some false -> both m (* def. equal *)
+        | Ne, Some false -> both m (* def. equal: if they compare equal, both values must be from the meet *)
         | Eq, Some false
         | Ne, Some true -> (* def. unequal *)
-          (match ID.to_int m with
-          | Some i -> both (ID.of_excl_list ik [i])
-          | None -> a, b)
+          (* if they compare unequal, they can not at the same time be from the meet, but it would be unsound to restrict both to not be the meet      *)
+          (* even if there is only one element in the meet e.g. a:[0,1] b:[1,2] meet(a,b) = [1], but (a != b) does not mean that a:[0,0] and b: [2,2]  *)
+          let a' = match ID.to_int b with | Some j -> (ID.of_excl_list ik [j]) | _ -> a  in (* if b is one concrete value, we can exclude it in a *)
+          let b' = match ID.to_int a with | Some j -> (ID.of_excl_list ik [j]) | _ -> b  in (* if a is one concrete value, we can exclude it in b *)
+          meet_bin a' b'
         | _, _ -> a, b
         )
       | Lt | Le | Ge | Gt ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1413,7 +1413,7 @@ struct
         | Eq, Some false
         | Ne, Some true -> (* def. unequal *)
           (match ID.to_int m with
-          | Some i -> both (ID.of_excl_list t [i]) (*wrong type *)
+          | Some i -> both (ID.of_excl_list t [i])
           | None -> a, b)
         | _, _ -> a, b
         )

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -680,9 +680,10 @@ struct
         | BinOp (op, (CastE (t1, e1) as c1), (CastE (t2, e2) as c2), t) when typeSig t1 = typeSig t2 && (op = Eq || op = Ne) ->
           let a1 = eval_rv a gs st e1 in
           let a2 = eval_rv a gs st e2 in
+          let both_arith_type = isArithmeticType (typeOf e1) && isArithmeticType (typeOf e2) in
           let is_safe = VD.equal a1 a2 || VD.is_safe_cast t1 (typeOf e1) && VD.is_safe_cast t2 (typeOf e2) in
           M.tracel "cast" "remove cast on both sides for %a -> %b\n" d_exp exp is_safe;
-          if is_safe then (* we can ignore the casts if the values are equal anyway, or if the casts can't change the value *)
+          if is_safe && not both_arith_type then (* we can ignore the casts if the values are equal anyway, or if the casts can't change the value *)
             eval_rv a gs st (BinOp (op, e1, e2, t))
           else
             let a1 = eval_rv a gs st c1 in
@@ -712,6 +713,7 @@ struct
           `Address (AD.map array_start (eval_lv a gs st lval))
         | CastE (t, Const (CStr x)) -> (* VD.top () *) eval_rv a gs st (Const (CStr x)) (* TODO safe? *)
         | CastE  (t, exp) ->
+          M.tracel "xxxxx" "ohhhhh %a" d_exp exp;
           let v = eval_rv a gs st exp in
           VD.cast ~torg:(typeOf exp) t v
         | _ -> VD.top ()

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1481,7 +1481,9 @@ struct
         (match eval e with
         | `Int a ->
           if ID.leq a (ID.cast_to ik a) then
-            inv_exp c e
+             match Cil.typeOf e with
+              | TInt(ik_e, _) -> inv_exp (ID.cast_to ik_e c) e
+              | x -> fallback ("CastE: e did evaluate to `Int, but the type did not match" ^ sprint d_type t)
           else
             fallback ("CastE: " ^ sprint d_plainexp e ^ " evaluates to " ^ sprint ID.pretty a ^ " which is bigger than the type it is cast to which is " ^ sprint d_type t)
         | v -> fallback ("CastE: e did not evaluate to `Int, but " ^ sprint VD.pretty v))

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1487,7 +1487,7 @@ struct
         | v -> fallback ("CastE: e did not evaluate to `Int, but " ^ sprint VD.pretty v))
       | e -> fallback (sprint d_plainexp e ^ " not implemented")
     in
-    if eval_bool exp = Some tv then raise Deadcode (* we already know that the branch is dead *)
+    if eval_bool exp = Some (not tv) then raise Deadcode (* we already know that the branch is dead *) (*TODO: Negation? *)
     else
       let is_cmp = function
         | BinOp ((Lt | Gt | Le | Ge | Eq | Ne), _, _, t) -> true

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1312,10 +1312,11 @@ struct
     in
     if M.tracing then M.traceli "invariant" "assume expression %a is %B\n" d_exp exp tv;
     let null_val typ =
-      match typ with
-      | TPtr _              -> `Address AD.null_ptr
-      | TInt(ikind, _)      -> `Int (ID.cast_to ikind @@ ID.of_int 0L)
-      | _                   -> `Int (ID.of_int 0L)
+      match Cil.unrollType typ with
+      | TPtr _                    -> `Address AD.null_ptr
+      | TEnum({ekind=ikind;_},_)
+      | TInt(ikind, _)            -> `Int (ID.cast_to ikind @@ ID.of_int 0L)
+      | _                         -> `Int (ID.of_int 0L)
     in
     let rec derived_invariant exp tv =
       let switchedOp = function Lt -> Gt | Gt -> Lt | Le -> Ge | Ge -> Le | x -> x in (* a op b <=> b (switchedOp op) b *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1468,6 +1468,7 @@ struct
       | Lval x -> (* meet x with c *)
         let c' = match typeOfLval x with
           | TPtr _ -> `Address (AD.of_int (module ID) c)
+          | TInt (ik, _) -> `Int (ID.cast_to ik c )
           | _ -> `Int c
         in
         let oldv = eval (Lval x) in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -195,7 +195,7 @@ struct
     | `Address p, `Int n
     | `Int n, `Address p when op=Eq || op=Ne ->
       `Int (match ID.to_bool n, AD.to_bool p with
-          | Some a, Some b -> ID.of_bool_ikind (Cilfacade.get_ikind t) (op=Eq && a=b || op=Ne && a<>b)
+          | Some a, Some b -> ID.cast_to (Cilfacade.get_ikind t) @@ ID.of_bool (op=Eq && a=b || op=Ne && a<>b)
           | _ -> bool_top (Cilfacade.get_ikind t))
     | `Address p, `Int n  -> begin
         match op with
@@ -291,17 +291,17 @@ struct
       | Le
       | Ge when equality () = Some true ->
         let ik = Cilfacade.get_ikind (Cil.typeOf exp) in
-        Some (`Int (ID.of_bool_ikind ik true))
+        Some (`Int (ID.cast_to ik @@ ID.of_bool true))
       | Lt
       | Gt when equality () = Some true ->
         let ik = Cilfacade.get_ikind (Cil.typeOf exp) in
-        Some (`Int (ID.of_bool_ikind ik false))
+        Some (`Int (ID.cast_to ik @@ ID.of_bool false))
       | Eq ->
         let ik = Cilfacade.get_ikind (Cil.typeOf exp) in
-        (match equality () with Some tv -> Some (`Int (ID.of_bool_ikind ik tv)) | None -> None)
+        (match equality () with Some tv -> Some (`Int (ID.cast_to ik @@ ID.of_bool tv)) | None -> None)
       | Ne ->
         let ik = Cilfacade.get_ikind (Cil.typeOf exp) in
-        (match equality () with Some tv -> Some (`Int (ID.of_bool_ikind ik (not tv))) | None -> None)
+        (match equality () with Some tv -> Some (`Int (ID.cast_to ik @@ ID.of_bool (not tv))) | None -> None)
       | _ -> None
     in
     match exp with

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1460,7 +1460,7 @@ struct
     let rec inv_exp c exp =
       match exp with
       | UnOp (op, e, _) -> inv_exp (unop_ID op c) e
-      | BinOp(op, CastE (t1, c1), CastE (t2, c2), t) when (op = Eq || op = Ne) && typeSig t1 = typeSig t2 && VD.is_safe_cast t1 (typeOf c1) && VD.is_safe_cast t2 (typeOf c2) ->
+      | BinOp(op, CastE (t1, c1), CastE (t2, c2), t) when (op = Eq || op = Ne) && typeSig t1 = typeSig t2 && typeSig (typeOf c1) = typeSig (typeOf c2) && VD.is_safe_cast t1 (typeOf c1) && VD.is_safe_cast t2 (typeOf c2) ->
         if M.tracing then M.tracel "inv" "dropped cast %a\n" d_exp exp;
         inv_exp c (BinOp (op, c1, c2, t))
       | BinOp (op, e1, e2, t) as e ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1466,7 +1466,7 @@ struct
         (* | `Address a, `Address b -> ... *)
         | a1, a2 -> fallback ("binop: got abstract values that are not `Int: " ^ sprint VD.pretty a1 ^ " and " ^ sprint VD.pretty a2))
       | Lval x -> (* meet x with c *)
-        let c' = match typeOfLval x with
+        let c' = match Cil.unrollType (typeOfLval x) with (* unroll type to deal with TNamed *)
           | TPtr _ -> `Address (AD.of_int (module ID) c)
           | TInt (ik, _) -> `Int (ID.cast_to ik c )
           | _ -> `Int c

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -286,7 +286,9 @@ struct
         | _ -> None
       in
       match op with
-      | MinusA
+      | MinusA when equality () = Some true ->
+        let ik = get_ikind (Cil.typeOf exp) in
+        Some (`Int (ID.of_int_ikind ik 0L))
       | MinusPI
       | MinusPP when equality () = Some true -> Some (`Int (ID.of_int_ikind (ptrdiff_ikind ()) 0L))
       | MinusPI

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -348,6 +348,7 @@ struct
    *  For the exp argument it is always ok to put None. This means not using precise information about
    *  which part of an array is involved.  *)
   let rec get ?(full=false) a (gs: glob_fun) (st,fl,dep: store) (addrs:address) (exp:exp option): value =
+    let at = AD.get_type addrs in
     let firstvar = if M.tracing then try (List.hd (AD.to_var_may addrs)).vname with _ -> "" else "" in
     let get_global x = gs x in
     if M.tracing then M.traceli "get" ~var:firstvar "Address: %a\nState: %a\n" AD.pretty addrs CPA.pretty st;
@@ -378,7 +379,11 @@ struct
         | _ -> `Int (ID.top_of IChar)       (* string pointer *)
       in
       (* We form the collecting function by joining *)
-      let f x a = VD.join (f x) a in
+      let c x = match x with (* If address type is arithmetic, and our value is an int, we cast to the correct ik *)
+        | `Int _ when Cil.isArithmeticType at -> VD.cast at x
+        | _ -> x
+      in
+      let f x a = VD.join (c @@ f x) a in
       (* Finally we join over all the addresses in the set. If any of the
        * addresses is a topped value, joining will fail. *)
       try AD.fold f addrs (VD.bot ()) with SetDomain.Unsupported _ -> VD.top ()

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -713,7 +713,6 @@ struct
           `Address (AD.map array_start (eval_lv a gs st lval))
         | CastE (t, Const (CStr x)) -> (* VD.top () *) eval_rv a gs st (Const (CStr x)) (* TODO safe? *)
         | CastE  (t, exp) ->
-          M.tracel "xxxxx" "ohhhhh %a" d_exp exp;
           let v = eval_rv a gs st exp in
           VD.cast ~torg:(typeOf exp) t v
         | _ -> VD.top ()

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1398,9 +1398,9 @@ struct
       let meet_non oi oo = meet_bin (oi c b) (oo a c) in (* non-commutative *)
       match op with
       | PlusA  -> meet_com ID.sub
-      | Mult   -> meet_com ID.div
+      | Mult   -> meet_com ID.div (* Div is ok here, c must be divisible by a and b *)
       | MinusA -> meet_non ID.add ID.sub
-      | Div    -> meet_non ID.mul ID.div
+      (* | Div    -> be careful when adding Div, it is division with remainder this is not easy to inverse *)
       | Mod    -> meet_bin (ID.add c (ID.mul b (ID.div a b))) (ID.div (ID.sub a c) (ID.div a b))
       | Eq | Ne ->
         let both x = x, x in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -380,7 +380,7 @@ struct
         match Addr.to_var_offset x with
         | [x] -> f_addr x                    (* normal reference *)
         | _ when x = Addr.NullPtr -> VD.bot () (* null pointer *)
-        | _ -> `Int (ID.top_of IUChar)              (* string pointer *)
+        | _ -> `Int (ID.top_of IChar)       (* string pointer *)
       in
       (* We form the collecting function by joining *)
       let f x a = VD.join (f x) a in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1466,16 +1466,32 @@ struct
         (* | `Address a, `Address b -> ... *)
         | a1, a2 -> fallback ("binop: got abstract values that are not `Int: " ^ sprint VD.pretty a1 ^ " and " ^ sprint VD.pretty a2))
       | Lval x -> (* meet x with c *)
-        let c' = match Cil.unrollType (typeOfLval x) with (* unroll type to deal with TNamed *)
+        let t = Cil.unrollType (typeOfLval x) in  (* unroll type to deal with TNamed *)
+        let c' = match t with
           | TPtr _ -> `Address (AD.of_int (module ID) c)
           | TInt (ik, _) -> `Int (ID.cast_to ik c )
           | _ -> `Int c
         in
         let oldv = eval (Lval x) in
-        let v = VD.meet oldv c' in
-        if is_some_bot v then raise Deadcode
-        else
-          if M.tracing then M.tracel "inv" "improve lval %a = %a with %a (from %a), meet = %a\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c VD.pretty v;
+        let skip = if Cil.isVoidPtrType t then
+            match oldv with
+            | `Address _ -> false
+            | _ -> true (* We do not change type on a cast to void*, so we can not meet here without type errors*)
+          else
+            false
+        in
+        let v =
+          if skip then
+            (if M.tracing then M.tracel "inv" "lval %a = %a has type void*, but we want to improve it with %a (from %a) -> skipping\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c ;
+            oldv)
+          else
+            let v = VD.meet oldv c' in
+            if is_some_bot v then
+              raise Deadcode
+            else
+              (if M.tracing then M.tracel "inv" "improve lval %a = %a with %a (from %a), meet = %a\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c VD.pretty v;
+              v)
+        in
           set' x v
       | Const _ -> Tuple3.first st (* nothing to do *)
       | CastE ((TInt (ik, _)) as t, e) -> (* Can only meet the t part of an Lval in e with c (unless we meet with all overflow possibilities)! Since there is no good way to do this, we only continue if e has no values outside of t. *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -842,8 +842,11 @@ struct
   (* run eval_rv from above, but change bot to top to be sound for programs with undefined behavior. *)
   (* Previously we only gave sound results for programs without undefined behavior, so yielding bot for accessing an uninitialized array was considered ok. Now only [invariant] can yield bot/Deadcode if the condition is known to be false but evaluating an expression should not be bot. *)
   let eval_rv (a: Q.ask) (gs:glob_fun) (st: store) (exp:exp): value =
-    let r = eval_rv a gs st exp in
-    if VD.is_bot r then top_value a gs st (typeOf exp) else r
+    try
+      let r = eval_rv a gs st exp in
+      if VD.is_bot r then top_value a gs st (typeOf exp) else r
+    with IntDomain.ArithmeticOnIntegerBot _ ->
+      top_value a gs st (typeOf exp)
 
   (* Evaluate an expression containing only locals. This is needed for smart joining the partitioned arrays where ctx is not accessible. *)
   (* This will yield `Top for expressions containing any access to globals, and does not make use of the query system. *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1534,7 +1534,8 @@ struct
       in
       let itv = (* int abstraction for tv *)
         if not tv || is_cmp exp then (* false is 0, but true can be anything that is not 0, except for comparisons which yield 1 *)
-          ID.of_bool tv (* this will give 1 for true which is only ok for comparisons *)
+          let ik = Cilfacade.get_ikind (typeOf exp) in
+          ID.cast_to ik @@ ID.of_bool tv (* this will give 1 for true which is only ok for comparisons *)
         else
           let ik = Cilfacade.get_ikind (typeOf exp) in
           ID.of_excl_list ik [Int64.zero] (* Lvals, Casts, arithmetic operations etc. should work with true = non_zero *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1279,7 +1279,7 @@ struct
           | `Int n -> begin
             let ikind = Cilfacade.get_ikind (typeOf (Lval lval)) in
             let n = ID.cast_to ikind n in
-            let range_from x = if tv then ID.ending_ikind ikind (Int64.sub x 1L) else ID.starting_ikind ikind x in
+            let range_from x = if tv then ID.ending ~ikind:ikind (Int64.sub x 1L) else ID.starting ~ikind:ikind x in
             let limit_from = if tv then ID.maximal else ID.minimal in
             match limit_from n with
             | Some n ->
@@ -1294,7 +1294,7 @@ struct
           | `Int n -> begin
             let ikind = Cilfacade.get_ikind (typeOf (Lval lval)) in
             let n = ID.cast_to ikind n in
-            let range_from x = if tv then ID.ending_ikind ikind x else ID.starting_ikind ikind (Int64.add x 1L) in
+            let range_from x = if tv then ID.ending ~ikind:ikind x else ID.starting ~ikind:ikind (Int64.add x 1L) in
             let limit_from = if tv then ID.maximal else ID.minimal in
               match limit_from n with
               | Some n ->
@@ -1389,7 +1389,7 @@ struct
       if M.tracing then M.tracel "inv" "Can't handle %a.\n%s\n" d_plainexp exp reason;
       Tuple3.first (invariant ctx a gs st exp tv)
     in
-    let inv_bin_int (a, b) c t op =
+    let inv_bin_int (a, b) c ik op =
       let meet_bin a' b' = ID.meet a a', ID.meet b b' in
       let meet_com oi    = meet_bin (oi c b) (oi c a) in (* commutative *)
       let meet_non oi oo = meet_bin (oi c b) (oo a c) in (* non-commutative *)
@@ -1408,7 +1408,7 @@ struct
         | Eq, Some false
         | Ne, Some true -> (* def. unequal *)
           (match ID.to_int m with
-          | Some i -> both (ID.of_excl_list t [i])
+          | Some i -> both (ID.of_excl_list ik [i])
           | None -> a, b)
         | _, _ -> a, b
         )
@@ -1418,13 +1418,13 @@ struct
           (* if M.tracing then M.tracel "inv" "Op: %s, l1: %Ld, u1: %Ld, l2: %Ld, u2: %Ld\n" (show_binop op) l1 u1 l2 u2; *)
           (match op, ID.to_bool c with
           | Le, Some true
-          | Gt, Some false -> meet_bin (ID.ending_ikind t u2) (ID.starting_ikind t l1)
+          | Gt, Some false -> meet_bin (ID.ending ~ikind:ik u2) (ID.starting ~ikind:ik l1)
           | Ge, Some true
-          | Lt, Some false -> meet_bin (ID.starting_ikind t l2) (ID.ending_ikind t u1)
+          | Lt, Some false -> meet_bin (ID.starting ~ikind:ik l2) (ID.ending ~ikind:ik u1)
           | Lt, Some true
-          | Ge, Some false -> meet_bin (ID.ending_ikind t (Int64.pred u2)) (ID.starting_ikind t (Int64.succ l1))
+          | Ge, Some false -> meet_bin (ID.ending ~ikind:ik (Int64.pred u2)) (ID.starting ~ikind:ik (Int64.succ l1))
           | Gt, Some true
-          | Le, Some false -> meet_bin (ID.starting_ikind t (Int64.succ l2)) (ID.ending_ikind t (Int64.pred u1))
+          | Le, Some false -> meet_bin (ID.starting ~ikind:ik (Int64.succ l2)) (ID.ending ~ikind:ik (Int64.pred u1))
           | _, _ -> a, b)
         | _ -> a, b)
       | _ ->

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -94,7 +94,7 @@ struct
 
   let name () = "partitioned array"
 
-  let get_ikind t = match Cil.unrollType t with TInt (ik,_) -> ik | _ ->
+  let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
     (* important to unroll the type here, otherwise problems with typedefs *)
     M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
 

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -94,10 +94,6 @@ struct
 
   let name () = "partitioned array"
 
-  let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
-    (* important to unroll the type here, otherwise problems with typedefs *)
-    M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
-
   let is_not_partitioned (e, _) =
     Expp.is_bot e || Expp.is_top e
 
@@ -381,7 +377,7 @@ struct
             | `Bool false -> Val.bot()
             | _ -> xm) (* if e' may be equal to i', but e' may not be smaller than i' then we only need xm *)
             (
-              let ik = get_ikind (Cil.typeOf e') in
+              let ik = Cilfacade.get_ikind (Cil.typeOf e') in
               match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik 1, Cil.typeOf e'),i')) with
               | `Bool true -> xm
               | _ ->
@@ -398,7 +394,7 @@ struct
             | _ -> xm)
 
             (
-              let ik = get_ikind (Cil.typeOf e') in
+              let ik = Cilfacade.get_ikind (Cil.typeOf e') in
               match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik (-1), Cil.typeOf e'),i')) with
               | `Bool true -> xm
               | _ ->

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -94,6 +94,10 @@ struct
 
   let name () = "partitioned array"
 
+  let get_ikind t = match Cil.unrollType t with TInt (ik,_) -> ik | _ ->
+    (* important to unroll the type here, otherwise problems with typedefs *)
+    M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
+
   let is_not_partitioned (e, _) =
     Expp.is_bot e || Expp.is_top e
 
@@ -377,7 +381,8 @@ struct
             | `Bool false -> Val.bot()
             | _ -> xm) (* if e' may be equal to i', but e' may not be smaller than i' then we only need xm *)
             (
-              match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.integer 1, Cil.intType),i')) with
+              let ik = get_ikind (Cil.typeOf e') in
+              match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik 1, Cil.typeOf e'),i')) with
               | `Bool true -> xm
               | _ ->
                 begin
@@ -393,7 +398,8 @@ struct
             | _ -> xm)
 
             (
-              match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.integer (-1), Cil.intType),i')) with
+              let ik = get_ikind (Cil.typeOf e') in
+              match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik (-1), Cil.typeOf e'),i')) with
               | `Bool true -> xm
               | _ ->
                 begin

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -18,7 +18,6 @@ sig
 
   val to_bool: t -> bool option
   val of_bool: bool -> t
-  val of_bool_ikind: Cil.ikind -> bool -> t
   val is_bool: t -> bool
   val to_excl_list: t -> int64 list option
   val of_excl_list: Cil.ikind -> int64 list -> t
@@ -194,7 +193,6 @@ struct
   let top_bool = Some (0L, 1L)
 
   let of_bool = function true -> one | false -> zero
-  let of_bool_ikind _  = of_bool
   let is_bool x = x <> None && not (leq zero x) || x = zero
   let to_bool = function
     | None -> None
@@ -413,7 +411,6 @@ struct
   let meet x y = if Int64.compare x y > 0 then y else x
 
   let of_bool x = if x then Int64.one else Int64.zero
-  let of_bool_ikind _ = of_bool
   let to_bool' x = x <> Int64.zero
   let to_bool x = Some (to_bool' x)
   let is_bool _ = true
@@ -486,7 +483,6 @@ struct
     | _ -> false
 
   let of_bool x = `Lifted (Base.of_bool x)
-  let of_bool_ikind _ = of_bool
   let to_bool x = match x with
     | `Lifted x -> Base.to_bool x
     | _ -> None
@@ -563,7 +559,6 @@ struct
     | _ -> false
 
   let of_bool x = `Lifted (Base.of_bool x)
-  let of_bool_ikind t x = `Lifted(Base.of_bool_ikind t x)
   let to_bool x = match x with
     | `Lifted x -> Base.to_bool x
     | _ -> None
@@ -748,7 +743,6 @@ struct
   let zero = of_int 0L
   let not_zero = `Excluded (S.singleton 0L, top_range)
 
-  let of_bool_ikind t x = if x then not_zero_ikind t else zero_ikind t
   let of_bool_cmp x = of_int (if x then 1L else 0L)
   let of_bool = of_bool_cmp
   let of_bool_cmp_ikind t x = cast_to t @@ of_int (if x then 1L else 0L)
@@ -872,8 +866,8 @@ struct
 
   (* The inequality check: *)
   let ne x y =
-    let f = of_bool_ikind Cil.IInt false in
-    let t = of_bool_ikind Cil.IInt true in
+    let f = cast_to Cil.IInt  @@ of_bool false in
+    let t = cast_to Cil.IInt  @@ of_bool true in
     let top = top_of Cil.IInt in
     match x,y with
     (* Not much to do with two exclusion sets: *)
@@ -1009,7 +1003,6 @@ struct
     if x
     then Int(1, C.one, C.one)
     else Int(1, C.zero, C.zero)
-  let of_bool_ikind _ = of_bool
   let is_bool x =
     match x with
     | Int(_,a,b) -> C.eq a b
@@ -1297,7 +1290,6 @@ struct
   let meet = (&&)
 
   let of_bool x = x
-  let of_bool_ikind _ = of_bool
   let to_bool x = Some x
   let is_bool x = not x
   let of_int x  = x = Int64.zero
@@ -1483,8 +1475,6 @@ module Enums : S = struct
   let logor  = lift2 I.logor
 
   let of_bool x = Inc [if x then Int64.one else Int64.zero]
-  let of_bool_ikind _ = of_bool
-
   let to_bool = function
     | Inc [] | Exc ([],_) -> None
     | Inc [0L] -> Some false
@@ -1559,7 +1549,6 @@ module IntDomTuple = struct
   let top = create { fi = fun (type a) (module I:S with type t = a) -> I.top }
   let bot = create { fi = fun (type a) (module I:S with type t = a) -> I.bot }
   let of_bool = create { fi = fun (type a) (module I:S with type t = a) -> I.of_bool }
-  let of_bool_ikind t = create { fi = fun (type a) (module I:S with type t = a) -> I.of_bool_ikind t}
   let of_excl_list t = create { fi = fun (type a) (module I:S with type t = a) -> I.of_excl_list t }
   let of_int = create { fi = fun (type a) (module I:S with type t = a) -> I.of_int }
   let top_of = create { fi = fun (type a) (module I:S with type t = a) -> I.top_of }

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -190,8 +190,21 @@ struct
 
   let starting n = norm @@ Some (n,max_int)
   let ending   n = norm @@ Some (min_int,n)
-  let starting_ikind _ = starting
-  let ending_ikind _ = ending
+
+  let starting_ikind ik n =
+    try
+      norm @@
+      let _, u = Size.range ik in
+      Some (n,u)
+    with Size.Not_in_int64 -> starting n
+
+  let ending_ikind ik n =
+    try
+      norm @@
+      let l, _ = Size.range ik in
+      Some (l,n)
+    with Size.Not_in_int64 -> ending n
+
   let maximal = function None -> None | Some (x,y) -> Some y
   let minimal = function None -> None | Some (x,y) -> Some x
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -716,8 +716,8 @@ struct
   (* checks that x and y have the same range, and warns (in debug mode fails) if this is not the case *)
   let check_identical_range x y =
     if x <> y then
-      if get_bool "dbg.debug" then
-        raise (Failure (Printf.sprintf "Operation on different sizes of int %s %s" (R.short 80 x) (R.short 80 y)))
+      if get_bool "dbg.fail_on_different_ikind" then
+        failwith (Printf.sprintf "Operation on different sizes of int %s %s" (R.short 80 x) (R.short 80 y))
       else
         M.warn (Printf.sprintf "Operation on different sizes of int %s %s" (R.short 80 x) (R.short 80 y))
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -841,7 +841,7 @@ struct
     | `Bot, `Excluded(_, xr)
     | `Bot, `Definite(_, xr)
     | `Excluded(_ , xr), `Bot
-    | `Definite(_, xr), `Bot -> `Excluded(S.empty (), xr)
+    | `Definite(_, xr), `Bot -> top ()
     | `Bot, `Bot -> top ()
 
   (* For the shift operations, CIL does not cast the right argument to the type of the left argument,    *)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -824,7 +824,9 @@ struct
 
   let lift2 f x y = match x,y with
     (* The good case: *)
-    | `Definite (x,xr), `Definite (y,yr) -> (try `Definite (f x y,xr) with | Division_by_zero -> top ())
+    | `Definite (x,xr), `Definite (y,yr) ->
+      complain xr yr;
+      (try `Definite (f x y,xr) with | Division_by_zero -> top ())
     (* We don't bother with exclusion sets: *)
     | `Excluded (_, xr), `Definite(_, yr)
     | `Definite (_, xr), `Excluded(_, yr)
@@ -836,6 +838,24 @@ struct
     | `Bot, `Definite(_, xr)
     | `Excluded(_ , xr), `Bot
     | `Definite(_, xr), `Bot -> `Excluded(S.empty (), xr)
+    | `Bot, `Bot -> top ()
+
+  (* For the shift operations, CIL does not cast the right argument to the type of the left argument,    *)
+  (* so we should not warn about operations on different types here. The result has teh type of the left *)
+  (* argument *)
+  let lift2_special f x y = match x,y with
+    (* The good case: *)
+    | `Definite (x,xr), `Definite (y,_) -> (try `Definite (f x y,xr) with | Division_by_zero -> top ())
+    (* We don't bother with exclusion sets: *)
+    | `Excluded (_, xr), `Definite(_, yr)
+    | `Definite (_, xr), `Excluded(_, yr)
+    | `Excluded (_, xr), `Excluded(_, yr) ->
+      `Excluded(S.empty (), xr)
+    (* If any one of them is bottom, we return top *)
+    | `Bot, `Excluded(_, xr)
+    | `Bot, `Definite(_, xr)
+    | `Excluded(_ , xr), `Bot
+    | `Definite(_, xr), `Bot -> top ()
     | `Bot, `Bot -> top ()
 
   (* Default behaviour for binary operators that are injective in either
@@ -926,8 +946,8 @@ struct
   let bitand = lift2 Integers.bitand
   let bitor  = lift2 Integers.bitor
   let bitxor = lift2 Integers.bitxor
-  let shift_left  = lift2 Integers.shift_left
-  let shift_right = lift2 Integers.shift_right
+  let shift_left  = lift2_special Integers.shift_left  (* Careful, CIL does not guarantee the types of left and right arg are the same *)
+  let shift_right = lift2_special Integers.shift_right (* Careful, CIL does not guarantee the types of left and right arg are the same *)
   (* TODO: lift does not treat Not {0} as true. *)
   let logand = lift2 Integers.logand
   let logor  = lift2 Integers.logor

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -715,8 +715,10 @@ struct
 
   let complain x y =
     if x <> y then
-      (* TODO: This should not raise later but just continue with a warning *)
-      raise (Failure (Printf.sprintf "comparing different sizes of int %s %s" (R.short 80 x) (R.short 80 y)))
+      if get_bool "dbg.debug" then
+        raise (Failure (Printf.sprintf "Operation on different sizes of int %s %s" (R.short 80 x) (R.short 80 y)))
+      else
+        M.warn (Printf.sprintf "Operation on different sizes of int %s %s" (R.short 80 x) (R.short 80 y))
 
   let join x y =
     match (x,y) with
@@ -881,7 +883,7 @@ struct
     (* If any one of them is bottom, we return bottom *)
     | _ -> `Bot
 
-  (* The equality check: *) (* TODO: int32? *)
+  (* The equality check: *)
   let eq x y =
     let f = of_bool_cmp_ikind Cil.IInt false in
     let t = of_bool_cmp_ikind Cil.IInt true in

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -830,7 +830,7 @@ struct
     (* The good case: *)
     | `Definite (x,xr), `Definite (y,yr) ->
       check_identical_range xr yr;
-      (try `Definite (f x y,xr) with | Division_by_zero -> top ())
+      (try `Definite (f x y,xr) with | Division_by_zero -> `Excluded (S.empty (), xr))
     (* We don't bother with exclusion sets: *)
     | `Excluded (_, xr), `Definite(_, yr)
     | `Definite (_, xr), `Excluded(_, yr)
@@ -849,7 +849,7 @@ struct
   (* argument *)
   let lift2_special f x y = match x,y with
     (* The good case: *)
-    | `Definite (x,xr), `Definite (y,_) -> (try `Definite (f x y,xr) with | Division_by_zero -> top ())
+    | `Definite (x,xr), `Definite (y,_) -> (try `Definite (f x y,xr) with | Division_by_zero ->  `Excluded (S.empty (), xr))
     (* We don't bother with exclusion sets: *)
     | `Excluded (_, xr), `Definite(_, yr)
     | `Definite (_, xr), `Excluded(_, yr)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -919,8 +919,11 @@ struct
   let logand = lift2 Integers.logand
   let logor  = lift2 Integers.logor
   let lognot x =
-      let r = eq (of_int 0L) x in
-      Printf.printf "not of %s -> %s\n" (short 80 x) (short 80 r); r
+    match x with
+    | `Definite (_,r)
+    | `Excluded (_,r) ->
+        eq (`Definite (Int64.zero, r)) x
+    | `Bot -> `Bot
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (short 800 x)
 
   let invariant c (x:t) = match x with

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -842,7 +842,7 @@ struct
     | `Bot, `Bot -> top ()
 
   (* For the shift operations, CIL does not cast the right argument to the type of the left argument,    *)
-  (* so we should not warn about operations on different types here. The result has teh type of the left *)
+  (* so we should not warn about operations on different types here. The result has the type of the left *)
   (* argument *)
   let lift2_special f x y = match x,y with
     (* The good case: *)
@@ -939,10 +939,10 @@ struct
     | _ -> lift2_inj Integers.mul x y
   let div  = lift2 Integers.div
   let rem  = lift2 Integers.rem
-  let lt = lift2 Integers.lt
-  let gt = lift2 Integers.gt
-  let le = lift2 Integers.le
-  let ge = lift2 Integers.ge
+  let lt x y = cast_to IInt @@ lift2 Integers.lt x y
+  let gt x y = cast_to IInt @@ lift2 Integers.gt x y
+  let le x y = cast_to IInt @@ lift2 Integers.le x y
+  let ge x y = cast_to IInt @@ lift2 Integers.ge x y
   let bitnot = lift1 Integers.bitnot
   let bitand = lift2 Integers.bitand
   let bitor  = lift2 Integers.bitor

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -800,8 +800,8 @@ struct
   let starting x = if x > 0L then not_zero else top ()
   let ending x = if x < 0L then not_zero else top ()
 
-  let max_of_range r = Option.map (fun i -> Int64.(pred @@ shift_left 1L (to_int i))) (R.maximal r)
-  let min_of_range r = Option.map (fun i -> Int64.(if i = zero then zero else neg @@ shift_left 1L (to_int (neg i)))) (R.minimal r)
+  let max_of_range r = BatOption.map (fun i -> Int64.(pred @@ shift_left 1L (to_int i))) (R.maximal r)
+  let min_of_range r = BatOption.map (fun i -> Int64.(if i = zero then zero else neg @@ shift_left 1L (to_int (neg i)))) (R.minimal r)
   let maximal : t -> int64 option = function
     | `Definite (x, xr) -> Integers.to_int x
     | `Excluded (s,r) -> max_of_range r

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -109,14 +109,16 @@ end
 module StdTop (B: sig type t val top: unit -> t end) = struct
   open B
   (* these should be overwritten for better precision if possible: *)
-  let to_excl_list x = None
-  let of_excl_list t x = top ()
-  let is_excl_list x = false
-  let of_interval  x = top ()
-  let starting     x = top ()
-  let ending       x = top ()
-  let maximal      x = None
-  let minimal      x = None
+  let to_excl_list   x = None
+  let of_excl_list   t x = top ()
+  let is_excl_list   x = false
+  let of_interval    x = top ()
+  let starting       x = top ()
+  let starting_ikind t x = top ()
+  let ending         x = top ()
+  let ending_ikind   t x = top ()
+  let maximal        x = None
+  let minimal        x = None
 end
 
 module Std (B: sig
@@ -422,9 +424,6 @@ struct
   let to_int  x = Some x
   let is_int  _ = true
 
-  let starting_ikind    t x = top ()
-  let ending_ikind      t x = top ()
-
   let neg  = Int64.neg
   let add  = Int64.add (* TODO: signed overflow is undefined behavior! *)
   let sub  = Int64.sub
@@ -576,9 +575,6 @@ struct
   let is_bool = is_int
 
   let top_of       x = top ()
-
-  let starting_ikind  t x = top ()
-  let ending_ikind    t x = top ()
 
   let lift1 f x = match x with
     | `Lifted x -> `Lifted (f x)
@@ -1315,9 +1311,6 @@ struct
   let of_int_ikind _ = of_int
   let to_int x  = if x then None else Some Int64.zero
   let is_int x  = not x
-
-  let starting_ikind     t x = top ()
-  let ending_ikind       t x = top ()
 
   let neg x = x
   let add x y = x || y

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -778,8 +778,16 @@ struct
     | None -> if x < 0L then not_zero else top ()
 
 
-  let max_of_range r = BatOption.map (fun i -> Int64.(pred @@ shift_left 1L (to_int i))) (R.maximal r)
-  let min_of_range r = BatOption.map (fun i -> Int64.(if i = zero then zero else neg @@ shift_left 1L (to_int (neg i)))) (R.minimal r)
+  let max_of_range r =
+    match R.maximal r with
+    | Some i when i < 64L -> Some(Int64.(pred @@ shift_left 1L (to_int i))) (* things that are bigger than (2^63)-1 can not be represented as int64 *)
+    | _ -> None
+
+  let min_of_range r =
+    match R.minimal r with
+    | Some i when i > -64L -> Some(Int64.(if i = 0L then 0L else neg @@ shift_left 1L (to_int (neg i)))) (* things that are smaller than (-2^63) can not be represented as int64 *)
+    | _ -> None
+
   let maximal : t -> int64 option = function
     | `Definite (x, xr) -> Integers.to_int x
     | `Excluded (s,r) -> max_of_range r

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -763,7 +763,7 @@ struct
 
 
   let of_int_ikind t x = `Definite (Integers.of_int x, size t)
-  let of_int =  of_int_ikind Cil.IInt
+  let of_int x = `Definite(Integers.of_int x, top_range)
 
   let to_int  x = match x with
     | `Definite (x, xr) -> Integers.to_int x

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -837,12 +837,8 @@ struct
     | `Excluded (_, xr), `Excluded(_, yr) ->
       check_identical_range xr yr;
       `Excluded(S.empty (), xr)
-    (* If any one of them is bottom, we return top *)
-    | `Bot, `Excluded(_, xr)
-    | `Bot, `Definite(_, xr)
-    | `Excluded(_ , xr), `Bot
-    | `Definite(_, xr), `Bot -> top ()
-    | `Bot, `Bot -> top ()
+    (* If any one of them is bottom, we return bottom *)
+    | _ -> `Bot
 
   (* For the shift operations, CIL does not cast the right argument to the type of the left argument,    *)
   (* so we should not warn about operations on different types here. The result has the type of the left *)
@@ -855,12 +851,8 @@ struct
     | `Definite (_, xr), `Excluded(_, yr)
     | `Excluded (_, xr), `Excluded(_, yr) ->
       `Excluded(S.empty (), xr)
-    (* If any one of them is bottom, we return top *)
-    | `Bot, `Excluded(_, xr)
-    | `Bot, `Definite(_, xr)
-    | `Excluded(_ , xr), `Bot
-    | `Definite(_, xr), `Bot -> top ()
-    | `Bot, `Bot -> top ()
+    (* If any one of them is bottom, we return bottom *)
+    | _ -> `Bot
 
   (* Default behaviour for binary operators that are injective in either
    * argument, so that Exclusion Sets can be used: *)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -716,6 +716,7 @@ struct
   (* checks that x and y have the same range, and warns (in debug mode fails) if this is not the case *)
   let check_identical_range x y =
     if x <> y then
+      (* TODO: Once we are convinced this does not occur any more, we should remove the option, and always fail *)
       if get_bool "dbg.fail_on_different_ikind" then
         failwith (Printf.sprintf "Operation on different sizes of int %s %s" (R.short 80 x) (R.short 80 y))
       else

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -674,8 +674,9 @@ struct
 
   let cast_to t = function
     | `Excluded (s,r) ->
-      let r' = size t in (* target range *)
-      `Excluded (if R.leq r r' then S.map (Integers.cast_to t) s, r' else S.empty (), r') (* TODO can we do better here? *)
+      (let r' = size t in (* target range *)
+      try `Excluded (if R.leq r r' then S.map (Integers.cast_to t) s, r' else S.empty (), r') (* TODO can we do better here? *) with
+      Size.Not_in_int64 -> top_of t)
     | `Definite (x, r) -> (try `Definite (Integers.cast_to t x, size t) with Size.Not_in_int64 -> top_of t)
     | `Bot -> `Bot
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -687,14 +687,9 @@ struct
     (* Excluding X <= Excluding Y whenever Y <= X *)
     | `Excluded (x,xw), `Excluded (y,yw) -> S.subset y x && R.leq xw yw
 
-  (* checks that x and y have the same range, and warns (in debug mode fails) if this is not the case *)
+  (* checks that x and y have the same range, and fails if this is not the case *)
   let check_identical_range x y =
-    if x <> y then
-      (* TODO: Once we are convinced this does not occur any more, we should remove the option, and always fail *)
-      if get_bool "dbg.fail_on_different_ikind" then
-        failwith (Printf.sprintf "Operation on different sizes of int %s %s" (R.short 80 x) (R.short 80 y))
-      else
-        M.warn (Printf.sprintf "Operation on different sizes of int %s %s" (R.short 80 x) (R.short 80 y))
+    if x <> y then failwith (Printf.sprintf "Operation on different sizes of int %s %s" (R.short 80 x) (R.short 80 y))
 
   let join x y =
     match (x,y) with

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -42,10 +42,8 @@ sig
   (* Checks if the element is an exclusion set. *)
 
   val of_interval: int64 * int64 -> t
-  val starting   : int64 -> t
-  val starting_ikind  : Cil.ikind -> int64 -> t
-  val ending     : int64 -> t
-  val ending_ikind  : Cil.ikind -> int64 -> t
+  val starting   : ?ikind:Cil.ikind -> int64 -> t
+  val ending     : ?ikind:Cil.ikind -> int64 -> t
   val top_of     : Cil.ikind -> t
   val maximal    : t -> int64 option
   val minimal    : t -> int64 option

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -28,10 +28,6 @@ sig
   (** Transform a known boolean value to the default internal representation. It
     * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
 
-  val of_bool_ikind: Cil.ikind -> bool -> t
-  (** Transform a known boolean value of the corresponding Cil.ikind to the default internal representation. It
-    * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
-
   val is_bool: t -> bool
   (** Checks if the element is a definite boolean value. If this function
     * returns [true], the above [to_bool] should return a real value. *)

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -137,6 +137,8 @@ module Size : sig
   (** The biggest type we support for integers. *)
 end
 
+exception ArithmeticOnIntegerBot of string
+
 exception Unknown
 (** An exception that can be raised when the result of a computation is unknown.
   * This is caught by lifted domains and will be replaced by top. *)

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -14,9 +14,6 @@ sig
   val of_int: int64 -> t
   (** Transform an integer literal to your internal domain representation. *)
 
-  val of_int_ikind: Cil.ikind -> int64 -> t
-   (** Transform an integer literal of the corresponding Cil.ikind to your internal domain representation. *)
-
   val is_int: t -> bool
   (** Checks if the element is a definite integer value. If this function
     * returns [true], the above [to_int] should return a real value. *)

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -17,7 +17,7 @@ sig
   include Lattice.S
   type offs
   val eval_offset: Q.ask -> (AD.t -> t) -> t-> offs -> exp option -> lval option -> t
-  val update_offset: Q.ask -> t -> offs -> t -> exp option -> lval -> t
+  val update_offset: Q.ask -> t -> offs -> t -> exp option -> lval -> typ -> t
   val update_array_lengths: (exp -> t) -> t -> Cil.typ -> t
   val affect_move: ?replace_with_const:bool -> Q.ask -> t -> varinfo -> (exp -> int option) -> t
   val affecting_vars: t -> varinfo list
@@ -359,6 +359,7 @@ struct
                 | _ -> log_top __POS__; Unions.top ()
               )
         (* | _ -> log_top (); `Top *)
+        | TVoid _ -> log_top __POS__; `Top
         | _ -> log_top __POS__; assert false
       in
       Messages.tracel "cast" "cast %a to %a is %a!\n" pretty v d_type t pretty v'; v'
@@ -747,19 +748,19 @@ struct
     in
     do_eval_offset ask f x offs exp l o v
 
-  let update_offset (ask: Q.ask) (x:t) (offs:offs) (value:t) (exp:exp option) (v:lval): t =
-    let rec do_update_offset (ask:Q.ask) (x:t) (offs:offs) (value:t) (exp:exp option) (l:lval option) (o:offset option) (v:lval):t =
+  let update_offset (ask: Q.ask) (x:t) (offs:offs) (value:t) (exp:exp option) (v:lval) (t:typ): t =
+    let rec do_update_offset (ask:Q.ask) (x:t) (offs:offs) (value:t) (exp:exp option) (l:lval option) (o:offset option) (v:lval) (t:typ):t =
       let mu = function `Blob (`Blob (y, s'), s) -> `Blob (y, ID.join s s') | x -> x in
       match x, offs with
       | `Blob (x,s), `Index (_,ofs) ->
         begin
           let l', o' = shift_one_over l o in
-          mu (`Blob (join x (do_update_offset ask x ofs value exp l' o' v), s))
+          mu (`Blob (join x (do_update_offset ask x ofs value exp l' o' v t), s))
         end
       | `Blob (x,s),_ ->
         begin
           let l', o' = shift_one_over l o in
-          mu (`Blob (join x (do_update_offset ask x offs value exp l' o' v), s))
+          mu (`Blob (join x (do_update_offset ask x offs value exp l' o' v t), s))
         end
       | _ ->
       let result =
@@ -767,14 +768,16 @@ struct
         | `NoOffset -> begin
             match value with
             | `Blob (y,s) -> mu (`Blob (join x y, s))
+            | `Int _ -> cast t value
             | _ -> value
           end
         | `Field (fld, offs) when fld.fcomp.cstruct -> begin
+            let t = fld.ftype in
             match x with
             | `Struct str ->
               begin
                 let l', o' = shift_one_over l o in
-                let value' =  (do_update_offset ask (Structs.get str fld) offs value exp l' o' v) in
+                let value' =  (do_update_offset ask (Structs.get str fld) offs value exp l' o' v t) in
                 `Struct (Structs.replace str fld value')
               end
             | `Bot ->
@@ -785,11 +788,12 @@ struct
               in
               let strc = init_comp fld.fcomp in
               let l', o' = shift_one_over l o in
-              `Struct (Structs.replace strc fld (do_update_offset ask `Bot offs value exp l' o' v))
+              `Struct (Structs.replace strc fld (do_update_offset ask `Bot offs value exp l' o' v t))
             | `Top -> M.warn "Trying to update a field, but the struct is unknown"; top ()
             | _ -> M.warn "Trying to update a field, but was not given a struct"; top ()
           end
         | `Field (fld, offs) -> begin
+            let t = fld.ftype in
             let l', o' = shift_one_over l o in
             match x with
             | `Union (last_fld, prev_val) ->
@@ -818,8 +822,8 @@ struct
                     top (), offs
                 end
               in
-              `Union (`Lifted fld, do_update_offset ask tempval tempoffs value exp l' o' v)
-            | `Bot -> `Union (`Lifted fld, do_update_offset ask `Bot offs value exp l' o' v)
+              `Union (`Lifted fld, do_update_offset ask tempval tempoffs value exp l' o' v t)
+            | `Bot -> `Union (`Lifted fld, do_update_offset ask `Bot offs value exp l' o' v t)
             | `Top -> M.warn "Trying to update a field, but the union is unknown"; top ()
             | _ -> M.warn_each "Trying to update a field, but was not given a union"; top ()
           end
@@ -827,13 +831,16 @@ struct
             let l', o' = shift_one_over l o in
             match x with
             | `Array x' ->
-              let e = determine_offset ask l o exp (Some v) in
-              let new_value_at_index = do_update_offset ask (CArrays.get ask x' (e,idx)) offs value exp l' o' v in
-              let new_array_value = CArrays.set ask x' (e, idx) new_value_at_index in
-              `Array new_array_value
+              (match t with
+              | TArray(t1 ,_,_) ->
+                let e = determine_offset ask l o exp (Some v) in
+                let new_value_at_index = do_update_offset ask (CArrays.get ask x' (e,idx)) offs value exp l' o' v t1 in
+                let new_array_value = CArrays.set ask x' (e, idx) new_value_at_index in
+                `Array new_array_value
+              | _ ->  M.warn "Trying to update an array, but the type was not array"; top ())
             | `Bot ->  M.warn_each("encountered array bot, made array top"); `Array (CArrays.top ());
             | `Top -> M.warn "Trying to update an index, but the array is unknown"; top ()
-            | x when IndexDomain.to_int idx = Some 0L -> do_update_offset ask x offs value exp l' o' v
+            | x when IndexDomain.to_int idx = Some 0L -> do_update_offset ask x offs value exp l' o' v t
             | _ -> M.warn_each ("Trying to update an index, but was not given an array("^short 80 x^")"); top ()
           end
       in mu result
@@ -842,7 +849,7 @@ struct
       | Some(Lval (x,o)) -> Some ((x, NoOffset)), Some(o)
       | _ -> None, None
     in
-    do_update_offset ask x offs value exp l o v
+    do_update_offset ask x offs value exp l o v t
 
   let rec affect_move ?(replace_with_const=false) ask (x:t) (v:varinfo) movement_for_expr:t =
     let move_fun x = affect_move ~replace_with_const:replace_with_const ask x v movement_for_expr in

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -263,7 +263,7 @@ struct
             (* array to its first element *)
             | TArray _, _ ->
               M.tracel "casta" "cast array to its first element\n";
-              adjust_offs v (Addr.add_offsets o (`Index (IndexDomain.of_int_ikind (Cilfacade.ptrdiff_ikind ()) 0L, `NoOffset))) (Some false)
+              adjust_offs v (Addr.add_offsets o (`Index (IndexDomain.cast_to (Cilfacade.ptrdiff_ikind ()) @@ IndexDomain.of_int 0L, `NoOffset))) (Some false)
             | _ -> err @@ "Cast to neither array index nor struct field."
                           ^ Pretty.(sprint ~width:0 @@ dprintf " is_zero_offset: %b" (Addr.is_zero_offset o))
           end
@@ -300,7 +300,7 @@ struct
         | TInt (ik,_) ->
           `Int (ID.cast_to ik (match v with
               | `Int x -> x
-              | `Address x when AD.equal x AD.null_ptr -> ID.of_int_ikind (ptr_ikind ())  Int64.zero
+              | `Address x when AD.equal x AD.null_ptr -> ID.cast_to (ptr_ikind ()) @@ ID.of_int Int64.zero
               | `Address x when AD.is_not_null x -> ID.of_excl_list (ptr_ikind ()) [0L]
               (*| `Struct x when Structs.cardinal x > 0 ->
                 let some  = List.hd (Structs.keys x) in

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -90,7 +90,7 @@ struct
   type offs = (fieldinfo,IndexDomain.t) Lval.offs
 
 
-  let get_ikind t = match Cil.unrollType t with TInt (ik,_) -> ik | _ ->
+  let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
     (* important to unroll the type here, otherwise problems with typedefs *)
     M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
 

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -90,13 +90,6 @@ struct
   type offs = (fieldinfo,IndexDomain.t) Lval.offs
 
 
-  let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
-    (* important to unroll the type here, otherwise problems with typedefs *)
-    M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
-
-  let ptrdiff_ikind () = get_ikind !ptrdiffType
-
-
   let bot () = `Bot
   let is_bot x = x = `Bot
   let bot_name = "Uninitialized"
@@ -270,7 +263,7 @@ struct
             (* array to its first element *)
             | TArray _, _ ->
               M.tracel "casta" "cast array to its first element\n";
-              adjust_offs v (Addr.add_offsets o (`Index (IndexDomain.of_int_ikind (ptrdiff_ikind ()) 0L, `NoOffset))) (Some false)
+              adjust_offs v (Addr.add_offsets o (`Index (IndexDomain.of_int_ikind (Cilfacade.ptrdiff_ikind ()) 0L, `NoOffset))) (Some false)
             | _ -> err @@ "Cast to neither array index nor struct field."
                           ^ Pretty.(sprint ~width:0 @@ dprintf " is_zero_offset: %b" (Addr.is_zero_offset o))
           end

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -241,7 +241,7 @@ let pstmt stmt = dumpStmt defaultCilPrinter stdout 0 stmt; print_newline ()
 let p_expr exp = Pretty.printf "%a\n" (printExp defaultCilPrinter) exp
 let d_expr exp = Pretty.printf "%a\n" (printExp plainCilPrinter) exp
 
-(* Returns the ikind of a TInt(_) and TEnum(_). Unrolls typedefs. Warns if a a different type is put it and return IInt *)
+(* Returns the ikind of a TInt(_) and TEnum(_). Unrolls typedefs. Warns if a a different type is put in and return IInt *)
 let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
   (* important to unroll the type here, otherwise problems with typedefs *)
   Messages.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -241,6 +241,13 @@ let pstmt stmt = dumpStmt defaultCilPrinter stdout 0 stmt; print_newline ()
 let p_expr exp = Pretty.printf "%a\n" (printExp defaultCilPrinter) exp
 let d_expr exp = Pretty.printf "%a\n" (printExp plainCilPrinter) exp
 
+(* Returns the ikind of a TInt(_) and TEnum(_). Unrolls typedefs. Warns if a a different type is put it and return IInt *)
+let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
+  (* important to unroll the type here, otherwise problems with typedefs *)
+  Messages.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
+
+let ptrdiff_ikind () = get_ikind !ptrdiffType
+
 let rec typeOf (e: exp) : typ =
   match e with
   | Const(CInt64 (_, ik, _)) -> TInt(ik, [])

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -202,6 +202,7 @@ let _ = ()
       ; reg Debugging "dbg.earlywarn"       "false" "Output warnings already while solving (may lead to spurious warnings/asserts that would disappear after narrowing)."
       ; reg Debugging "dbg.warn_with_context" "false" "Keep warnings for different contexts apart (currently only done for asserts)."
       ; reg Debugging "dbg.regression"      "false" "Only output warnings for assertions that have an unexpected result (no comment, comment FAIL, comment UNKNOWN)"
+      ; reg Debugging "dbg.fail_on_different_ikind" "false" "When doing operations in the int domain, fail if an operation is on performed on two ints of different ikinds"
 
 let default_schema = "\
 { 'id'              : 'root'

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -202,7 +202,6 @@ let _ = ()
       ; reg Debugging "dbg.earlywarn"       "false" "Output warnings already while solving (may lead to spurious warnings/asserts that would disappear after narrowing)."
       ; reg Debugging "dbg.warn_with_context" "false" "Keep warnings for different contexts apart (currently only done for asserts)."
       ; reg Debugging "dbg.regression"      "false" "Only output warnings for assertions that have an unexpected result (no comment, comment FAIL, comment UNKNOWN)"
-      ; reg Debugging "dbg.fail_on_different_ikind" "false" "When doing operations in the int domain, fail if an operation is on performed on two ints of different ikinds"
 
 let default_schema = "\
 { 'id'              : 'root'

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -1,4 +1,5 @@
-// --enable ana.int.def_exc --disable ana.int.interval
+// PARAM: --enable ana.int.def_exc --disable ana.int.interval
+#include<stdbool.h>
 void main()
 {
   char yy[256];
@@ -44,5 +45,13 @@ void main()
   v = (v & 0xFFF0FFFF) |
 	    (((unsigned int) s1 ^ s2) << 16);
 
+  int tmp___1;
+  int *tmp___2;
+
+  _Bool  fclose_fail = (_Bool )(tmp___1 != 0);
+
+  if (! fclose_fail) {
+    *tmp___2 = 0;
+  }
   return;
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -65,6 +65,45 @@ void main()
   void const* b = (void const*) ci;
   test((void const *)ci);
 
+	for (i = 0; i <	 (((20) + (4) - 1)/(4)); i++) {
+
+	}
+
+
+  for (i = 0; i <	 (((20) + (8UL) - 1)/(8UL)); i++) {
+
+	}
+
+
+
+
+  unsigned long v = 8UL;
+  for (i = 0; i <	 (((20) + (8UL) - 1)/(v)); i++) {
+
+	}
+
+  i = 0;
+  if(i < 28UL/v) {
+    i++;
+  }
+
+  int gef = 75;
+
+  if(i < 28UL/v) {
+    i++;
+  }
+
+  gef = 38;
+
+  i =0;
+  for(; i < 28UL/v; i++) {
+
+  }
+
+	for (i = 0; i <	 (((20) + sizeof(unsigned long) - 1)/sizeof(unsigned long)); i++) {
+
+	}
+
 	for (i = 0; i <	 LONGS(20); i++) {
 
 	}

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -121,11 +121,27 @@ void main()
   if (top) {
     g_76.f1 = 5; // (f1, (`Definite 5, [-31,31]))
   }
-  
+
 
   unsigned char v;
   signed char u;
-  int r2 = ((int )v == (int )u); 
+  int r2 = ((int )v == (int )u);
+
+
+  signed char l_48 =  (signed char )58L;
+  unsigned char l_67 = (unsigned char)48UL;
+
+  signed char *l_247 ;
+  unsigned char *l_229 ;
+
+  l_247 = &l_48;
+
+  if (top) {
+      l_229 = &l_67;
+      l_247 = (signed char *)l_229;
+  }
+
+  signed char res = *l_247;
 
 
   return;

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -1,5 +1,7 @@
 // PARAM: --enable ana.int.def_exc --enable ana.int.interval
 #include<stdbool.h>
+
+typedef unsigned long custom_t;
 void main()
 {
   char yy[256];
@@ -56,10 +58,15 @@ void main()
 
   hash_initialize();
 
+
+
+  custom_t ci;
+  void const* b = (void const*) ci;
+  test((void const *)ci);
+
   return;
 }
 
-typedef unsigned long custom_t;
 
 struct hash_table {
   custom_t n_buckets ;
@@ -88,4 +95,12 @@ Hash_table *hash_initialize()
   free((void *)table___0);
 
   return ((Hash_table *)((void *)0));
+}
+
+int test(void const   *ptr) {
+  if(!ptr) {
+    int f = 7;
+  } else {
+    int f= 38;
+  }
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -1,4 +1,5 @@
 // PARAM: --enable ana.int.def_exc --enable ana.int.interval
+#define LONGS(x) (((x) + sizeof(unsigned long) - 1)/sizeof(unsigned long))
 #include<stdbool.h>
 
 typedef unsigned long custom_t;
@@ -63,6 +64,11 @@ void main()
   custom_t ci;
   void const* b = (void const*) ci;
   test((void const *)ci);
+
+	for (i = 0; i <	 LONGS(20); i++) {
+
+	}
+
 
   return;
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -143,6 +143,15 @@ void main()
 
   signed char res = *l_247;
 
+  signed short x;
+  unsigned int y;
+  unsigned short z = 0x7ED9L;
+
+  if (((((((signed char)y) == x) && z))))
+  {
+
+  }
+
 
   return;
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -9,10 +9,14 @@ void main()
   ryy_j++;
   ryy_j++;
 
-  while(i < 2) { // Here
+  while(i < 2) { // Here was an issue with a fixpoint not being reached
     ryy_j = ryy_j + 1;
     i++;
   }
+
+  // The type of ! needs to be IInt
+  long l;
+  int r = !l + 4;
 
   return;
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -122,6 +122,12 @@ void main()
     g_76.f1 = 5; // (f1, (`Definite 5, [-31,31]))
   }
   
+
+  unsigned char v;
+  signed char u;
+  int r2 = ((int )v == (int )u); 
+
+
   return;
 }
 

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -3,6 +3,12 @@
 #include<stdbool.h>
 
 typedef unsigned long custom_t;
+
+union U1 {
+   unsigned char f0;
+   int f1;
+};
+
 void main()
 {
   char yy[256];
@@ -108,7 +114,14 @@ void main()
 
 	}
 
+  int top;
 
+  union U1 g_76;
+  g_76.f0 = 12; // (f0, (`Definite 12, [0,8]))
+  if (top) {
+    g_76.f1 = 5; // (f1, (`Definite 5, [-31,31]))
+  }
+  
   return;
 }
 

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.def_exc --disable ana.int.interval
+// PARAM: --enable ana.int.def_exc --enable ana.int.interval
 #include<stdbool.h>
 void main()
 {
@@ -53,5 +53,39 @@ void main()
   if (! fclose_fail) {
     *tmp___2 = 0;
   }
+
+  hash_initialize();
+
   return;
+}
+
+typedef unsigned long custom_t;
+
+struct hash_table {
+  custom_t n_buckets ;
+};
+
+typedef struct hash_table Hash_table;
+
+Hash_table *hash_initialize()
+{ Hash_table *table___0 ;
+  void *tmp ;
+  _Bool tmp___0 ;
+  void *tmp___1 ;
+
+  tmp = malloc(sizeof(*table___0));
+
+  custom_t n;
+  table___0 = (Hash_table *)tmp;
+  table___0->n_buckets = n;
+
+  if (! table___0->n_buckets) {
+
+    goto fail;
+  }
+  fail:
+
+  free((void *)table___0);
+
+  return ((Hash_table *)((void *)0));
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -32,5 +32,17 @@ void main()
     t++;
   }
 
+  unsigned int v;
+  unsigned short s1, s2;
+
+  v = v & 0xFFF0FFFF;
+  v = v << 16;
+
+  v = (unsigned int)(((unsigned int) (s1 ^ s2)));
+  v = (unsigned int)(((unsigned int) (s1 ^ s2)) << (16));
+
+  v = (v & 0xFFF0FFFF) |
+	    (((unsigned int) s1 ^ s2) << 16);
+
   return;
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -99,8 +99,10 @@ Hash_table *hash_initialize()
 
 int test(void const   *ptr) {
   if(!ptr) {
+    assert(ptr == 0);
     int f = 7;
   } else {
+    assert(ptr != 0);
     int f= 38;
   }
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -18,5 +18,19 @@ void main()
   long l;
   int r = !l + 4;
 
+  // From dtlk driver example, produces
+  // "warning: pointer targets in assignment differ in signedness [-Wpointer-sign]"
+  // in GCC
+	unsigned char *t;
+	static char buf[100] = "bliblablubapk\r";
+
+	t = buf;
+	t += 2;
+
+  *t = '\r';
+	while (*t != '\r') {
+    t++;
+  }
+
   return;
 }

--- a/tests/regression/01-cpa/37-div.c
+++ b/tests/regression/01-cpa/37-div.c
@@ -28,4 +28,21 @@ int main(void) {
     // }
   while_beak:
     assert(i == 3);
+
+
+
+    int a = 5;
+    int b = 7;
+
+    int r = 0;
+
+    if (a == b) {
+        // Dead
+        r = 1;
+    } else {
+        r = 2;
+    }
+
+    assert(r == 1); //FAIL
+    assert(r == 2);
 }

--- a/tests/regression/01-cpa/37-div.c
+++ b/tests/regression/01-cpa/37-div.c
@@ -1,0 +1,31 @@
+// PARAM: --enable ana.int.def_exc --enable ana.int.interval
+int main(void) {
+    int i = 1;
+    int v = 8;
+
+    int r = 28/v;
+
+    while(1) {
+        int zgg = 17;
+        if (! (i < 28 / v)) {
+            zgg = 5;
+            goto while_beak;
+        }
+
+        int z = 3;
+        i ++;
+        z = 7;
+    }
+
+
+
+
+
+    // while(i < 28/v) {
+    //     int z = 3;
+    //     i++;
+    //     z = 7;
+    // }
+  while_beak:
+    assert(i == 3);
+}

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int global;
 
 int main(void)

--- a/tests/regression/22-partitioned_arrays/02-pointers_array.c
+++ b/tests/regression/22-partitioned_arrays/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
+++ b/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
+++ b/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
+++ b/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/22-partitioned_arrays/06-interprocedural.c
+++ b/tests/regression/22-partitioned_arrays/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/07-global_array.c
+++ b/tests/regression/22-partitioned_arrays/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/08-unsupported.c
+++ b/tests/regression/22-partitioned_arrays/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 // This is just to test that the analysis does not cause problems for features that are not explicetly dealt with
 int main(void) {
   callok();

--- a/tests/regression/22-partitioned_arrays/09-one_by_one.c
+++ b/tests/regression/22-partitioned_arrays/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/22-partitioned_arrays/10-array_octagon.c
+++ b/tests/regression/22-partitioned_arrays/10-array_octagon.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/11-was_problematic.c
+++ b/tests/regression/22-partitioned_arrays/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
+++ b/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   int arr[260];

--- a/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
+++ b/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 struct some_struct
 {
     int dir[7];

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int global;
 
 int main(void)

--- a/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
+++ b/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
+++ b/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
+++ b/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/07-global_array.c
+++ b/tests/regression/23-partitioned_arrays_last/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/08-unsupported.c
+++ b/tests/regression/23-partitioned_arrays_last/08-unsupported.c
@@ -1,5 +1,5 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
-// This is just to test that the analysis does not cause problems for features that are not explicetly dealt with
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {
   vla();
   callok();

--- a/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
+++ b/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/23-partitioned_arrays_last/10-array_octagon.c
+++ b/tests/regression/23-partitioned_arrays_last/10-array_octagon.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
+++ b/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
+++ b/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   int arr[260];

--- a/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
+++ b/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits  --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
 }

--- a/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
+++ b/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
 }

--- a/tests/regression/24-octagon/01-octagon_simple.c
+++ b/tests/regression/24-octagon/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 void main(void) {
   int X = 0;

--- a/tests/regression/24-octagon/02-octagon_interprocudral.c
+++ b/tests/regression/24-octagon/02-octagon_interprocudral.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 int main(void) {
     f1();
 }

--- a/tests/regression/24-octagon/03-previously_problematic_a.c
+++ b/tests/regression/24-octagon/03-previously_problematic_a.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/04-previously_problematic_b.c
+++ b/tests/regression/24-octagon/04-previously_problematic_b.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 typedef int wchar_t;

--- a/tests/regression/24-octagon/05-previously_problematic_c.c
+++ b/tests/regression/24-octagon/05-previously_problematic_c.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/06-previously_problematic_d.c
+++ b/tests/regression/24-octagon/06-previously_problematic_d.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/07-previously_problematic_e.c
+++ b/tests/regression/24-octagon/07-previously_problematic_e.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/08-previously_problematic_f.c
+++ b/tests/regression/24-octagon/08-previously_problematic_f.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/09-previously_problematic_g.c
+++ b/tests/regression/24-octagon/09-previously_problematic_g.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/10-previously_problematic_h.c
+++ b/tests/regression/24-octagon/10-previously_problematic_h.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/11-previously_problematic_i.c
+++ b/tests/regression/24-octagon/11-previously_problematic_i.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 char buf2[67];

--- a/tests/regression/24-octagon/12-previously_problematic_j.c
+++ b/tests/regression/24-octagon/12-previously_problematic_j.c
@@ -1,0 +1,11 @@
+// PARAM: --sets solver td3 --disable exp.fast_global_inits --set ana.activated "['base','octagon']"
+void main(void) {
+  int i = 0;
+  int j = i;
+
+  i++;
+  j = i;
+
+  int x = (int) j-1;
+  int z = x +1;
+}

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -36,8 +36,14 @@ int main() {
     assert(yl == 6);
   if (yl/xl == 2 && xl == 3)
     assert(xl == 3); // TODO yl == 6
-  if (2+(3-xl)*4/5 == 6 && 2*yl >= xl+4)
-    assert(xl == -2 && yl >= 1);
-  if (xl > 1 && xl < 5 && xl % 2 == 1)
-    assert(xl != 2); // [2,4] -> [3,4] TODO x % 2 == 1
+  if (2+(3-xl)*4/5 == 6 && 2*yl >= xl+4) {
+
+  }
+    // UNKNOWN due to Interval32 not being able to represent long
+    // assert(xl == -2 && yl >= 1);
+  if (xl > 1 && xl < 5 && xl % 2 == 1) {
+
+  }
+    // UNKNOWN due to Interval32 not being able to represent long
+    // assert(xl != 2); // [2,4] -> [3,4] TODO x % 2 == 1
 }

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -46,4 +46,25 @@ int main() {
   }
     // UNKNOWN due to Interval32 not being able to represent long
     // assert(xl != 2); // [2,4] -> [3,4] TODO x % 2 == 1
-}
+
+  short xs, ys, zs;
+  if (xs+1 == 2) {
+    assert(xs == 1);
+  } else {
+    // Does not survive the casts inserted by CIL
+    // assert(xs != 1);
+  }
+  if (5-xs == 3)
+    assert(xs == 2);
+  if (5-xs == 3 && xs+ys == xs*3)
+    assert(xs == 2 && ys == 4);
+  if (xs == 3 && ys/xs == 2)
+    assert(ys == 6);
+  if (ys/xs == 2 && xs == 3)
+    assert(xs == 3); // TODO yl == 6
+  if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
+    assert(xs == -2 && ys >= 1);
+  }
+  if (xs > 1 && xs < 5 && xs % 2 == 1) {
+    assert(xs != 2);
+  }}

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -70,14 +70,21 @@ int main() {
     assert(xs == 2);
   if (5-xs == 3 && xs+ys == xs*3)
     assert(xs == 2 && ys == 4);
-  if (xs == 3 && ys/xs == 2)
+  if (xs == 3 && ys/xs == 2) {
     // ys could for example also be 7
     assert(ys == 6); // UNKNOWN!
+    assert(RANGE(ys, 6, 8));
+  }
+  if (ys/3 == -2)
+    assert(RANGE(ys, -8, -6));
+  if (ys/-3 == -2)
+    assert(RANGE(ys, 6, 8));
   if (ys/xs == 2 && xs == 3)
     assert(xs == 3); // TODO yl == 6
-  if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
+  if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+5) {
     // xs could also be -3
     assert(xs == -2 && ys >= 1); //UNKNOWN!
+    assert(RANGE(xs, -3, -2) && ys >= 1);
   }
   if (xs > 1 && xs < 5 && xs % 2 == 1) {
     assert(xs != 2);
@@ -103,9 +110,11 @@ int main2() {
     assert(x == two);
   if (five-x == three && x+y == x*three)
     assert(x == two && y == four);
-  if (x == three && y/x == two)
+  if (x == three && y/x == two) {
     // y could for example also be 7
     assert(y == six);  // UNKNOWN!
+    assert(RANGE(y, 6, 8));
+  }
   if (y/x == two && x == three)
     assert(x == three); // TODO y == six
   if (two+(three-x)*four/five == six && two*y >= x+four)
@@ -113,6 +122,18 @@ int main2() {
     assert(x == -two && y >= one); //UNKNOWN!
   if (x > one && x < five && x % two == one)
     assert(x != two); // [two,four] -> [three,four] TODO x % two == one
+
+  if (y/three == -two)
+    assert(RANGE(y, -8, -6));
+  if (y/-three == -two)
+    assert(RANGE(y, 6, 8));
+  if (y/x == two && x == three)
+    assert(x == 3); // TODO y == [6,8]; this does not work because CIL transforms this into two if-statements
+  if (two+(three-x)*four/five == six && two*y >= x+five)
+    assert(RANGE(x, -3, -2) && y >= 1);
+  if (x > one && x < five && x % two == one) // x = [2,4] && x % 2 = 1 => x = 3
+    assert(x != 2); // [3,4] TODO [3,3]
+
 
 
   long xl, yl, zl;
@@ -150,16 +171,25 @@ int main2() {
     assert(xs == two);
   if (five-xs == three && xs+ys == xs*three)
     assert(xs == two && ys == four);
-  if (xs == three && ys/xs == two)
+  if (xs == three && ys/xs == two) {
     // ys could for example also be 7
     assert(ys == six); // UNKNOWN!
+    assert(RANGE(ys, six, 8));
+  }
   if (ys/xs == two && xs == three)
     assert(xs == three); // TODO yl == six
-  if (two+(three-xs)*four/five == six && two*ys >= xs+four) {
+  if (two+(three-xs)*four/five == six && two*ys >= xs+five) {
     // xs could also be -three
     assert(xs == -two && ys >= one); //UNKNOWN!
+    assert(RANGE(xs, -three, -two) && ys >= one);
   }
   if (xs > one && xs < five && xs % two == one) {
     assert(xs != two);
   }
+  if (ys/three == -two)
+    assert(RANGE(ys, -8, -6));
+  if (ys/-three == -two)
+    assert(RANGE(ys, 6, 8));
+  if (ys/xs == two && xs == three)
+    assert(xs == 3); // TODO y == [6,8]; this does not work because CIL transforms this into two if-statements
 }

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -12,12 +12,14 @@ int main() {
     assert(x == 2);
   if (5-x == 3 && x+y == x*3)
     assert(x == 2 && y == 4);
-  // if (x == 3 && y/x == 2)
-  //   assert(y == 6);
+  if (x == 3 && y/x == 2)
+    // y could for example also be 7
+    assert(y == 6);  // UNKNOWN!
   if (y/x == 2 && x == 3)
     assert(x == 3); // TODO y == 6
-  // if (2+(3-x)*4/5 == 6 && 2*y >= x+4)
-  //   assert(x == -2 && y >= 1);
+  if (2+(3-x)*4/5 == 6 && 2*y >= x+4)
+    // x could also be -3
+    assert(x == -2 && y >= 1); //UNKNOWN!
   if (x > 1 && x < 5 && x % 2 == 1)
     assert(x != 2); // [2,4] -> [3,4] TODO x % 2 == 1
 
@@ -32,20 +34,19 @@ int main() {
     assert(xl == 2);
   if (5-xl == 3 && xl+yl == xl*3)
     assert(xl == 2 && yl == 4);
-  // if (xl == 3 && yl/xl == 2)
-  //   assert(yl == 6);
+  if (xl == 3 && yl/xl == 2)
+    // yl could for example also be 7
+    assert(yl == 6); // UNKNOWN!
   if (yl/xl == 2 && xl == 3)
     assert(xl == 3); // TODO yl == 6
-  if (2+(3-xl)*4/5 == 6 && 2*yl >= xl+4) {
-
-  }
-    // UNKNOWN due to Interval32 not being able to represent long
-    // assert(xl == -2 && yl >= 1);
+  if (2+(3-xl)*4/5 == 6 && 2*yl >= xl+4)
+    // xl could also be -3
+    assert(xl == -2 && yl >= 1); //UNKNOWN!
   if (xl > 1 && xl < 5 && xl % 2 == 1) {
-
-  }
     // UNKNOWN due to Interval32 not being able to represent long
     // assert(xl != 2); // [2,4] -> [3,4] TODO x % 2 == 1
+  }
+
 
   short xs, ys, zs;
   if (xs+1 == 2) {
@@ -58,13 +59,16 @@ int main() {
     assert(xs == 2);
   if (5-xs == 3 && xs+ys == xs*3)
     assert(xs == 2 && ys == 4);
-  // if (xs == 3 && ys/xs == 2)
-  //   assert(ys == 6);
+  if (xs == 3 && ys/xs == 2)
+    // ys could for example also be 7
+    assert(ys == 6); // UNKNOWN!
   if (ys/xs == 2 && xs == 3)
     assert(xs == 3); // TODO yl == 6
-  // if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
-  //   assert(xs == -2 && ys >= 1);
-  // }
+  if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
+    // xs could also be -3
+    assert(xs == -2 && ys >= 1); //UNKNOWN!
+  }
   if (xs > 1 && xs < 5 && xs % 2 == 1) {
     assert(xs != 2);
-  }}
+  }
+}

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -12,12 +12,12 @@ int main() {
     assert(x == 2);
   if (5-x == 3 && x+y == x*3)
     assert(x == 2 && y == 4);
-  if (x == 3 && y/x == 2)
-    assert(y == 6);
+  // if (x == 3 && y/x == 2)
+  //   assert(y == 6);
   if (y/x == 2 && x == 3)
     assert(x == 3); // TODO y == 6
-  if (2+(3-x)*4/5 == 6 && 2*y >= x+4)
-    assert(x == -2 && y >= 1);
+  // if (2+(3-x)*4/5 == 6 && 2*y >= x+4)
+  //   assert(x == -2 && y >= 1);
   if (x > 1 && x < 5 && x % 2 == 1)
     assert(x != 2); // [2,4] -> [3,4] TODO x % 2 == 1
 
@@ -32,8 +32,8 @@ int main() {
     assert(xl == 2);
   if (5-xl == 3 && xl+yl == xl*3)
     assert(xl == 2 && yl == 4);
-  if (xl == 3 && yl/xl == 2)
-    assert(yl == 6);
+  // if (xl == 3 && yl/xl == 2)
+  //   assert(yl == 6);
   if (yl/xl == 2 && xl == 3)
     assert(xl == 3); // TODO yl == 6
   if (2+(3-xl)*4/5 == 6 && 2*yl >= xl+4) {
@@ -58,13 +58,13 @@ int main() {
     assert(xs == 2);
   if (5-xs == 3 && xs+ys == xs*3)
     assert(xs == 2 && ys == 4);
-  if (xs == 3 && ys/xs == 2)
-    assert(ys == 6);
+  // if (xs == 3 && ys/xs == 2)
+  //   assert(ys == 6);
   if (ys/xs == 2 && xs == 3)
     assert(xs == 3); // TODO yl == 6
-  if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
-    assert(xs == -2 && ys >= 1);
-  }
+  // if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
+  //   assert(xs == -2 && ys >= 1);
+  // }
   if (xs > 1 && xs < 5 && xs % 2 == 1) {
     assert(xs != 2);
   }}

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -2,6 +2,9 @@
 #include <assert.h>
 
 int main() {
+  main2();
+
+
   int x, y, z;
   if (x+1 == 2) {
     assert(x == 1);
@@ -70,5 +73,85 @@ int main() {
   }
   if (xs > 1 && xs < 5 && xs % 2 == 1) {
     assert(xs != 2);
+  }
+
+}
+
+int main2() {
+  int one = 1;
+  int two = 2;
+  int three = 3;
+  int four = 4;
+  int five = 5;
+  int six = 6;
+
+  int x, y, z;
+  if (x+one == two) {
+    assert(x == one);
+  } else {
+    assert(x != one);
+  }
+  if (five-x == three)
+    assert(x == two);
+  if (five-x == three && x+y == x*three)
+    assert(x == two && y == four);
+  if (x == three && y/x == two)
+    // y could for example also be 7
+    assert(y == six);  // UNKNOWN!
+  if (y/x == two && x == three)
+    assert(x == three); // TODO y == six
+  if (two+(three-x)*four/five == six && two*y >= x+four)
+    // x could also be -three
+    assert(x == -two && y >= one); //UNKNOWN!
+  if (x > one && x < five && x % two == one)
+    assert(x != two); // [two,four] -> [three,four] TODO x % two == one
+
+
+  long xl, yl, zl;
+  if (xl+one == two) {
+    assert(xl == one);
+  } else {
+    assert(xl != one);
+  }
+  if (five-xl == three)
+    assert(xl == two);
+  if (five-xl == three && xl+yl == xl*three)
+    assert(xl == two && yl == four);
+  if (xl == three && yl/xl == two)
+    // yl could for example also be 7
+    assert(yl == six); // UNKNOWN!
+  if (yl/xl == two && xl == three)
+    assert(xl == three); // TODO yl == six
+  if (two+(three-xl)*four/five == six && two*yl >= xl+four)
+    // xl could also be -three
+    assert(xl == -two && yl >= one); //UNKNOWN!
+  if (xl > one && xl < five && xl % two == one) {
+    // UNKNOWN due to Intervalthreetwo not being able to represent long
+    // assert(xl != two); // [two,four] -> [three,four] TODO x % two == one
+  }
+
+
+  short xs, ys, zs;
+  if (xs+one == two) {
+    assert(xs == one);
+  } else {
+    // Does not survive the casts inserted by CIL
+    // assert(xs != one);
+  }
+  if (five-xs == three)
+    assert(xs == two);
+  if (five-xs == three && xs+ys == xs*three)
+    assert(xs == two && ys == four);
+  if (xs == three && ys/xs == two)
+    // ys could for example also be 7
+    assert(ys == six); // UNKNOWN!
+  if (ys/xs == two && xs == three)
+    assert(xs == three); // TODO yl == six
+  if (two+(three-xs)*four/five == six && two*ys >= xs+four) {
+    // xs could also be -three
+    assert(xs == -two && ys >= one); //UNKNOWN!
+  }
+  if (xs > one && xs < five && xs % two == one) {
+    assert(xs != two);
   }
 }


### PR DESCRIPTION
This fixes `def_exc` by equipping `Definite` with a range as well. Previous discussion on this was in #83 that I can unfortunately not re-open.
Normally, no operations should be performed on two different types of int, as CIL should insert all the casts: Therefore we check that the ranges are the same, and warn (in debug mode: fail) if they are not.
This lead to a lot of places where we were doing operations on different types of ints, this PR also fixes those issues. 
It also includes some new regression tests and configures more regression tests to run with `def_exc` enabled, to catch problems earlier.

As one of the next steps, the same probably needs to be done to the enum domain.
