### PR TITLE
Remove unused must-equals component from region analysis

### DIFF
--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -3,8 +3,6 @@
 open Prelude.Ana
 open Analyses
 
-(* module Equ = MusteqDomain.Equ *)
-module Equ = RegionDomain.Equ
 module RegMap = RegionDomain.RegMap
 module RegPart = RegionDomain.RegPart
 module Reg = RegionDomain.Reg
@@ -26,7 +24,7 @@ struct
 
   let regions exp part st : Lval.CilLval.t list =
     match st with
-    | `Lifted (equ,reg) ->
+    | `Lifted reg ->
       let ev = Reg.eval_exp exp in
       let to_exp (v,f) = (v,Lval.Fields.to_offs' f) in
       List.map to_exp (Reg.related_globals ev (part,reg))
@@ -35,7 +33,7 @@ struct
 
   let is_bullet exp part st : bool =
     match st with
-    | `Lifted (equ,reg) ->
+    | `Lifted reg ->
       begin match Reg.eval_exp exp with
         | Some (_,v,_) -> (try RegionDomain.RS.is_single_bullet (RegMap.find v reg) with Not_found -> false)
         | _ -> false
@@ -85,13 +83,12 @@ struct
   (* transfer functions *)
   let assign ctx (lval:lval) (rval:exp) : D.t =
     match ctx.local with
-    | `Lifted (equ,reg) ->
+    | `Lifted reg ->
       let old_regpart = get_regpart ctx in
-      let equ = Equ.assign lval rval equ in
       let regpart, reg = Reg.assign lval rval (old_regpart, reg) in
       if not (RegPart.leq regpart old_regpart) then
         set_regpart ctx regpart;
-      `Lifted (equ,reg)
+      `Lifted reg
     | x -> x
 
   let branch ctx (exp:exp) (tv:bool) : D.t =
@@ -103,8 +100,7 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     let locals = f.sformals @ f.slocals in
     match ctx.local with
-    | `Lifted (equ,reg) ->
-      let equ = Equ.kill_vars locals equ in
+    | `Lifted reg ->
       let old_regpart = get_regpart ctx in
       let regpart, reg = match exp with
         | Some exp -> Reg.assign (BS.return_lval ()) exp (old_regpart, reg)
@@ -113,7 +109,7 @@ struct
       let regpart, reg = Reg.kill_vars locals (Reg.remove_vars locals (regpart, reg)) in
       if not (RegPart.leq regpart old_regpart) then
         set_regpart ctx regpart;
-      `Lifted (equ,reg)
+      `Lifted reg
     | x -> x
 
 
@@ -124,21 +120,19 @@ struct
       | _ -> r
     in
     match ctx.local with
-    | `Lifted (equ,reg) ->
+    | `Lifted reg ->
       let fundec = Cilfacade.getdec f in
-      let f x r eq = Equ.assign (var x) r eq in
-      let equ  = fold_right2 f fundec.sformals args equ in
       let f x r reg = Reg.assign (var x) r reg in
       let old_regpart = get_regpart ctx in
       let regpart, reg = fold_right2 f fundec.sformals args (old_regpart,reg) in
       if not (RegPart.leq regpart old_regpart) then
         set_regpart ctx regpart;
-      [ctx.local, `Lifted (equ,reg)]
+      [ctx.local, `Lifted reg]
     | x -> [x,x]
 
   let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
     match au with
-    | `Lifted (equ, reg) -> begin
+    | `Lifted reg -> begin
       let old_regpart = get_regpart ctx in
       let regpart, reg = match lval with
         | None -> (old_regpart, reg)
@@ -147,7 +141,7 @@ struct
       let regpart, reg = Reg.remove_vars [BS.return_varinfo ()] (regpart, reg) in
       if not (RegPart.leq regpart old_regpart) then
         set_regpart ctx regpart;
-      `Lifted (equ,reg)
+      `Lifted reg
       end
     | _ -> au
 
@@ -155,12 +149,12 @@ struct
     match f.vname with
     | "malloc" | "calloc" | "kmalloc"| "kzalloc" | "__kmalloc" | "usb_alloc_urb" -> begin
         match ctx.local, lval with
-        | `Lifted (equ,reg), Some lv ->
+        | `Lifted reg, Some lv ->
           let old_regpart = get_regpart ctx in
           let regpart, reg = Reg.assign_bullet lv (old_regpart, reg) in
           if not (RegPart.leq regpart old_regpart) then
             set_regpart ctx regpart;
-          `Lifted (equ, reg)
+          `Lifted reg
         | _ -> ctx.local
       end
     | _ ->
@@ -174,10 +168,10 @@ struct
       | _ -> ctx.local
 
   let startstate v =
-    `Lifted (Equ.top (), RegMap.bot ())
+    `Lifted (RegMap.bot ())
 
   let otherstate v =
-    `Lifted (Equ.top (), RegMap.bot ())
+    `Lifted (RegMap.bot ())
 
   let exitstate = otherstate
 

--- a/src/analyses/shapes.ml
+++ b/src/analyses/shapes.ml
@@ -115,12 +115,12 @@ struct
     in
     let nre =
       match nre with
-      | `Lifted (e,m) -> `Lifted (e,RegMap.fold update rm m)
+      | `Lifted m -> `Lifted (RegMap.fold update rm m)
       | x -> x
     in
     let _ =
       match nre with
-      | `Lifted (_,m) ->
+      | `Lifted m ->
         let alive =
           match MyLiveness.getLiveSet !Cilfacade.currentStatement.sid with
           | Some x -> x

--- a/src/cdomains/regionDomain.ml
+++ b/src/cdomains/regionDomain.ml
@@ -258,14 +258,5 @@ struct
     | None -> Messages.warn "Access to unknown address could be global"; []
 end
 
-(* module Equ = MusteqDomain.Equ *)
-module Equ =
-struct
-  include Lattice.Unit
-
-  let assign lval rval st = st
-  let kill_vars vars st = st
-end
-module LD  = Lattice.Prod (Equ) (RegMap)
-
-module RegionDom = Lattice.Lift (LD) (struct let top_name = "Unknown" let bot_name = "Error" end)
+(* TODO: remove Lift *)
+module RegionDom = Lattice.Lift (RegMap) (struct let top_name = "Unknown" let bot_name = "Error" end)


### PR DESCRIPTION
The transfer functions did update it but other than that nothing read it. Thus nothing really depended on it either. No point in wasting CPU cycles for something completely irrelevant.

This is something I noticed a while ago but now that we're already simplifying region analysis, it might make sense to also do this. In the git history I have a commit where I also replaced the `Equ` component with `Unit` to easily prove a point that nothing used it.

I'm not sure what the original intention of the must-equals component might've been. Maybe it should be somehow used, then there's a bug that it isn't. Maybe the use of `region` in combination with `symb_locks` and `var_eq` automagically covers the originally required behavior.