### PR TITLE
Fix handling of multiplication in Base.invariant

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1422,7 +1422,15 @@ struct
       let meet_non oi oo = meet_bin (oi c b) (oo a c) in (* non-commutative *)
       function
       | PlusA  -> meet_com ID.sub
-      | Mult   -> meet_com ID.div (* Div is ok here, c must be divisible by a and b *)
+      | Mult   ->
+        (* Only multiplication with odd numbers is an invertible operation in (mod 2^n), *)
+        (* refine x by information about y, using x * y == c *)
+        let refine_by x y = (match ID.to_int y with
+          | None -> x
+          | Some v when Int64.rem v 2L = 0L -> x (* A refinement would still be possible here, but has to take non-injectivity into account. *)
+          | Some v (* when Int64.rem v 2L = 1L *) -> ID.meet x (ID.div c y)) (* Div is ok here, c must be divisible by a and b *)
+        in
+        (refine_by a b, refine_by b a)
       | MinusA -> meet_non ID.add ID.sub
       | Div    ->
         (* If b must be zero, we have must UB *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1423,7 +1423,7 @@ struct
       function
       | PlusA  -> meet_com ID.sub
       | Mult   ->
-        (* Only multiplication with odd numbers is an invertible operation in (mod 2^n), *)
+        (* Only multiplication with odd numbers is an invertible operation in (mod 2^n) *)
         (* refine x by information about y, using x * y == c *)
         let refine_by x y = (match ID.to_int y with
           | None -> x

--- a/tests/regression/27-inv_invariants/01-ints.c
+++ b/tests/regression/27-inv_invariants/01-ints.c
@@ -30,7 +30,7 @@ int main() {
   if (y/x == 2 && x == 3)
     assert(x == 3); // TO-DO y == [6,8]; this does not work because CIL transforms this into two if-statements
   if (2+(3-x)*4/5 == 6 && 2*y >= x+5)
-    assert(RANGE(x, -3, -2) && y >= 1);
+    assert(RANGE(x, -3, -2) && y >= 1); // UNKNOWN
   if (x > 1 && x < 5 && x % 2 == 1) // x = [2,4] && x % 2 = 1 => x = 3
     assert(x == 3);
 
@@ -84,7 +84,7 @@ int main() {
   if (2+(3-xs)*4/5 == 6 && 2*ys >= xs+5) {
     // xs could also be -3
     assert(xs == -2 && ys >= 1); //UNKNOWN!
-    assert(RANGE(xs, -3, -2) && ys >= 1);
+    assert(RANGE(xs, -3, -2) && ys >= 1); // UNKNOWN
   }
   if (xs > 1 && xs < 5 && xs % 2 == 1) {
     assert(xs != 2);
@@ -130,7 +130,7 @@ int main2() {
   if (y/x == two && x == three)
     assert(x == 3); // TO-DO y == [6,8]; this does not work because CIL transforms this into two if-statements
   if (two+(three-x)*four/five == six && two*y >= x+five)
-    assert(RANGE(x, -3, -2) && y >= 1);
+    assert(RANGE(x, -3, -2) && y >= 1); // UNKNOWN
   if (x > one && x < five && x % two == one) // x = [2,4] && x % 2 = 1 => x = 3
     assert(x != 2); // [3,4] TO-DO [3,3]
 
@@ -181,7 +181,7 @@ int main2() {
   if (two+(three-xs)*four/five == six && two*ys >= xs+five) {
     // xs could also be -three
     assert(xs == -two && ys >= one); //UNKNOWN!
-    assert(RANGE(xs, -three, -two) && ys >= one);
+    assert(RANGE(xs, -three, -two) && ys >= one); // UNKNOWN
   }
   if (xs > one && xs < five && xs % two == one) {
     assert(xs != two);

--- a/tests/regression/27-inv_invariants/04-mul-arith.c
+++ b/tests/regression/27-inv_invariants/04-mul-arith.c
@@ -1,0 +1,16 @@
+// PARAM: --disable ana.int.interval --enable ana.int.def_exc --enable ana.int.enums
+#include <assert.h>
+#include <stdio.h>
+
+int main(){
+    unsigned int i;
+
+    // With i = 7 the then-branch will be reached.
+    // i = 7;
+    unsigned int r = i * 1073741824u;
+    if(i *  1073741824u == 3221225472u){
+        printf("%u\n", i);
+        assert(i == 3); // UNKNOWN
+    }
+    return 0;
+}

--- a/tests/regression/27-inv_invariants/06-mul-arith.c
+++ b/tests/regression/27-inv_invariants/06-mul-arith.c
@@ -10,7 +10,7 @@ int main(){
     unsigned int r = i * 1073741824u;
     if(i *  1073741824u == 3221225472u){
         printf("%u\n", i);
-        assert(i == 3); // UNKNOWN
+        assert(i == 3); // UNKNOWN!
     }
     return 0;
 }


### PR DESCRIPTION
Multiplication with machine integers (i.e. mod 2^n) is not an injective operation in general. This must be taken into account in Base.invariant to preserve soundness. As multiplication with odd numbers is injective, we can still perform the refinement of an operand, if the other operand is known to be an odd number. In principle a refinement is also possible for values that are multiplied with even numbers, but this would have to take the non-injectivity into account. 

Obviously, we lose some precision with this patch. 