### PR TITLE
DefExc: Define widen by join.

### DIFF
--- a/src/cdomains/arincDomain.ml
+++ b/src/cdomains/arincDomain.ml
@@ -32,7 +32,6 @@ module D =
 struct
   type t = process [@@deriving to_yojson]
   include Printable.Std
-  include Lattice.StdCousot
 
   (* printing *)
   let short w x = Printf.sprintf "{ pid=%s; pri=%s; per=%s; cap=%s; pmo=%s; pre=%s; pred=%s; ctx=%s }" (Pid.short 3 x.pid) (Pri.short 3 x.pri) (Per.short 3 x.per) (Cap.short 3 x.cap) (Pmo.short 3 x.pmo) (PrE.short 3 x.pre) (Pretty.sprint 200 (Pred.pretty () x.pred)) (Ctx.short 50 x.ctx)
@@ -85,5 +84,7 @@ struct
     (* let s x = if is_top x then "TOP" else if is_bot x then "BOT" else short 0 x in M.debug_each @@ "JOIN\t" ^ if equal x y then "EQUAL" else s x ^ "\n\t" ^ s y ^ "\n->\t" ^ s r; *)
     if Pred.cardinal r.pred > 5 then (Messages.debug_each @@ "Pred.cardinal r.pred = " ^ string_of_int (Pred.cardinal r.pred) ^ " with value " ^ short 100 r(* ; failwith "STOP" *));
     r
+  let widen = join
   let meet = op_scheme Pid.meet Pri.meet Per.meet Cap.meet Pmo.meet PrE.meet Pred.meet Ctx.meet
+  let narrow = meet
 end

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -707,6 +707,8 @@ struct
     (* For two exclusion sets, only their intersection can be excluded: *)
     | `Excluded (x,wx), `Excluded (y,wy) -> `Excluded (S.inter x y, R.join wx wy)
 
+  let widen = join
+
   let meet x y =
     match (x,y) with
     (* Greatest LOWER bound with the least element is trivial: *)
@@ -1328,7 +1330,7 @@ module Enums : S = struct
         let s' = List.map (I.cast_to ik) s in
         Exc (s', r')
       else (* downcast: may overflow *)
-        Exc ([], r')   
+        Exc ([], r')
     |  Inc x -> Inc (List.map (Integers.cast_to ik) x)
 
   let of_interval (x,y) = (* TODO this implementation might lead to very big lists; also use ana.int.enums_max? *)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -398,7 +398,6 @@ end
 module Integers = (* no top/bot, order is <= *)
 struct
   include Printable.Std
-  include Lattice.StdCousot
   let name () = "integers"
   type t = int64 [@@deriving to_yojson]
   let top () = raise Unknown
@@ -414,7 +413,9 @@ struct
   let equal_to i x = if i > x then `Neq else `Top
   let leq x y = x <= y
   let join x y = if Int64.compare x y > 0 then x else y
+  let widen = join
   let meet x y = if Int64.compare x y > 0 then y else x
+  let narrow = meet
 
   let of_bool x = if x then Int64.one else Int64.zero
   let to_bool' x = x <> Int64.zero
@@ -610,7 +611,6 @@ struct
   module S = SetDomain.Make (Integers)
   module R = Interval32 (* range for exclusion *)
   let size t = R.of_interval (let a,b = Size.bits_i64 t in Int64.neg a,b)
-  include Lattice.StdCousot
   type t = [
     | `Excluded of S.t * R.t
     | `Definite of Integers.t
@@ -727,7 +727,7 @@ struct
       let in_range i = R.leq (R.of_int i) r' in
       let s' = S.union x y |> S.filter in_range in
       `Excluded (s', r')
-
+  let narrow = meet
   let of_int  x = `Definite (Integers.of_int x)
   let to_int  x = match x with
     | `Definite x -> Integers.to_int x
@@ -1238,7 +1238,6 @@ end
 
 module MakeBooleans (N: BooleansNames) =
 struct
-  include Lattice.StdCousot
   type t = bool [@@deriving to_yojson]
   let name () = "booleans"
   let top () = true
@@ -1252,7 +1251,9 @@ struct
 
   let leq x y = not x || y
   let join = (||)
+  let widen = join
   let meet = (&&)
+  let narrow = meet
 
   let of_bool x = x
   let to_bool x = Some x

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -434,7 +434,6 @@ struct
   module I = Basetype.CilExp
   module FI = Printable.Either (F) (I)
   include Printable.Liszt (FI)
-  include Lattice.StdCousot
 
   let rec short w x = match x with
     | [] -> ""
