### PR TITLE
Fix handling of ! in `invariant`

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1481,7 +1481,8 @@ struct
         let c' =
           match ID.to_bool (unop_ID LNot c) with
           | Some true ->
-            (* LNot x is 1 for any x != 0 *)
+            (* i.e. e should evaluate to [1,1] *)
+            (* LNot x is 0 for any x != 0 *)
             let ikind = Cilfacade.get_ikind @@ typeOf e in
             ID.of_excl_list ikind [0L]
           | Some false -> ID.of_bool false

--- a/tests/regression/01-cpa/34-def-exc.c
+++ b/tests/regression/01-cpa/34-def-exc.c
@@ -190,6 +190,7 @@ int test(void const   *ptr) {
     assert(ptr == 0);
     int f = 7;
   } else {
+    assert(ptr == 1); //UNKNOWN!
     assert(ptr != 0);
     int f= 38;
   }

--- a/tests/regression/27-inv_invariants/03-ints-not.c
+++ b/tests/regression/27-inv_invariants/03-ints-not.c
@@ -1,0 +1,9 @@
+int main() {
+    int x;
+
+    if(!x) {
+        assert(x==0);
+    } else {
+        assert(x==1); //UNKNOWN!
+    }
+}

--- a/tests/regression/27-inv_invariants/04-ints-not-interval.c
+++ b/tests/regression/27-inv_invariants/04-ints-not-interval.c
@@ -1,0 +1,10 @@
+//PARAM: --disable ana.int.def_exc --enable ana.int.interval
+int main() {
+    int x;
+
+    if(!x) {
+        assert(x==0);
+    } else {
+        assert(x==1); //UNKNOWN!
+    }
+}

--- a/tests/regression/27-inv_invariants/04-ints-not-interval.c
+++ b/tests/regression/27-inv_invariants/04-ints-not-interval.c
@@ -3,7 +3,6 @@ int main() {
     int x;
 
     if(!x) {
-        assert(x==0);
     } else {
         assert(x==1); //UNKNOWN!
     }


### PR DESCRIPTION
Fix unsoundness in handling of `LNot` in `invariant`:

In the new implementation of `invariant` handle `LNot` differently from `BNot` and `Neg` as it is not invertible.
If `(!x)` evaluates to `[0,0]`, restrict `x` to `Excluded 0`.

The old `invariant` does not need to be modified, as it propagates `bool` and not `ID.t` values and so does not suffer from this problem.

Closes #103 