### PR TITLE
DefExc: #89 without range for definite values + #95 better cast of exclusion range

### DIFF
--- a/regtest.sh
+++ b/regtest.sh
@@ -9,7 +9,7 @@ if [ ! -e $file ]; then
   exit 1
 fi
 params="`grep -oP "PARAM: \K.*" $file`"
-cmd="./goblint --enable dbg.fail_on_different_ikind --enable dbg.debug --sets warnstyle \"legacy\" --enable colors --enable dbg.showtemps --enable dbg.regression --html $params ${@:3} $file" #  --enable dbg.verbose --enable printstats
+cmd="./goblint --enable dbg.debug --sets warnstyle \"legacy\" --enable colors --enable dbg.showtemps --enable dbg.regression --html $params ${@:3} $file" #  --enable dbg.verbose --enable printstats
 cmd=`echo "$cmd" | sed "s:ana.osek.oil :ana.osek.oil $(dirname $file)/:"` # regression tests are run inside the test's directory which is why we either also need to cd there or instead prepend the path to the test directory for file parameters like these .oil files
 echo "$cmd"
 eval $cmd

--- a/regtest.sh
+++ b/regtest.sh
@@ -9,7 +9,7 @@ if [ ! -e $file ]; then
   exit 1
 fi
 params="`grep -oP "PARAM: \K.*" $file`"
-cmd="./goblint --enable dbg.debug --sets warnstyle \"legacy\" --enable colors --enable dbg.showtemps --enable dbg.regression --html $params ${@:3} $file" #  --enable dbg.verbose --enable printstats
+cmd="./goblint --enable dbg.fail_on_different_ikind --enable dbg.debug --sets warnstyle \"legacy\" --enable colors --enable dbg.showtemps --enable dbg.regression --html $params ${@:3} $file" #  --enable dbg.verbose --enable printstats
 cmd=`echo "$cmd" | sed "s:ana.osek.oil :ana.osek.oil $(dirname $file)/:"` # regression tests are run inside the test's directory which is why we either also need to cd there or instead prepend the path to the test directory for file parameters like these .oil files
 echo "$cmd"
 eval $cmd

--- a/scripts/update_suite.rb
+++ b/scripts/update_suite.rb
@@ -166,7 +166,6 @@ regs.sort.each do |d|
       tests[-1] = "term"
       debug = true
     end
-    params << " --enable dbg.fail_on_different_ikind"
     params << " --set dbg.debug true" if debug
     p = Project.new(id, testname, 0, groupname, path, params, tests, tests_line, true)
     projects << p

--- a/scripts/update_suite.rb
+++ b/scripts/update_suite.rb
@@ -166,6 +166,7 @@ regs.sort.each do |d|
       tests[-1] = "term"
       debug = true
     end
+    params << " --enable dbg.fail_on_different_ikind"
     params << " --set dbg.debug true" if debug
     p = Project.new(id, testname, 0, groupname, path, params, tests, tests_line, true)
     projects << p

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -278,7 +278,7 @@ struct
       match op with
       | MinusA when equality () = Some true ->
         let ik = Cilfacade.get_ikind (Cil.typeOf exp) in
-        Some (`Int (ID.of_int_ikind ik 0L))
+        Some (`Int (ID.cast_to ik @@ ID.of_int 0L))
       | MinusPI
       | MinusPP when equality () = Some true -> Some (`Int (ID.of_int 0L))
       | MinusPI

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -829,8 +829,11 @@ struct
   (* run eval_rv from above, but change bot to top to be sound for programs with undefined behavior. *)
   (* Previously we only gave sound results for programs without undefined behavior, so yielding bot for accessing an uninitialized array was considered ok. Now only [invariant] can yield bot/Deadcode if the condition is known to be false but evaluating an expression should not be bot. *)
   let eval_rv (a: Q.ask) (gs:glob_fun) (st: store) (exp:exp): value =
-    let r = eval_rv a gs st exp in
-    if VD.is_bot r then top_value a gs st (typeOf exp) else r
+    try
+      let r = eval_rv a gs st exp in
+      if VD.is_bot r then top_value a gs st (typeOf exp) else r
+    with IntDomain.ArithmeticOnIntegerBot _ ->
+      top_value a gs st (typeOf exp)
 
   (* Evaluate an expression containing only locals. This is needed for smart joining the partitioned arrays where ctx is not accessible. *)
   (* This will yield `Top for expressions containing any access to globals, and does not make use of the query system. *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -279,7 +279,9 @@ struct
       in
       let ptrdiff_ikind = match !ptrdiffType with TInt (ik,_) -> ik | _ -> assert false in
       match op with
-      | MinusA
+      | MinusA when equality () = Some true ->
+        let ik = get_ikind (Cil.typeOf exp) in
+        Some (`Int (ID.of_int_ikind ik 0L))
       | MinusPI
       | MinusPP when equality () = Some true -> Some (`Int (ID.of_int 0L))
       | MinusPI

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -979,7 +979,11 @@ struct
         let e2_val = eval_rv ctx.ask ctx.global ctx.local e2 in
         match e1_val, e2_val with
         | `Int i1, `Int i2 -> begin
-            if ID.is_bot (ID.meet i1 i2) then
+            (* This should behave like == and also work on different int types, hence the cast (just like with == in C) *)
+            let e1_ik = get_ikind (Cil.typeOf e1) in
+            let e2_ik = get_ikind (Cil.typeOf e2) in
+            let ik= Cil.commonIntKind e1_ik e2_ik in
+            if ID.is_bot (ID.meet (ID.cast_to ik i1) (ID.cast_to ik i2)) then
               begin
                 (* Printf.printf "----------------------> NOPE may equality check for %s and %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
                 `Bool(false)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -100,7 +100,7 @@ struct
     | 0 -> Flag.compare x2 y2
     | x -> x
 
-  let ikindOf t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
+  let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
     (* important to unroll the type here, otherwise problems with typedefs *)
     M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
 
@@ -1442,7 +1442,8 @@ struct
         let t = Cil.unrollType (typeOfLval x) in  (* unroll type to deal with TNamed *)
         let c' = match t with
           | TPtr _ -> `Address (AD.of_int (module ID) c)
-          | TInt (ik, _) -> `Int (ID.cast_to ik c )
+          | TInt (ik, _)
+          | TEnum ({ekind = ik; _}, _) -> `Int (ID.cast_to ik c )
           | _ -> `Int c
         in
         let oldv = eval (Lval x) in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1303,9 +1303,10 @@ struct
     in
     if M.tracing then M.traceli "invariant" "assume expression %a is %B\n" d_exp exp tv;
     let null_val typ =
-      match typ with
-      | TPtr _ -> `Address AD.null_ptr
-      | _      -> `Int (ID.of_int 0L)
+      match Cil.unrollType typ with
+      | TPtr _                    -> `Address AD.null_ptr
+      | TEnum({ekind=ikind;_},_)
+      | _                         -> `Int (ID.of_int 0L)
     in
     let rec derived_invariant exp tv =
       let switchedOp = function Lt -> Gt | Gt -> Lt | Le -> Ge | Ge -> Le | x -> x in (* a op b <=> b (switchedOp op) b *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1425,7 +1425,7 @@ struct
         | Ne, Some false -> both m (* def. equal: if they compare equal, both values must be from the meet *)
         | Eq, Some false
         | Ne, Some true -> (* def. unequal *)
-          (* Both values can not be in the meet together, but it's not sound to exlcude the meet from both. *)
+          (* Both values can not be in the meet together, but it's not sound to exclude the meet from both. *)
           (* e.g. a=[0,1], b=[1,2], meet a b = [1,1], but (a != b) does not imply a=[0,0], b=[2,2] since others are possible: a=[1,1], b=[2,2] *)
           (* Only if a is a definite value, we can exclude it from b: *)
           let excl a b = match ID.to_int a with Some x -> ID.of_excl_list ILongLong [x] | None -> b in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1385,9 +1385,9 @@ struct
       let meet_non oi oo = meet_bin (oi c b) (oo a c) in (* non-commutative *)
       function
       | PlusA  -> meet_com ID.sub
-      | Mult   -> meet_com ID.div
+      | Mult   -> meet_com ID.div (* Div is ok here, c must be divisible by a and b *)
       | MinusA -> meet_non ID.add ID.sub
-      | Div    -> meet_non ID.mul ID.div
+      (* | Div    -> be careful when adding Div, it is division with remainder this is not easy to inverse *)
       | Mod    -> meet_bin (ID.add c (ID.mul b (ID.div a b))) (ID.div (ID.sub a c) (ID.div a b))
       | Eq | Ne as op ->
         let both x = x, x in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1447,26 +1447,12 @@ struct
           | _ -> `Int c
         in
         let oldv = eval (Lval x) in
-        let skip = if Cil.isVoidPtrType t then
-            match oldv with
-            | `Address _ -> false
-            | _ -> true (* We do not change type on a cast to void*, so we can not meet here without type errors*)
-          else
-            false
-        in
-        let v =
-          if skip then
-            (if M.tracing then M.tracel "inv" "lval %a = %a has type void*, but we want to improve it with %a (from %a) -> skipping\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c ;
-            oldv)
-          else
-            let v = VD.meet oldv c' in
-            if is_some_bot v then
-              raise Deadcode
-            else
-              (if M.tracing then M.tracel "inv" "improve lval %a = %a with %a (from %a), meet = %a\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c VD.pretty v;
-              v)
-        in
-          set' x v
+        let v = VD.meet oldv c' in
+        if is_some_bot v then
+          raise Deadcode
+        else
+          (if M.tracing then M.tracel "inv" "improve lval %a = %a with %a (from %a), meet = %a\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c VD.pretty v;
+          set' x v)
       | Const _ -> Tuple3.first st (* nothing to do *)
       | CastE ((TInt (ik, _)) as t, e) -> (* Can only meet the t part of an Lval in e with c (unless we meet with all overflow possibilities)! Since there is no good way to do this, we only continue if e has no values outside of t. *)
         (match eval e with

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -365,7 +365,7 @@ struct
         match Addr.to_var_offset x with
         | [x] -> f_addr x                    (* normal reference *)
         | _ when x = Addr.NullPtr -> VD.bot () (* null pointer *)
-        | _ -> `Int (ID.top ())              (* string pointer *)
+        | _ -> `Int (ID.top_of IChar)       (* string pointer *)
       in
       (* We form the collecting function by joining *)
       let f x a = VD.join (f x) a in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1439,16 +1439,32 @@ struct
         (* | `Address a, `Address b -> ... *)
         | a1, a2 -> fallback ("binop: got abstract values that are not `Int: " ^ sprint VD.pretty a1 ^ " and " ^ sprint VD.pretty a2))
       | Lval x -> (* meet x with c *)
-        let c' = match Cil.unrollType (typeOfLval x) with (* unroll type to deal with TNamed *)
+        let t = Cil.unrollType (typeOfLval x) in  (* unroll type to deal with TNamed *)
+        let c' = match t with
           | TPtr _ -> `Address (AD.of_int (module ID) c)
           | TInt (ik, _) -> `Int (ID.cast_to ik c )
           | _ -> `Int c
         in
         let oldv = eval (Lval x) in
-        let v = VD.meet oldv c' in
-        if is_some_bot v then raise Deadcode
-        else
-          if M.tracing then M.tracel "inv" "improve lval %a = %a with %a (from %a), meet = %a\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c VD.pretty v;
+        let skip = if Cil.isVoidPtrType t then
+            match oldv with
+            | `Address _ -> false
+            | _ -> true (* We do not change type on a cast to void*, so we can not meet here without type errors*)
+          else
+            false
+        in
+        let v =
+          if skip then
+            (if M.tracing then M.tracel "inv" "lval %a = %a has type void*, but we want to improve it with %a (from %a) -> skipping\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c ;
+            oldv)
+          else
+            let v = VD.meet oldv c' in
+            if is_some_bot v then
+              raise Deadcode
+            else
+              (if M.tracing then M.tracel "inv" "improve lval %a = %a with %a (from %a), meet = %a\n" d_lval x VD.pretty oldv VD.pretty c' ID.pretty c VD.pretty v;
+              v)
+        in
           set' x v
       | Const _ -> Tuple3.first st (* nothing to do *)
       | CastE ((TInt (ik, _)) as t, e) -> (* Can only meet the t part of an Lval in e with c (unless we meet with all overflow possibilities)! Since there is no good way to do this, we only continue if e has no values outside of t. *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1097,12 +1097,13 @@ struct
               | `Bool t -> Q.BD.to_bool t = Some true
               | _ -> false
             in
+            let ik = get_ikind (typeOf currentE') in
             let newE = Basetype.CilExp.replace l' r' currentE' in
-            let currentEPlusOne = BinOp (PlusA, currentE', Cil.integer 1, Cil.intType) in
+            let currentEPlusOne = BinOp (PlusA, currentE', Cil.kinteger ik 1, typeOf currentE') in
             if are_equal newE currentEPlusOne then
               Some 1
             else
-              let currentEMinusOne = BinOp (MinusA, currentE', Cil.integer 1, Cil.intType) in
+              let currentEMinusOne = BinOp (MinusA, currentE', Cil.kinteger ik 1, typeOf currentE') in
               if are_equal newE currentEMinusOne then
                 Some (-1)
               else

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1439,7 +1439,7 @@ struct
         (* | `Address a, `Address b -> ... *)
         | a1, a2 -> fallback ("binop: got abstract values that are not `Int: " ^ sprint VD.pretty a1 ^ " and " ^ sprint VD.pretty a2))
       | Lval x -> (* meet x with c *)
-        let c' = match typeOfLval x with
+        let c' = match Cil.unrollType (typeOfLval x) with (* unroll type to deal with TNamed *)
           | TPtr _ -> `Address (AD.of_int (module ID) c)
           | TInt (ik, _) -> `Int (ID.cast_to ik c )
           | _ -> `Int c

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1454,7 +1454,9 @@ struct
         (match eval e with
         | `Int a ->
           if ID.leq a (ID.cast_to ik a) then
-            inv_exp c e
+             match Cil.typeOf e with
+              | TInt(ik_e, _) -> inv_exp (ID.cast_to ik_e c) e
+              | x -> fallback ("CastE: e did evaluate to `Int, but the type did not match" ^ sprint d_type t)
           else
             fallback ("CastE: " ^ sprint d_plainexp e ^ " evaluates to " ^ sprint ID.pretty a ^ " which is bigger than the type it is cast to which is " ^ sprint d_type t)
         | v -> fallback ("CastE: e did not evaluate to `Int, but " ^ sprint VD.pretty v))

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1268,7 +1268,7 @@ struct
           | `Int n -> begin
             let ikind = Cilfacade.get_ikind (typeOf (Lval lval)) in
             let n = ID.cast_to ikind n in
-            let range_from x = if tv then ID.ending_ikind ikind (Int64.sub x 1L) else ID.starting_ikind ikind x in
+            let range_from x = if tv then ID.ending ~ikind:ikind (Int64.sub x 1L) else ID.starting ~ikind:ikind x in
             let limit_from = if tv then ID.maximal else ID.minimal in
             match limit_from n with
             | Some n ->
@@ -1285,7 +1285,7 @@ struct
           | `Int n -> begin
             let ikind = Cilfacade.get_ikind (typeOf (Lval lval)) in
             let n = ID.cast_to ikind n in
-            let range_from x = if tv then ID.ending_ikind ikind x else ID.starting_ikind ikind (Int64.add x 1L) in
+            let range_from x = if tv then ID.ending ~ikind:ikind x else ID.starting ~ikind:ikind (Int64.add x 1L) in
             let limit_from = if tv then ID.maximal else ID.minimal in
               match limit_from n with
               | Some n ->
@@ -1376,7 +1376,7 @@ struct
       Tuple3.first (invariant ctx a gs st exp tv)
     in
     (* inverse values for binary operation a `op` b == c *)
-    let inv_bin_int (a, b) c =
+    let inv_bin_int (a, b) ik c =
       let meet_bin a' b'  = ID.meet a a', ID.meet b b' in
       let meet_com oi    = meet_bin (oi c b) (oi c a) in (* commutative *)
       let meet_non oi oo = meet_bin (oi c b) (oo a c) in (* non-commutative *)
@@ -1395,7 +1395,7 @@ struct
         | Eq, Some false
         | Ne, Some true -> (* def. unequal *)
           (match ID.to_int m with
-          | Some i -> both (ID.of_excl_list ILongLong [i])
+          | Some i -> both (ID.of_excl_list ik [i])
           | None -> a, b)
         | _, _ -> a, b
         )
@@ -1405,13 +1405,13 @@ struct
           (* if M.tracing then M.tracel "inv" "Op: %s, l1: %Ld, u1: %Ld, l2: %Ld, u2: %Ld\n" (show_binop op) l1 u1 l2 u2; *)
           (match op, ID.to_bool c with
           | Le, Some true
-          | Gt, Some false -> meet_bin (ID.ending u2) (ID.starting l1)
+          | Gt, Some false -> meet_bin (ID.ending ~ikind:ik u2) (ID.starting ~ikind:ik l1)
           | Ge, Some true
-          | Lt, Some false -> meet_bin (ID.starting l2) (ID.ending u1)
+          | Lt, Some false -> meet_bin (ID.starting ~ikind:ik l2) (ID.ending ~ikind:ik u1)
           | Lt, Some true
-          | Ge, Some false -> meet_bin (ID.ending (Int64.pred u2)) (ID.starting (Int64.succ l1))
+          | Ge, Some false -> meet_bin (ID.ending ~ikind:ik (Int64.pred u2)) (ID.starting ~ikind:ik (Int64.succ l1))
           | Gt, Some true
-          | Le, Some false -> meet_bin (ID.starting (Int64.succ l2)) (ID.ending (Int64.pred u1))
+          | Le, Some false -> meet_bin (ID.starting ~ikind:ik (Int64.succ l2)) (ID.ending ~ikind:ik (Int64.pred u1))
           | _, _ -> a, b)
         | _ -> a, b)
       | op ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1472,7 +1472,7 @@ struct
         | v -> fallback ("CastE: e did not evaluate to `Int, but " ^ sprint VD.pretty v))
       | e -> fallback (sprint d_plainexp e ^ " not implemented")
     in
