### PR TITLE
Fix region analysis unsoundness on three regression tests

### DIFF
--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -80,15 +80,15 @@ struct
       v.vname ^ sprint pretty_offs os
     in
     let es = LSSet.empty () in
-    let add_region xs r =
-      LSSet.add("region", show r) xs
+    let add_region ps r =
+      LSSSet.add (LSSet.singleton ("region", show r)) ps
     in
     match get_region ctx e' with
     | None -> (LSSSet.empty (),es)
     | Some xs ->
-      let ps = List.fold_left add_region (LSSet.empty ()) xs in
+      let ps = List.fold_left add_region (LSSSet.empty ()) xs in
       (* ignore (Pretty.printf "%a in region %a\n" d_exp e LSSSet.pretty ps); *)
-      (LSSSet.singleton ps, es)
+      (ps, es)
 
   (* queries *)
   let query ctx (q:Queries.t) : Queries.Result.t =

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -390,7 +390,9 @@ let add_propagate e w conf ty ls p =
     List.iter (just_vars t) vars
 
 let rec distribute_access_lval f w r c lv =
-  f w r c (mkAddrOf lv);
+  (* Use unoptimized AddrOf so RegionDomain.Reg.eval_exp knows about dereference *)
+  (* f w r c (mkAddrOf lv); *)
+  f w r c (AddrOf lv);
   distribute_access_lval_addr f w r c lv
 
 and distribute_access_lval_addr f w r c lv =

--- a/tests/regression/09-regions/29-malloc_race_cp.c
+++ b/tests/regression/09-regions/29-malloc_race_cp.c
@@ -1,0 +1,36 @@
+// PARAM: --set ana.activated[+] "'region'"
+// Copy of 02/25 with region enabled
+#include <stdlib.h>
+#include <pthread.h>
+#include <stdio.h>
+
+int *x;
+int *y;
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&m);
+  *x = 3; // NOWARN
+  *y = 8; // RACE
+  pthread_mutex_unlock(&m);
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  int *z;
+
+  x = malloc(sizeof(int));
+  y = malloc(sizeof(int));
+  z = y;
+
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_mutex_lock(&m);
+  printf("%d\n",*x); // NOWARN
+  pthread_mutex_unlock(&m);
+  printf("%d\n",*z); // RACE
+
+  return 0;
+}

--- a/tests/regression/09-regions/30-list2alloc-offsets.c
+++ b/tests/regression/09-regions/30-list2alloc-offsets.c
@@ -1,0 +1,47 @@
+// SKIP PARAM: --set ana.activated[+] "'region'" --enable exp.region-offsets
+// Copy of 09/30 with region offsets enabled
+#include<pthread.h>
+#include<stdlib.h>
+#include<stdio.h>
+
+struct s {
+  int datum;
+  struct s *next;
+} *A, *B;
+
+struct s *new(int x) {
+  struct s *p = malloc(sizeof(struct s));
+  p->datum = x;
+  p->next = NULL;
+  return p;
+}
+
+pthread_mutex_t A_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t B_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&A_mutex);
+  A->datum++; // RACE <-- this line is also relevant.
+  pthread_mutex_unlock(&A_mutex);
+
+  pthread_mutex_lock(&B_mutex);
+  B->datum++; // <-- this is not relevant at all.
+  pthread_mutex_unlock(&B_mutex);
+  return NULL;
+}
+
+int main () {
+  pthread_t t1;
+
+  A = new(3);
+  B = new(5);
+
+  pthread_create(&t1, NULL, t_fun, NULL);
+
+  int *data;
+  pthread_mutex_lock(&A_mutex);
+  data = &A->datum; // NORACE
+  pthread_mutex_unlock(&A_mutex);
+  *data = 42; // RACE <-- this is the real bug!
+  return 0;
+}

--- a/tests/regression/09-regions/30-list2alloc-offsets.c
+++ b/tests/regression/09-regions/30-list2alloc-offsets.c
@@ -1,5 +1,5 @@
 // PARAM: --set ana.activated[+] "'region'" --enable exp.region-offsets
-// Copy of 09/30 with region offsets enabled
+// Copy of 09/28 with region offsets enabled
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>

--- a/tests/regression/09-regions/30-list2alloc-offsets.c
+++ b/tests/regression/09-regions/30-list2alloc-offsets.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] "'region'" --enable exp.region-offsets
+// PARAM: --set ana.activated[+] "'region'" --enable exp.region-offsets
 // Copy of 09/30 with region offsets enabled
 #include<pthread.h>
 #include<stdlib.h>

--- a/tests/regression/09-regions/31-equ_rc.c
+++ b/tests/regression/09-regions/31-equ_rc.c
@@ -1,0 +1,50 @@
+// SKIP PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'" --set ana.activated[+] "'region'"
+// Copy of 06/10 with region enabled
+#include<pthread.h>
+#include<stdlib.h>
+
+struct q { int x; int y; };
+struct s {
+  int datum;
+  struct q inside;
+  pthread_mutex_t mutex;
+} A, B;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&A.mutex);
+  B.datum = 5; //RACE
+  pthread_mutex_lock(&A.mutex);
+  return NULL;
+}
+
+int main () {
+  int x;
+  pthread_t id;
+
+  // struct s *s = malloc(sizeof(struct s));
+  struct s *s;
+  //struct q *q;
+  int *d;
+
+  pthread_mutex_t *m;
+
+  if (x) {
+	  s = &A;
+	  x++;
+  } else {
+	  s = &B;
+	  x++;
+  }
+
+  //q = &s->inside;
+  m = &s->mutex;
+  d = &s->datum;
+
+  pthread_create(&id,NULL,t_fun,NULL);
+
+  pthread_mutex_lock(m);
+  *d = 8; //RACE
+  pthread_mutex_unlock(m);
+
+  return 0;
+}

--- a/tests/regression/09-regions/32-equ_nr.c
+++ b/tests/regression/09-regions/32-equ_nr.c
@@ -1,5 +1,5 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'" --set ana.activated[+] "'region'"
-// Copy of 06/10 with region enabled
+// Copy of 06/11 with region enabled
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -12,7 +12,7 @@ struct s {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A.mutex);
-  B.datum = 5; //RACE
+  A.datum = 5; //NORACE
   pthread_mutex_lock(&A.mutex);
   return NULL;
 }
@@ -43,7 +43,7 @@ int main () {
   pthread_create(&id,NULL,t_fun,NULL);
 
   pthread_mutex_lock(m);
-  *d = 8; //RACE
+  *d = 8; //NORACE
   pthread_mutex_unlock(m);
 
   return 0;


### PR DESCRIPTION
Fixes the following regression tests (with copies using new `PARAM`):
* 02/25 with region (as 09/29)
* 06/10 with region (as 09/31)
* 09/28 with region offsets (as 09/30)