@@ -516,10 +515,14 @@ struct
     | x::xs, y::ys when FI.equal x y -> x :: meet xs ys
     | _ -> failwith "Arguments do not meet"
 
+  let narrow = meet
+
   let rec join x y =
     match x,y with
     | x::xs, y::ys when FI.equal x y -> x :: join xs ys
     | _ -> []
+
+  let widen = join
 
   let rec collapse x y =
     match x,y with

--- a/src/cdomains/lvalMapDomain.ml
+++ b/src/cdomains/lvalMapDomain.ml
@@ -86,7 +86,6 @@ struct
   let split (x,y) = try Must'.elements x |> Set.of_list, May.elements y |> Set.of_list with SetDomain.Unsupported _ -> Set.empty, Set.empty
 
   include Printable.Std
-  include Lattice.StdCousot
 
   (* special variable used for indirection *)
   let alias_var = Goblintutil.create_var @@ Cil.makeVarinfo false "@alias" Cil.voidType, `NoOffset

--- a/src/cdomains/osektupel.ml
+++ b/src/cdomains/osektupel.ml
@@ -2,7 +2,6 @@ type t' = Val of int | Bot
 and t = t' * t' * t'* t' [@@deriving to_yojson]
 
 include Printable.Blank
-include Lattice.StdCousot
 
 (* lowest priority obtained over:
    1st component = critical region (between first and last variable access)
@@ -66,7 +65,9 @@ let leq_t' a b = match (a,b) with
 let leq (a1,a2,a3,a4) (b1,b2,b3,b4) = leq_t' a1 b1 && leq_t' a2 b2 && leq_t' a3 b3 && leq_t' a4 b4
 
 let join (a1,a2,a3,a4) (b1,b2,b3,b4) = (min_t' a1 b1 ,min_t' a2 b2 ,min_t' a3 b3 ,min_t' a4 b4 )
+let widen = join
 let meet (a1,a2,a3,a4) (b1,b2,b3,b4) = (max_t' a1 b1 ,max_t' a2 b2 ,max_t' a3 b3 ,max_t' a4 b4 )
+let narrow = meet
 
 (* composition operator  (b \fcon a) *)
 let fcon (a1,a2,a3,a4) (b1,b2,b3,b4) =  match (a2,b2) with

--- a/src/cdomains/shapeDomain.ml
+++ b/src/cdomains/shapeDomain.ml
@@ -582,4 +582,5 @@ struct
     | _ , Set s when cardinal m2 = 1 && SHMap.is_top (choose m2) -> true
     |  _ -> leq m1 m2
 
+  let widen = join
 end

--- a/src/domains/lattice.ml
+++ b/src/domains/lattice.ml
@@ -32,12 +32,6 @@ sig
   val is_top: t -> bool
 end
 
-module StdCousot =
-struct
-  let widen x y = y
-  let narrow x y = x
-end
-
 exception TopValue
 exception BotValue
 exception Unsupported of string
@@ -46,10 +40,12 @@ let unsupported x = raise (Unsupported x)
 module UnitConf (N: Printable.Name) =
 struct
   include Printable.UnitConf (N)
-  include StdCousot
   let leq _ _ = true
   let join _ _ = ()
+  let widen = join
   let meet _ _ = ()
+
+  let narrow = meet
   let top () = ()
   let is_top _ = true
   let bot () = ()
@@ -61,12 +57,13 @@ module Unit = UnitConf (struct let name = "()" end)
 module Fake (Base: Printable.S) =
 struct
   include Base
-  include StdCousot
   let leq = equal
   let join x y =
     if equal x y then x else raise (Unsupported "fake join")
+  let widen = join
   let meet x y =
     if equal x y then x else raise (Unsupported "fake meet")
+  let narrow = meet
   let top () = raise (Unsupported "fake top")
   let is_top _ = false
   let bot () = raise (Unsupported "fake bot")
@@ -82,10 +79,11 @@ end
 module FakeSingleton (Base: PD) =
 struct
   include Base
-  include StdCousot
   let leq x y = true
   let join x y = x
+  let widen = join
   let meet x y = x
+  let narrow = meet
   let top () = Base.dummy
   let bot () = Base.dummy
   let is_top _ = true
@@ -130,8 +128,6 @@ end
 module Flat (Base: Printable.S) (N: Printable.LiftingNames) =
 struct
   include Printable.Lift (Base) (N)
-  include StdCousot
-
   let bot () = `Bot
   let is_bot x = x = `Bot
   let top () = `Top
@@ -158,6 +154,8 @@ struct
     | (`Lifted x, `Lifted y) when Base.equal x y -> `Lifted x
     | _ -> `Top
 
