### PR TITLE
Reviewed data race regression tests for SV-COMP submission

### DIFF
--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -85,6 +85,7 @@ struct
     in
     match get_region ctx e' with
     | None -> (LSSSet.empty (),es)
+    | Some [] -> (LSSSet.singleton es, es) (* Should it happen in the first place that RegMap has empty value? *)
     | Some xs ->
       let ps = List.fold_left add_region (LSSSet.empty ()) xs in
       (* ignore (Pretty.printf "%a in region %a\n" d_exp e LSSSet.pretty ps); *)

--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -67,10 +67,6 @@ struct
 
   let part_access ctx e _ _ = (*todo: remove regions that cannot be reached from the var*)
     let open Access in
-    let e' = match e with
-      | AddrOf lv -> Lval lv
-      | _ -> e
-    in
     let rec pretty_offs () = function
       | `NoOffset     -> dprintf ""
       | `Field (f,os) -> dprintf ".%s%a" f.fname pretty_offs os
@@ -83,7 +79,7 @@ struct
     let add_region ps r =
       LSSSet.add (LSSet.singleton ("region", show r)) ps
     in
-    match get_region ctx e' with
+    match get_region ctx e with
     | None -> (LSSSet.empty (),es)
     | Some [] -> (LSSSet.singleton es, es) (* Should it happen in the first place that RegMap has empty value? *)
     | Some xs ->

--- a/src/cdomains/regionDomain.ml
+++ b/src/cdomains/regionDomain.ml
@@ -150,7 +150,7 @@ struct
     in
     let rec eval_rval deref rval =
       match rval with
-      | Lval lval -> eval_lval deref lval
+      | Lval lval -> Option.map (fun (deref, v, offs) -> (deref, v, [])) (eval_lval deref lval)
       | AddrOf lval -> eval_lval deref lval
       | CastE (typ, exp) -> eval_rval deref exp
       | BinOp (MinusPI, p, i, typ)

--- a/src/cdomains/regionDomain.ml
+++ b/src/cdomains/regionDomain.ml
@@ -148,6 +148,11 @@ struct
       | Index (_, offs) -> do_offs deref def offs
       | NoOffset -> def
     in
+    (* The intuition for the offset computations is that we keep the static _suffix_ of an 
+     * access path. These can be used to partition accesses when fields do not overlap. 
+     * This means that for pointer dereferences and when obtaining the value from an lval 
+     * (but not under AddrOf), we drop the offsets because we land somewhere 
+     * unknown in the region. *)
     let rec eval_rval deref rval =
       match rval with
       | Lval lval -> Option.map (fun (deref, v, offs) -> (deref, v, [])) (eval_lval deref lval)

--- a/tests/regression/02-base/24-malloc_races.c
+++ b/tests/regression/02-base/24-malloc_races.c
@@ -9,8 +9,8 @@ pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m);
-  *x = 3; // NOWARN
-  *y = 8; // RACE
+  *x = 3; // NORACE
+  *y = 8; // RACE!
   pthread_mutex_unlock(&m);
   return NULL;
 }
@@ -22,12 +22,12 @@ int main() {
   y = malloc(sizeof(int));
 
   pthread_create(&id, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&m);
-  printf("%d\n",*x); // NOWARN
+  printf("%d\n",*x); // NORACE
   pthread_mutex_unlock(&m);
-  printf("%d\n",*y); // RACE
-  
+  printf("%d\n",*y); // RACE!
+
   return 0;
 }
 

--- a/tests/regression/02-base/25-malloc_race_cp.c
+++ b/tests/regression/02-base/25-malloc_race_cp.c
@@ -9,8 +9,8 @@ pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m);
-  *x = 3; // NOWARN
-  *y = 8; // RACE
+  *x = 3; // NORACE
+  *y = 8; // RACE!
   pthread_mutex_unlock(&m);
   return NULL;
 }
@@ -24,11 +24,11 @@ int main() {
   z = y;
 
   pthread_create(&id, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&m);
-  printf("%d\n",*x); // NOWARN
+  printf("%d\n",*x); // NORACE
   pthread_mutex_unlock(&m);
-  printf("%d\n",*z); // RACE
-  
+  printf("%d\n",*z); // RACE!
+
   return 0;
 }

--- a/tests/regression/02-base/26-malloc_struct.c
+++ b/tests/regression/02-base/26-malloc_struct.c
@@ -14,7 +14,7 @@ pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m);
   d->x = 3; // NORACE
-  d->y = 8; // RACE
+  d->y = 8; // RACE!
   pthread_mutex_unlock(&m);
   return NULL;
 }
@@ -27,11 +27,11 @@ int main() {
   z = d;
 
   pthread_create(&id, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&m);
   printf("%d\n",d->x); // NORACE
   pthread_mutex_unlock(&m);
-  printf("%d\n",z->y); // RACE
-  
+  printf("%d\n",z->y); // RACE!
+
   return 0;
 }

--- a/tests/regression/02-base/27-malloc_array.c
+++ b/tests/regression/02-base/27-malloc_array.c
@@ -10,7 +10,7 @@ pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m);
   d[2] = 3; // NORACE
-  d[3] = 8; // RACE
+  d[3] = 8; // RACE!
   pthread_mutex_unlock(&m);
   return NULL;
 }
@@ -20,11 +20,11 @@ int main() {
   d = calloc(10, sizeof(int));
 
   pthread_create(&id, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&m);
   printf("%d\n",d[2]); // NORACE
   pthread_mutex_unlock(&m);
-  printf("%d\n",d[3]); // RACE
-  
+  printf("%d\n",d[3]); // RACE!
+
   return 0;
 }

--- a/tests/regression/03-practical/08-nonterm1.c
+++ b/tests/regression/03-practical/08-nonterm1.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int();
+
 #include <pthread.h>
 #include <stdio.h>
 
@@ -6,7 +8,7 @@ pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 void fun(void) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_mutex_lock(&mutex2);
   myglobal=myglobal+1; // RACE!
   pthread_mutex_unlock(&mutex2);

--- a/tests/regression/03-practical/08-nonterm1.c
+++ b/tests/regression/03-practical/08-nonterm1.c
@@ -16,7 +16,7 @@ void fun(void) {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex1);
-  myglobal=myglobal+1; // RACE!
+  myglobal=myglobal+1; // RACE
   pthread_mutex_unlock(&mutex1);
   fun();
   return NULL;

--- a/tests/regression/04-mutex/02-simple_nr.c
+++ b/tests/regression/04-mutex/02-simple_nr.c
@@ -7,7 +7,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex1);
-  myglobal=myglobal+1; // NOWARN!
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(&mutex1);
   return NULL;
 }
@@ -16,7 +16,7 @@ int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&mutex1);
-  myglobal=myglobal+1; // NOWARN!
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(&mutex1);
   pthread_join (id, NULL);
   return 0;

--- a/tests/regression/04-mutex/03-munge_rc.c
+++ b/tests/regression/04-mutex/03-munge_rc.c
@@ -12,7 +12,7 @@ void munge(pthread_mutex_t *m) {
 }
 
 void *t_fun(void *arg) {
-  munge(&mutex2); // NOWARN
+  munge(&mutex2);
   return NULL;
 }
 
