### PR TITLE
Fix Enums (c.f. #93)

### DIFF
--- a/tests/regression/01-cpa/35-enum.c
+++ b/tests/regression/01-cpa/35-enum.c
@@ -1,7 +1,0 @@
-// PARAM: --disable ana.int.interval --disable ana.int.def_exc --enable ana.int.enums
-void main(){
-    int n = 1;
-    for (; n; n++) { // fixed point not reached here
-	}
-	return;
-}

--- a/tests/regression/01-cpa/35-enum.c
+++ b/tests/regression/01-cpa/35-enum.c
@@ -1,0 +1,7 @@
+// PARAM: --disable ana.int.interval --disable ana.int.def_exc --enable ana.int.enums
+void main(){
+    int n = 1;
+    for (; n; n++) { // fixed point not reached here
+	}
+	return;
+}

--- a/tests/regression/01-cpa/38-enum.c
+++ b/tests/regression/01-cpa/38-enum.c
@@ -1,0 +1,7 @@
+// PARAM: --disable ana.int.interval --disable ana.int.def_exc --enable ana.int.enums  --set ana.int.enums_max 2
+void main(){
+    int n = 1;
+    for (; n; n++) { // fixed point not reached here
+	}
+	return;
+}

--- a/tests/regression/01-cpa/39-interval-and-enums.c
+++ b/tests/regression/01-cpa/39-interval-and-enums.c
@@ -1,0 +1,72 @@
+// PARAM: --enable ana.int.interval --enable ana.int.def_exc --enable ana.int.enums  --set ana.int.enums_max 2
+#include<stdio.h>
+#include<assert.h>
+
+
+int main () {
+  int a = 1,b = 2,c = 3;
+  int x,y,z;
+  int w;
+  int false = 0;
+  int true = 42;
+
+  if (x){
+    assert(x != 0);
+  } else {
+    assert(x == 0);
+  }
+
+  assert(!! true);
+  assert(!  false);
+
+  if (a){
+    a = a;
+  } else
+    assert(0); // NOWARN
+
+
+  if (!a)
+    assert(0); // NOWARN
+  else
+    a = a;
+
+  if (z != 0){
+    a = 8;
+    b = 9;
+  } else {
+    a = 9;
+    b = 8;
+  }
+
+  assert(a);
+  assert(a!=b); //UNKNOWN
+  assert(a<10);
+  assert(a<=9);
+  assert(!(a<8));
+  assert(a==8); //UNKNOWN
+  assert(b>7);
+  assert(b>=8);
+  assert(!(a>9));
+  assert(b==8); //UNKNOWN
+
+  for(x = 0; x < 10; x++){
+    assert(x >= 0);
+    assert(x <= 9);
+  }
+  assert(x == 10);
+
+  if (0 <= w)
+  {
+  }
+  else
+  {
+      return 0;
+  }
+
+  if (w > 0)
+  {
+      assert(1);
+  }
+
+  return 0;
+}

--- a/tests/regression/01-cpa/39-interval-and-enums.c
+++ b/tests/regression/01-cpa/39-interval-and-enums.c
@@ -50,7 +50,9 @@ int main () {
   assert(b==8); //UNKNOWN
 
   for(x = 0; x < 10; x++){
-    assert(x >= 0);
+    assert(x >= 0);  // UNKNOWN
+    // Because the false branch remains false for more iterations, the analysis behaves differently, meaning
+    // with ana.in.enums enabled, we don't know (x >= 0) here
     assert(x <= 9);
   }
   assert(x == 10);

--- a/tests/regression/01-cpa/39-interval-and-enums.c
+++ b/tests/regression/01-cpa/39-interval-and-enums.c
@@ -50,9 +50,9 @@ int main () {
   assert(b==8); //UNKNOWN
 
   for(x = 0; x < 10; x++){
-    assert(x >= 0);  // UNKNOWN
-    // Because the false branch remains unreachable for more iterations, the analysis behaves differently, meaning
-    // with ana.int.enums enabled, we don't know (x >= 0) here
+    assert(x >= 0);
+    // Because the false branch remained unreachable for more iterations, the analysis behaved differently, meaning
+    // with ana.int.enums enabled, we didn't know (x >= 0) here
     assert(x <= 9);
   }
   assert(x == 10);

--- a/tests/regression/01-cpa/39-interval-and-enums.c
+++ b/tests/regression/01-cpa/39-interval-and-enums.c
@@ -51,8 +51,8 @@ int main () {
 
   for(x = 0; x < 10; x++){
     assert(x >= 0);  // UNKNOWN
-    // Because the false branch remains false for more iterations, the analysis behaves differently, meaning
-    // with ana.in.enums enabled, we don't know (x >= 0) here
+    // Because the false branch remains unreachable for more iterations, the analysis behaves differently, meaning
+    // with ana.int.enums enabled, we don't know (x >= 0) here
     assert(x <= 9);
   }
   assert(x == 10);


### PR DESCRIPTION
This mirrors the changes made in #93 to `Def_Exc`:

- Change `cast_to` to handle casts correctly
- Introduce a new special range for top: `(-99L, 99)` bigger than any C-type

Changes to the functions for arithmetic operations were not needed here, as the domain does not compute with `Exc` values and instead goes to top.

What is a bit surprising is that enabling `enums` on top of `interval` and `def_exc` might sometimes lead to a solution that is less precise:

~~~C
  for(int x = 0; x < 10; x++){
    assert(x >= 0);  // UNKNOWN
    assert(x <= 9);
  }
~~~

This seems to be because the false branch remains unreachable for more iterations, causing the analysis to behave differently.