+  let widen = join
+
   let meet x y =
     match (x,y) with
     | (`Bot, _) -> `Bot
@@ -166,6 +164,9 @@ struct
     | (x, `Top) -> x
     | (`Lifted x, `Lifted y) when Base.equal x y -> `Lifted x
     | _ -> `Bot
+
+  let narrow = meet
+
 end
 
 
@@ -566,7 +567,6 @@ module Option (Base: S) (N: Printable.Name) = Either (Base) (UnitConf (N))
 module Liszt (Base: S) =
 struct
   include Printable.Liszt (Base)
-  include StdCousot
   let bot () = raise (Unsupported "bot?")
   let is_top _ = false
   let top () = raise (Unsupported "top?")
@@ -577,14 +577,16 @@ struct
     List.fold_left2 f true
 
   let join = List.map2 Base.join
+  let widen = join
   let meet = List.map2 Base.meet
+  let narrow = meet
 end
 
 module Chain (P: Printable.ChainParams) =
 struct
   include Printable.Std
   include Printable.Chain (P)
-  include StdCousot
+
   let bot () = 0
   let is_bot x = x = 0
   let top () = P.n - 1
@@ -592,5 +594,7 @@ struct
 
   let leq x y = x <= y
   let join x y = max x y
+  let widen = join
   let meet x y = min x y
+  let narrow = meet
 end

--- a/src/domains/octagonDomain.ml
+++ b/src/domains/octagonDomain.ml
@@ -28,7 +28,6 @@ struct
   let copy_oct oct =
     Array.map Array.copy oct
   (* TODO: implement better narrow function *)
-  include Lattice.StdCousot
   include Printable.Blank
 
   type t = elt array array

--- a/src/domains/partitionDomain.ml
+++ b/src/domains/partitionDomain.ml
@@ -36,6 +36,8 @@ struct
     fold f s2 false
 
   let add e s = join s (singleton e)
+
+  let widen = join
 end
 
 module type CollapseSet = sig
@@ -90,6 +92,8 @@ struct
 
   let add (s:set) (p:t): t = join p (singleton s)
 
+  let widen = join
+  let narrow = meet
 end
 
 
@@ -155,6 +159,8 @@ struct
   let find_class (x: Base.t) (ss: t): set option =
     try Some (E.choose (E.filter (B.mem x) ss)) with Not_found -> None
 
+  let widen = join
+  let narrow = meet
 end
 
 module ExpPartitions = SetSet (Exp.Exp)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -17,7 +17,6 @@ module ES =
 struct
   include ES_r
   include Printable.Std
-  include Lattice.StdCousot
   let bot = ES_r.top
   let top = ES_r.bot
   let leq x y = ES_r.leq y x

--- a/src/domains/setDomain.ml
+++ b/src/domains/setDomain.ml
@@ -74,13 +74,14 @@ end
 module Make (Base: Printable.S) =
 struct
   include Printable.Blank
-  include Lattice.StdCousot
   include BatSet.Make(Base)
   let name () = "Set (" ^ Base.name () ^ ")"
   let empty _ = empty
   let leq  = subset
   let join = union
+  let widen = join
   let meet = inter
+  let narrow = meet
   let bot = empty
   let is_bot = is_empty
   let top () = raise (Lattice.Unsupported "Set has no top")
@@ -212,7 +213,6 @@ module ToppedSet (Base: Printable.S) (N: ToppedSetNames) =
 struct
   module S = Make (Base)
   include Printable.Blank
-  include Lattice.StdCousot
   type t = All | Set of S.t [@@deriving to_yojson]
   type elt = Base.t
 
@@ -338,7 +338,9 @@ struct
 
   let leq = subset
   let join = union
+  let widen = join
   let meet = inter
+  let narrow = meet
   let pretty_diff () ((x:t),(y:t)): Pretty.doc =
     match x,y with
     | Set x, Set y -> S.pretty_diff () (x,y)


### PR DESCRIPTION
Previously, `DefExc` used the widening operator as implemented by `Lattice.StdCousot` -- which is not a valid widening operator (as of now), because it just returns the second argument:
https://github.com/goblint/analyzer/blob/0a88b34c8356d49c9889c42926a8532b0c100020/src/domains/lattice.ml#L35-L39

So now we define the `widen` simply by the `join` for `DefExc`. 

More generally speaking, there are 16 includes of `StdCousot` in the code base (not counting those in `arrayDomain_deprecated` and `intDomain_unused`). At some of these places, the `widen` might not be overridden and the resulting behavior might be unsound. 