### PR TITLE
Def_exc: Fix issues in leq, join, narrow, meet with broken checking for in_range

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -788,7 +788,8 @@ struct
       let s' = S.union x y |> S.filter (in_range r') in
       `Excluded (s', r')
 
-  let narrow = meet
+  let narrow x y = x
+
   let of_int  x = `Definite (Integers.of_int x)
   let to_int  x = match x with
     | `Definite x -> Integers.to_int x

--- a/src/domains/domainProperties.ml
+++ b/src/domains/domainProperties.ml
@@ -52,7 +52,7 @@ struct
   ]
 end
 
-module Join (D: Lattice.S): S =
+module Join (D: Lattice.S) =
 struct
   include DomainTest (D)
 
@@ -65,6 +65,13 @@ struct
   let tests = [
     join_leq;
     join_assoc;
+    join_comm;
+    join_idem;
+    join_abs
+  ]
+
+  let tests_non_assoc = [
+    join_leq;
     join_comm;
     join_idem;
     join_abs
@@ -172,4 +179,19 @@ struct
   module N = Narrow (D)
 
   let tests = E.tests @ L.tests @ J.tests @ M.tests @ B.tests @ T.tests @ C.tests @ W.tests @ N.tests
+end
+
+module AllNonAssoc(D:Lattice.S): S =
+struct
+  module E = Equal (D)
+  module L = Leq (D)
+  module J = Join (D)
+  module M = Meet (D)
+  module B = Bot (D)
+  module T = Top (D)
+  module C = Connect (D)
+  module W = Widen (D)
+  module N = Narrow (D)
+
+  let tests = E.tests @ L.tests @ J.tests_non_assoc @ M.tests @ B.tests @ T.tests @ C.tests @ W.tests @ N.tests
 end

--- a/src/maindomaintest.ml
+++ b/src/maindomaintest.ml
@@ -55,7 +55,7 @@ let domains: (module Lattice.S) list = [
 
   (* TODO: fix *)
   (* (module IntDomain.CircInterval); *)
-  (* (module IntDomain.DefExc); *)
+  (module IntDomain.DefExc);
   (* (module IntDomain.Enums); *)
   (* (module IntDomain.IntDomTuple); *)
 

--- a/src/maindomaintest.ml
+++ b/src/maindomaintest.ml
@@ -55,12 +55,15 @@ let domains: (module Lattice.S) list = [
 
   (* TODO: fix *)
   (* (module IntDomain.CircInterval); *)
-  (module IntDomain.DefExc);
   (* (module IntDomain.Enums); *)
   (* (module IntDomain.IntDomTuple); *)
 
   (module ArbitraryLattice);
   (module SetDomain.Hoare (ArbitraryLattice) (struct let topname = "Top" end));
+]
+
+let nonAssocDomains: (module Lattice.S) list = [
+  (module IntDomain.DefExc);
 ]
 
 let intDomains: (module IntDomain.S) list = [
@@ -80,6 +83,13 @@ let testsuite =
       DP.tests)
     domains
   |> List.flatten
+let nonAssocTestsuite =
+  List.map (fun d ->
+      let module D = (val d: Lattice.S) in
+      let module DP = DomainProperties.AllNonAssoc (D) in
+      DP.tests)
+    nonAssocDomains
+  |> List.flatten
 let intTestsuite =
   List.map (fun d ->
       let module D = (val d: IntDomain.S) in
@@ -89,4 +99,4 @@ let intTestsuite =
   |> List.flatten
 
 let () =
-  QCheck_runner.run_tests_main ~argv:Sys.argv (testsuite @ intTestsuite)
+  QCheck_runner.run_tests_main ~argv:Sys.argv (testsuite @ nonAssocTestsuite @ intTestsuite)

--- a/tests/regression/02-base/33-backwards-loop.c
+++ b/tests/regression/02-base/33-backwards-loop.c
@@ -1,0 +1,10 @@
+// PARAM: --sets solver td3
+void main(void) {
+    int x;
+    int i = 41;
+
+    while(i >= 12) {
+        x = 0;
+        i--;
+    }
+}

--- a/tests/regression/02-base/33-backwards-loop.c
+++ b/tests/regression/02-base/33-backwards-loop.c
@@ -7,4 +7,12 @@ void main(void) {
         x = 0;
         i--;
     }
+
+    int y;
+    int j = -40;
+
+    while(-5 >= j) {
+        y = 0;
+        j++;
+    }
 }

--- a/tests/regression/02-base/33-meet-def-exc.c
+++ b/tests/regression/02-base/33-meet-def-exc.c
@@ -15,4 +15,11 @@ void main(void) {
         y = 0;
         j++;
     }
+
+    int z;
+    int k = 41;
+    while(k != 0) {
+        z = 0;
+        k--;
+    }
 }


### PR DESCRIPTION
This fixes some of the issues quickcheck (see #99) found for `def_exc`.

- `leq`: between `Definite` and `Excluded` did not take the ranges into account
- `join`: was too eager to increase the range.
- `meet`: checked whether the excluded value on the right was in the range interval instead of checking if it is in the range represented by that interval

It also fixes an issue where `narrow` was changed by mistake in #97 causing a time-out on some of the regression tests.
It now runs the quickchecks but skips the test for associativity of join, as our join is not associative.


###  The join i still not associative

**Because of the ranges (fixed now)**
```
a: Unknown int([-63,63]) 
b: 0
c: 7317727852

join(a,b) : Unknown int([-63,63]) 
join(join(a,b), c): Unknown int([-63,63])

join(b,c): Unknown int([0,64])
join(join(b,c), a):  Unknown int([-63,64])
```

This problem comes from having to chose an exclusion range for a join of two definites. Whichever way one does this (so `long` vs. `unsigned long` here), this problem will crop up.
I guess one could go to the non-C range of `[0,n-1]` for values that fit both into the signed and unsigned type of size n.

**And more fundamentally**
```
a: Not {1}([-63,63]) 
b: 0
c: -1

join(a,b): Not {1}([-63,63]) 
join(join(a,b),c): Not {1}([-63,63])

join(b,c): Unknown int([-7,7]) 
join(a, join(b,c)): Unknown int([-63,63])
```