@@ -20,7 +20,7 @@ void *t_fun(void *arg) {
 int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  munge(&mutex1); // NOWARN
+  munge(&mutex1);
   pthread_join (id, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/03-munge_rc.c
+++ b/tests/regression/04-mutex/03-munge_rc.c
@@ -12,7 +12,7 @@ void munge(pthread_mutex_t *m) {
 }
 
 void *t_fun(void *arg) {
-  munge(&mutex2); // NOWARN!
+  munge(&mutex2); // NOWARN
   return NULL;
 }
 
@@ -20,7 +20,7 @@ void *t_fun(void *arg) {
 int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  munge(&mutex1); // NOWARN!
+  munge(&mutex1); // NOWARN
   pthread_join (id, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/04-munge_nr.c
+++ b/tests/regression/04-mutex/04-munge_nr.c
@@ -11,7 +11,7 @@ void munge(pthread_mutex_t *m) {
 }
 
 void *t_fun(void *arg) {
-  munge(&mutex); // NOWARN
+  munge(&mutex);
   return NULL;
 }
 
@@ -19,7 +19,7 @@ void *t_fun(void *arg) {
 int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  munge(&mutex); // NOWARN
+  munge(&mutex);
   pthread_join (id, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/04-munge_nr.c
+++ b/tests/regression/04-mutex/04-munge_nr.c
@@ -6,12 +6,12 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void munge(pthread_mutex_t *m) {
   pthread_mutex_lock(m);
-  myglobal=myglobal+1; // NOWARN!
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(m);
 }
 
 void *t_fun(void *arg) {
-  munge(&mutex); // NOWARN!
+  munge(&mutex); // NOWARN
   return NULL;
 }
 
@@ -19,7 +19,7 @@ void *t_fun(void *arg) {
 int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  munge(&mutex); // NOWARN!
+  munge(&mutex); // NOWARN
   pthread_join (id, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/05-lockfuns.c
+++ b/tests/regression/04-mutex/05-lockfuns.c
@@ -15,7 +15,7 @@ void unlock() {
 
 void *t_fun(void *arg) {
   lock();
-  myglobal++; // NOWARN!
+  myglobal++; // NORACE
   unlock();
   return NULL;
 }
@@ -25,7 +25,7 @@ int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   lock();
-  myglobal++; // NOWARN!
+  myglobal++; // NORACE
   unlock();
   pthread_join (id, NULL);
   return 0;

--- a/tests/regression/04-mutex/06-ps_rc.c
+++ b/tests/regression/04-mutex/06-ps_rc.c
@@ -1,10 +1,12 @@
+extern int __VERIFIER_nondet_int();
+
 #include<stdio.h>
 #include<pthread.h>
 #include<assert.h>
 
 int glob;
-pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER; 
-pthread_mutex_t n = PTHREAD_MUTEX_INITIALIZER; 
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t n = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&n);
@@ -14,20 +16,20 @@ void *t_fun(void *arg) {
 }
 
 int main() {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t id;
 
   // Create the thread
   pthread_create(&id, NULL, t_fun, NULL);
-  
+
   printf("Do the work? ");
-  if (i) 
+  if (i)
     pthread_mutex_lock(&m);
   printf("Now we do the work..\n");
-  if (i) 
+  if (i)
     glob++; // RACE!
   printf("Work is completed...");
-  if (i) 
+  if (i)
     pthread_mutex_unlock(&m);
 
   return 0;

--- a/tests/regression/04-mutex/07-ps_nr.c
+++ b/tests/regression/04-mutex/07-ps_nr.c
@@ -3,11 +3,11 @@
 #include<assert.h>
 
 int glob;
-pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER; 
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m);
-  glob++; // NOWARN!
+  glob++; // NORACE
   pthread_mutex_unlock(&m);
   return NULL;
 }
@@ -18,15 +18,15 @@ int main() {
 
   // Create the thread
   pthread_create(&id, NULL, t_fun, NULL);
-  
+
   printf("Do the work? ");
-  if (i) 
+  if (i)
     pthread_mutex_lock(&m);
   printf("Now we do the work..\n");
-  if (i) 
-    glob++; // NOWARN!
+  if (i)
+    glob++; // NORACE
   printf("Work is completed...");
-  if (i) 
+  if (i)
     pthread_mutex_unlock(&m);
 
   return 0;

--- a/tests/regression/04-mutex/07-ps_nr.c
+++ b/tests/regression/04-mutex/07-ps_nr.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int();
+
 #include<stdio.h>
 #include<pthread.h>
 #include<assert.h>
@@ -13,7 +15,7 @@ void *t_fun(void *arg) {
 }
 
 int main() {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t id;
 
   // Create the thread

--- a/tests/regression/04-mutex/09-ptrmunge_rc.c
+++ b/tests/regression/04-mutex/09-ptrmunge_rc.c
@@ -13,14 +13,14 @@ void munge(pthread_mutex_t *m, int *v) {
 }
 
 void *t_fun(void *arg) {
-  munge(&mutex1, &myglobal1); // NOWARN!
+  munge(&mutex1, &myglobal1); // NOWARN
   return NULL;
 }
 
 int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  munge(&mutex2,&myglobal1); // NOWARN!
+  munge(&mutex2,&myglobal1); // NOWARN
   pthread_join (id, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/09-ptrmunge_rc.c
+++ b/tests/regression/04-mutex/09-ptrmunge_rc.c
@@ -13,14 +13,14 @@ void munge(pthread_mutex_t *m, int *v) {
 }
 
 void *t_fun(void *arg) {
-  munge(&mutex1, &myglobal1); // NOWARN
+  munge(&mutex1, &myglobal1);
   return NULL;
 }
 
 int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  munge(&mutex2,&myglobal1); // NOWARN
+  munge(&mutex2,&myglobal1);
   pthread_join (id, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/10-ptrmunge_nr.c
+++ b/tests/regression/04-mutex/10-ptrmunge_nr.c
@@ -13,14 +13,14 @@ void munge(pthread_mutex_t *m, int *v) {
 }
 
 void *t_fun(void *arg) {
-  munge(&mutex1, &myglobal1); // NOWARN
+  munge(&mutex1, &myglobal1);
   return NULL;
 }
 
 int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  munge(&mutex2,&myglobal2); // NOWARN
+  munge(&mutex2,&myglobal2);
   pthread_join (id, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/10-ptrmunge_nr.c
+++ b/tests/regression/04-mutex/10-ptrmunge_nr.c
@@ -8,19 +8,19 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 void munge(pthread_mutex_t *m, int *v) {
   pthread_mutex_lock(m);
-  *v=*v+1; // NOWARN!
+  *v=*v+1; // NORACE
   pthread_mutex_unlock(m);
 }
 
 void *t_fun(void *arg) {
-  munge(&mutex1, &myglobal1); // NOWARN!
+  munge(&mutex1, &myglobal1); // NOWARN
   return NULL;
 }
 
 int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  munge(&mutex2,&myglobal2); // NOWARN!
+  munge(&mutex2,&myglobal2); // NOWARN
   pthread_join (id, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/12-ptr_nr.c
+++ b/tests/regression/04-mutex/12-ptr_nr.c
@@ -8,7 +8,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 void *t_fun(void *arg) {
   int *p = &myglobal;
   pthread_mutex_lock(&mutex1);
-  *p = *p + 1; // NOWARN!
+  *p = *p + 1; // NORACE
   pthread_mutex_unlock(&mutex1);
   return NULL;
 }
@@ -17,7 +17,7 @@ int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&mutex1);
-  myglobal=myglobal+1; // NOWARN!
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(&mutex1);
   pthread_join (id, NULL);
   return 0;

--- a/tests/regression/04-mutex/14-funarg_rc.c
+++ b/tests/regression/04-mutex/14-funarg_rc.c
@@ -15,7 +15,7 @@ void *t_fun(void *arg) {
 }
 
 int add1 (int x) {
-  return x+1; // NOWARN!
+  return x+1;
 }
 
 int main(void) {

--- a/tests/regression/04-mutex/15-funarg_nr.c
+++ b/tests/regression/04-mutex/15-funarg_nr.c
@@ -9,7 +9,7 @@ pthread_mutex_t mutex3 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex1);
-  myglobal=myglobal+1; // NOWARN!
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(&mutex1);
   return NULL;
 }
@@ -23,11 +23,11 @@ int main(void) {
   pthread_create(&id, NULL, t_fun, NULL);
 
   pthread_mutex_lock(&mutex1);
-  printf("myglobal equals %d\n",myglobal);
+  printf("myglobal equals %d\n",myglobal); // NORACE
   pthread_mutex_unlock(&mutex1);
 
   pthread_mutex_lock(&mutex1);
-  add1(myglobal); // NOWARN!
+  add1(myglobal); // NORACE
   pthread_mutex_unlock(&mutex1);
 
   pthread_join (id, NULL);

--- a/tests/regression/04-mutex/16-ps_add1_rc.c
+++ b/tests/regression/04-mutex/16-ps_add1_rc.c
@@ -1,9 +1,11 @@
+extern int __VERIFIER_nondet_int();
+
 #include<stdio.h>
 #include<pthread.h>
 #include<assert.h>
 
 int glob;
-pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER; 
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m);
@@ -13,19 +15,19 @@ void *t_fun(void *arg) {
 }
 
 int main() {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  
+
   printf("Do the work? ");
-  if (i) 
+  if (i)
     pthread_mutex_lock(&m);
   printf("Now we do the work..\n");
   i++;
-  if (i) 
+  if (i)
     glob++; // RACE!
   printf("Work is completed...");
-  if (i) 
+  if (i)
     pthread_mutex_unlock(&m);
 
   return 0;

--- a/tests/regression/04-mutex/17-ps_add1_nr.c
+++ b/tests/regression/04-mutex/17-ps_add1_nr.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int();
+
 #include<stdio.h>
 #include<pthread.h>
 #include<assert.h>
@@ -13,7 +15,7 @@ void *t_fun(void *arg) {
 }
 
 int main() {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
 

--- a/tests/regression/04-mutex/17-ps_add1_nr.c
+++ b/tests/regression/04-mutex/17-ps_add1_nr.c
@@ -3,11 +3,11 @@
 #include<assert.h>
 
 int glob;
-pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER; 
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m);
-  glob++; // NOWARN!
+  glob++; // NORACE
   pthread_mutex_unlock(&m);
   return NULL;
 }
@@ -16,16 +16,16 @@ int main() {
   int i;
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  
+
   printf("Do the work? ");
-  if (i) 
+  if (i)
     pthread_mutex_lock(&m);
   printf("Now we do the work..\n");
   i++;
-  if (i-1) 
-    glob++; // NOWARN!
+  if (i-1)
+    glob++; // NORACE
   printf("Work is completed...");
-  if (i) 
+  if (i)
     pthread_mutex_unlock(&m);
 
   return 0;

--- a/tests/regression/04-mutex/18-glob_guards.c
+++ b/tests/regression/04-mutex/18-glob_guards.c
@@ -6,7 +6,7 @@ pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
-  if (myglobal) // NOWARN!
+  if (myglobal) // NORACE
     printf("How do you do?\n");
   return NULL;
 }
@@ -18,7 +18,7 @@ int main(void) {
   myglobal = k;
   // create thread
   pthread_create(&id, NULL, t_fun, NULL);
-  if (myglobal)  // NOWARN!
+  if (myglobal)  // NORACE
     printf("Hello!\n");
   pthread_join (id, NULL);
   return 0;

--- a/tests/regression/04-mutex/18-glob_guards.c
+++ b/tests/regression/04-mutex/18-glob_guards.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int();
+
 #include <pthread.h>
 #include <stdio.h>
 
@@ -14,7 +16,7 @@ void *t_fun(void *arg) {
 int main(void) {
   pthread_t id;
   // invalidate myglobal
-  int k;
+  int k = __VERIFIER_nondet_int();
   myglobal = k;
   // create thread
   pthread_create(&id, NULL, t_fun, NULL);

--- a/tests/regression/04-mutex/22-deref_read.c
+++ b/tests/regression/04-mutex/22-deref_read.c
@@ -7,7 +7,7 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex);
-  *p = 8; // NOWARN!
+  *p = 8; // NORACE
   pthread_mutex_unlock(&mutex);
   return NULL;
 }
@@ -15,9 +15,9 @@ void *t_fun(void *arg) {
 int main() {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  q = p; // NOWARN!
+  q = p; // NORACE
   pthread_mutex_lock(&mutex);
-  *q = 8; // NOWARN!
+  *q = 8; // NORACE
   pthread_mutex_unlock(&mutex);
   return 0;
 }

--- a/tests/regression/04-mutex/23-sound_unlock.c
+++ b/tests/regression/04-mutex/23-sound_unlock.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int();
+
 #include <pthread.h>
 #include <stdio.h>
 
@@ -13,7 +15,7 @@ void *t_fun(void *arg) {
 }
 
 int main(void) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t id;
   pthread_mutex_t *m = &mutex1;
   if (i) m = &mutex2;

--- a/tests/regression/04-mutex/24-sound_lock.c
+++ b/tests/regression/04-mutex/24-sound_lock.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int();
+
 #include <pthread.h>
 #include <stdio.h>
 
@@ -13,7 +15,7 @@ void *t_fun(void *arg) {
 }
 
 int main(void) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t id;
   pthread_mutex_t *m = &mutex1;
   if (i) m = &mutex2;

--- a/tests/regression/04-mutex/25-single_acc.c
+++ b/tests/regression/04-mutex/25-single_acc.c
@@ -3,7 +3,7 @@
 int x;
 
 void *t_fun(void *arg) {
-  x++; // RACE
+  x++; // RACE!
   return NULL;
 }
 
@@ -12,6 +12,6 @@ int main() {
 
   pthread_create(&id1, NULL, t_fun, NULL);
   pthread_create(&id2, NULL, t_fun, NULL);
-  
+
   return 0;
 }

--- a/tests/regression/04-mutex/27-base_rc.c
+++ b/tests/regression/04-mutex/27-base_rc.c
@@ -4,12 +4,12 @@
 int global;
 pthread_mutex_t gm = PTHREAD_MUTEX_INITIALIZER;
 
-void bad() { 
+void bad() {
   global++; // RACE!
-} 
-void good() { 
+}
+void good() {
   pthread_mutex_lock(&gm);
-  global++;
+  global++; // RACE
   pthread_mutex_unlock(&gm);
 }
 
@@ -20,7 +20,7 @@ void *t_fun(void *arg) {
   void (*g)();
 
   pthread_mutex_lock(&fm);
-  g = f;
+  g = f; // NORACE
   pthread_mutex_unlock(&fm);
 
   g();
@@ -32,7 +32,7 @@ int main() {
   pthread_create(&id, NULL, t_fun, NULL);
 
   pthread_mutex_lock(&fm);
-  f = bad;
+  f = bad; // NORACE
   pthread_mutex_unlock(&fm);
 
   pthread_mutex_lock(&gm);

--- a/tests/regression/04-mutex/28-base_nr.c
+++ b/tests/regression/04-mutex/28-base_nr.c
@@ -4,12 +4,12 @@
 int global;
 pthread_mutex_t gm = PTHREAD_MUTEX_INITIALIZER;
 
-void bad() { 
-  global++;
-} 
-void good() { 
+void bad() {
+  global++; // NORACE
+}
+void good() {
   pthread_mutex_lock(&gm);
-  global++; // NORACE!
+  global++; // NORACE
   pthread_mutex_unlock(&gm);
 }
 
@@ -20,7 +20,7 @@ void *t_fun(void *arg) {
   void (*g)();
 
   pthread_mutex_lock(&fm);
-  g = f;
+  g = f; // NORACE
   pthread_mutex_unlock(&fm);
 
   g();
@@ -32,11 +32,11 @@ int main() {
   pthread_create(&id, NULL, t_fun, NULL);
 
   pthread_mutex_lock(&fm);
-  f = good;
+  f = good; // NORACE
   pthread_mutex_unlock(&fm);
 
   pthread_mutex_lock(&gm);
-  printf("global: %d\n", global); // NORACE!
+  printf("global: %d\n", global); // NORACE
   pthread_mutex_unlock(&gm);
 
   return 0;

--- a/tests/regression/04-mutex/29-funstruct_rc.c
+++ b/tests/regression/04-mutex/29-funstruct_rc.c
@@ -17,14 +17,14 @@ int inc(int x) {
 }
 void glob() {
   pthread_mutex_lock(&B_mutex);
-  x++; // RACE
+  x++; // RACE!
   pthread_mutex_unlock(&B_mutex);
   return;
 }
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A_mutex);
-  x++; // RACE
+  x++; // RACE!
   pthread_mutex_unlock(&A_mutex);
   return NULL;
 }

--- a/tests/regression/04-mutex/35-trylock_rc.c
+++ b/tests/regression/04-mutex/35-trylock_rc.c
@@ -49,7 +49,7 @@ void *monitor_thread (void *arg) {
     if (status != EBUSY) {
       if (status != 0)
         err_abort (status, "Trylock mutex");
-      printf ("Counter is %ld\n", counter/SPIN); // RACE!
+      printf ("Counter is %ld\n", counter/SPIN); // RACE
       status = pthread_mutex_unlock (&mutex);
       if (status != 0)
         err_abort (status, "Unlock mutex");

--- a/tests/regression/04-mutex/36-trylock_nr.c
+++ b/tests/regression/04-mutex/36-trylock_nr.c
@@ -29,7 +29,7 @@ void *counter_thread (void *arg) {
     if (status != 0)
       err_abort (status, "Lock mutex");
     for (spin = 0; spin < SPIN; spin++)
-      counter++; // NORACE!
+      counter++; // NORACE
     status = pthread_mutex_unlock (&mutex);
     if (status != 0)
       err_abort (status, "Unlock mutex");
@@ -49,7 +49,7 @@ void *monitor_thread (void *arg) {
     if (status != EBUSY) {
       if (status != 0)
         err_abort (status, "Trylock mutex");
-      printf ("Counter is %ld\n", counter/SPIN); // NORACE!
+      printf ("Counter is %ld\n", counter/SPIN); // NORACE
       status = pthread_mutex_unlock (&mutex);
       if (status != 0)
         err_abort (status, "Unlock mutex");

--- a/tests/regression/04-mutex/37-indirect_rc.c
+++ b/tests/regression/04-mutex/37-indirect_rc.c
@@ -7,7 +7,7 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex);
-  (*g1)++; // RACE
+  (*g1)++; // RACE!
   pthread_mutex_lock(&mutex);
   return NULL;
 }
@@ -19,7 +19,7 @@ int main(void) {
 
   pthread_create(&id, NULL, t_fun, NULL);
 
-  (*g2)++; //RACE
+  (*g2)++; // RACE!
 
   pthread_join (id, NULL);
   return 0;

--- a/tests/regression/04-mutex/38-indexing_malloc.c
+++ b/tests/regression/04-mutex/38-indexing_malloc.c
@@ -5,7 +5,7 @@ int* s;
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
-  s[0] = 8; // RACE
+  s[0] = 8; // RACE!
   return NULL;
 }
 
@@ -13,7 +13,7 @@ int main(void) {
   pthread_t id;
   s = (int*)malloc(sizeof(int));
   pthread_create(&id, NULL, t_fun, NULL);
-  s[0] = 9; // RACE
+  s[0] = 9; // RACE!
   pthread_join (id, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/41-pt_rwlock.c
+++ b/tests/regression/04-mutex/41-pt_rwlock.c
@@ -8,8 +8,8 @@ static pthread_rwlock_t rwlock = PTHREAD_RWLOCK_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_rwlock_wrlock(&rwlock);
-  data1++;            //NORACE!
-  printf("%d",data2); //RACE!
+  data1++;            // NORACE
+  printf("%d",data2); // RACE
   pthread_rwlock_unlock(&rwlock);
   return NULL;
 }
@@ -19,8 +19,8 @@ int main(void) {
   pthread_create(&id, NULL, t_fun, NULL);
 
   pthread_rwlock_rdlock(&rwlock);
-  printf("%d",data1); //NORACE!
-  data2++;            //RACE
+  printf("%d",data1); // NORACE
+  data2++;            // RACE
   pthread_rwlock_unlock(&rwlock);
 
   pthread_join (id, NULL);

--- a/tests/regression/04-mutex/42-trylock_2mutex.c
+++ b/tests/regression/04-mutex/42-trylock_2mutex.c
@@ -6,11 +6,11 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex1);
-  g1++; // NORACE!
+  g1++; // NORACE
   pthread_mutex_unlock(&mutex1);
 
   pthread_mutex_lock(&mutex2);
-  g2++; // NORACE!
+  g2++; // NORACE
   pthread_mutex_unlock(&mutex2);
   return NULL;
 }
@@ -24,9 +24,9 @@ int main(void) {
     pthread_mutex_unlock(&mutex1);
     pthread_mutex_lock(&mutex1);
   }
-  
-  g1=g2+1; // NORACE!
-  
+
+  g1=g2+1; // NORACE
+
   pthread_mutex_unlock(&mutex2);
   pthread_mutex_unlock(&mutex1);
 

--- a/tests/regression/04-mutex/43-thread_create_nr.c
+++ b/tests/regression/04-mutex/43-thread_create_nr.c
@@ -8,16 +8,16 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex1);
-  myglobal=myglobal+1; // NORACE!
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(&mutex1);
   return NULL;
 }
 
 int main(void) {
   pthread_t id;
-  debug = 0; // NORACE!
-  myglobal=myglobal+1; // NORACE!
+  debug = 0; // NORACE
+  myglobal=myglobal+1; // NORACE
   pthread_create(&id, NULL, t_fun, NULL);
-  debug++; // NORACE!
+  debug++; // NORACE
   return 0;
 }

--- a/tests/regression/04-mutex/44-malloc_sound.c
+++ b/tests/regression/04-mutex/44-malloc_sound.c
@@ -7,7 +7,7 @@ pthread_mutex_t *p, *q;
 
 void *f(void *x){
   pthread_mutex_lock(q);
-  glob++; // RACE
+  glob++; // RACE!
   pthread_mutex_unlock(q);
   return NULL;
 }
@@ -30,7 +30,7 @@ int main() {
   pthread_create(&t1, 0, f, 0);
 
   pthread_mutex_lock(p);
-  glob++; // RACE
+  glob++; // RACE!
   pthread_mutex_unlock(p);
 
   return 1;

--- a/tests/regression/04-mutex/46-escape_nr.c
+++ b/tests/regression/04-mutex/46-escape_nr.c
@@ -7,7 +7,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 void *t_fun(void *arg) {
   int *p = (int *) arg;
   pthread_mutex_lock(&mutex1);
-  (*p)++; // NOWARN!
+  (*p)++; // NORACE
   pthread_mutex_unlock(&mutex1);
   return NULL;
 }
@@ -17,7 +17,7 @@ int main(void) {
   int i;
   pthread_create(&id, NULL, t_fun, (void *) &i);
   pthread_mutex_lock(&mutex1);
-  i++; // NOWARN!
+  i++; // NORACE
   pthread_mutex_unlock(&mutex1);
   pthread_join (id, NULL);
   return 0;

--- a/tests/regression/04-mutex/49-type-invariants.c
+++ b/tests/regression/04-mutex/49-type-invariants.c
@@ -19,7 +19,7 @@ extern struct S* getS();
 int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
-  getS()->field = 10; // RACE!!11
+  getS()->field = 10; // RACE!
   return 0;
 }
- 
+

--- a/tests/regression/04-mutex/50-funptr_rc.c
+++ b/tests/regression/04-mutex/50-funptr_rc.c
@@ -12,7 +12,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex1);
-  fp = f2; // RACE
+  fp = f2; // RACE!
   pthread_mutex_unlock(&mutex1);
   return NULL;
 }
@@ -21,7 +21,7 @@ int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&mutex2);
-  fp();  // RACE
+  fp();  // RACE!
   pthread_mutex_unlock(&mutex2);
   pthread_join (id, NULL);
   return 0;

--- a/tests/regression/04-mutex/51-mutex_ptr.c
+++ b/tests/regression/04-mutex/51-mutex_ptr.c
@@ -9,9 +9,9 @@ pthread_mutex_t * mp = &mutex1;
 void *t_fun(void *arg) {
   pthread_mutex_t * mp1;
   int *p = &myglobal;
-  mp1 = mp;
+  mp1 = mp; // NORACE
   pthread_mutex_lock(mp);
-  *p = *p + 1; // NOWARN!
+  *p = *p + 1; // NORACE
   pthread_mutex_unlock(mp);
   return NULL;
 }
@@ -19,11 +19,11 @@ void *t_fun(void *arg) {
 int main(void) {
   pthread_mutex_t * mp1;
   pthread_t id;
-  mp = &mutex1;
+  mp = &mutex1; // NORACE
   pthread_create(&id, NULL, t_fun, NULL);
-  mp1 = mp;
+  mp1 = mp; // NORACE
   pthread_mutex_lock(mp);
-  myglobal=myglobal+1; // NOWARN!
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(mp);
   pthread_join (id, NULL);
   return 0;

--- a/tests/regression/04-mutex/52-confid_rc.c
+++ b/tests/regression/04-mutex/52-confid_rc.c
@@ -38,8 +38,10 @@ void *t_fun(void *arg) {
 }
 
 int main(void) {
-  pthread_t id;
+  pthread_t id, id2;
   pthread_create(&id, NULL, t_fun, NULL);
+  pthread_create(&id2, NULL, t_fun, NULL);
   pthread_join (id, NULL);
+  pthread_join (id2, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/54-pt_rwlock_ww.c
+++ b/tests/regression/04-mutex/54-pt_rwlock_ww.c
@@ -1,0 +1,29 @@
+#include <pthread.h>
+#include <stdio.h>
+
+static int data1;
+static int data2;
+static pthread_rwlock_t rwlock = PTHREAD_RWLOCK_INITIALIZER;
+
+
+void *t_fun(void *arg) {
+  pthread_rwlock_wrlock(&rwlock);
+  data1++;            // NORACE
+  printf("%d",data2); // NORACE
+  pthread_rwlock_unlock(&rwlock);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_rwlock_wrlock(&rwlock);
+  printf("%d",data1); // NORACE
+  data2++;            // NORACE
+  pthread_rwlock_unlock(&rwlock);
+
+  pthread_join (id, NULL);
+  return 0;
+}
+

--- a/tests/regression/04-mutex/55-pt_rwlock_rr.c
+++ b/tests/regression/04-mutex/55-pt_rwlock_rr.c
@@ -1,0 +1,29 @@
+#include <pthread.h>
+#include <stdio.h>
+
+static int data1;
+static int data2;
+static pthread_rwlock_t rwlock = PTHREAD_RWLOCK_INITIALIZER;
+
+
+void *t_fun(void *arg) {
+  pthread_rwlock_rdlock(&rwlock);
+  data1++;            // RACE!
+  printf("%d",data2); // RACE!
+  pthread_rwlock_unlock(&rwlock);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_rwlock_rdlock(&rwlock);
+  printf("%d",data1); // RACE!
+  data2++;            // RACE!
+  pthread_rwlock_unlock(&rwlock);
+
+  pthread_join (id, NULL);
+  return 0;
+}
+

--- a/tests/regression/05-lval_ls/02-idx_nr.c
+++ b/tests/regression/05-lval_ls/02-idx_nr.c
@@ -5,7 +5,7 @@ pthread_mutex_t m[10];
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m[4]);
-  data++; // NOWARN!
+  data++; // NORACE
   pthread_mutex_unlock(&m[4]);
   return NULL;
 }
@@ -14,7 +14,7 @@ int main() {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&m[4]);
-  data++; // NOWARN!
+  data++; // NORACE
   pthread_mutex_unlock(&m[4]);
   return 0;
 }

--- a/tests/regression/05-lval_ls/04-fld_nr.c
+++ b/tests/regression/05-lval_ls/04-fld_nr.c
@@ -9,7 +9,7 @@ struct {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m.x);
-  glob++; // NOWARN!
+  glob++; // NORACE
   pthread_mutex_unlock(&m.x);
   return NULL;
 }
@@ -18,7 +18,7 @@ int main() {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&m.x);
-  glob++; // NOWARN!
+  glob++; // NORACE
   pthread_mutex_lock(&m.x);
   return 0;
 }

--- a/tests/regression/05-lval_ls/08-glob_fld_2_rc.c
+++ b/tests/regression/05-lval_ls/08-glob_fld_2_rc.c
@@ -7,13 +7,14 @@ struct {
 } data;
 
 void *t_fun(void *arg) {
-  data.x++; // RACE
+  data.x++; // RACE!
   return NULL;
 }
 
 int main() {
-  pthread_t id;
+  pthread_t id, id2;
   pthread_create(&id, NULL, t_fun, NULL);
+  pthread_create(&id2, NULL, t_fun, NULL);
   data.y++; // NORACE
   return 0;
 }

--- a/tests/regression/05-lval_ls/12-fldsense_nr.c
+++ b/tests/regression/05-lval_ls/12-fldsense_nr.c
@@ -5,7 +5,7 @@ struct { pthread_mutex_t x; pthread_mutex_t y; } m;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m.x);
-  data.x++; // NOWARN!
+  data.x++; // NORACE
   pthread_mutex_unlock(&m.x);
   return NULL;
 }
@@ -14,10 +14,10 @@ int main() {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&m.x);
-  data.x++; // NOWARN!
+  data.x++; // NORACE
   pthread_mutex_unlock(&m.x);
   pthread_mutex_lock(&m.y);
-  data.y++; // NOWARN!
+  data.y++; // NORACE
   pthread_mutex_unlock(&m.y);
   return 0;
 }

--- a/tests/regression/05-lval_ls/13-idxunknown_lock.c
+++ b/tests/regression/05-lval_ls/13-idxunknown_lock.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int();
+
 #include <pthread.h>
 
 int data[10];
@@ -11,7 +13,7 @@ void *t_fun(void *arg) {
 }
 
 int main() {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&m[i]);

--- a/tests/regression/05-lval_ls/13-idxunknown_lock.c
+++ b/tests/regression/05-lval_ls/13-idxunknown_lock.c
@@ -1,4 +1,8 @@
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include <pthread.h>
 
@@ -14,6 +18,7 @@ void *t_fun(void *arg) {
 
 int main() {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&m[i]);

--- a/tests/regression/05-lval_ls/14-idxunknown_access.c
+++ b/tests/regression/05-lval_ls/14-idxunknown_access.c
@@ -1,4 +1,8 @@
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include <pthread.h>
 
@@ -11,6 +15,7 @@ void *t_fun(void *arg) {
 
 int main() {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   data[i]++; // RACE!

--- a/tests/regression/05-lval_ls/14-idxunknown_access.c
+++ b/tests/regression/05-lval_ls/14-idxunknown_access.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int();
+
 #include <pthread.h>
 
 int data[10];
@@ -8,7 +10,7 @@ void *t_fun(void *arg) {
 }
 
 int main() {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   data[i]++; // RACE!

--- a/tests/regression/05-lval_ls/15-fldunknown_access.c
+++ b/tests/regression/05-lval_ls/15-fldunknown_access.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int();
+
 #include <stdio.h>
 #include <pthread.h>
 
@@ -12,7 +14,7 @@ void *t_fun(void *arg) {
 }
 
 int main() {
-  int *i,j;
+  int *i,j = __VERIFIER_nondet_int();
   pthread_t id;
   if (j) i = &data.x;
   else i = &data.y;

--- a/tests/regression/05-lval_ls/16-idxunknown_unlock.c
+++ b/tests/regression/05-lval_ls/16-idxunknown_unlock.c
@@ -1,4 +1,8 @@
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include <pthread.h>
 
@@ -14,6 +18,7 @@ void *t_fun(void *arg) {
 
 int main() {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&m[4]);

--- a/tests/regression/05-lval_ls/16-idxunknown_unlock.c
+++ b/tests/regression/05-lval_ls/16-idxunknown_unlock.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int();
+
 #include <pthread.h>
 
 int data;
@@ -11,7 +13,7 @@ void *t_fun(void *arg) {
 }
 
 int main() {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&m[4]);

--- a/tests/regression/06-symbeq/02-funloop_norace.c
+++ b/tests/regression/06-symbeq/02-funloop_norace.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 #include<stdio.h>
 
@@ -9,14 +9,14 @@ struct cache_entry {
 
 void cache_entry_addref(struct cache_entry *entry) {
   pthread_mutex_lock(&entry->refs_mutex);
-  entry->refs++; // NOWARN
+  entry->refs++; // NORACE
   pthread_mutex_unlock(&entry->refs_mutex);
 }
 
 void *t_fun(void *arg) {
   int i;
-  for(i=0; i<10; i++) 
-    cache_entry_addref(&cache[i]); // NOWARN
+  for(i=0; i<10; i++)
+    cache_entry_addref(&cache[i]); // NORACE
   return NULL;
 }
 
@@ -24,7 +24,7 @@ int main () {
   int i;
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
-  for(i=0; i<10; i++) 
-    cache_entry_addref(&cache[i]); // NOWARN
+  for(i=0; i<10; i++)
+    cache_entry_addref(&cache[i]); // NORACE
   return 0;
 }

--- a/tests/regression/06-symbeq/05-funloop_hard2.c
+++ b/tests/regression/06-symbeq/05-funloop_hard2.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 #include<stdio.h>
 
@@ -9,7 +9,7 @@ struct cache_entry {
 
 void cache_entry_addref(struct cache_entry *entry) {
   pthread_mutex_lock(&entry->refs_mutex);
-  entry->refs++; // NOWARN!
+  entry->refs++; // NORACE
   pthread_mutex_unlock(&entry->refs_mutex);
 }
 
@@ -26,7 +26,7 @@ int main () {
   for(i=0; i<10; i++) cache_entry_addref(&cache[i]);
 
   pthread_mutex_lock(&cache[5].refs_mutex);
-  cache[5].refs++; // NOWARN!
+  cache[5].refs++; // NORACE
   pthread_mutex_lock(&cache[5].refs_mutex);
   return 0;
 }

--- a/tests/regression/06-symbeq/06-tricky_address1.c
+++ b/tests/regression/06-symbeq/06-tricky_address1.c
@@ -1,4 +1,6 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdio.h>
 
@@ -8,7 +10,7 @@ struct s {
 } a[10];
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
   p->datum++; // NORACE
@@ -17,7 +19,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
 

--- a/tests/regression/06-symbeq/06-tricky_address1.c
+++ b/tests/regression/06-symbeq/06-tricky_address1.c
@@ -1,5 +1,9 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdio.h>
@@ -11,6 +15,7 @@ struct s {
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
   p->datum++; // NORACE
@@ -20,6 +25,7 @@ void *t_fun(void *arg) {
 
 int main () {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
 

--- a/tests/regression/06-symbeq/06-tricky_address1.c
+++ b/tests/regression/06-symbeq/06-tricky_address1.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 #include<stdio.h>
 
@@ -11,7 +11,7 @@ void *t_fun(void *arg) {
   int i;
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
-  p->datum++; // NOWARN
+  p->datum++; // NORACE
   pthread_mutex_unlock(&p->mutex);
   return NULL;
 }
@@ -20,9 +20,9 @@ int main () {
   int i;
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&a[i].mutex);
-  a[i].datum++; // NOWARN
+  a[i].datum++; // NORACE
   pthread_mutex_unlock(&a[i].mutex);
   return 0;
 }

--- a/tests/regression/06-symbeq/07-tricky_address2.c
+++ b/tests/regression/06-symbeq/07-tricky_address2.c
@@ -1,5 +1,9 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdio.h>
@@ -11,6 +15,7 @@ struct s {
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
   a[i].datum++; // NORACE
@@ -20,6 +25,7 @@ void *t_fun(void *arg) {
 
 int main () {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
 

--- a/tests/regression/06-symbeq/07-tricky_address2.c
+++ b/tests/regression/06-symbeq/07-tricky_address2.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 #include<stdio.h>
 
@@ -11,7 +11,7 @@ void *t_fun(void *arg) {
   int i;
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
-  a[i].datum++; // NOWARN
+  a[i].datum++; // NORACE
   pthread_mutex_unlock(&p->mutex);
   return NULL;
 }
@@ -20,9 +20,9 @@ int main () {
   int i;
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&a[i].mutex);
-  a[i].datum++; // NOWARN
+  a[i].datum++; // NORACE
   pthread_mutex_unlock(&a[i].mutex);
   return 0;
 }

--- a/tests/regression/06-symbeq/07-tricky_address2.c
+++ b/tests/regression/06-symbeq/07-tricky_address2.c
@@ -1,4 +1,6 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdio.h>
 
@@ -8,7 +10,7 @@ struct s {
 } a[10];
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
   a[i].datum++; // NORACE
@@ -17,7 +19,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
 

--- a/tests/regression/06-symbeq/08-tricky_address3.c
+++ b/tests/regression/06-symbeq/08-tricky_address3.c
@@ -1,5 +1,9 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdio.h>
@@ -11,6 +15,7 @@ struct s {
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
   i++;
@@ -21,6 +26,7 @@ void *t_fun(void *arg) {
 
 int main () {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
 

--- a/tests/regression/06-symbeq/08-tricky_address3.c
+++ b/tests/regression/06-symbeq/08-tricky_address3.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 #include<stdio.h>
 
@@ -12,7 +12,7 @@ void *t_fun(void *arg) {
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
   i++;
-  p->datum++; // NOWARN
+  p->datum++; // NORACE
   pthread_mutex_unlock(&p->mutex);
   return NULL;
 }
@@ -21,9 +21,9 @@ int main () {
   int i;
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&a[i].mutex);
-  a[i].datum++; // NOWARN
+  a[i].datum++; // NORACE
   pthread_mutex_unlock(&a[i].mutex);
   return 0;
 }

--- a/tests/regression/06-symbeq/08-tricky_address3.c
+++ b/tests/regression/06-symbeq/08-tricky_address3.c
@@ -1,4 +1,6 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdio.h>
 
@@ -8,7 +10,7 @@ struct s {
 } a[10];
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
   i++;
@@ -18,7 +20,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
 

--- a/tests/regression/06-symbeq/09-tricky_address4.c
+++ b/tests/regression/06-symbeq/09-tricky_address4.c
@@ -1,4 +1,6 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdio.h>
 
@@ -8,7 +10,7 @@ struct s {
 } a[10];
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
   i++;
@@ -18,10 +20,10 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&a[i].mutex);
   a[i].datum++; // RACE!
   pthread_mutex_unlock(&a[i].mutex);

--- a/tests/regression/06-symbeq/09-tricky_address4.c
+++ b/tests/regression/06-symbeq/09-tricky_address4.c
@@ -1,5 +1,9 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdio.h>
@@ -11,6 +15,7 @@ struct s {
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 9);
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
   i++;
@@ -21,6 +26,7 @@ void *t_fun(void *arg) {
 
 int main () {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_t t1;
   pthread_create(&t1, NULL, t_fun, NULL);
 

--- a/tests/regression/06-symbeq/10-equ_rc.c
+++ b/tests/regression/06-symbeq/10-equ_rc.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -11,7 +11,7 @@ struct s {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A.mutex);
-  B.datum = 5; //RACE
+  B.datum = 5; // RACE!
   pthread_mutex_lock(&A.mutex);
   return NULL;
 }
@@ -42,7 +42,7 @@ int main () {
   pthread_create(&id,NULL,t_fun,NULL);
 
   pthread_mutex_lock(m);
-  *d = 8; //RACE
+  *d = 8; // RACE!
   pthread_mutex_unlock(m);
 
   return 0;

--- a/tests/regression/06-symbeq/10-equ_rc.c
+++ b/tests/regression/06-symbeq/10-equ_rc.c
@@ -1,4 +1,6 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -17,7 +19,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int x;
+  int x = __VERIFIER_nondet_int();
   pthread_t id;
 
   // struct s *s = malloc(sizeof(struct s));

--- a/tests/regression/06-symbeq/11-equ_nr.c
+++ b/tests/regression/06-symbeq/11-equ_nr.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -11,7 +11,7 @@ struct s {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A.mutex);
-  A.datum = 5; //NORACE
+  A.datum = 5; // NORACE
   pthread_mutex_lock(&A.mutex);
   return NULL;
 }
@@ -42,7 +42,7 @@ int main () {
   pthread_create(&id,NULL,t_fun,NULL);
 
   pthread_mutex_lock(m);
-  *d = 8; //NORACE
+  *d = 8; // NORACE
   pthread_mutex_unlock(m);
 
   return 0;

--- a/tests/regression/06-symbeq/11-equ_nr.c
+++ b/tests/regression/06-symbeq/11-equ_nr.c
@@ -1,4 +1,6 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -17,7 +19,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int x;
+  int x = __VERIFIER_nondet_int();
   pthread_t id;
 
   // struct s *s = malloc(sizeof(struct s));

--- a/tests/regression/06-symbeq/12-equ_proc_rc.c
+++ b/tests/regression/06-symbeq/12-equ_proc_rc.c
@@ -9,13 +9,13 @@ struct s {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&B.mutex);
-  A.datum = 5; //RACE
+  A.datum = 5; // RACE!
   pthread_mutex_lock(&B.mutex);
   return NULL;
 }
 
 void update(int *p) {
-  *p = 8; //RACE
+  *p = 8; // RACE!
 }
 
 int main () {
@@ -27,9 +27,9 @@ int main () {
 
   pthread_mutex_t *m;
 
-  if (x) 
-    s = &A; 
-  else 
+  if (x)
+    s = &A;
+  else
     s = &B;
 
   m = &s->mutex;

--- a/tests/regression/06-symbeq/13-equ_proc_nr.c
+++ b/tests/regression/06-symbeq/13-equ_proc_nr.c
@@ -1,4 +1,6 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -19,7 +21,7 @@ void update(int *p) {
 }
 
 int main () {
-  int x;
+  int x = __VERIFIER_nondet_int();
   pthread_t id;
 
   struct s *s;

--- a/tests/regression/06-symbeq/13-equ_proc_nr.c
+++ b/tests/regression/06-symbeq/13-equ_proc_nr.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -9,13 +9,13 @@ struct s {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A.mutex);
-  A.datum = 5; //NORACE
+  A.datum = 5; // NORACE
   pthread_mutex_lock(&A.mutex);
   return NULL;
 }
 
 void update(int *p) {
-  *p = 8; //NORACE
+  *p = 8; // NORACE
 }
 
 int main () {
@@ -27,9 +27,9 @@ int main () {
 
   pthread_mutex_t *m;
 
-  if (x) 
-    s = &A; 
-  else 
+  if (x)
+    s = &A;
+  else
     s = &B;
 
   m = &s->mutex;

--- a/tests/regression/06-symbeq/14-list_entry_rc.c
+++ b/tests/regression/06-symbeq/14-list_entry_rc.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -21,7 +21,7 @@ void update (int *p) {
   struct s *s = list_entry(p, struct s, list);
   pthread_mutex_lock(&s->mutex);
   s++;
-  s->datum++; //RACE
+  s->datum++; // RACE!
   pthread_mutex_lock(&s->mutex);
 }
 

--- a/tests/regression/06-symbeq/15-list_entry_nr.c
+++ b/tests/regression/06-symbeq/15-list_entry_nr.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -20,7 +20,7 @@ void init (struct s *p, int x) {
 void update (int *p) {
   struct s *s = list_entry(p, struct s, list);
   pthread_mutex_lock(&s->mutex);
-  s->datum++; //NORACE
+  s->datum++; // NORACE
   pthread_mutex_lock(&s->mutex);
 }
 

--- a/tests/regression/06-symbeq/16-type_rc.c
+++ b/tests/regression/06-symbeq/16-type_rc.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 
 struct s {
@@ -10,7 +10,7 @@ extern struct s *get_s();
 
 void *t_fun(void *arg) {
   struct s *s = get_s();
-  s->datum = 5; //RACE
+  s->datum = 5; // RACE!
   return NULL;
 }
 
@@ -25,7 +25,7 @@ int main () {
   d = &s->datum;
 
   pthread_create(&id,NULL,t_fun,NULL);
-  *d = 8; //RACE
+  *d = 8; // RACE!
 
   return 0;
 }

--- a/tests/regression/06-symbeq/21-mult_accs_rc.c
+++ b/tests/regression/06-symbeq/21-mult_accs_rc.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 
 struct s {
@@ -9,11 +9,11 @@ struct s {
 extern struct s *get_s();
 
 void *t_fun(void *arg) {
-  struct s *s; 
+  struct s *s;
   s = get_s();
   pthread_mutex_lock(&s->mutex);
-  s = get_s(); 
-  s->data = 5; // RACE
+  s = get_s();
+  s->data = 5; // RACE!
   pthread_mutex_lock(&s->mutex);
   return NULL;
 }
@@ -31,7 +31,7 @@ int main () {
   pthread_create(&id,NULL,t_fun,NULL);
 
   pthread_mutex_lock(m);
-  *d = 8; // RACE
+  *d = 8; // RACE!
   pthread_mutex_unlock(m);
 
   return 0;

--- a/tests/regression/06-symbeq/23-idxsense_nr.c
+++ b/tests/regression/06-symbeq/23-idxsense_nr.c
@@ -1,5 +1,5 @@
-// SKIP works with --sets ana.activated[+] symb_locks --sets ana.activated[+] var_eq
-// Copied to 06/23
+// PARAM: --sets ana.activated[+] symb_locks --sets ana.activated[+] var_eq
+// Copy of 05/10 with symb_locks enabled
 #include <pthread.h>
 
 int data[10];

--- a/tests/regression/09-regions/01-list_rc.c
+++ b/tests/regression/09-regions/01-list_rc.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] "'region'" 
+// PARAM: --set ana.activated[+] "'region'"
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -20,7 +20,7 @@ void *t_fun(void *arg) {
   struct s *p = malloc(sizeof(struct s));
   struct s *t;
   init(p,7);
-  
+
   pthread_mutex_lock(&B_mutex);
   t = A->next;
   A->next = p; // RACE!
@@ -39,9 +39,9 @@ int main () {
   A->next = p;
 
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&A_mutex);
-  p = A->next; // RACE
+  p = A->next; // RACE!
   printf("%d\n", p->datum);
   pthread_mutex_unlock(&A_mutex);
   return 0;

--- a/tests/regression/09-regions/03-list2_rc.c
+++ b/tests/regression/09-regions/03-list2_rc.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] "'region'" 
+// PARAM: --set ana.activated[+] "'region'"
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -18,11 +18,11 @@ pthread_mutex_t B_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A_mutex);
-  A->next->datum++; // RACE
+  A->next->datum++; // RACE!
   pthread_mutex_unlock(&A_mutex);
 
   pthread_mutex_lock(&B_mutex);
-  B->next->datum++; // RACE
+  B->next->datum++; // RACE!
   pthread_mutex_unlock(&B_mutex);
   return NULL;
 }
@@ -41,15 +41,15 @@ int main () {
   B->next = p;
 
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&A_mutex);
-  p = A->next; 
-  printf("%d\n", p->datum); // RACE
+  p = A->next;
+  printf("%d\n", p->datum); // RACE!
   pthread_mutex_unlock(&A_mutex);
 
   pthread_mutex_lock(&B_mutex);
-  p = B->next; 
-  printf("%d\n", p->datum); // RACE
+  p = B->next;
+  printf("%d\n", p->datum); // RACE!
   pthread_mutex_unlock(&B_mutex);
   return 0;
 }

--- a/tests/regression/09-regions/05-ptra_rc.c
+++ b/tests/regression/09-regions/05-ptra_rc.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] "'region'" 
+// PARAM: --set ana.activated[+] "'region'"
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -24,7 +24,7 @@ void *t_fun(void *arg) {
   struct s *t, *sp;
   struct s *p = malloc(sizeof(struct s));
   init(p,7);
-  
+
   pthread_mutex_lock(&B_mutex);
   t = A->next;
   A->next = sp; // RACE!
@@ -47,12 +47,12 @@ int main () {
   init(B,5);
 
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   ip = &p->datum;
   sp = list_entry(ip, struct s, datum);
 
   pthread_mutex_lock(&A_mutex);
-  p = A->next; // RACE
+  p = A->next; // RACE!
   printf("%d\n", p->datum);
   pthread_mutex_unlock(&A_mutex);
   return 0;

--- a/tests/regression/09-regions/05-ptra_rc.c
+++ b/tests/regression/09-regions/05-ptra_rc.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'region'"
+extern void* __VERIFIER_nondet_pointer();
+
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -21,7 +23,7 @@ pthread_mutex_t B_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   int *ip;
-  struct s *t, *sp;
+  struct s *t, *sp = __VERIFIER_nondet_pointer();
   struct s *p = malloc(sizeof(struct s));
   init(p,7);
 

--- a/tests/regression/09-regions/09-arraylist.c
+++ b/tests/regression/09-regions/09-arraylist.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -28,6 +32,7 @@ struct s *slot[10];
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_mutex_lock(&mutex);
   list_add(new(3), slot[i]);
   pthread_mutex_unlock(&mutex);
@@ -36,6 +41,7 @@ void *t_fun(void *arg) {
 
 int main () {
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j && j < 10);
   pthread_t t1;
   struct s *p;
 

--- a/tests/regression/09-regions/09-arraylist.c
+++ b/tests/regression/09-regions/09-arraylist.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -25,7 +27,7 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 struct s *slot[10];
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_mutex_lock(&mutex);
   list_add(new(3), slot[i]);
   pthread_mutex_unlock(&mutex);
@@ -33,7 +35,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int j;
+  int j = __VERIFIER_nondet_int();
   pthread_t t1;
   struct s *p;
 
@@ -41,7 +43,7 @@ int main () {
   list_add(new(2), slot[j]);
 
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&mutex);
   p = slot[j]->next; // NORACE
   printf("%d\n", p->datum);

--- a/tests/regression/09-regions/10-arraylist_rc.c
+++ b/tests/regression/09-regions/10-arraylist_rc.c
@@ -1,4 +1,4 @@
-// SKIP! PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+// PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -36,14 +36,14 @@ int main () {
   int j;
   struct s *p;
   pthread_t t1;
- 
+
   slot[j] = new(1);
   list_add(new(2), slot[j]);
 
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&mutex[j]);
-  p = slot[j]->next; // RACE
+  p = slot[j]->next; // RACE!
   printf("%d\n", p->datum);
   pthread_mutex_unlock(&mutex[j]);
   return 0;

--- a/tests/regression/09-regions/10-arraylist_rc.c
+++ b/tests/regression/09-regions/10-arraylist_rc.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -28,6 +32,7 @@ struct s *slot[10];
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 9);
   pthread_mutex_lock(&mutex[i+1]);
   list_add(new(3), slot[i]);
   pthread_mutex_unlock(&mutex[i+1]);
@@ -36,6 +41,7 @@ void *t_fun(void *arg) {
 
 int main () {
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j && j < 10);
   struct s *p;
   pthread_t t1;
 

--- a/tests/regression/09-regions/10-arraylist_rc.c
+++ b/tests/regression/09-regions/10-arraylist_rc.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -25,7 +27,7 @@ pthread_mutex_t mutex[10];
 struct s *slot[10];
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_mutex_lock(&mutex[i+1]);
   list_add(new(3), slot[i]);
   pthread_mutex_unlock(&mutex[i+1]);
@@ -33,7 +35,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int j;
+  int j = __VERIFIER_nondet_int();
   struct s *p;
   pthread_t t1;
 

--- a/tests/regression/09-regions/11-arraylist_nr.c
+++ b/tests/regression/09-regions/11-arraylist_nr.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -28,6 +32,7 @@ struct s *slot[10];
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_mutex_lock(&mutex[i]);
   list_add(new(3), slot[i]);
   pthread_mutex_unlock(&mutex[i]);
@@ -36,6 +41,7 @@ void *t_fun(void *arg) {
 
 int main () {
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j && j < 10);
   struct s *p;
   pthread_t t1;
 

--- a/tests/regression/09-regions/11-arraylist_nr.c
+++ b/tests/regression/09-regions/11-arraylist_nr.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -25,7 +27,7 @@ pthread_mutex_t mutex[10];
 struct s *slot[10];
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_mutex_lock(&mutex[i]);
   list_add(new(3), slot[i]);
   pthread_mutex_unlock(&mutex[i]);
@@ -33,15 +35,15 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int j;
+  int j = __VERIFIER_nondet_int();
   struct s *p;
   pthread_t t1;
- 
+
   slot[j] = new(1);
   list_add(new(2), slot[j]);
 
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&mutex[j]);
   p = slot[j]->next; // NORACE
   printf("%d\n", p->datum);

--- a/tests/regression/09-regions/12-arraycollapse_rc.c
+++ b/tests/regression/09-regions/12-arraycollapse_rc.c
@@ -36,7 +36,7 @@ int main () {
   int j, k;
   struct s *p;
   pthread_t t1;
- 
+
   slot[j] = new(1);
   list_add(new(2), slot[j]);
 
@@ -49,11 +49,11 @@ int main () {
 
   // If it happens that i = k /= j, then it is a real race: the element in p
   // will be accessed with locks mutex[i] and mutex[j].
- 
+
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&mutex[j]);
-  p = slot[j]->next; // RACE
+  p = slot[j]->next; // RACE!
   printf("%d\n", p->datum);
   pthread_mutex_unlock(&mutex[j]);
   return 0;

--- a/tests/regression/09-regions/12-arraycollapse_rc.c
+++ b/tests/regression/09-regions/12-arraycollapse_rc.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -25,7 +27,7 @@ pthread_mutex_t mutex[10];
 struct s *slot[10];
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_mutex_lock(&mutex[i]);
   list_add(new(3), slot[i]);
   pthread_mutex_unlock(&mutex[i]);
@@ -33,7 +35,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int j, k;
+  int j = __VERIFIER_nondet_int(), k = __VERIFIER_nondet_int();
   struct s *p;
   pthread_t t1;
 

--- a/tests/regression/09-regions/12-arraycollapse_rc.c
+++ b/tests/regression/09-regions/12-arraycollapse_rc.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -28,6 +32,7 @@ struct s *slot[10];
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_mutex_lock(&mutex[i]);
   list_add(new(3), slot[i]);
   pthread_mutex_unlock(&mutex[i]);
@@ -36,6 +41,8 @@ void *t_fun(void *arg) {
 
 int main () {
   int j = __VERIFIER_nondet_int(), k = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j && j < 10);
+  assume_abort_if_not(0 <= k && k < 10);
   struct s *p;
   pthread_t t1;
 

--- a/tests/regression/09-regions/13-arraycollapse_nr.c
+++ b/tests/regression/09-regions/13-arraycollapse_nr.c
@@ -1,4 +1,6 @@
 //PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -25,7 +27,7 @@ pthread_mutex_t mutex[10];
 struct s *slot[10];
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_mutex_lock(&mutex[i]);
   list_add(new(3), slot[i]);
   pthread_mutex_unlock(&mutex[i]);
@@ -33,7 +35,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int j, k;
+  int j = __VERIFIER_nondet_int(), k = __VERIFIER_nondet_int();
   struct s *p;
   pthread_t t1;
 

--- a/tests/regression/09-regions/13-arraycollapse_nr.c
+++ b/tests/regression/09-regions/13-arraycollapse_nr.c
@@ -1,5 +1,9 @@
 //PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -28,6 +32,7 @@ struct s *slot[10];
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_mutex_lock(&mutex[i]);
   list_add(new(3), slot[i]);
   pthread_mutex_unlock(&mutex[i]);
@@ -36,6 +41,8 @@ void *t_fun(void *arg) {
 
 int main () {
   int j = __VERIFIER_nondet_int(), k = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j && j < 10);
+  assume_abort_if_not(0 <= k && k < 10);
   struct s *p;
   pthread_t t1;
 

--- a/tests/regression/09-regions/16-arrayloop_rc.c
+++ b/tests/regression/09-regions/16-arrayloop_rc.c
@@ -1,4 +1,4 @@
-// SKIP! PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+// PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -40,18 +40,18 @@ int main () {
   int j;
   struct s *p;
   pthread_t t1;
- 
+
   for (j=0; j<N; j++) {
     pthread_mutex_init(&mutex[j],NULL);
     slot[j] = new(j);
   }
 
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   for (j=0; j<N; j++) {
     pthread_mutex_lock(&mutex[j]);
     list_add(new(j), slot[j]);
-    p = slot[j]->next; // RACE
+    p = slot[j]->next; // RACE!
     printf("%d\n", p->datum);
     pthread_mutex_unlock(&mutex[j]);
   }

--- a/tests/regression/09-regions/18-nested_rc.c
+++ b/tests/regression/09-regions/18-nested_rc.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -27,7 +29,7 @@ void list_add(struct s *node, struct s *list) {
 }
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_mutex_lock(&c.mutex[i+1]);
   list_add(new(3), c.slots[i]);
   pthread_mutex_unlock(&c.mutex[i+1]);
@@ -35,7 +37,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int j;
+  int j = __VERIFIER_nondet_int();
   struct s *p;
   pthread_t t1;
 

--- a/tests/regression/09-regions/18-nested_rc.c
+++ b/tests/regression/09-regions/18-nested_rc.c
@@ -38,14 +38,14 @@ int main () {
   int j;
   struct s *p;
   pthread_t t1;
- 
+
   c.slots[j] = new(1);
   list_add(new(2), c.slots[j]);
 
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&c.mutex[j]);
-  p = c.slots[j]->next; // RACE
+  p = c.slots[j]->next; // RACE!
   printf("%d\n", p->datum);
   pthread_mutex_unlock(&c.mutex[j]);
   return 0;

--- a/tests/regression/09-regions/18-nested_rc.c
+++ b/tests/regression/09-regions/18-nested_rc.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -30,6 +34,7 @@ void list_add(struct s *node, struct s *list) {
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 9);
   pthread_mutex_lock(&c.mutex[i+1]);
   list_add(new(3), c.slots[i]);
   pthread_mutex_unlock(&c.mutex[i+1]);
@@ -38,6 +43,7 @@ void *t_fun(void *arg) {
 
 int main () {
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j && j < 10);
   struct s *p;
   pthread_t t1;
 

--- a/tests/regression/09-regions/19-nested_nr.c
+++ b/tests/regression/09-regions/19-nested_nr.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -30,6 +34,7 @@ void list_add(struct s *node, struct s *list) {
 
 void *t_fun(void *arg) {
   int i = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= i && i < 10);
   pthread_mutex_lock(&c.mutex[i]);
   list_add(new(3), c.slots[i]);
   pthread_mutex_unlock(&c.mutex[i]);
@@ -38,6 +43,7 @@ void *t_fun(void *arg) {
 
 int main () {
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j && j < 10);
   struct s *p;
   pthread_t t1;
 

--- a/tests/regression/09-regions/19-nested_nr.c
+++ b/tests/regression/09-regions/19-nested_nr.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -27,7 +29,7 @@ void list_add(struct s *node, struct s *list) {
 }
 
 void *t_fun(void *arg) {
-  int i;
+  int i = __VERIFIER_nondet_int();
   pthread_mutex_lock(&c.mutex[i]);
   list_add(new(3), c.slots[i]);
   pthread_mutex_unlock(&c.mutex[i]);
@@ -35,15 +37,15 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int j;
+  int j = __VERIFIER_nondet_int();
   struct s *p;
   pthread_t t1;
- 
+
   c.slots[j] = new(1);
   list_add(new(2), c.slots[j]);
 
   pthread_create(&t1, NULL, t_fun, NULL);
-  
+
   pthread_mutex_lock(&c.mutex[j]);
   p = c.slots[j]->next; // NORACE
   printf("%d\n", p->datum);

--- a/tests/regression/09-regions/20-arrayloop2_rc.c
+++ b/tests/regression/09-regions/20-arrayloop2_rc.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -44,6 +48,7 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
 void *f(void *arg) {
   struct s *pos ;
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j);
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 
@@ -67,6 +72,7 @@ void *f(void *arg) {
 void *g(void *arg) {
   struct s *pos ;
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j);
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 

--- a/tests/regression/09-regions/20-arrayloop2_rc.c
+++ b/tests/regression/09-regions/20-arrayloop2_rc.c
@@ -39,19 +39,19 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
   head->next = new;
 }
 
-void *f(void *arg) { 
+void *f(void *arg) {
   struct s *pos ;
   int j;
   struct list_head  const  *p ;
   struct list_head  const  *q ;
-    
+
   while (j < 10) {
     pthread_mutex_lock(&c.slots_mutex[j]);
     p = c.slot[j].next;
     pos = (struct s *)((char *)p - (size_t)(& ((struct s *)0)->list));
 
     while (& pos->list != & c.slot[j]) {
-      pos->datum++; //RACE
+      pos->datum++; // RACE!
       q = pos->list.next;
       pos = (struct s *)((char *)q - (size_t)(& ((struct s *)0)->list));
     }
@@ -72,13 +72,13 @@ void *g(void *arg) {
     pthread_mutex_lock(&c.slots_mutex[j+1]);
     p = c.slot[j].next;
     pos = (struct s *)((char *)p - (size_t)(& ((struct s *)0)->list));
-  
+
     while (& pos->list != & c.slot[j]) {
-      pos->datum++; //RACE
+      pos->datum++; // RACE!
       q = pos->list.next;
       pos = (struct s *)((char *)q - (size_t)(& ((struct s *)0)->list));
     }
- 
+
     pthread_mutex_unlock(&c.slots_mutex[j+1]);
     j ++;
   }

--- a/tests/regression/09-regions/20-arrayloop2_rc.c
+++ b/tests/regression/09-regions/20-arrayloop2_rc.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -41,7 +43,7 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
 
 void *f(void *arg) {
   struct s *pos ;
-  int j;
+  int j = __VERIFIER_nondet_int();
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 
@@ -64,7 +66,7 @@ void *f(void *arg) {
 
 void *g(void *arg) {
   struct s *pos ;
-  int j;
+  int j = __VERIFIER_nondet_int();
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 

--- a/tests/regression/09-regions/21-arrayloop2_nr.c
+++ b/tests/regression/09-regions/21-arrayloop2_nr.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -41,7 +43,7 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
 
 void *f(void *arg) {
   struct s *pos ;
-  int j;
+  int j = __VERIFIER_nondet_int();
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 

--- a/tests/regression/09-regions/21-arrayloop2_nr.c
+++ b/tests/regression/09-regions/21-arrayloop2_nr.c
@@ -39,23 +39,23 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
   head->next = new;
 }
 
-void *f(void *arg) { 
+void *f(void *arg) {
   struct s *pos ;
   int j;
   struct list_head  const  *p ;
   struct list_head  const  *q ;
-    
+
   while (j < 10) {
     pthread_mutex_lock(&c.slots_mutex[j]);
     p = c.slot[j].next;
     pos = (struct s *)((char *)p - (size_t)(& ((struct s *)0)->list));
-  
+
     while (& pos->list != & c.slot[j]) {
-      pos->datum++; //NORACE
+      pos->datum++; // NORACE
       q = pos->list.next;
       pos = (struct s *)((char *)q - (size_t)(& ((struct s *)0)->list));
     }
- 
+
     pthread_mutex_unlock(&c.slots_mutex[j]);
     j ++;
   }

--- a/tests/regression/09-regions/21-arrayloop2_nr.c
+++ b/tests/regression/09-regions/21-arrayloop2_nr.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -44,6 +48,7 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
 void *f(void *arg) {
   struct s *pos ;
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j);
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 

--- a/tests/regression/09-regions/22-nocollapse.c
+++ b/tests/regression/09-regions/22-nocollapse.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -43,6 +47,7 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
 
 inline static struct list_head *lookup (int d) {
   int hvalue = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= hvalue && hvalue < 10);
   struct list_head *p;
   p = c.slot[hvalue].next;
   return p;
@@ -51,6 +56,7 @@ inline static struct list_head *lookup (int d) {
 void *f(void *arg) {
   struct s *pos ;
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j);
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 
@@ -73,6 +79,7 @@ void *f(void *arg) {
 int main() {
   struct list_head *p;
   int x = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= x && x < 10);
   pthread_t t1, t2;
   for (int i = 0; i < 10; i++) {
     INIT_LIST_HEAD(&c.slot[i]);

--- a/tests/regression/09-regions/22-nocollapse.c
+++ b/tests/regression/09-regions/22-nocollapse.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -40,7 +42,7 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
 }
 
 inline static struct list_head *lookup (int d) {
-  int hvalue;
+  int hvalue = __VERIFIER_nondet_int();
   struct list_head *p;
   p = c.slot[hvalue].next;
   return p;
@@ -48,7 +50,7 @@ inline static struct list_head *lookup (int d) {
 
 void *f(void *arg) {
   struct s *pos ;
-  int j;
+  int j = __VERIFIER_nondet_int();
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 
@@ -70,7 +72,7 @@ void *f(void *arg) {
 
 int main() {
   struct list_head *p;
-  int x;
+  int x = __VERIFIER_nondet_int();
   pthread_t t1, t2;
   for (int i = 0; i < 10; i++) {
     INIT_LIST_HEAD(&c.slot[i]);

--- a/tests/regression/09-regions/22-nocollapse.c
+++ b/tests/regression/09-regions/22-nocollapse.c
@@ -46,7 +46,7 @@ inline static struct list_head *lookup (int d) {
   return p;
 }
 
-void *f(void *arg) { 
+void *f(void *arg) {
   struct s *pos ;
   int j;
   struct list_head  const  *p ;
@@ -58,7 +58,7 @@ void *f(void *arg) {
     pos = (struct s *)((char *)p - (size_t)(& ((struct s *)0)->list));
 
     while (& pos->list != & c.slot[j]) {
-      pos->datum++; // NORACE!
+      pos->datum++; // NORACE
       q = pos->list.next;
       pos = (struct s *)((char *)q - (size_t)(& ((struct s *)0)->list));
     }

--- a/tests/regression/09-regions/23-evilcollapse_rc.c
+++ b/tests/regression/09-regions/23-evilcollapse_rc.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -43,6 +47,7 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
 
 inline static struct list_head *lookup (int d) {
   int hvalue = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= hvalue && hvalue < 10);
   struct list_head *p;
   p = c.slot[hvalue].next;
   return p;
@@ -51,6 +56,7 @@ inline static struct list_head *lookup (int d) {
 void *f(void *arg) {
   struct s *pos ;
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j);
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 

--- a/tests/regression/09-regions/23-evilcollapse_rc.c
+++ b/tests/regression/09-regions/23-evilcollapse_rc.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -40,15 +42,15 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
 }
 
 inline static struct list_head *lookup (int d) {
-  int hvalue;
+  int hvalue = __VERIFIER_nondet_int();
   struct list_head *p;
   p = c.slot[hvalue].next;
   return p;
 }
 
-void *f(void *arg) { 
+void *f(void *arg) {
   struct s *pos ;
-  int j;
+  int j = __VERIFIER_nondet_int();
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 

--- a/tests/regression/09-regions/24-evilcollapse_nr.c
+++ b/tests/regression/09-regions/24-evilcollapse_nr.c
@@ -53,7 +53,7 @@ inline static struct list_head *lookup2 (int d) {
   return p;
 }
 
-void *f(void *arg) { 
+void *f(void *arg) {
   struct s *pos ;
   int j;
   struct list_head  const  *p ;
@@ -65,7 +65,7 @@ void *f(void *arg) {
     pos = (struct s *)((char *)p - (size_t)(& ((struct s *)0)->list));
 
     while (& pos->list != & c.slot[j]) {
-      pos->datum++; // NORACE!
+      pos->datum++; // NORACE
       q = pos->list.next;
       pos = (struct s *)((char *)q - (size_t)(& ((struct s *)0)->list));
     }

--- a/tests/regression/09-regions/24-evilcollapse_nr.c
+++ b/tests/regression/09-regions/24-evilcollapse_nr.c
@@ -1,5 +1,9 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
 extern int __VERIFIER_nondet_int();
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 
 #include<pthread.h>
 #include<stdlib.h>
@@ -43,6 +47,7 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
 
 inline static struct list_head *lookup1 (int d) {
   int hvalue1 = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= hvalue1 && hvalue1 < 10);
   struct list_head *p;
   p = c.slot[hvalue1].next;
   return p;
@@ -50,6 +55,7 @@ inline static struct list_head *lookup1 (int d) {
 
 inline static struct list_head *lookup2 (int d) {
   int hvalue2 = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= hvalue2 && hvalue2 < 10);
   struct list_head *p;
   p = c.slot[hvalue2].next;
   return p;
@@ -58,6 +64,7 @@ inline static struct list_head *lookup2 (int d) {
 void *f(void *arg) {
   struct s *pos ;
   int j = __VERIFIER_nondet_int();
+  assume_abort_if_not(0 <= j);
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 

--- a/tests/regression/09-regions/24-evilcollapse_nr.c
+++ b/tests/regression/09-regions/24-evilcollapse_nr.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"  --set ana.activated[+] "'region'"  --set exp.region-offsets true
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -40,14 +42,14 @@ static inline void list_add(struct list_head *new, struct list_head *head) {
 }
 
 inline static struct list_head *lookup1 (int d) {
-  int hvalue1;
+  int hvalue1 = __VERIFIER_nondet_int();
   struct list_head *p;
   p = c.slot[hvalue1].next;
   return p;
 }
 
 inline static struct list_head *lookup2 (int d) {
-  int hvalue2;
+  int hvalue2 = __VERIFIER_nondet_int();
   struct list_head *p;
   p = c.slot[hvalue2].next;
   return p;
@@ -55,7 +57,7 @@ inline static struct list_head *lookup2 (int d) {
 
 void *f(void *arg) {
   struct s *pos ;
-  int j;
+  int j = __VERIFIER_nondet_int();
   struct list_head  const  *p ;
   struct list_head  const  *q ;
 
@@ -77,7 +79,7 @@ void *f(void *arg) {
 }
 
 int main() {
-  int x;
+  int x = __VERIFIER_nondet_int();
   struct list_head *pp;
   pthread_t t1, t2;
   for (int i = 0; i < 10; i++) {

--- a/tests/regression/09-regions/26-alloc_region_rc.c
+++ b/tests/regression/09-regions/26-alloc_region_rc.c
@@ -24,20 +24,20 @@ pthread_mutex_t B_mutex = PTHREAD_MUTEX_INITIALIZER;
 void *t_fun(void *arg) {
   struct s *p = malloc(sizeof(struct s));
   init(p,7);
-  
+
   pthread_mutex_lock(&A_mutex);
   insert(p, &A);
   pthread_mutex_unlock(&A_mutex);
 
   pthread_mutex_lock(&B_mutex);
-  p->datum++; //RACE
+  p->datum++; // RACE!
   pthread_mutex_unlock(&B_mutex);
   return NULL;
 }
 
 int main () {
   pthread_t t1;
-  struct s *p; 
+  struct s *p;
   A = malloc(sizeof(struct s));
   init(A,3);
 
@@ -49,12 +49,13 @@ int main () {
   pthread_mutex_lock(&A_mutex);
   insert(p, &A);
   pthread_mutex_unlock(&A_mutex);
-  
+
   pthread_mutex_lock(&A_mutex);
   p = A;
-  while (p->next)
+  while (p->next) {
     p = p->next;
-  printf("%d\n", p->datum); //RACE!
+    printf("%d\n", p->datum); // RACE!
+  }
   pthread_mutex_unlock(&A_mutex);
   return 0;
 }

--- a/tests/regression/09-regions/28-list2alloc.c
+++ b/tests/regression/09-regions/28-list2alloc.c
@@ -20,7 +20,7 @@ pthread_mutex_t B_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A_mutex);
-  A->datum++; // RACE <-- this line is also relevant.
+  A->datum++; // RACE! <-- this line is also relevant.
   pthread_mutex_unlock(&A_mutex);
 
   pthread_mutex_lock(&B_mutex);
@@ -41,6 +41,6 @@ int main () {
   pthread_mutex_lock(&A_mutex);
   data = &A->datum; // NORACE
   pthread_mutex_unlock(&A_mutex);
-  *data = 42; // RACE <-- this is the real bug!
+  *data = 42; // RACE! <-- this is the real bug!
   return 0;
 }

--- a/tests/regression/09-regions/29-malloc_race_cp.c
+++ b/tests/regression/09-regions/29-malloc_race_cp.c
@@ -11,8 +11,8 @@ pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&m);
-  *x = 3; // NOWARN
-  *y = 8; // RACE
+  *x = 3; // NORACE
+  *y = 8; // RACE!
   pthread_mutex_unlock(&m);
   return NULL;
 }
@@ -28,9 +28,9 @@ int main() {
   pthread_create(&id, NULL, t_fun, NULL);
 
   pthread_mutex_lock(&m);
-  printf("%d\n",*x); // NOWARN
+  printf("%d\n",*x); // NORACE
   pthread_mutex_unlock(&m);
-  printf("%d\n",*z); // RACE
+  printf("%d\n",*z); // RACE!
 
   return 0;
 }

--- a/tests/regression/09-regions/30-list2alloc-offsets.c
+++ b/tests/regression/09-regions/30-list2alloc-offsets.c
@@ -21,7 +21,7 @@ pthread_mutex_t B_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A_mutex);
-  A->datum++; // RACE <-- this line is also relevant.
+  A->datum++; // RACE! <-- this line is also relevant.
   pthread_mutex_unlock(&A_mutex);
 
   pthread_mutex_lock(&B_mutex);
@@ -42,6 +42,6 @@ int main () {
   pthread_mutex_lock(&A_mutex);
   data = &A->datum; // NORACE
   pthread_mutex_unlock(&A_mutex);
-  *data = 42; // RACE <-- this is the real bug!
+  *data = 42; // RACE! <-- this is the real bug!
   return 0;
 }

--- a/tests/regression/09-regions/31-equ_rc.c
+++ b/tests/regression/09-regions/31-equ_rc.c
@@ -1,5 +1,7 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'" --set ana.activated[+] "'region'"
 // Copy of 06/10 with region enabled
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -18,7 +20,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int x;
+  int x = __VERIFIER_nondet_int();
   pthread_t id;
 
   // struct s *s = malloc(sizeof(struct s));

--- a/tests/regression/09-regions/31-equ_rc.c
+++ b/tests/regression/09-regions/31-equ_rc.c
@@ -12,7 +12,7 @@ struct s {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A.mutex);
-  B.datum = 5; //RACE
+  B.datum = 5; // RACE!
   pthread_mutex_lock(&A.mutex);
   return NULL;
 }
@@ -43,7 +43,7 @@ int main () {
   pthread_create(&id,NULL,t_fun,NULL);
 
   pthread_mutex_lock(m);
-  *d = 8; //RACE
+  *d = 8; // RACE!
   pthread_mutex_unlock(m);
 
   return 0;

--- a/tests/regression/09-regions/32-equ_nr.c
+++ b/tests/regression/09-regions/32-equ_nr.c
@@ -1,5 +1,7 @@
 // PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'" --set ana.activated[+] "'region'"
 // Copy of 06/11 with region enabled
+extern int __VERIFIER_nondet_int();
+
 #include<pthread.h>
 #include<stdlib.h>
 
@@ -18,7 +20,7 @@ void *t_fun(void *arg) {
 }
 
 int main () {
-  int x;
+  int x = __VERIFIER_nondet_int();
   pthread_t id;
 
   // struct s *s = malloc(sizeof(struct s));

--- a/tests/regression/09-regions/32-equ_nr.c
+++ b/tests/regression/09-regions/32-equ_nr.c
@@ -12,7 +12,7 @@ struct s {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A.mutex);
-  A.datum = 5; //NORACE
+  A.datum = 5; // NORACE
   pthread_mutex_lock(&A.mutex);
   return NULL;
 }
@@ -43,7 +43,7 @@ int main () {
   pthread_create(&id,NULL,t_fun,NULL);
 
   pthread_mutex_lock(m);
-  *d = 8; //NORACE
+  *d = 8; // NORACE
   pthread_mutex_unlock(m);
 
   return 0;

--- a/tests/regression/09-regions/33-alloc_region_rc_next_flip.c
+++ b/tests/regression/09-regions/33-alloc_region_rc_next_flip.c
@@ -1,4 +1,5 @@
-// PARAM: --set ana.activated[+] "'region'"  --set exp.region-offsets true
+// SKIP PARAM: --set ana.activated[+] "'region'"  --set exp.region-offsets true
+// Copy of 09/26 with next flipped
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>
@@ -53,8 +54,8 @@ int main () {
   pthread_mutex_lock(&A_mutex);
   p = A;
   while (p->next) {
+    p = p->next; // p points-to disappears!
     printf("%d\n", p->datum); // RACE!
-    p = p->next;
   }
   pthread_mutex_unlock(&A_mutex);
   return 0;

--- a/tests/regression/09-regions/34-escape_rc.c
+++ b/tests/regression/09-regions/34-escape_rc.c
@@ -1,0 +1,26 @@
+// PARAM: --set ana.activated[+] "'region'"
+// Copy of 04/45 with region enabled
+#include <pthread.h>
+#include <stdio.h>
+
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  int *p = (int *) arg;
+  pthread_mutex_lock(&mutex1);
+  (*p)++; // RACE!
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  int i;
+  pthread_create(&id, NULL, t_fun, (void *) &i);
+  pthread_mutex_lock(&mutex2);
+  i++; // RACE!
+  pthread_mutex_unlock(&mutex2);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/09-regions/35-list2_rc-offsets-thread.c
+++ b/tests/regression/09-regions/35-list2_rc-offsets-thread.c
@@ -1,5 +1,5 @@
-// PARAM: --set ana.activated[+] "'region'" --enable exp.region-offsets
-// Copy of 09/03 with region offsets enabled
+// PARAM: --set ana.activated[+] "'region'" --enable exp.region-offsets --set ana.activated[+] "'thread'"
+// Copy of 09/03 with region offsets and thread enabled
 #include<pthread.h>
 #include<stdlib.h>
 #include<stdio.h>

--- a/tests/regression/09-regions/35-list2_rc-offsets.c
+++ b/tests/regression/09-regions/35-list2_rc-offsets.c
@@ -1,0 +1,56 @@
+// PARAM: --set ana.activated[+] "'region'" --enable exp.region-offsets
+// Copy of 09/03 with region offsets enabled
+#include<pthread.h>
+#include<stdlib.h>
+#include<stdio.h>
+
+struct s {
+  int datum;
+  struct s *next;
+} *A, *B;
+
+void init (struct s *p, int x) {
+  p -> datum = x;
+  p -> next = NULL;
+}
+
+pthread_mutex_t A_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t B_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&A_mutex);
+  A->next->datum++; // RACE!
+  pthread_mutex_unlock(&A_mutex);
+
+  pthread_mutex_lock(&B_mutex);
+  B->next->datum++; // RACE!
+  pthread_mutex_unlock(&B_mutex);
+  return NULL;
+}
+
+int main () {
+  pthread_t t1;
+  struct s *p = malloc(sizeof(struct s));
+  init(p,9);
+
+  A = malloc(sizeof(struct s));
+  init(A,3);
+  A->next = p;
+  B = malloc(sizeof(struct s));
+  init(B,5);
+
+  B->next = p;
+
+  pthread_create(&t1, NULL, t_fun, NULL);
+
+  pthread_mutex_lock(&A_mutex);
+  p = A->next;
+  printf("%d\n", p->datum); // RACE!
+  pthread_mutex_unlock(&A_mutex);
+
+  pthread_mutex_lock(&B_mutex);
+  p = B->next;
+  printf("%d\n", p->datum); // RACE!
+  pthread_mutex_unlock(&B_mutex);
+  return 0;
+}

--- a/tests/regression/10-synch/01-thread_unique.c
+++ b/tests/regression/10-synch/01-thread_unique.c
@@ -5,7 +5,7 @@
 int myglobal;
 
 void *t_fun(void *arg) {
-  myglobal=40; //NOWARN
+  myglobal=40; // NORACE
   return NULL;
 }
 

--- a/tests/regression/10-synch/02-thread_nonunique.c
+++ b/tests/regression/10-synch/02-thread_nonunique.c
@@ -5,7 +5,7 @@
 int myglobal;
 
 void *t_fun(void *arg) {
-  myglobal=42; //RACE!
+  myglobal=42; // RACE!
   return NULL;
 }
 

--- a/tests/regression/10-synch/03-two_unique.c
+++ b/tests/regression/10-synch/03-two_unique.c
@@ -6,12 +6,12 @@ int myglobal1;
 int myglobal2;
 
 void *f1(void *arg) {
-  myglobal1=42; //NOWARN
+  myglobal1=42; // NORACE
   return NULL;
 }
 
 void *f2(void *arg) {
-  myglobal2=42; //NOWARN
+  myglobal2=42; // NORACE
   return NULL;
 }
 

--- a/tests/regression/10-synch/11-join_nr.c
+++ b/tests/regression/10-synch/11-join_nr.c
@@ -7,7 +7,7 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex);
-  myglobal=myglobal+1; //NOWARN
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(&mutex);
   return NULL;
 }
@@ -16,9 +16,9 @@ int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_mutex_lock(&mutex);
-  myglobal=myglobal+1; //NOWARN
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(&mutex);
   pthread_join (id, NULL);
-  myglobal=myglobal+1; //NOWARN
+  myglobal=myglobal+1; // NORACE
   return 0;
 }

--- a/tests/regression/10-synch/12-join_rc.c
+++ b/tests/regression/10-synch/12-join_rc.c
@@ -7,7 +7,7 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex);
-  myglobal=myglobal+1;
+  myglobal=myglobal+1; // RACE!
   pthread_mutex_unlock(&mutex);
   return NULL;
 }
@@ -18,10 +18,10 @@ int main(void) {
   for (i=0; i<10; i++)
     pthread_create(&id[i], NULL, t_fun, NULL);
   pthread_mutex_lock(&mutex);
-  myglobal=myglobal+1;
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(&mutex);
   for (i=0; i<9; i++)
     pthread_join(&id[i], NULL, t_fun, NULL);
-  myglobal=myglobal+1; //RACE
+  myglobal=myglobal+1; // RACE!
   return 0;
 }

--- a/tests/regression/10-synch/13-two_threads_nr.c
+++ b/tests/regression/10-synch/13-two_threads_nr.c
@@ -5,18 +5,18 @@
 int myglobal;
 
 void *t_fun(void *arg) {
-  myglobal=42; //NOWARN
+  myglobal=42; // NORACE
   return NULL;
 }
 
 int main(void) {
   pthread_t t1, t2;
-  myglobal = 1; //NOWARN
+  myglobal = 1; // NORACE
   pthread_create(&t1, NULL, t_fun, NULL);
   pthread_join (t1, NULL);
-  myglobal = 2; //NOWARN
+  myglobal = 2; // NORACE
   pthread_create(&t2, NULL, t_fun, NULL);
   pthread_join (t2, NULL);
-  myglobal = 3; //NOWARN
+  myglobal = 3; // NORACE
   return 0;
 }

--- a/tests/regression/10-synch/14-two_threads_rc.c
+++ b/tests/regression/10-synch/14-two_threads_rc.c
@@ -5,18 +5,18 @@
 int myglobal;
 
 void *t_fun(void *arg) {
-  myglobal=42; //RACE
+  myglobal=42; // RACE!
   return NULL;
 }
 
 int main(void) {
   pthread_t t1, t2;
-  myglobal = 1; //NOWARN
+  myglobal = 1; // NORACE
   pthread_create(&t1, NULL, t_fun, NULL);
   pthread_create(&t2, NULL, t_fun, NULL);
-  myglobal = 2; //RACE
+  myglobal = 2; // RACE!
   pthread_join (t1, NULL);
   pthread_join (t2, NULL);
-  myglobal = 3; //NOWARN
+  myglobal = 3; // NORACE
   return 0;
 }

--- a/tests/regression/10-synch/15-join_other_nr.c
+++ b/tests/regression/10-synch/15-join_other_nr.c
@@ -5,7 +5,7 @@
 int myglobal;
 
 void *t2_fun(void *arg) {
-  myglobal=42; //NOWARN
+  myglobal=42; // NORACE
   return NULL;
 }
 
@@ -18,9 +18,9 @@ void *t1_fun(void *arg) {
 
 int main(void) {
   pthread_t t1, t2;
-  myglobal = 1; //NOWARN
+  myglobal = 1; // NORACE
   pthread_create(&t1, NULL, t1_fun, NULL);
   pthread_join(t1, NULL);
-  myglobal = 3; //NOWARN
+  myglobal = 3; // NORACE
   return 0;
 }

--- a/tests/regression/10-synch/16-join_loop_nr.c
+++ b/tests/regression/10-synch/16-join_loop_nr.c
@@ -7,7 +7,7 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex);
-  myglobal=myglobal+1;
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(&mutex);
   return NULL;
 }
@@ -18,10 +18,10 @@ int main(void) {
   for (i=0; i<10; i++)
     pthread_create(&id[i], NULL, t_fun, NULL);
   pthread_mutex_lock(&mutex);
-  myglobal=myglobal+1;
+  myglobal=myglobal+1; // NORACE
   pthread_mutex_unlock(&mutex);
   for (i=0; i<10; i++)
     pthread_join(&id[i], NULL, t_fun, NULL);
-  myglobal=myglobal+1; //NOWARN
+  myglobal=myglobal+1; // NORACE
   return 0;
 }

--- a/tests/regression/10-synch/17-glob_fld_nr.c
+++ b/tests/regression/10-synch/17-glob_fld_nr.c
@@ -1,4 +1,5 @@
-// Copied to 10/17 with thread enabled
+// PARAM: --sets ana.activated[+] thread
+// Copy of 05/08 with thread enabled
 #include <pthread.h>
 
 struct {
@@ -7,7 +8,7 @@ struct {
 } data;
 
 void *t_fun(void *arg) {
-  data.x++; // RACE
+  data.x++; // NORACE
   return NULL;
 }
 


### PR DESCRIPTION
In the regression tests suitable for #102, I did the following:
* Consistently used `RACE!` for actual races.
* Consistently used `NORACE` for the lack of races (as opposed to `NORACE!`, `NOWARN` or `NOWARN!`).
* Consistently used `RACE` for races Goblint finds due to imprecision which aren't actually races.
* Replaces uninitialized variables for nondeterminism with an extern `__VERIFIER_nondet_*`.
* (Includes automatic trailing whitespace deletion in the files I happened to touch.)

I only looked at data race tests which are not based on assertions and which make sense as independent programs (so ignored kernel ones and a few others).

Having these in our repo is good for consistency and also makes it easy to automatically convert them to sv-benchmarks.