-    if eval_bool exp = Some tv then raise Deadcode (* we already know that the branch is dead *)
+    if eval_bool exp = Some (not tv) then raise Deadcode (* we already know that the branch is dead *) (*TODO: Negation? *)
     else
       let is_cmp = function
         | BinOp ((Lt | Gt | Le | Ge | Eq | Ne), _, _, t) -> true

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1441,6 +1441,7 @@ struct
       | Lval x -> (* meet x with c *)
         let c' = match typeOfLval x with
           | TPtr _ -> `Address (AD.of_int (module ID) c)
+          | TInt (ik, _) -> `Int (ID.cast_to ik c )
           | _ -> `Int c
         in
         let oldv = eval (Lval x) in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -831,6 +831,7 @@ struct
   let eval_rv (a: Q.ask) (gs:glob_fun) (st: store) (exp:exp): value =
     try
       let r = eval_rv a gs st exp in
+      if M.tracing then M.tracel "eval" "eval_rv %a = %a\n" d_exp exp VD.pretty r;
       if VD.is_bot r then top_value a gs st (typeOf exp) else r
     with IntDomain.ArithmeticOnIntegerBot _ ->
       top_value a gs st (typeOf exp)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -362,7 +362,7 @@ struct
         match Addr.to_var_offset x with
         | [x] -> f_addr x                    (* normal reference *)
         | _ when x = Addr.NullPtr -> VD.bot () (* null pointer *)
-        | _ -> `Int (ID.top_of IChar)       (* string pointer *)
+        | _ -> `Int (ID.cast_to IChar (ID.top ()))       (* string pointer *)
       in
       (* We form the collecting function by joining *)
       let f x a = VD.join (f x) a in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1265,13 +1265,11 @@ struct
         end
       | Ne, x, value, _ -> helper Eq x value (not tv)
       | Lt, x, value, _ -> begin
-          let range_from x = if tv then ID.ending (Int64.sub x 1L) else ID.starting x in
-          let limit_from = if tv then ID.maximal else ID.minimal in
           match value with
           | `Int n -> begin
             let ikind = Cilfacade.get_ikind (typeOf (Lval lval)) in
             let n = ID.cast_to ikind n in
-            let range_from x = if tv then ID.ending ~ikind:ikind (Int64.sub x 1L) else ID.starting ~ikind:ikind x in
+            let range_from x = if tv then ID.ending ~ikind (Int64.sub x 1L) else ID.starting ~ikind x in
             let limit_from = if tv then ID.maximal else ID.minimal in
             match limit_from n with
             | Some n ->
@@ -1282,13 +1280,11 @@ struct
           | _ -> None
         end
       | Le, x, value, _ -> begin
-          let range_from x = if tv then ID.ending x else ID.starting (Int64.add x 1L) in
-          let limit_from = if tv then ID.maximal else ID.minimal in
           match value with
           | `Int n -> begin
             let ikind = Cilfacade.get_ikind (typeOf (Lval lval)) in
             let n = ID.cast_to ikind n in
-            let range_from x = if tv then ID.ending ~ikind:ikind x else ID.starting ~ikind:ikind (Int64.add x 1L) in
+            let range_from x = if tv then ID.ending ~ikind x else ID.starting ~ikind (Int64.add x 1L) in
             let limit_from = if tv then ID.maximal else ID.minimal in
               match limit_from n with
               | Some n ->
@@ -1308,7 +1304,7 @@ struct
     let null_val typ =
       match Cil.unrollType typ with
       | TPtr _                    -> `Address AD.null_ptr
-      | TEnum({ekind=ikind;_},_)
+      | TEnum({ekind=_;_},_)
       | _                         -> `Int (ID.of_int 0L)
     in
     let rec derived_invariant exp tv =
@@ -1440,7 +1436,7 @@ struct
             (* | Lor and land? *)
             | _ -> Cilfacade.get_ikind (Cil.typeOf exp)
           in
-          let a', b' = inv_bin_int (a, b) (ID.cast_to ik c) ik op in
+          let a', b' = inv_bin_int (a, b) ik (ID.cast_to ik c) op in
           let m1 = inv_exp (ID.cast_to (Cilfacade.get_ikind (Cil.typeOf e1)) a') e1 in
           let m2 = inv_exp (ID.cast_to (Cilfacade.get_ikind (Cil.typeOf e2)) b') e2 in
           CPA.meet m1 m2
@@ -1484,7 +1480,7 @@ struct
         if not tv || is_cmp exp then (* false is 0, but true can be anything that is not 0, except for comparisons which yield 1 *)
           ID.of_bool tv (* this will give 1 for true which is only ok for comparisons *)
         else
-          let ik = ikindOf (typeOf exp) in
+          let ik = Cilfacade.get_ikind (typeOf exp) in
           ID.of_excl_list ik [Int64.zero] (* Lvals, Casts, arithmetic operations etc. should work with true = non_zero *)
       in
       Tuple3.map1 (fun _ -> inv_exp itv exp) st

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1394,12 +1394,14 @@ struct
         let m = ID.meet a b in
         (match op, ID.to_bool c with
         | Eq, Some true
-        | Ne, Some false -> both m (* def. equal *)
+        | Ne, Some false -> both m (* def. equal: if they compare equal, both values must be from the meet *)
         | Eq, Some false
         | Ne, Some true -> (* def. unequal *)
-          (match ID.to_int m with
-          | Some i -> both (ID.of_excl_list ik [i])
-          | None -> a, b)
+          (* if they compare unequal, they can not at the same time be from the meet, but it would be unsound to restrict both to not be the meet      *)
+          (* even if there is only one element in the meet e.g. a:[0,1] b:[1,2] meet(a,b) = [1], but (a != b) does not mean that a:[0,0] and b: [2,2]  *)
+          let a' = match ID.to_int b with | Some j -> (ID.of_excl_list ik [j]) | _ -> a  in (* if b is one concrete value, we can exclude it in a *)
+          let b' = match ID.to_int a with | Some j -> (ID.of_excl_list ik [j]) | _ -> b  in (* if a is one concrete value, we can exclude it in b *)
+          meet_bin a' b'
         | _, _ -> a, b
         )
       | Lt | Le | Ge | Gt as op ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1387,7 +1387,7 @@ struct
       | PlusA  -> meet_com ID.sub
       | Mult   -> meet_com ID.div (* Div is ok here, c must be divisible by a and b *)
       | MinusA -> meet_non ID.add ID.sub
-      (* | Div    -> be careful when adding Div, it is division with remainder this is not easy to inverse *)
+      | Div    -> meet_bin (ID.add (ID.mul b c) (ID.rem a b)) (ID.div (ID.sub a (ID.rem a b)) c)
       | Mod    -> meet_bin (ID.add c (ID.mul b (ID.div a b))) (ID.div (ID.sub a c) (ID.div a b))
       | Eq | Ne as op ->
         let both x = x, x in
@@ -1472,7 +1472,7 @@ struct
         | v -> fallback ("CastE: e did not evaluate to `Int, but " ^ sprint VD.pretty v))
       | e -> fallback (sprint d_plainexp e ^ " not implemented")
     in
-    if eval_bool exp = Some (not tv) then raise Deadcode (* we already know that the branch is dead *) (*TODO: Negation? *)
+    if eval_bool exp = Some (not tv) then raise Deadcode (* we already know that the branch is dead *)
     else
       let is_cmp = function
         | BinOp ((Lt | Gt | Le | Ge | Eq | Ne), _, _, t) -> true

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1043,7 +1043,7 @@ struct
   (** [set st addr val] returns a state where [addr] is set to [val]
   * it is always ok to put None for lval_raw and rval_raw, this amounts to not using/maintaining
   * precise information about arrays. *)
-  let set a ?(ctx=None) ?(effect=true) ?(change_array=true) ?lval_raw ?rval_raw (gs:glob_fun) (st,fl,dep: store) (lval: AD.t) (value: value) : store =
+  let set a ?(ctx=None) ?(effect=true) ?(change_array=true) ?lval_raw ?rval_raw ?t_override (gs:glob_fun) (st,fl,dep: store) (lval: AD.t) (value: value) : store =
     let update_variable x y z =
       if M.tracing then M.tracel "setosek" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a\n\n" x.vname VD.pretty y CPA.pretty z;
       let r = update_variable x y z in (* refers to defintion that is outside of set *)
@@ -1056,6 +1056,9 @@ struct
      * not include the flag. *)
     let update_one_addr (x, offs) (nst, fl, dep): store =
       let cil_offset = Offs.to_cil_offset offs in
+      let t = match t_override with
+        | Some t -> t
+        | None -> Cil.typeOf (Lval(Var x, cil_offset)) in
       if M.tracing then M.tracel "setosek" ~var:firstvar "update_one_addr: start with '%a' (type '%a') \nstate:%a\n\n" AD.pretty (AD.from_var_offset (x,offs)) d_type x.vtype CPA.pretty st;
       if isFunctionType x.vtype then begin
         if M.tracing then M.tracel "setosek" ~var:firstvar "update_one_addr: returning: '%a' is a function type \n" d_type x.vtype;
@@ -1082,13 +1085,13 @@ struct
           if M.tracing then M.tracel "setosek" ~var:x.vname "update_one_addr: update a global var '%s' ...\n" x.vname;
           (* Here, an effect should be generated, but we add it to the local
            * state, waiting for the sync function to publish it. *)
