### PR TITLE
DefExc: better cast of exclusion range

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1431,7 +1431,7 @@ struct
           (* Both values can not be in the meet together, but it's not sound to exlcude the meet from both. *)
           (* e.g. a=[0,1], b=[1,2], meet a b = [1,1], but (a != b) does not imply a=[0,0], b=[2,2] since others are possible: a=[1,1], b=[2,2] *)
           (* Only if a is a definite value, we can exclude it from b: *)
-          let excl a b = match ID.to_int a with Some x -> ID.of_excl_list ILongLong [x] | None -> b in
+          let excl a b = match ID.to_int a with Some x -> ID.of_excl_list ik [x] | None -> b in
           meet_bin (excl b a) (excl a b)
         | _, _ -> a, b
         )

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -161,6 +161,7 @@ struct
 
   (* Evaluate binop for two abstract values: *)
   let evalbinop (op: binop) (t1:typ) (a1:value) (t2:typ) (a2:value): value =
+    if M.tracing then M.tracel "eval" "evalbinop %a %a %a\n" d_binop op VD.pretty a1 VD.pretty a2;
     (* We define a conversion function for the easy cases when we can just use
      * the integer domain operations. *)
     let bool_top () = ID.(join (of_int 0L) (of_int 1L)) in
@@ -271,7 +272,9 @@ struct
     let binop op e1 e2 =
       let equality () =
         match ask (Q.ExpEq (e1,e2)) with
-        | `Bool x -> Some x
+        | `Bool x ->
+          if M.tracing then M.tracel "query" "ExpEq (%a, %a) = %b\n" d_exp e1 d_exp e2 x;
+          Some x
         | _ -> None
       in
       let ptrdiff_ikind = match !ptrdiffType with TInt (ik,_) -> ik | _ -> assert false in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1469,7 +1469,7 @@ struct
           let ik = match op with
             | Cil.Eq|Cil.Ne|Cil.Lt|Cil.Le|Cil.Ge|Cil.Gt -> (Cilfacade.get_ikind (Cil.typeOf e1))
             (* | Lor and land? *)
-            | _ -> Cilfacade.get_ikind (Cil.typeOf exp)
+            | _ -> Cilfacade.get_ikind (Cil.typeOf e)
           in
           let a', b' = inv_bin_int (a, b) ik (ID.cast_to ik c) op in
           let m1 = inv_exp (ID.cast_to (Cilfacade.get_ikind (Cil.typeOf e1)) a') e1 in

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -852,15 +852,15 @@ struct
   let add  = lift2_inj Integers.add
   let sub  = lift2_inj Integers.sub
   let mul x y = match x, y with
-    | `Definite 0L, _
-    | _, `Definite 0L -> `Definite 0L
+    | `Definite 0L, (`Excluded _ | `Definite _)
+    | (`Excluded _ | `Definite _), `Definite 0L -> `Definite 0L
     | _ -> lift2_inj Integers.mul x y
   let div  = lift2 Integers.div
   let rem  = lift2 Integers.rem
   let lt = lift2 Integers.lt
   let gt = lift2 Integers.gt
   let le = lift2 Integers.le
-  let ge= lift2 Integers.ge
+  let ge = lift2 Integers.ge
   let bitnot = lift1 Integers.bitnot
   let bitand = lift2 Integers.bitand
   let bitor  = lift2 Integers.bitor

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -660,10 +660,12 @@ struct
           let s' = S.map (Integers.cast_to ik) s in
           s', r'
         else (* downcast: may overflow *)
-          let s' = S.map (Integers.cast_to ik) s in
+          (* let s' = S.map (Integers.cast_to ik) s in *)
           (* We want to filter out all i in s' where (t)x with x in r could be i. *)
           (* Since this is hard to compute, we just keep all i in s' which overflowed, since those are safe - all i which did not overflow may now be possible due to overflow of r. *)
-          S.diff s' s, r'
+          (* S.diff s' s, r' *)
+          (* The above is needed for test 21/03, but not sound! See example https://github.com/goblint/analyzer/pull/95#discussion_r483023140 *)
+          S.empty (), r'
       )
     | `Definite x -> `Definite (Integers.cast_to ik x)
     | `Bot -> `Bot

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -720,7 +720,11 @@ struct
     | `Definite x, `Excluded (s,r) -> if S.mem x s then `Bot else `Definite x
     (* The greatest lower bound of two exclusion sets is their union, this is
      * just DeMorgans Law *)
-    | `Excluded (x,wx), `Excluded (y,wy) -> `Excluded (S.union x y, R.meet wx wy)
+    | `Excluded (x,r1), `Excluded (y,r2) ->
+      let r' = R.meet r1 r2 in
+      let in_range i = R.leq (R.of_int i) r' in
+      let s' = S.union x y |> S.filter in_range in
+      `Excluded (s', r')
 
   let of_int  x = `Definite (Integers.of_int x)
   let to_int  x = match x with

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -659,9 +659,11 @@ struct
         else if torg = None then (* same static type -> no overflows for r, but we need to cast s since it may be out of range after lift2_inj *)
           let s' = S.map (Integers.cast_to ik) s in
           s', r'
-        else (* downcast: may overflow -> top *)
-          (* TODO instead filter out all i in s' where (t)x with x in r could be i. *)
-          S.empty (), r'
+        else (* downcast: may overflow *)
+          let s' = S.map (Integers.cast_to ik) s in
+          (* We want to filter out all i in s' where (t)x with x in r could be i. *)
+          (* Since this is hard to compute, we just keep all i in s' which overflowed, since those are safe - all i which did not overflow may now be possible due to overflow of r. *)
+          S.diff s' s, r'
       )
     | `Definite x -> `Definite (Integers.cast_to ik x)
     | `Bot -> `Bot

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -125,7 +125,7 @@ sig
 
   (** {b Cast} *)
 
-  val cast_to: Cil.ikind -> t -> t
+  val cast_to: ?torg:Cil.typ -> Cil.ikind -> t -> t
   (** Cast interval/integer to type of the given width. *)
 end
 (** The signature of integral value domains. They need to support all integer

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -126,7 +126,7 @@ sig
   (** {b Cast} *)
 
   val cast_to: ?torg:Cil.typ -> Cil.ikind -> t -> t
-  (** Cast interval/integer to type of the given width. *)
+  (** Cast from original type [torg] to integer type [Cil.ikind]. Currently, [torg] is only present for actual casts. The function is also called to handle overflows/wrap around after operations. In these cases (where the type stays the same) [torg] is None. *)
 end
 (** The signature of integral value domains. They need to support all integer
   * operations that are allowed in C *)

--- a/tests/regression/01-cpa/29-fun_struct_array.c
+++ b/tests/regression/01-cpa/29-fun_struct_array.c
@@ -15,7 +15,7 @@ int main(){
   struct a A[1] = {50, (unsigned long)&QQ};
 
   assert(A[0].aa == 50);
-  assert(A[0].qq == (unsigned long)&QQ);
+  assert(A[0].qq == (unsigned long)&QQ); // UNKNOWN
 
   return 0;
 }

--- a/tests/regression/01-cpa/29-fun_struct_array.c
+++ b/tests/regression/01-cpa/29-fun_struct_array.c
@@ -15,7 +15,7 @@ int main(){
   struct a A[1] = {50, (unsigned long)&QQ};
 
   assert(A[0].aa == 50);
-  assert(A[0].qq == (unsigned long)&QQ); // UNKNOWN
+  assert(A[0].qq == (unsigned long)&QQ);
 
   return 0;
 }

--- a/tests/regression/21-casts/03-Exc-overflow.c
+++ b/tests/regression/21-casts/03-Exc-overflow.c
@@ -14,15 +14,15 @@ int main () {
   assert(c != -128); // UNKNOWN!
 
   int top;
-  unsigned long acc = 77777777;
+  unsigned long ul = 77777777;
 
   if(top) {
-    acc = 255;
+    ul = 255;
   }
 
-  if(acc != 511) {
-      unsigned char c = (unsigned char)acc;
-      assert(c != 255); //UNKNOWN!
-      int b = 42;
+  if(ul != 511) {
+      unsigned char uc = (unsigned char)ul;
+      assert(uc != 255); //UNKNOWN!
+      ul = 1;
   }
 }

--- a/tests/regression/21-casts/03-Exc-overflow.c
+++ b/tests/regression/21-casts/03-Exc-overflow.c
@@ -14,7 +14,7 @@ int main () {
   assert(c != -128); // UNKNOWN!
 
   int top;
-  unsigned char ul = 77777777;
+  unsigned long ul = 77777777;
 
   if(top) {
     ul = 255;

--- a/tests/regression/21-casts/03-Exc-overflow.c
+++ b/tests/regression/21-casts/03-Exc-overflow.c
@@ -7,9 +7,9 @@ int main () {
   if(a == 127) return;
   char b = a+1; // (char)128 = -128
   printf("b: %d\n", b);
-  assert(b != -128); // UNKNOWN
+  assert(b != -128);
   int c;
   if (c == -128) return; // c is not -128
-  c = (char) c; // c could be 128, cast to char = -128
+  c = (char) c; // actual downcast: c could be 128, cast to char = -128
   assert(c != -128); // UNKNOWN!
 }

--- a/tests/regression/21-casts/03-Exc-overflow.c
+++ b/tests/regression/21-casts/03-Exc-overflow.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <assert.h>
+
+int main () {
+  char a;
+  // a = 127;
+  if(a == 127) return;
+  char b = a+1; // (char)128 = -128
+  printf("b: %d\n", b);
+  assert(b != -128); // UNKNOWN
+  int c;
+  if (c == -128) return; // c is not -128
+  c = (char) c; // c could be 128, cast to char = -128
+  assert(c != -128); // UNKNOWN!
+}

--- a/tests/regression/21-casts/03-Exc-overflow.c
+++ b/tests/regression/21-casts/03-Exc-overflow.c
@@ -7,7 +7,7 @@ int main () {
   if(a == 127) return;
   char b = a+1; // (char)128 = -128
   printf("b: %d\n", b);
-  assert(b != -128);
+  assert(b != -128); // UNKNOWN
   int c;
   if (c == -128) return; // c is not -128
   c = (char) c; // actual downcast: c could be 128, cast to char = -128

--- a/tests/regression/21-casts/03-Exc-overflow.c
+++ b/tests/regression/21-casts/03-Exc-overflow.c
@@ -12,4 +12,17 @@ int main () {
   if (c == -128) return; // c is not -128
   c = (char) c; // actual downcast: c could be 128, cast to char = -128
   assert(c != -128); // UNKNOWN!
+
+  int top;
+  unsigned long acc = 77777777;
+
+  if(top) {
+    acc = 255;
+  }
+
+  if(acc != 511) {
+      unsigned char c = (unsigned char)acc;
+      assert(c != 255); //UNKNOWN!
+      int b = 42;
+  }
 }

--- a/tests/regression/21-casts/03-Exc-overflow.c
+++ b/tests/regression/21-casts/03-Exc-overflow.c
@@ -14,7 +14,7 @@ int main () {
   assert(c != -128); // UNKNOWN!
 
   int top;
-  unsigned long ul = 77777777;
+  unsigned char ul = 77777777;
 
   if(top) {
     ul = 255;


### PR DESCRIPTION
Based on #93.
Test 01/29 fails because it is more precise now. All other tests pass.
The only change is that the exclusion range is kept small on injection/cast, i.e. it grows only by join/computation.