-          update_variable x (VD.update_offset a (get x nst) offs value (Option.map (fun x -> Lval x) lval_raw) (Var x, cil_offset)) nst, fl, dep
+          update_variable x (VD.update_offset a (get x nst) offs value (Option.map (fun x -> Lval x) lval_raw) (Var x, cil_offset) t) nst, fl, dep
         end
       else begin
         if M.tracing then M.tracel "setosek" ~var:x.vname "update_one_addr: update a local var '%s' ...\n" x.vname;
         (* Normal update of the local state *)
         let lval_raw = (Option.map (fun x -> Lval x) lval_raw) in
-        let new_value = VD.update_offset a (CPA.find x nst) offs value lval_raw ((Var x), cil_offset) in
+        let new_value = VD.update_offset a (CPA.find x nst) offs value lval_raw ((Var x), cil_offset) t in
         (* what effect does changing this local variable have on arrays -
            we only need to do this here since globals are not allowed in the
            expressions for partitioning *)
@@ -1261,11 +1264,15 @@ struct
           let limit_from = if tv then ID.maximal else ID.minimal in
           match value with
           | `Int n -> begin
-              match limit_from n with
-              | Some n ->
-                if M.tracing then M.tracec "invariant" "Yes, success! %a is not %Ld\n\n" d_lval x n;
-                Some (x, `Int (range_from n))
-              | None -> None
+            let ikind = get_ikind (typeOf (Lval lval)) in
+            let n = ID.cast_to ikind n in
+            let range_from x = if tv then ID.ending_ikind ikind (Int64.sub x 1L) else ID.starting_ikind ikind x in
+            let limit_from = if tv then ID.maximal else ID.minimal in
+            match limit_from n with
+            | Some n ->
+              if M.tracing then M.tracec "invariant" "Yes, success! %a is not %Ld\n\n" d_lval x n;
+              Some (x, `Int (range_from n))
+            | None -> None
             end
           | _ -> None
         end
@@ -1274,6 +1281,10 @@ struct
           let limit_from = if tv then ID.maximal else ID.minimal in
           match value with
           | `Int n -> begin
+            let ikind = get_ikind (typeOf (Lval lval)) in
+            let n = ID.cast_to ikind n in
+            let range_from x = if tv then ID.ending_ikind ikind x else ID.starting_ikind ikind (Int64.add x 1L) in
+            let limit_from = if tv then ID.maximal else ID.minimal in
               match limit_from n with
               | Some n ->
                 if M.tracing then M.tracec "invariant" "Yes, success! %a is not %Ld\n\n" d_lval x n;
@@ -1338,6 +1349,8 @@ struct
       else
         let oldval = get a gs st addr None in (* None is ok here, we could try to get more precise, but this is ok (reading at unknown position in array) *)
         let oldval = if is_some_bot oldval then (M.tracec "invariant" "%a is bot! This should not happen. Will continue with top!" d_lval lval; VD.top ()) else oldval in
+        let state_with_excluded = set a gs st addr value ~effect:false ~change_array:false ~ctx:(Some ctx) in
+        let value =  get a gs state_with_excluded addr None in
         let new_val = apply_invariant oldval value in
         if M.tracing then M.traceu "invariant" "New value is %a\n" VD.pretty new_val;
         (* make that address meet the invariant, i.e exclusion sets will be joined *)
@@ -1413,8 +1426,16 @@ struct
         if M.tracing then M.tracel "inv" "binop %a with %a %s %a == %a\n" d_exp e VD.pretty (eval e1) (show_binop op) VD.pretty (eval e2) ID.pretty c;
         (match eval e1, eval e2 with
         | `Int a, `Int b ->
-          let a', b' = inv_bin_int (a, b) c op in
-          CPA.meet (inv_exp a' e1) (inv_exp b' e2)
+          (* the ikind of comparisons is always TInt(IInt,[]) in CIL *)
+          let ik = match op with
+            | Cil.Eq|Cil.Ne|Cil.Lt|Cil.Le|Cil.Ge|Cil.Gt -> (get_ikind (Cil.typeOf e1))
+            (* | Lor and land? *)
+            | _ -> get_ikind (Cil.typeOf exp)
+          in
+          let a', b' = inv_bin_int (a, b) (ID.cast_to ik c) ik op in
+          let m1 = inv_exp (ID.cast_to (get_ikind (Cil.typeOf e1)) a') e1 in
+          let m2 = inv_exp (ID.cast_to (get_ikind (Cil.typeOf e2)) b') e2 in
+          CPA.meet m1 m2
         (* | `Address a, `Address b -> ... *)
         | a1, a2 -> fallback ("binop: got abstract values that are not `Int: " ^ sprint VD.pretty a1 ^ " and " ^ sprint VD.pretty a2))
       | Lval x -> (* meet x with c *)
@@ -1539,8 +1560,9 @@ struct
         | `Bot -> (* current value is VD `Bot *)
           (match Addr.to_var_offset (AD.choose lval_val) with
           | [(x,offs)] ->
+            let t = v.vtype in
             let iv = bot_value ctx.ask ctx.global ctx.local v.vtype in (* correct bottom value for top level variable *)
-            let nv = VD.update_offset ctx.ask iv offs rval_val (Some  (Lval lval)) lval in (* do desired update to value *)
+            let nv = VD.update_offset ctx.ask iv offs rval_val (Some  (Lval lval)) lval t in (* do desired update to value *)
             set_savetop ctx.ask ctx.global ctx.local (AD.from_var v) nv (* set top-level variable to updated value *)
           | _ ->
             set_savetop ctx.ask ctx.global ctx.local lval_val rval_val ~lval_raw:lval ~rval_raw:rval
@@ -1630,7 +1652,13 @@ struct
       let nst = rem_many ctx.ask nst_part locals in
       match exp with
       | None -> nst
-      | Some exp -> set ctx.ask ctx.global nst (return_var ()) (eval_rv ctx.ask ctx.global ctx.local exp)
+      | Some exp ->
+        let t_override = match fundec.svar.vtype with
+          | TFun(TVoid _, _, _, _) -> M.warn "Returning a value from a void function"; assert false
+          | TFun(ret, _, _, _) -> ret
+          | _ -> assert false
+        in
+        set ~t_override ctx.ask ctx.global nst (return_var ()) (eval_rv ctx.ask ctx.global ctx.local exp)
         (* lval_raw:None, and rval_raw:None is correct here *)
 
   let vdecl ctx (v:varinfo) =

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -94,7 +94,7 @@ struct
 
   let name () = "partitioned array"
 
-  let get_ikind t = match Cil.unrollType t with TInt (ik,_) -> ik | _ ->
+  let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
     (* important to unroll the type here, otherwise problems with typedefs *)
     M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
 

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -94,10 +94,6 @@ struct
 
   let name () = "partitioned array"
 
-  let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
-    (* important to unroll the type here, otherwise problems with typedefs *)
-    M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
-
   let is_not_partitioned (e, _) =
     Expp.is_bot e || Expp.is_top e
 
@@ -381,7 +377,7 @@ struct
             | `Bool false -> Val.bot()
             | _ -> xm) (* if e' may be equal to i', but e' may not be smaller than i' then we only need xm *)
             (
-              let ik = get_ikind (Cil.typeOf e') in
+              let ik = Cilfacade.get_ikind (Cil.typeOf e') in
               match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik 1, Cil.typeOf e'),i')) with
               | `Bool true -> xm
               | _ ->
@@ -398,7 +394,7 @@ struct
             | _ -> xm)
 
             (
-              let ik = get_ikind (Cil.typeOf e') in
+              let ik = Cilfacade.get_ikind (Cil.typeOf e') in
               match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik (-1), Cil.typeOf e'),i')) with
               | `Bool true -> xm
               | _ ->

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -94,6 +94,10 @@ struct
 
   let name () = "partitioned array"
 
+  let get_ikind t = match Cil.unrollType t with TInt (ik,_) -> ik | _ ->
+    (* important to unroll the type here, otherwise problems with typedefs *)
+    M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
+
   let is_not_partitioned (e, _) =
     Expp.is_bot e || Expp.is_top e
 
@@ -377,7 +381,8 @@ struct
             | `Bool false -> Val.bot()
             | _ -> xm) (* if e' may be equal to i', but e' may not be smaller than i' then we only need xm *)
             (
-              match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.integer 1, Cil.intType),i')) with
+              let ik = get_ikind (Cil.typeOf e') in
+              match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik 1, Cil.typeOf e'),i')) with
               | `Bool true -> xm
               | _ ->
                 begin
@@ -393,7 +398,8 @@ struct
             | _ -> xm)
 
             (
-              match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.integer (-1), Cil.intType),i')) with
+              let ik = get_ikind (Cil.typeOf e') in
+              match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik (-1), Cil.typeOf e'),i')) with
               | `Bool true -> xm
               | _ ->
                 begin

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -224,6 +224,7 @@ struct
     | AddrOf l -> occurs_lv l
     | UnOp (_,e,_) -> occurs x e
     | BinOp (_,e1,e2,_) -> occurs x e1 || occurs x e2
+    | CastE (_,e) -> occurs x e
     | _ -> false
 
   let replace (x:varinfo) (exp: exp) (e:exp): exp =
@@ -243,6 +244,7 @@ struct
       | AddrOf l -> Lval (replace_lv l)
       | UnOp (op,e,t) -> UnOp (op, replace_rv e, t)
       | BinOp (op,e1,e2,t) -> BinOp (op, replace_rv e1, replace_rv e2, t)
+      | CastE (t,e) -> CastE(t, replace_rv e)
       | x -> x
     in
     constFold true (replace_rv e)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -708,8 +708,8 @@ struct
   let starting x = if x > 0L then not_zero else top ()
   let ending x = if x < 0L then not_zero else top ()
 
-  let max_of_range r = BatOption.map (fun i -> Int64.(pred @@ shift_left 1L (to_int i))) (R.maximal r)
-  let min_of_range r = BatOption.map (fun i -> Int64.(neg @@ shift_left 1L (to_int (neg i)))) (R.minimal r)
+  let max_of_range r = Option.map (fun i -> Int64.(pred @@ shift_left 1L (to_int i))) (R.maximal r)
+  let min_of_range r = Option.map (fun i -> Int64.(if i = zero then zero else neg @@ shift_left 1L (to_int (neg i)))) (R.minimal r)
   let maximal : t -> int64 option = function
     | `Definite x -> Integers.to_int x
     | `Excluded (s,r) -> max_of_range r

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1470,7 +1470,7 @@ module IntDomTuple = struct
   let minimal = flat List.max % mapp { fp = fun (type a) (module I:S with type t = a) -> I.minimal }
   let maximal = flat List.min % mapp { fp = fun (type a) (module I:S with type t = a) -> I.maximal }
   (* exists/for_all *)
-  let is_bot = for_all % mapp { fp = fun (type a) (module I:S with type t = a) -> I.is_bot }
+  let is_bot = exists % mapp { fp = fun (type a) (module I:S with type t = a) -> I.is_bot }
   let is_top = for_all % mapp { fp = fun (type a) (module I:S with type t = a) -> I.is_top }
   let is_int = exists % mapp { fp = fun (type a) (module I:S with type t = a) -> I.is_int }
   let is_bool = exists % mapp { fp = fun (type a) (module I:S with type t = a) -> I.is_bool }

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -199,6 +199,21 @@ struct
 
   let starting n = norm @@ Some (n,max_int)
   let ending   n = norm @@ Some (min_int,n)
+
+  let starting_ikind ik n =
+    try
+      norm @@
+      let _, u = Size.range ik in
+      Some (n,u)
+    with Size.Not_in_int64 -> starting n
+
+  let ending_ikind ik n =
+    try
+      norm @@
+      let l, _ = Size.range ik in
+      Some (l,n)
+    with Size.Not_in_int64 -> ending n
+
   let maximal = function None -> None | Some (x,y) -> Some y
   let minimal = function None -> None | Some (x,y) -> Some x
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -818,12 +818,7 @@ struct
   (* TODO: lift does not treat Not {0} as true. *)
   let logand = lift2 Integers.logand
   let logor  = lift2 Integers.logor
-  let lognot x =
-    match x with
-    | `Definite (_,r)
-    | `Excluded (_,r) ->
-        eq (`Definite (Int64.zero, r)) x
-    | `Bot -> `Bot
+  let lognot = eq zero
 
   let invariant c (x:t) = match x with
     | `Definite x -> Invariant.of_string (c ^ " == " ^ Int64.to_string x)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -888,10 +888,10 @@ struct
     | _ -> lift2_inj Integers.mul x y
   let div  = lift2 Integers.div
   let rem  = lift2 Integers.rem
-  let lt x y = cast_to IInt @@ lift2 Integers.lt x y
-  let gt x y = cast_to IInt @@ lift2 Integers.gt x y
-  let le x y = cast_to IInt @@ lift2 Integers.le x y
-  let ge x y = cast_to IInt @@ lift2 Integers.ge x y
+  let lt x y = lift2 Integers.lt x y
+  let gt x y = lift2 Integers.gt x y
+  let le x y = lift2 Integers.le x y
+  let ge x y = lift2 Integers.ge x y
   let bitnot = lift1 Integers.bitnot
   let bitand = lift2 Integers.bitand
   let bitor  = lift2 Integers.bitor

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -747,8 +747,16 @@ struct
     | None -> if x < 0L then not_zero else top ()
 
 
-  let max_of_range r = BatOption.map (fun i -> Int64.(pred @@ shift_left 1L (to_int i))) (R.maximal r)
-  let min_of_range r = BatOption.map (fun i -> Int64.(if i = zero then zero else neg @@ shift_left 1L (to_int (neg i)))) (R.minimal r)
+  let max_of_range r =
+    match R.maximal r with
+    | Some i when i < 64L -> Some(Int64.(pred @@ shift_left 1L (to_int i))) (* things that are bigger than (2^63)-1 can not be represented as int64 *)
+    | _ -> None
+
+  let min_of_range r =
+    match R.minimal r with
+    | Some i when i > -64L -> Some(Int64.(if i = 0L then 0L else neg @@ shift_left 1L (to_int (neg i)))) (* things that are smaller than (-2^63) can not be represented as int64 *)
+    | _ -> None
+
   let maximal : t -> int64 option = function
     | `Definite x -> Integers.to_int x
     | `Excluded (s,r) -> max_of_range r

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -764,7 +764,7 @@ struct
     | _ -> top ()
 
   (* For the shift operations, CIL does not cast the right argument to the type of the left argument,    *)
-  (* so we should not warn about operations on different types here. The result has teh type of the left *)
+  (* so we should not warn about operations on different types here. The result has the type of the left *)
   (* argument *)
   let lift2_special f x y = match x,y with
     (* The good case: *)
@@ -843,10 +843,10 @@ struct
     | _ -> lift2_inj Integers.mul x y
   let div  = lift2 Integers.div
   let rem  = lift2 Integers.rem
-  let lt = lift2 Integers.lt
-  let gt = lift2 Integers.gt
-  let le = lift2 Integers.le
-  let ge = lift2 Integers.ge
+  let lt x y = cast_to IInt @@ lift2 Integers.lt x y
+  let gt x y = cast_to IInt @@ lift2 Integers.gt x y
+  let le x y = cast_to IInt @@ lift2 Integers.le x y
+  let ge x y = cast_to IInt @@ lift2 Integers.ge x y
   let bitnot = lift1 Integers.bitnot
   let bitand = lift2 Integers.bitand
   let bitor  = lift2 Integers.bitor

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1478,6 +1478,7 @@ module IntDomTuple = struct
   let of_bool = create { fi = fun (type a) (module I:S with type t = a) -> I.of_bool }
   let of_excl_list t = create { fi = fun (type a) (module I:S with type t = a) -> I.of_excl_list t }
   let of_int = create { fi = fun (type a) (module I:S with type t = a) -> I.of_int }
+  let top_of = create { fi = fun (type a) (module I:S with type t = a) -> I.top_of }
   let starting = create { fi = fun (type a) (module I:S with type t = a) -> I.starting }
   let ending = create { fi = fun (type a) (module I:S with type t = a) -> I.ending }
   let of_interval = create { fi = fun (type a) (module I:S with type t = a) -> I.of_interval }

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -756,12 +756,13 @@ struct
       complain xr yr;
       (try `Definite (f x y,xr) with | Division_by_zero -> top ())
     (* We don't bother with exclusion sets: *)
-    | `Excluded _, _ -> top ()
-    | _, `Excluded _ -> top ()
-    (* The good case: *)
-    | `Definite x, `Definite y -> (try `Definite (f x y) with | Division_by_zero -> top ())
-    (* If any one of them is bottom, we return top *)
-    | _ -> top ()
+    | `Excluded (_, xr), `Definite(_, yr)
+    | `Definite (_, xr), `Excluded(_, yr)
+    | `Excluded (_, xr), `Excluded(_, yr) ->
+      check_identical_range xr yr;
+      `Excluded(S.empty (), xr)
+    (* If any one of them is bottom, we return bottom *)
+    | _ -> `Bot
 
   (* For the shift operations, CIL does not cast the right argument to the type of the left argument,    *)
   (* so we should not warn about operations on different types here. The result has the type of the left *)
@@ -774,12 +775,8 @@ struct
     | `Definite (_, xr), `Excluded(_, yr)
     | `Excluded (_, xr), `Excluded(_, yr) ->
       `Excluded(S.empty (), xr)
-    (* If any one of them is bottom, we return top *)
-    | `Bot, `Excluded(_, xr)
-    | `Bot, `Definite(_, xr)
-    | `Excluded(_ , xr), `Bot
-    | `Definite(_, xr), `Bot -> top ()
-    | `Bot, `Bot -> top ()
+    (* If any one of them is bottom, we return bottom *)
+    | _ -> `Bot
 
   (* Default behaviour for binary operators that are injective in either
    * argument, so that Exclusion Sets can be used: *)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -25,7 +25,6 @@ sig
   val of_interval: int64 * int64 -> t
   val starting   : ?ikind:Cil.ikind -> int64 -> t
   val ending     : ?ikind:Cil.ikind -> int64 -> t
-  val top_of     : Cil.ikind -> t
   val maximal    : t -> int64 option
   val minimal    : t -> int64 option
 
@@ -1523,7 +1522,6 @@ module IntDomTuple = struct
   let of_bool = create { fi = fun (type a) (module I:S with type t = a) -> I.of_bool }
   let of_excl_list t = create { fi = fun (type a) (module I:S with type t = a) -> I.of_excl_list t }
   let of_int = create { fi = fun (type a) (module I:S with type t = a) -> I.of_int }
-  let top_of = create { fi = fun (type a) (module I:S with type t = a) -> I.top_of }
   let starting ?ikind = create { fi = fun (type a) (module I:S with type t = a) x -> match ikind with | None -> I.starting x | Some ik -> I.starting ~ikind:ik x } (* Does not compile without making x explicit *)
   let ending ?ikind = create { fi = fun (type a) (module I:S with type t = a) x -> match ikind with | None -> I.ending x | Some ik -> I.ending  ~ikind:ik x } (* Does not compile without making x explicit *)
   let of_interval = create { fi = fun (type a) (module I:S with type t = a) -> I.of_interval }

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -793,22 +793,6 @@ struct
       (* If only one of them is bottom, we raise an exception that eval_rv will catch *)
       raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
 
-  (* For the shift operations, CIL does not cast the right argument to the type of the left argument,    *)
-  (* so we should not warn about operations on different types here. The result has the type of the left *)
-  (* argument *)
-  let lift2_special f x y = match x,y with
-    (* The good case: *)
-    | `Definite x, `Definite y -> (try `Definite (f x y) with | Division_by_zero -> top ())
-    (* We don't bother with exclusion sets: *)
-    | `Excluded (_, r), `Definite _
-    | `Definite _, `Excluded (_, r)
-    | `Excluded (_, r), `Excluded (_, _) ->
-      `Excluded (S.empty (), r)
-    | `Bot, `Bot -> `Bot
-    | _ ->
-      (* If only one of them is bottom, we raise an exception that eval_rv will catch *)
-      raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
-
   (* Default behaviour for binary operators that are injective in either
    * argument, so that Exclusion Sets can be used: *)
   let lift2_inj f x y = match x,y with
@@ -879,20 +863,20 @@ struct
     | _ -> lift2_inj Integers.mul x y
   let div  = lift2 Integers.div
   let rem  = lift2 Integers.rem
-  let lt x y = lift2 Integers.lt x y
-  let gt x y = lift2 Integers.gt x y
-  let le x y = lift2 Integers.le x y
-  let ge x y = lift2 Integers.ge x y
+  let lt = lift2 Integers.lt
+  let gt = lift2 Integers.gt
+  let le = lift2 Integers.le
+  let ge= lift2 Integers.ge
   let bitnot = lift1 Integers.bitnot
   let bitand = lift2 Integers.bitand
   let bitor  = lift2 Integers.bitor
   let bitxor = lift2 Integers.bitxor
-  let shift_left  = lift2_special Integers.shift_left  (* Careful, CIL does not guarantee the types of left and right arg are the same *)
-  let shift_right = lift2_special Integers.shift_right (* Careful, CIL does not guarantee the types of left and right arg are the same *)
+  let shift_left  = lift2 Integers.shift_left
+  let shift_right = lift2 Integers.shift_right
   (* TODO: lift does not treat Not {0} as true. *)
   let logand = lift2 Integers.logand
   let logor  = lift2 Integers.logor
-  let lognot = eq zero
+  let lognot = eq (of_int 0L)
 
   let invariant c (x:t) = match x with
     | `Definite x -> Invariant.of_string (c ^ " == " ^ Int64.to_string x)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -104,14 +104,16 @@ end
 module StdTop (B: sig type t val top: unit -> t end) = struct
   open B
   (* these should be overwritten for better precision if possible: *)
-  let to_excl_list x = None
-  let of_excl_list t x = top ()
-  let is_excl_list x = false
-  let of_interval  x = top ()
-  let starting     x = top ()
-  let ending       x = top ()
-  let maximal      x = None
-  let minimal      x = None
+  let to_excl_list   x = None
+  let of_excl_list   t x = top ()
+  let is_excl_list   x = false
+  let of_interval    x = top ()
+  let starting       x = top ()
+  let starting_ikind t x = top ()
+  let ending         x = top ()
+  let ending_ikind   t x = top ()
+  let maximal        x = None
+  let minimal        x = None
 end
 
 module Std (B: sig

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -708,8 +708,8 @@ struct
   let starting x = if x > 0L then not_zero else top ()
   let ending x = if x < 0L then not_zero else top ()
 
-  let max_of_range r = Option.map (fun i -> Int64.(pred @@ shift_left 1L (to_int i))) (R.maximal r)
-  let min_of_range r = Option.map (fun i -> Int64.(if i = zero then zero else neg @@ shift_left 1L (to_int (neg i)))) (R.minimal r)
+  let max_of_range r = BatOption.map (fun i -> Int64.(pred @@ shift_left 1L (to_int i))) (R.maximal r)
+  let min_of_range r = BatOption.map (fun i -> Int64.(if i = zero then zero else neg @@ shift_left 1L (to_int (neg i)))) (R.minimal r)
   let maximal : t -> int64 option = function
     | `Definite x -> Integers.to_int x
     | `Excluded (s,r) -> max_of_range r

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -636,9 +636,10 @@ struct
 
   let cast_to t = function
     | `Excluded (s,r) ->
-      let r' = size t in (* target range *)
-      `Excluded (if R.leq r r' then S.map (Integers.cast_to t) s, r' else S.empty (), r') (* TODO can we do better here? *)
-    | `Definite x -> (try `Definite (Integers.cast_to t x) with Size.Not_in_int64 -> top_of t)
+      (let r' = size t in (* target range *)
+      try `Excluded (if R.leq r r' then S.map (Integers.cast_to t) s, r' else S.empty (), r') (* TODO can we do better here? *) with
+      Size.Not_in_int64 -> top_of t)
+    | `Definite (x, r) -> (try `Definite (Integers.cast_to t x, size t) with Size.Not_in_int64 -> top_of t)
     | `Bot -> `Bot
 
   let leq x y = match (x,y) with

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -102,6 +102,10 @@ module Size = struct (* size in bits as int, range as int64 *)
     try int64_of_big_int y with _ -> raise Not_in_int64
 end
 
+exception Unknown
+exception Error
+exception ArithmeticOnIntegerBot of string
+
 module StdTop (B: sig type t val top: unit -> t end) = struct
   open B
   (* these should be overwritten for better precision if possible: *)
@@ -249,8 +253,9 @@ struct
 
   let log f i1 i2 =
     match is_bot i1, is_bot i2 with
+    | true, true -> bot ()
     | true, _
-    | _   , true -> bot ()
+    | _   , true -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 i1) (short 80 i2)))
     | _ ->
       match to_bool i1, to_bool i2 with
       | Some x, Some y -> of_bool (f x y)
@@ -271,8 +276,9 @@ struct
 
   let bit f i1 i2 =
     match is_bot i1, is_bot i2 with
+    | true, true -> bot ()
     | true, _
-    | _   , true -> bot ()
+    | _   , true -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 i1) (short 80 i2)))
     | _ ->
       match to_int i1, to_int i2 with
       | Some x, Some y -> (try norm (of_int (f x y)) with Division_by_zero -> top ())
@@ -298,7 +304,8 @@ struct
 
   let add x y =
     match x, y with
-    | None, _ | _, None -> None
+    | None, None -> None
+    | None, _ | _, None -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
     | Some (x1,x2), Some (y1,y2) -> norm @@ Some (Int64.add x1 y1, Int64.add x2 y2)
 
   let sub i1 i2 = add i1 (neg i2)
@@ -309,7 +316,8 @@ struct
 
   let mul x y =
     match x, y with
-    | None, _ | _, None -> bot ()
+    | None, None -> bot ()
+    | None, _ | _, None -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
     | Some (x1,x2), Some (y1,y2) ->
       let x1y1 = (Int64.mul x1 y1) in let x1y2 = (Int64.mul x1 y2) in
       let x2y1 = (Int64.mul x2 y1) in let x2y2 = (Int64.mul x2 y2) in
@@ -318,7 +326,8 @@ struct
 
   let rec div x y =
     match x, y with
-    | None, _ | _, None -> bot ()
+    | None, None -> bot ()
+    | None, _ | _, None -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
     | Some (x1,x2), Some (y1,y2) ->
       begin match y1, y2 with
         | 0L, 0L       -> top () (* TODO warn about undefined behavior *)
@@ -339,7 +348,8 @@ struct
 
   let ge x y =
     match x, y with
-    | None, _ | _, None -> None
+    | None, None -> bot ()
+    | None, _ | _, None -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
     | Some (x1,x2), Some (y1,y2) ->
       if Int64.compare y2 x1 <= 0 then of_bool true
       else if Int64.compare x2 y1 < 0 then of_bool false
@@ -347,7 +357,8 @@ struct
 
   let le x y =
     match x, y with
-    | None, _ | _, None -> None
+    | None, None -> bot ()
+    | None, _ | _, None -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
     | Some (x1,x2), Some (y1,y2) ->
       if Int64.compare x2 y1 <= 0 then of_bool true
       else if Int64.compare  y2 x1 < 0 then of_bool false
@@ -355,7 +366,8 @@ struct
 
   let gt x y =
     match x, y with
-    | None, _ | _, None -> None
+    | None, None -> bot ()
+    | None, _ | _, None -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
     | Some (x1,x2), Some (y1,y2) ->
       if Int64.compare  y2 x1 < 0 then of_bool true
       else if Int64.compare x2 y1 <= 0 then of_bool false
@@ -363,7 +375,8 @@ struct
 
   let lt x y =
     match x, y with
-    | None, _ | _, None -> None
+    | None, None -> bot ()
+    | None, _ | _, None -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
     | Some (x1,x2), Some (y1,y2) ->
       if Int64.compare x2 y1 < 0 then of_bool true
       else if Int64.compare y2 x1 <= 0 then of_bool false
@@ -381,8 +394,6 @@ struct
 end
 
 
-exception Unknown
-exception Error
 
 module Integers = (* no top/bot, order is <= *)
 struct
@@ -773,8 +784,10 @@ struct
     | `Excluded (_, xr), `Excluded(_, yr) ->
       check_identical_range xr yr;
       `Excluded(S.empty (), xr)
-    (* If any one of them is bottom, we return bottom *)
-    | _ -> `Bot
+    | ` Bot, `Bot -> `Bot
+    | _ ->
+      (* If only one of them is bottom, we raise an exception that eval_rv will catch *)
+      raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
 
   (* For the shift operations, CIL does not cast the right argument to the type of the left argument,    *)
   (* so we should not warn about operations on different types here. The result has the type of the left *)
@@ -787,8 +800,10 @@ struct
     | `Definite (_, xr), `Excluded(_, yr)
     | `Excluded (_, xr), `Excluded(_, yr) ->
       `Excluded(S.empty (), xr)
-    (* If any one of them is bottom, we return bottom *)
-    | _ -> `Bot
+    | `Bot, `Bot -> `Bot
+    | _ ->
+      (* If only one of them is bottom, we raise an exception that eval_rv will catch *)
+      raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
 
   (* Default behaviour for binary operators that are injective in either
    * argument, so that Exclusion Sets can be used: *)
@@ -813,9 +828,13 @@ struct
       | _ , _ -> top_range in
       `Excluded (S.map (f x) s, r')
     (* The good case: *)
-    | `Definite x, `Definite y -> `Definite (f x y)
-    (* If any one of them is bottom, we return bottom *)
-    | _ -> `Bot
+    | `Definite (x,xr), `Definite (y,yr) ->
+      check_identical_range xr yr;
+      `Definite (f x y, xr)
+    | `Bot, `Bot -> `Bot
+    | _ ->
+      (* If only one of them is bottom, we raise an exception that eval_rv will catch *)
+      raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
 
   (* The equality check: *)
   let eq x y = match x,y with
@@ -826,9 +845,13 @@ struct
     | `Definite x, `Excluded (s,r) -> if S.mem x s then of_bool false else top ()
     | `Excluded (s,r), `Definite x -> if S.mem x s then of_bool false else top ()
     (* The good case: *)
-    | `Definite x, `Definite y -> of_bool_cmp (x=y)
-    (* If either one of them is bottom, we return bottom *)
-    | _ -> `Bot
+    | `Definite (x,xr), `Definite (y,yr) ->
+      check_identical_range xr yr;
+      if x=y then t else f
+    | `Bot, `Bot -> `Bot
+    | _ ->
+      (* If only one of them is bottom, we raise an exception that eval_rv will catch *)
+      raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
 
   (* The inequality check: *)
   let ne x y = match x,y with
@@ -839,9 +862,13 @@ struct
     | `Definite x, `Excluded (s,r) -> if S.mem x s then of_bool true else top ()
     | `Excluded (s,r), `Definite x -> if S.mem x s then of_bool true else top ()
     (* The good case: *)
-    | `Definite x, `Definite y -> of_bool_cmp (x<>y)
-    (* If either one of them is bottom, we return bottom *)
-    | _ -> `Bot
+    | `Definite (x,xr), `Definite (y,yr) ->
+      check_identical_range xr yr;
+      if x=y then f else t
+    | `Bot, `Bot -> `Bot
+    | _ ->
+      (* If only one of them is bottom, we raise an exception that eval_rv will catch *)
+      raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))
 
   let neg  = lift1 Integers.neg
   let add  = lift2_inj Integers.add

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -670,10 +670,6 @@ struct
     (* Excluding X <= Excluding Y whenever Y <= X *)
     | `Excluded (x,xw), `Excluded (y,yw) -> S.subset y x && R.leq xw yw
 
-  (* checks that x and y have the same range, and fails if this is not the case *)
-  let check_identical_range x y =
-    if x <> y then print_endline (Printf.sprintf "Operation on different sizes of int %s %s" (R.short 80 x) (R.short 80 y))
-
   let join x y =
     match (x,y) with
     (* The least upper bound with the bottom element: *)
@@ -778,17 +774,14 @@ struct
     | `Bot -> `Bot
 
   let lift2 f x y = match x,y with
+    (* We don't bother with exclusion sets: *)
+    | `Excluded _, `Definite _
+    | `Definite _, `Excluded _
+    | `Excluded _, `Excluded _ -> top ()
     (* The good case: *)
     | `Definite x, `Definite y ->
       (try `Definite (f x y) with | Division_by_zero -> top ())
-    (* We don't bother with exclusion sets: *)
-    | `Excluded (_, r), `Definite _
-    | `Definite _, `Excluded (_, r) ->
-      `Excluded (S.empty (), r)
-    | `Excluded (_, xr), `Excluded (_, yr) ->
-      check_identical_range xr yr;
-      `Excluded (S.empty (), xr)
-    | ` Bot, `Bot -> `Bot
+    | `Bot, `Bot -> `Bot
     | _ ->
       (* If only one of them is bottom, we raise an exception that eval_rv will catch *)
       raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 x) (short 80 y)))

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -818,7 +818,12 @@ struct
   (* TODO: lift does not treat Not {0} as true. *)
   let logand = lift2 Integers.logand
   let logor  = lift2 Integers.logor
-  let lognot = eq (of_int 0L)
+  let lognot x =
+    match x with
+    | `Definite (_,r)
+    | `Excluded (_,r) ->
+        eq (`Definite (Int64.zero, r)) x
+    | `Bot -> `Bot
 
   let invariant c (x:t) = match x with
     | `Definite x -> Invariant.of_string (c ^ " == " ^ Int64.to_string x)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -23,8 +23,9 @@ sig
   val of_excl_list: Cil.ikind -> int64 list -> t
   val is_excl_list: t -> bool
   val of_interval: int64 * int64 -> t
-  val starting   : int64 -> t
-  val ending     : int64 -> t
+  val starting   : ?ikind:Cil.ikind -> int64 -> t
+  val ending     : ?ikind:Cil.ikind -> int64 -> t
+  val top_of     : Cil.ikind -> t
   val maximal    : t -> int64 option
   val minimal    : t -> int64 option
 
@@ -104,16 +105,14 @@ end
 module StdTop (B: sig type t val top: unit -> t end) = struct
   open B
   (* these should be overwritten for better precision if possible: *)
-  let to_excl_list   x = None
-  let of_excl_list   t x = top ()
-  let is_excl_list   x = false
-  let of_interval    x = top ()
-  let starting       x = top ()
-  let starting_ikind t x = top ()
-  let ending         x = top ()
-  let ending_ikind   t x = top ()
-  let maximal        x = None
-  let minimal        x = None
+  let to_excl_list    x = None
+  let of_excl_list    t x = top ()
+  let is_excl_list    x = false
+  let of_interval     x = top ()
+  let starting ?ikind x = top ()
+  let ending ?ikind   x = top ()
+  let maximal         x = None
+  let minimal         x = None
 end
 
 module Std (B: sig
@@ -199,22 +198,25 @@ struct
     | None | Some (0L, 0L) -> x
     | _ -> if leq zero x then top_bool else one
 
-  let starting n = norm @@ Some (n,max_int)
-  let ending   n = norm @@ Some (min_int,n)
+  let starting ?ikind n =
+    match ikind with
+    | Some ik ->
+      (try
+        norm @@
+        let _, u = Size.range ik in
+        Some (n,u)
+      with Size.Not_in_int64 -> norm @@ Some (n,max_int))
+    | None -> norm @@ Some (n,max_int)
 
-  let starting_ikind ik n =
-    try
-      norm @@
-      let _, u = Size.range ik in
-      Some (n,u)
-    with Size.Not_in_int64 -> starting n
-
-  let ending_ikind ik n =
-    try
-      norm @@
-      let l, _ = Size.range ik in
-      Some (l,n)
-    with Size.Not_in_int64 -> ending n
+  let ending ?ikind n =
+    match ikind with
+    | Some ik ->
+      (try
+        norm @@
+        let l, _ = Size.range ik in
+        Some (l,n)
+      with Size.Not_in_int64 -> norm @@ Some (min_int,n))
+    | None -> norm @@ Some (min_int,n)
 
   let maximal = function None -> None | Some (x,y) -> Some y
   let minimal = function None -> None | Some (x,y) -> Some x
@@ -482,8 +484,8 @@ struct
   let of_excl_list t x = top ()
   let is_excl_list x = false
   let of_interval  x = top ()
-  let starting     x = top ()
-  let ending       x = top ()
+  let starting     ?ikind x = top ()
+  let ending       ?ikind x = top ()
   let maximal      x = None
   let minimal      x = None
 
@@ -723,8 +725,16 @@ struct
     | _ -> false
 
   let of_interval (x,y) = if Int64.compare x y == 0 then of_int x else top ()
-  let starting x = if x > 0L then not_zero else top ()
-  let ending x = if x < 0L then not_zero else top ()
+
+  let starting ?ikind x =
+    match ikind with
+    | Some ik -> if x > 0L then not_zero_ikind ik else top_of ik
+    | None -> if x > 0L then not_zero else top ()
+  let ending ?ikind x =
+    match ikind with
+    | Some ik -> if x < 0L then not_zero_ikind ik else top_of ik
+    | None -> if x < 0L then not_zero else top ()
+
 
   let max_of_range r = BatOption.map (fun i -> Int64.(pred @@ shift_left 1L (to_int i))) (R.maximal r)
   let min_of_range r = BatOption.map (fun i -> Int64.(if i = zero then zero else neg @@ shift_left 1L (to_int (neg i)))) (R.minimal r)
@@ -951,12 +961,12 @@ struct
   let is_excl_list x = false
 
   (* Starting/Ending *)
-  let starting x =
+  let starting ?ikind x =
     let r = I.of_t max_width (C.of_int64 max_width x) (C.max_value max_width)
     in
     print_endline ("starting: "^(I.to_string r)^" .. "^(Int64.to_string x));
     r
-  let ending x =
+  let ending ?ikind x =
     let r = I.of_t max_width C.zero (C.of_int64 max_width x)
     in
     print_endline ("ending: "^(I.to_string r)^" .. "^(Int64.to_string x));
@@ -1418,8 +1428,8 @@ module Enums : S = struct
   let to_excl_list = function Exc (x,r) when x<>[] -> Some x | _ -> None
   let of_excl_list t x = Exc (x, size t)
   let is_excl_list = BatOption.is_some % to_excl_list
-  let starting     x = top ()
-  let ending       x = top ()
+  let starting     ?ikind x = top ()
+  let ending       ?ikind x = top ()
   let maximal = function Inc xs when xs<>[] -> Some (List.last xs) | _ -> None
   let minimal = function Inc (x::xs) -> Some x | _ -> None
   (* let of_incl_list xs = failwith "TODO" *)
@@ -1479,8 +1489,8 @@ module IntDomTuple = struct
   let of_excl_list t = create { fi = fun (type a) (module I:S with type t = a) -> I.of_excl_list t }
   let of_int = create { fi = fun (type a) (module I:S with type t = a) -> I.of_int }
   let top_of = create { fi = fun (type a) (module I:S with type t = a) -> I.top_of }
-  let starting = create { fi = fun (type a) (module I:S with type t = a) -> I.starting }
-  let ending = create { fi = fun (type a) (module I:S with type t = a) -> I.ending }
+  let starting ?ikind = create { fi = fun (type a) (module I:S with type t = a) x -> match ikind with | None -> I.starting x | Some ik -> I.starting ~ikind:ik x } (* Does not compile without making x explicit *)
+  let ending ?ikind = create { fi = fun (type a) (module I:S with type t = a) x -> match ikind with | None -> I.ending x | Some ik -> I.ending  ~ikind:ik x } (* Does not compile without making x explicit *)
   let of_interval = create { fi = fun (type a) (module I:S with type t = a) -> I.of_interval }
 
   (* f1: unary ops *)

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -44,7 +44,6 @@ sig
   val of_interval: int64 * int64 -> t
   val starting   : ?ikind:Cil.ikind -> int64 -> t
   val ending     : ?ikind:Cil.ikind -> int64 -> t
-  val top_of     : Cil.ikind -> t
   val maximal    : t -> int64 option
   val minimal    : t -> int64 option
 

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -137,6 +137,8 @@ module Size : sig
   (** The biggest type we support for integers. *)
 end
 
+exception ArithmeticOnIntegerBot of string
+
 exception Unknown
 (** An exception that can be raised when the result of a computation is unknown.
   * This is caught by lifted domains and will be replaced by top. *)

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -42,8 +42,9 @@ sig
   (* Checks if the element is an exclusion set. *)
 
   val of_interval: int64 * int64 -> t
-  val starting   : int64 -> t
-  val ending     : int64 -> t
+  val starting   : ?ikind:Cil.ikind -> int64 -> t
+  val ending     : ?ikind:Cil.ikind -> int64 -> t
+  val top_of     : Cil.ikind -> t
   val maximal    : t -> int64 option
   val minimal    : t -> int64 option
 

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -17,7 +17,7 @@ sig
   include Lattice.S
   type offs
   val eval_offset: Q.ask -> (AD.t -> t) -> t-> offs -> exp option -> lval option -> t
-  val update_offset: Q.ask -> t -> offs -> t -> exp option -> lval -> t
+  val update_offset: Q.ask -> t -> offs -> t -> exp option -> lval -> typ -> t
   val update_array_lengths: (exp -> t) -> t -> Cil.typ -> t
   val affect_move: ?replace_with_const:bool -> Q.ask -> t -> varinfo -> (exp -> int option) -> t
   val affecting_vars: t -> varinfo list
@@ -359,6 +359,7 @@ struct
                 | _ -> log_top __POS__; Unions.top ()
               )
         (* | _ -> log_top (); `Top *)
+        | TVoid _ -> log_top __POS__; `Top
         | _ -> log_top __POS__; assert false
       in
       Messages.tracel "cast" "cast %a to %a is %a!\n" pretty v d_type t pretty v'; v'
@@ -747,19 +748,19 @@ struct
     in
     do_eval_offset ask f x offs exp l o v
 
-  let update_offset (ask: Q.ask) (x:t) (offs:offs) (value:t) (exp:exp option) (v:lval): t =
-    let rec do_update_offset (ask:Q.ask) (x:t) (offs:offs) (value:t) (exp:exp option) (l:lval option) (o:offset option) (v:lval):t =
+  let update_offset (ask: Q.ask) (x:t) (offs:offs) (value:t) (exp:exp option) (v:lval) (t:typ): t =
+    let rec do_update_offset (ask:Q.ask) (x:t) (offs:offs) (value:t) (exp:exp option) (l:lval option) (o:offset option) (v:lval) (t:typ):t =
       let mu = function `Blob (`Blob (y, s'), s) -> `Blob (y, ID.join s s') | x -> x in
       match x, offs with
       | `Blob (x,s), `Index (_,ofs) ->
         begin
           let l', o' = shift_one_over l o in
-          mu (`Blob (join x (do_update_offset ask x ofs value exp l' o' v), s))
+          mu (`Blob (join x (do_update_offset ask x ofs value exp l' o' v t), s))
         end
       | `Blob (x,s),_ ->
         begin
           let l', o' = shift_one_over l o in
-          mu (`Blob (join x (do_update_offset ask x offs value exp l' o' v), s))
+          mu (`Blob (join x (do_update_offset ask x offs value exp l' o' v t), s))
         end
       | _ ->
       let result =
@@ -767,14 +768,16 @@ struct
         | `NoOffset -> begin
             match value with
             | `Blob (y,s) -> mu (`Blob (join x y, s))
+            | `Int _ -> cast t value
             | _ -> value
           end
         | `Field (fld, offs) when fld.fcomp.cstruct -> begin
+            let t = fld.ftype in
             match x with
             | `Struct str ->
               begin
                 let l', o' = shift_one_over l o in
-                let value' =  (do_update_offset ask (Structs.get str fld) offs value exp l' o' v) in
+                let value' =  (do_update_offset ask (Structs.get str fld) offs value exp l' o' v t) in
                 `Struct (Structs.replace str fld value')
               end
             | `Bot ->
@@ -785,11 +788,12 @@ struct
               in
               let strc = init_comp fld.fcomp in
               let l', o' = shift_one_over l o in
-              `Struct (Structs.replace strc fld (do_update_offset ask `Bot offs value exp l' o' v))
+              `Struct (Structs.replace strc fld (do_update_offset ask `Bot offs value exp l' o' v t))
             | `Top -> M.warn "Trying to update a field, but the struct is unknown"; top ()
             | _ -> M.warn "Trying to update a field, but was not given a struct"; top ()
           end
         | `Field (fld, offs) -> begin
+            let t = fld.ftype in
             let l', o' = shift_one_over l o in
             match x with
             | `Union (last_fld, prev_val) ->
@@ -818,8 +822,8 @@ struct
                     top (), offs
                 end
               in
-              `Union (`Lifted fld, do_update_offset ask tempval tempoffs value exp l' o' v)
-            | `Bot -> `Union (`Lifted fld, do_update_offset ask `Bot offs value exp l' o' v)
+              `Union (`Lifted fld, do_update_offset ask tempval tempoffs value exp l' o' v t)
+            | `Bot -> `Union (`Lifted fld, do_update_offset ask `Bot offs value exp l' o' v t)
             | `Top -> M.warn "Trying to update a field, but the union is unknown"; top ()
             | _ -> M.warn_each "Trying to update a field, but was not given a union"; top ()
           end
@@ -827,13 +831,16 @@ struct
             let l', o' = shift_one_over l o in
             match x with
             | `Array x' ->
-              let e = determine_offset ask l o exp (Some v) in
-              let new_value_at_index = do_update_offset ask (CArrays.get ask x' (e,idx)) offs value exp l' o' v in
-              let new_array_value = CArrays.set ask x' (e, idx) new_value_at_index in
-              `Array new_array_value
+              (match t with
+              | TArray(t1 ,_,_) ->
+                let e = determine_offset ask l o exp (Some v) in
+                let new_value_at_index = do_update_offset ask (CArrays.get ask x' (e,idx)) offs value exp l' o' v t1 in
+                let new_array_value = CArrays.set ask x' (e, idx) new_value_at_index in
+                `Array new_array_value
+              | _ ->  M.warn "Trying to update an array, but the type was not array"; top ())
             | `Bot ->  M.warn_each("encountered array bot, made array top"); `Array (CArrays.top ());
             | `Top -> M.warn "Trying to update an index, but the array is unknown"; top ()
-            | x when IndexDomain.to_int idx = Some 0L -> do_update_offset ask x offs value exp l' o' v
+            | x when IndexDomain.to_int idx = Some 0L -> do_update_offset ask x offs value exp l' o' v t
             | _ -> M.warn_each ("Trying to update an index, but was not given an array("^short 80 x^")"); top ()
           end
       in mu result
@@ -842,7 +849,7 @@ struct
       | Some(Lval (x,o)) -> Some ((x, NoOffset)), Some(o)
       | _ -> None, None
     in
-    do_update_offset ask x offs value exp l o v
+    do_update_offset ask x offs value exp l o v t
 
   let rec affect_move ?(replace_with_const=false) ask (x:t) (v:varinfo) movement_for_expr:t =
     let move_fun x = affect_move ~replace_with_const:replace_with_const ask x v movement_for_expr in

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -263,7 +263,7 @@ struct
             (* array to its first element *)
             | TArray _, _ ->
               M.tracel "casta" "cast array to its first element\n";
-              adjust_offs v (Addr.add_offsets o (`Index (IndexDomain.of_int_ikind (Cilfacade.ptrdiff_ikind ()) 0L, `NoOffset))) (Some false)
+              adjust_offs v (Addr.add_offsets o (`Index (IndexDomain.cast_to (Cilfacade.ptrdiff_ikind ()) @@ IndexDomain.of_int 0L, `NoOffset))) (Some false)
             | _ -> err @@ "Cast to neither array index nor struct field."
                           ^ Pretty.(sprint ~width:0 @@ dprintf " is_zero_offset: %b" (Addr.is_zero_offset o))
           end
@@ -300,7 +300,7 @@ struct
         | TInt (ik,_) ->
           `Int (ID.cast_to ik (match v with
               | `Int x -> x
-              | `Address x when AD.equal x AD.null_ptr -> ID.of_int_ikind (ptr_ikind ())  Int64.zero
+              | `Address x when AD.equal x AD.null_ptr -> ID.cast_to (ptr_ikind ()) @@ ID.of_int Int64.zero
               | `Address x when AD.is_not_null x -> ID.of_excl_list (ptr_ikind ()) [0L]
               (*| `Struct x when Structs.cardinal x > 0 ->
                 let some  = List.hd (Structs.keys x) in

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -90,7 +90,7 @@ struct
   type offs = (fieldinfo,IndexDomain.t) Lval.offs
 
 
-  let get_ikind t = match Cil.unrollType t with TInt (ik,_) -> ik | _ ->
+  let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
     (* important to unroll the type here, otherwise problems with typedefs *)
     M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
 

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -89,6 +89,14 @@ struct
 
   type offs = (fieldinfo,IndexDomain.t) Lval.offs
 
+
+  let get_ikind t = match Cil.unrollType t with TInt (ik,_) -> ik | _ ->
+    (* important to unroll the type here, otherwise problems with typedefs *)
+    M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
+
+  let ptrdiff_ikind () = get_ikind !ptrdiffType
+
+
   let bot () = `Bot
   let is_bot x = x = `Bot
   let bot_name = "Uninitialized"
@@ -262,7 +270,7 @@ struct
             (* array to its first element *)
             | TArray _, _ ->
               M.tracel "casta" "cast array to its first element\n";
-              adjust_offs v (Addr.add_offsets o (`Index (IndexDomain.of_int 0L, `NoOffset))) (Some false)
+              adjust_offs v (Addr.add_offsets o (`Index (IndexDomain.of_int_ikind (ptrdiff_ikind ()) 0L, `NoOffset))) (Some false)
             | _ -> err @@ "Cast to neither array index nor struct field."
                           ^ Pretty.(sprint ~width:0 @@ dprintf " is_zero_offset: %b" (Addr.is_zero_offset o))
           end

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -90,13 +90,6 @@ struct
   type offs = (fieldinfo,IndexDomain.t) Lval.offs
 
 
-  let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
-    (* important to unroll the type here, otherwise problems with typedefs *)
-    M.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
-
-  let ptrdiff_ikind () = get_ikind !ptrdiffType
-
-
   let bot () = `Bot
   let is_bot x = x = `Bot
   let bot_name = "Uninitialized"
@@ -270,7 +263,7 @@ struct
             (* array to its first element *)
             | TArray _, _ ->
               M.tracel "casta" "cast array to its first element\n";
-              adjust_offs v (Addr.add_offsets o (`Index (IndexDomain.of_int_ikind (ptrdiff_ikind ()) 0L, `NoOffset))) (Some false)
+              adjust_offs v (Addr.add_offsets o (`Index (IndexDomain.of_int_ikind (Cilfacade.ptrdiff_ikind ()) 0L, `NoOffset))) (Some false)
             | _ -> err @@ "Cast to neither array index nor struct field."
                           ^ Pretty.(sprint ~width:0 @@ dprintf " is_zero_offset: %b" (Addr.is_zero_offset o))
           end

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -241,7 +241,7 @@ let pstmt stmt = dumpStmt defaultCilPrinter stdout 0 stmt; print_newline ()
 let p_expr exp = Pretty.printf "%a\n" (printExp defaultCilPrinter) exp
 let d_expr exp = Pretty.printf "%a\n" (printExp plainCilPrinter) exp
 
-(* Returns the ikind of a TInt(_) and TEnum(_). Unrolls typedefs. Warns if a a different type is put it and return IInt *)
+(* Returns the ikind of a TInt(_) and TEnum(_). Unrolls typedefs. Warns if a a different type is put in and return IInt *)
 let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
   (* important to unroll the type here, otherwise problems with typedefs *)
   Messages.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -241,6 +241,13 @@ let pstmt stmt = dumpStmt defaultCilPrinter stdout 0 stmt; print_newline ()
 let p_expr exp = Pretty.printf "%a\n" (printExp defaultCilPrinter) exp
 let d_expr exp = Pretty.printf "%a\n" (printExp plainCilPrinter) exp
 
+(* Returns the ikind of a TInt(_) and TEnum(_). Unrolls typedefs. Warns if a a different type is put it and return IInt *)
+let get_ikind t = match Cil.unrollType t with TInt (ik,_) | TEnum ({ekind = ik; _},_) -> ik | _ ->
+  (* important to unroll the type here, otherwise problems with typedefs *)
+  Messages.warn "Something that we expected to be an integer type has a different type, assuming it is an IInt";  Cil.IInt
+
+let ptrdiff_ikind () = get_ikind !ptrdiffType
+
 let rec typeOf (e: exp) : typ =
   match e with
   | Const(CInt64 (_, ik, _)) -> TInt(ik, [])

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -202,6 +202,7 @@ let _ = ()
       ; reg Debugging "dbg.earlywarn"       "false" "Output warnings already while solving (may lead to spurious warnings/asserts that would disappear after narrowing)."
       ; reg Debugging "dbg.warn_with_context" "false" "Keep warnings for different contexts apart (currently only done for asserts)."
       ; reg Debugging "dbg.regression"      "false" "Only output warnings for assertions that have an unexpected result (no comment, comment FAIL, comment UNKNOWN)"
+      ; reg Debugging "dbg.fail_on_different_ikind" "false" "When doing operations in the int domain, fail if an operation is on performed on two ints of different ikinds"
 
 let default_schema = "\
 { 'id'              : 'root'

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -202,7 +202,6 @@ let _ = ()
       ; reg Debugging "dbg.earlywarn"       "false" "Output warnings already while solving (may lead to spurious warnings/asserts that would disappear after narrowing)."
       ; reg Debugging "dbg.warn_with_context" "false" "Keep warnings for different contexts apart (currently only done for asserts)."
       ; reg Debugging "dbg.regression"      "false" "Only output warnings for assertions that have an unexpected result (no comment, comment FAIL, comment UNKNOWN)"
-      ; reg Debugging "dbg.fail_on_different_ikind" "false" "When doing operations in the int domain, fail if an operation is on performed on two ints of different ikinds"
 
 let default_schema = "\
 { 'id'              : 'root'

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -1,0 +1,18 @@
+// --enable ana.int.def_exc --disable ana.int.interval
+void main()
+{
+  char yy[256];
+  char *ryy_j = &yy[1];
+
+  int i =0;
+
+  ryy_j++;
+  ryy_j++;
+
+  while(i < 2) { // Here
+    ryy_j = ryy_j + 1;
+    i++;
+  }
+
+  return;
+}

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -1,4 +1,5 @@
-// --enable ana.int.def_exc --disable ana.int.interval
+// PARAM: --enable ana.int.def_exc --disable ana.int.interval
+#include<stdbool.h>
 void main()
 {
   char yy[256];
@@ -44,5 +45,13 @@ void main()
   v = (v & 0xFFF0FFFF) |
 	    (((unsigned int) s1 ^ s2) << 16);
 
+  int tmp___1;
+  int *tmp___2;
+
+  _Bool  fclose_fail = (_Bool )(tmp___1 != 0);
+
+  if (! fclose_fail) {
+    *tmp___2 = 0;
+  }
   return;
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -65,6 +65,45 @@ void main()
   void const* b = (void const*) ci;
   test((void const *)ci);
 
+	for (i = 0; i <	 (((20) + (4) - 1)/(4)); i++) {
+
+	}
+
+
+  for (i = 0; i <	 (((20) + (8UL) - 1)/(8UL)); i++) {
+
+	}
+
+
+
+
+  unsigned long v = 8UL;
+  for (i = 0; i <	 (((20) + (8UL) - 1)/(v)); i++) {
+
+	}
+
+  i = 0;
+  if(i < 28UL/v) {
+    i++;
+  }
+
+  int gef = 75;
+
+  if(i < 28UL/v) {
+    i++;
+  }
+
+  gef = 38;
+
+  i =0;
+  for(; i < 28UL/v; i++) {
+
+  }
+
+	for (i = 0; i <	 (((20) + sizeof(unsigned long) - 1)/sizeof(unsigned long)); i++) {
+
+	}
+
 	for (i = 0; i <	 LONGS(20); i++) {
 
 	}

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -1,5 +1,7 @@
 // PARAM: --enable ana.int.def_exc --enable ana.int.interval
 #include<stdbool.h>
+
+typedef unsigned long custom_t;
 void main()
 {
   char yy[256];
@@ -56,10 +58,15 @@ void main()
 
   hash_initialize();
 
+
+
+  custom_t ci;
+  void const* b = (void const*) ci;
+  test((void const *)ci);
+
   return;
 }
 
-typedef unsigned long custom_t;
 
 struct hash_table {
   custom_t n_buckets ;
@@ -88,4 +95,12 @@ Hash_table *hash_initialize()
   free((void *)table___0);
 
   return ((Hash_table *)((void *)0));
+}
+
+int test(void const   *ptr) {
+  if(!ptr) {
+    int f = 7;
+  } else {
+    int f= 38;
+  }
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -1,4 +1,5 @@
 // PARAM: --enable ana.int.def_exc --enable ana.int.interval
+#define LONGS(x) (((x) + sizeof(unsigned long) - 1)/sizeof(unsigned long))
 #include<stdbool.h>
 
 typedef unsigned long custom_t;
@@ -63,6 +64,11 @@ void main()
   custom_t ci;
   void const* b = (void const*) ci;
   test((void const *)ci);
+
+	for (i = 0; i <	 LONGS(20); i++) {
+
+	}
+
 
   return;
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -9,10 +9,14 @@ void main()
   ryy_j++;
   ryy_j++;
 
-  while(i < 2) { // Here
+  while(i < 2) { // Here was an issue with a fixpoint not being reached
     ryy_j = ryy_j + 1;
     i++;
   }
+
+  // The type of ! needs to be IInt
+  long l;
+  int r = !l + 4;
 
   return;
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.def_exc --disable ana.int.interval
+// PARAM: --enable ana.int.def_exc --enable ana.int.interval
 #include<stdbool.h>
 void main()
 {
@@ -53,5 +53,39 @@ void main()
   if (! fclose_fail) {
     *tmp___2 = 0;
   }
+
+  hash_initialize();
+
   return;
+}
+
+typedef unsigned long custom_t;
+
+struct hash_table {
+  custom_t n_buckets ;
+};
+
+typedef struct hash_table Hash_table;
+
+Hash_table *hash_initialize()
+{ Hash_table *table___0 ;
+  void *tmp ;
+  _Bool tmp___0 ;
+  void *tmp___1 ;
+
+  tmp = malloc(sizeof(*table___0));
+
+  custom_t n;
+  table___0 = (Hash_table *)tmp;
+  table___0->n_buckets = n;
+
+  if (! table___0->n_buckets) {
+
+    goto fail;
+  }
+  fail:
+
+  free((void *)table___0);
+
+  return ((Hash_table *)((void *)0));
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -32,5 +32,17 @@ void main()
     t++;
   }
 
+  unsigned int v;
+  unsigned short s1, s2;
+
+  v = v & 0xFFF0FFFF;
+  v = v << 16;
+
+  v = (unsigned int)(((unsigned int) (s1 ^ s2)));
+  v = (unsigned int)(((unsigned int) (s1 ^ s2)) << (16));
+
+  v = (v & 0xFFF0FFFF) |
+	    (((unsigned int) s1 ^ s2) << 16);
+
   return;
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -99,8 +99,10 @@ Hash_table *hash_initialize()
 
 int test(void const   *ptr) {
   if(!ptr) {
+    assert(ptr == 0);
     int f = 7;
   } else {
+    assert(ptr != 0);
     int f= 38;
   }
 }

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -18,5 +18,19 @@ void main()
   long l;
   int r = !l + 4;
 
+  // From dtlk driver example, produces
+  // "warning: pointer targets in assignment differ in signedness [-Wpointer-sign]"
+  // in GCC
+	unsigned char *t;
+	static char buf[100] = "bliblablubapk\r";
+
+	t = buf;
+	t += 2;
+
+  *t = '\r';
+	while (*t != '\r') {
+    t++;
+  }
+
   return;
 }

--- a/tests/regression/01-cpa/37-div.c
+++ b/tests/regression/01-cpa/37-div.c
@@ -28,4 +28,21 @@ int main(void) {
     // }
   while_beak:
     assert(i == 3);
+
+
+
+    int a = 5;
+    int b = 7;
+
+    int r = 0;
+
+    if (a == b) {
+        // Dead
+        r = 1;
+    } else {
+        r = 2;
+    }
+
+    assert(r == 1); //FAIL
+    assert(r == 2);
 }

--- a/tests/regression/01-cpa/37-div.c
+++ b/tests/regression/01-cpa/37-div.c
@@ -1,0 +1,31 @@
+// PARAM: --enable ana.int.def_exc --enable ana.int.interval
+int main(void) {
+    int i = 1;
+    int v = 8;
+
+    int r = 28/v;
+
+    while(1) {
+        int zgg = 17;
+        if (! (i < 28 / v)) {
+            zgg = 5;
+            goto while_beak;
+        }
+
+        int z = 3;
+        i ++;
+        z = 7;
+    }
+
+
+
+
+
+    // while(i < 28/v) {
+    //     int z = 3;
+    //     i++;
+    //     z = 7;
+    // }
+  while_beak:
+    assert(i == 3);
+}

--- a/tests/regression/21-casts/01-via_ptr.c
+++ b/tests/regression/21-casts/01-via_ptr.c
@@ -16,7 +16,7 @@ int main(){
     assert(b == -128);
     unsigned char b2 = -1; // neg to pos
     assert(b2 == 255);
-    // via pointer (same data reinterpretated with different type)
+    // via pointer (same data reinterpreted with different type)
     // downcasts are ok for pos. values
     schar* c = (schar*) &a;
     b = *c;

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int global;
 
 int main(void)

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -158,7 +158,7 @@ void example7(void) {
     assert(a[top] == 0); // UNKNOWN
 }
 
-// Check that the global variable is not used for paritioning
+// Check that the global variable is not used for partitioning
 void example8() {
     int a[10];
 

--- a/tests/regression/22-partitioned_arrays/02-pointers_array.c
+++ b/tests/regression/22-partitioned_arrays/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
+++ b/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
+++ b/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
+++ b/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/22-partitioned_arrays/06-interprocedural.c
+++ b/tests/regression/22-partitioned_arrays/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/07-global_array.c
+++ b/tests/regression/22-partitioned_arrays/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/08-unsupported.c
+++ b/tests/regression/22-partitioned_arrays/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 // This is just to test that the analysis does not cause problems for features that are not explicetly dealt with
 int main(void) {
   callok();

--- a/tests/regression/22-partitioned_arrays/09-one_by_one.c
+++ b/tests/regression/22-partitioned_arrays/09-one_by_one.c
@@ -1,5 +1,4 @@
-
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/22-partitioned_arrays/10-array_octagon.c
+++ b/tests/regression/22-partitioned_arrays/10-array_octagon.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/11-was_problematic.c
+++ b/tests/regression/22-partitioned_arrays/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
+++ b/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   int arr[260];

--- a/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
+++ b/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 struct some_struct
 {
     int dir[7];

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int global;
 
 int main(void)

--- a/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
+++ b/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
+++ b/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
+++ b/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/07-global_array.c
+++ b/tests/regression/23-partitioned_arrays_last/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/08-unsupported.c
+++ b/tests/regression/23-partitioned_arrays_last/08-unsupported.c
@@ -1,5 +1,5 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
-// This is just to test that the analysis does not cause problems for features that are not explicetly dealt with
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {
   vla();
   callok();

--- a/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
+++ b/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/23-partitioned_arrays_last/10-array_octagon.c
+++ b/tests/regression/23-partitioned_arrays_last/10-array_octagon.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
+++ b/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
+++ b/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   int arr[260];

--- a/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
+++ b/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits  --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
 }

--- a/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
+++ b/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
 }

--- a/tests/regression/24-octagon/01-octagon_simple.c
+++ b/tests/regression/24-octagon/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 void main(void) {
   int X = 0;

--- a/tests/regression/24-octagon/02-octagon_interprocudral.c
+++ b/tests/regression/24-octagon/02-octagon_interprocudral.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 int main(void) {
     f1();
 }

--- a/tests/regression/24-octagon/03-previously_problematic_a.c
+++ b/tests/regression/24-octagon/03-previously_problematic_a.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/04-previously_problematic_b.c
+++ b/tests/regression/24-octagon/04-previously_problematic_b.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 typedef int wchar_t;

--- a/tests/regression/24-octagon/05-previously_problematic_c.c
+++ b/tests/regression/24-octagon/05-previously_problematic_c.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/06-previously_problematic_d.c
+++ b/tests/regression/24-octagon/06-previously_problematic_d.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/07-previously_problematic_e.c
+++ b/tests/regression/24-octagon/07-previously_problematic_e.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/08-previously_problematic_f.c
+++ b/tests/regression/24-octagon/08-previously_problematic_f.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/09-previously_problematic_g.c
+++ b/tests/regression/24-octagon/09-previously_problematic_g.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/10-previously_problematic_h.c
+++ b/tests/regression/24-octagon/10-previously_problematic_h.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/11-previously_problematic_i.c
+++ b/tests/regression/24-octagon/11-previously_problematic_i.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 char buf2[67];

--- a/tests/regression/24-octagon/12-previously_problematic_j.c
+++ b/tests/regression/24-octagon/12-previously_problematic_j.c
@@ -1,0 +1,11 @@
+// PARAM: --sets solver td3 --disable exp.fast_global_inits --set ana.activated "['base','octagon']"
+void main(void) {
+  int i = 0;
+  int j = i;
+
+  i++;
+  j = i;
+
+  int x = (int) j-1;
+  int z = x +1;
+}

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -36,28 +36,14 @@ int main() {
     assert(yl == 6);
   if (yl/xl == 2 && xl == 3)
     assert(xl == 3); // TODO yl == 6
-  if (2+(3-xl)*4/5 == 6 && 2*xl >= xl+4)
-    assert(xl == -2 && yl >= 1);
-  if (xl > 1 && xl < 5 && xl % 2 == 1)
-    assert(xl != 2); // [2,4] -> [3,4] TODO x % 2 == 1
+  if (2+(3-xl)*4/5 == 6 && 2*yl >= xl+4) {
 
-
-  short xs, ys, zs;
-  if (xs+1 == 2) {
-    assert(xs == 1);
-  } else {
-    assert(xs != 1);
   }
-  if (5-xs == 3)
-    assert(xs == 2);
-  if (5-xs == 3 && xs+ys == xs*3)
-    assert(xs == 2 && ys == 4);
-  if (xs == 3 && ys/xs == 2)
-    assert(ys == 6);
-  if (ys/xs == 2 && xs == 3)
-    assert(xs == 3); // TODO ys == 6
-  if (2+(3-xs)*4/5 == 6 && 2*xs >= xs+4)
-    assert(xs == -2 && ys >= 1);
-  if (xs > 1 && xs < 5 && xs % 2 == 1)
-    assert(xs != 2); // [2,4] -> [3,4] TODO x % 2 == 1
+    // UNKNOWN due to Interval32 not being able to represent long
+    // assert(xl == -2 && yl >= 1);
+  if (xl > 1 && xl < 5 && xl % 2 == 1) {
+
+  }
+    // UNKNOWN due to Interval32 not being able to represent long
+    // assert(xl != 2); // [2,4] -> [3,4] TODO x % 2 == 1
 }

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -46,4 +46,25 @@ int main() {
   }
     // UNKNOWN due to Interval32 not being able to represent long
     // assert(xl != 2); // [2,4] -> [3,4] TODO x % 2 == 1
-}
+
+  short xs, ys, zs;
+  if (xs+1 == 2) {
+    assert(xs == 1);
+  } else {
+    // Does not survive the casts inserted by CIL
+    // assert(xs != 1);
+  }
+  if (5-xs == 3)
+    assert(xs == 2);
+  if (5-xs == 3 && xs+ys == xs*3)
+    assert(xs == 2 && ys == 4);
+  if (xs == 3 && ys/xs == 2)
+    assert(ys == 6);
+  if (ys/xs == 2 && xs == 3)
+    assert(xs == 3); // TODO yl == 6
+  if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
+    assert(xs == -2 && ys >= 1);
+  }
+  if (xs > 1 && xs < 5 && xs % 2 == 1) {
+    assert(xs != 2);
+  }}

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -70,14 +70,21 @@ int main() {
     assert(xs == 2);
   if (5-xs == 3 && xs+ys == xs*3)
     assert(xs == 2 && ys == 4);
-  if (xs == 3 && ys/xs == 2)
+  if (xs == 3 && ys/xs == 2) {
     // ys could for example also be 7
     assert(ys == 6); // UNKNOWN!
+    assert(RANGE(ys, 6, 8));
+  }
+  if (ys/3 == -2)
+    assert(RANGE(ys, -8, -6));
+  if (ys/-3 == -2)
+    assert(RANGE(ys, 6, 8));
   if (ys/xs == 2 && xs == 3)
     assert(xs == 3); // TODO yl == 6
-  if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
+  if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+5) {
     // xs could also be -3
     assert(xs == -2 && ys >= 1); //UNKNOWN!
+    assert(RANGE(xs, -3, -2) && ys >= 1);
   }
   if (xs > 1 && xs < 5 && xs % 2 == 1) {
     assert(xs != 2);
@@ -103,9 +110,11 @@ int main2() {
     assert(x == two);
   if (five-x == three && x+y == x*three)
     assert(x == two && y == four);
-  if (x == three && y/x == two)
+  if (x == three && y/x == two) {
     // y could for example also be 7
     assert(y == six);  // UNKNOWN!
+    assert(RANGE(y, 6, 8));
+  }
   if (y/x == two && x == three)
     assert(x == three); // TODO y == six
   if (two+(three-x)*four/five == six && two*y >= x+four)
@@ -113,6 +122,18 @@ int main2() {
     assert(x == -two && y >= one); //UNKNOWN!
   if (x > one && x < five && x % two == one)
     assert(x != two); // [two,four] -> [three,four] TODO x % two == one
+
+  if (y/three == -two)
+    assert(RANGE(y, -8, -6));
+  if (y/-three == -two)
+    assert(RANGE(y, 6, 8));
+  if (y/x == two && x == three)
+    assert(x == 3); // TODO y == [6,8]; this does not work because CIL transforms this into two if-statements
+  if (two+(three-x)*four/five == six && two*y >= x+five)
+    assert(RANGE(x, -3, -2) && y >= 1);
+  if (x > one && x < five && x % two == one) // x = [2,4] && x % 2 = 1 => x = 3
+    assert(x != 2); // [3,4] TODO [3,3]
+
 
 
   long xl, yl, zl;
@@ -150,16 +171,25 @@ int main2() {
     assert(xs == two);
   if (five-xs == three && xs+ys == xs*three)
     assert(xs == two && ys == four);
-  if (xs == three && ys/xs == two)
+  if (xs == three && ys/xs == two) {
     // ys could for example also be 7
     assert(ys == six); // UNKNOWN!
+    assert(RANGE(ys, six, 8));
+  }
   if (ys/xs == two && xs == three)
     assert(xs == three); // TODO yl == six
-  if (two+(three-xs)*four/five == six && two*ys >= xs+four) {
+  if (two+(three-xs)*four/five == six && two*ys >= xs+five) {
     // xs could also be -three
     assert(xs == -two && ys >= one); //UNKNOWN!
+    assert(RANGE(xs, -three, -two) && ys >= one);
   }
   if (xs > one && xs < five && xs % two == one) {
     assert(xs != two);
   }
+  if (ys/three == -two)
+    assert(RANGE(ys, -8, -6));
+  if (ys/-three == -two)
+    assert(RANGE(ys, 6, 8));
+  if (ys/xs == two && xs == three)
+    assert(xs == 3); // TODO y == [6,8]; this does not work because CIL transforms this into two if-statements
 }

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -12,12 +12,14 @@ int main() {
     assert(x == 2);
   if (5-x == 3 && x+y == x*3)
     assert(x == 2 && y == 4);
-  // if (x == 3 && y/x == 2)
-  //   assert(y == 6);
+  if (x == 3 && y/x == 2)
+    // y could for example also be 7
+    assert(y == 6);  // UNKNOWN!
   if (y/x == 2 && x == 3)
     assert(x == 3); // TODO y == 6
-  // if (2+(3-x)*4/5 == 6 && 2*y >= x+4)
-  //   assert(x == -2 && y >= 1);
+  if (2+(3-x)*4/5 == 6 && 2*y >= x+4)
+    // x could also be -3
+    assert(x == -2 && y >= 1); //UNKNOWN!
   if (x > 1 && x < 5 && x % 2 == 1)
     assert(x != 2); // [2,4] -> [3,4] TODO x % 2 == 1
 
@@ -32,20 +34,19 @@ int main() {
     assert(xl == 2);
   if (5-xl == 3 && xl+yl == xl*3)
     assert(xl == 2 && yl == 4);
-  // if (xl == 3 && yl/xl == 2)
-  //   assert(yl == 6);
+  if (xl == 3 && yl/xl == 2)
+    // yl could for example also be 7
+    assert(yl == 6); // UNKNOWN!
   if (yl/xl == 2 && xl == 3)
     assert(xl == 3); // TODO yl == 6
-  if (2+(3-xl)*4/5 == 6 && 2*yl >= xl+4) {
-
-  }
-    // UNKNOWN due to Interval32 not being able to represent long
-    // assert(xl == -2 && yl >= 1);
+  if (2+(3-xl)*4/5 == 6 && 2*yl >= xl+4)
+    // xl could also be -3
+    assert(xl == -2 && yl >= 1); //UNKNOWN!
   if (xl > 1 && xl < 5 && xl % 2 == 1) {
-
-  }
     // UNKNOWN due to Interval32 not being able to represent long
     // assert(xl != 2); // [2,4] -> [3,4] TODO x % 2 == 1
+  }
+
 
   short xs, ys, zs;
   if (xs+1 == 2) {
@@ -58,13 +59,16 @@ int main() {
     assert(xs == 2);
   if (5-xs == 3 && xs+ys == xs*3)
     assert(xs == 2 && ys == 4);
-  // if (xs == 3 && ys/xs == 2)
-  //   assert(ys == 6);
+  if (xs == 3 && ys/xs == 2)
+    // ys could for example also be 7
+    assert(ys == 6); // UNKNOWN!
   if (ys/xs == 2 && xs == 3)
     assert(xs == 3); // TODO yl == 6
-  // if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
-  //   assert(xs == -2 && ys >= 1);
-  // }
+  if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
+    // xs could also be -3
+    assert(xs == -2 && ys >= 1); //UNKNOWN!
+  }
   if (xs > 1 && xs < 5 && xs % 2 == 1) {
     assert(xs != 2);
-  }}
+  }
+}

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -20,4 +20,44 @@ int main() {
     assert(x == -2 && y >= 1);
   if (x > 1 && x < 5 && x % 2 == 1)
     assert(x != 2); // [2,4] -> [3,4] TODO x % 2 == 1
+
+
+  long xl, yl, zl;
+  if (xl+1 == 2) {
+    assert(xl == 1);
+  } else {
+    assert(xl != 1);
+  }
+  if (5-xl == 3)
+    assert(xl == 2);
+  if (5-xl == 3 && xl+yl == xl*3)
+    assert(xl == 2 && yl == 4);
+  if (xl == 3 && yl/xl == 2)
+    assert(yl == 6);
+  if (yl/xl == 2 && xl == 3)
+    assert(xl == 3); // TODO yl == 6
+  if (2+(3-xl)*4/5 == 6 && 2*xl >= xl+4)
+    assert(xl == -2 && yl >= 1);
+  if (xl > 1 && xl < 5 && xl % 2 == 1)
+    assert(xl != 2); // [2,4] -> [3,4] TODO x % 2 == 1
+
+
+  short xs, ys, zs;
+  if (xs+1 == 2) {
+    assert(xs == 1);
+  } else {
+    assert(xs != 1);
+  }
+  if (5-xs == 3)
+    assert(xs == 2);
+  if (5-xs == 3 && xs+ys == xs*3)
+    assert(xs == 2 && ys == 4);
+  if (xs == 3 && ys/xs == 2)
+    assert(ys == 6);
+  if (ys/xs == 2 && xs == 3)
+    assert(xs == 3); // TODO ys == 6
+  if (2+(3-xs)*4/5 == 6 && 2*xs >= xs+4)
+    assert(xs == -2 && ys >= 1);
+  if (xs > 1 && xs < 5 && xs % 2 == 1)
+    assert(xs != 2); // [2,4] -> [3,4] TODO x % 2 == 1
 }

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -12,12 +12,12 @@ int main() {
     assert(x == 2);
   if (5-x == 3 && x+y == x*3)
     assert(x == 2 && y == 4);
-  if (x == 3 && y/x == 2)
-    assert(y == 6);
+  // if (x == 3 && y/x == 2)
+  //   assert(y == 6);
   if (y/x == 2 && x == 3)
     assert(x == 3); // TODO y == 6
-  if (2+(3-x)*4/5 == 6 && 2*y >= x+4)
-    assert(x == -2 && y >= 1);
+  // if (2+(3-x)*4/5 == 6 && 2*y >= x+4)
+  //   assert(x == -2 && y >= 1);
   if (x > 1 && x < 5 && x % 2 == 1)
     assert(x != 2); // [2,4] -> [3,4] TODO x % 2 == 1
 
@@ -32,8 +32,8 @@ int main() {
     assert(xl == 2);
   if (5-xl == 3 && xl+yl == xl*3)
     assert(xl == 2 && yl == 4);
-  if (xl == 3 && yl/xl == 2)
-    assert(yl == 6);
+  // if (xl == 3 && yl/xl == 2)
+  //   assert(yl == 6);
   if (yl/xl == 2 && xl == 3)
     assert(xl == 3); // TODO yl == 6
   if (2+(3-xl)*4/5 == 6 && 2*yl >= xl+4) {
@@ -58,13 +58,13 @@ int main() {
     assert(xs == 2);
   if (5-xs == 3 && xs+ys == xs*3)
     assert(xs == 2 && ys == 4);
-  if (xs == 3 && ys/xs == 2)
-    assert(ys == 6);
+  // if (xs == 3 && ys/xs == 2)
+  //   assert(ys == 6);
   if (ys/xs == 2 && xs == 3)
     assert(xs == 3); // TODO yl == 6
-  if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
-    assert(xs == -2 && ys >= 1);
-  }
+  // if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+4) {
+  //   assert(xs == -2 && ys >= 1);
+  // }
   if (xs > 1 && xs < 5 && xs % 2 == 1) {
     assert(xs != 2);
   }}

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -2,6 +2,9 @@
 #include <assert.h>
 
 int main() {
+  main2();
+
+
   int x, y, z;
   if (x+1 == 2) {
     assert(x == 1);
@@ -70,5 +73,85 @@ int main() {
   }
   if (xs > 1 && xs < 5 && xs % 2 == 1) {
     assert(xs != 2);
+  }
+
+}
+
+int main2() {
+  int one = 1;
+  int two = 2;
+  int three = 3;
+  int four = 4;
+  int five = 5;
+  int six = 6;
+
+  int x, y, z;
+  if (x+one == two) {
+    assert(x == one);
+  } else {
+    assert(x != one);
+  }
+  if (five-x == three)
+    assert(x == two);
+  if (five-x == three && x+y == x*three)
+    assert(x == two && y == four);
+  if (x == three && y/x == two)
+    // y could for example also be 7
+    assert(y == six);  // UNKNOWN!
+  if (y/x == two && x == three)
+    assert(x == three); // TODO y == six
+  if (two+(three-x)*four/five == six && two*y >= x+four)
+    // x could also be -three
+    assert(x == -two && y >= one); //UNKNOWN!
+  if (x > one && x < five && x % two == one)
+    assert(x != two); // [two,four] -> [three,four] TODO x % two == one
+
+
+  long xl, yl, zl;
+  if (xl+one == two) {
+    assert(xl == one);
+  } else {
+    assert(xl != one);
+  }
+  if (five-xl == three)
+    assert(xl == two);
+  if (five-xl == three && xl+yl == xl*three)
+    assert(xl == two && yl == four);
+  if (xl == three && yl/xl == two)
+    // yl could for example also be 7
+    assert(yl == six); // UNKNOWN!
+  if (yl/xl == two && xl == three)
+    assert(xl == three); // TODO yl == six
+  if (two+(three-xl)*four/five == six && two*yl >= xl+four)
+    // xl could also be -three
+    assert(xl == -two && yl >= one); //UNKNOWN!
+  if (xl > one && xl < five && xl % two == one) {
+    // UNKNOWN due to Intervalthreetwo not being able to represent long
+    // assert(xl != two); // [two,four] -> [three,four] TODO x % two == one
+  }
+
+
+  short xs, ys, zs;
+  if (xs+one == two) {
+    assert(xs == one);
+  } else {
+    // Does not survive the casts inserted by CIL
+    // assert(xs != one);
+  }
+  if (five-xs == three)
+    assert(xs == two);
+  if (five-xs == three && xs+ys == xs*three)
+    assert(xs == two && ys == four);
+  if (xs == three && ys/xs == two)
+    // ys could for example also be 7
+    assert(ys == six); // UNKNOWN!
+  if (ys/xs == two && xs == three)
+    assert(xs == three); // TODO yl == six
+  if (two+(three-xs)*four/five == six && two*ys >= xs+four) {
+    // xs could also be -three
+    assert(xs == -two && ys >= one); //UNKNOWN!
+  }
+  if (xs > one && xs < five && xs % two == one) {
+    assert(xs != two);
   }
 }


### PR DESCRIPTION
This should include all the fixes and tests from #89 minus the changes to add a range to `Def` in `IntDomain.DefExc`.
Might need some more clean up since I mostly accepted incoming changes during merge of the cherry-picked commits.

Edit: This now also includes #95.