### PR TITLE
Make fast_global_inits work again

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1620,7 +1620,7 @@ struct
   (**************************************************************************
    * Simple defs for the transfer functions
    **************************************************************************)
-  let zeroinit ctx v =
+  let zero_init ctx v =
     set ctx.ask ctx.global ctx.local (AD.from_var v) (zero_init_value v.vtype)
 
   let assign ctx (lval:lval) (rval:exp):store  =

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1620,6 +1620,9 @@ struct
   (**************************************************************************
    * Simple defs for the transfer functions
    **************************************************************************)
+  let zeroinit ctx v =
+    set ctx.ask ctx.global ctx.local (AD.from_var v) (zero_init_value v.vtype)
+
   let assign ctx (lval:lval) (rval:exp):store  =
     let char_array_hack () =
       let rec split_offset = function

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -793,10 +793,10 @@ struct
           M.debug ("Failed evaluating "^str^" to lvalue"); do_offs AD.unknown_ptr ofs
       end
 
-  let rec bot_value a (gs:glob_fun) (st: store) (t: typ): value =
+  let rec bot_value (t: typ): value =
     let bot_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let bot_field nstruct fd = ValueDomain.Structs.replace nstruct fd (bot_value a gs st fd.ftype) in
+      let bot_field nstruct fd = ValueDomain.Structs.replace nstruct fd (bot_value fd.ftype) in
       List.fold_left bot_field nstruct compinfo.cfields
     in
     match t with
@@ -805,17 +805,17 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (bot_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.bot ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.bot ()) (bot_value a gs st ai))
+      `Array (ValueDomain.CArrays.make (IdxDom.bot ()) (bot_value ai))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (bot_value a gs st ai))
-    | TNamed ({ttype=t; _}, _) -> bot_value a gs st t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (bot_value ai))
+    | TNamed ({ttype=t; _}, _) -> bot_value t
     | _ -> `Bot
 
-  let rec init_value a (gs:glob_fun) (st: store) (t: typ): value = (* TODO why is VD.top_value not used here? *)
+  let rec init_value (t: typ): value = (* TODO why is VD.top_value not used here? *)
     let init_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (init_value a gs st fd.ftype) in
+      let init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (init_value fd.ftype) in
       List.fold_left init_field nstruct compinfo.cfields
     in
     match t with
@@ -825,17 +825,17 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (init_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.bot ())  (if get_bool "exp.partition-arrays.enabled" then (init_value a gs st ai) else (bot_value a gs st ai)))
+      `Array (ValueDomain.CArrays.make (IdxDom.bot ())  (if get_bool "exp.partition-arrays.enabled" then (init_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (if get_bool "exp.partition-arrays.enabled" then (init_value a gs st ai) else (bot_value a gs st ai)))
-    | TNamed ({ttype=t; _}, _) -> init_value a gs st t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (if get_bool "exp.partition-arrays.enabled" then (init_value ai) else (bot_value ai)))
+    | TNamed ({ttype=t; _}, _) -> init_value t
     | _ -> `Top
 
-  let rec top_value a (gs:glob_fun) (st: store) (t: typ): value =
+  let rec top_value (t: typ): value =
     let top_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let top_field nstruct fd = ValueDomain.Structs.replace nstruct fd (top_value a gs st fd.ftype) in
+      let top_field nstruct fd = ValueDomain.Structs.replace nstruct fd (top_value fd.ftype) in
       List.fold_left top_field nstruct compinfo.cfields
     in
     match t with
@@ -844,11 +844,39 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (top_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (if get_bool "exp.partition-arrays.enabled" then (top_value a gs st ai) else (bot_value a gs st ai)))
+      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (if get_bool "exp.partition-arrays.enabled" then (top_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (if get_bool "exp.partition-arrays.enabled" then (top_value a gs st ai) else (bot_value a gs st ai)))
-    | TNamed ({ttype=t; _}, _) -> top_value a gs st t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (if get_bool "exp.partition-arrays.enabled" then (top_value ai) else (bot_value ai)))
+    | TNamed ({ttype=t; _}, _) -> top_value t
+    | _ -> `Top
+
+  let rec zero_init_value (t:typ): value =
+    let zero_init_comp compinfo: ValueDomain.Structs.t =
+      let nstruct = ValueDomain.Structs.top () in
+      let zero_init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (zero_init_value fd.ftype) in
+      List.fold_left zero_init_field nstruct compinfo.cfields
+    in
+    match t with
+    | TInt (ikind, _) -> `Int (ID.of_int 0L)
+    | TPtr _ -> `Address AD.null_ptr
+    | TComp ({cstruct=true; _} as ci,_) -> `Struct (zero_init_comp ci)
+    | TComp ({cstruct=false; _} as ci,_) ->
+      let v = try
+        (* C99 6.7.8.10: the first named member is initialized (recursively) according to these rules *)
+        let firstmember = List.hd ci.cfields in
+        `Lifted firstmember, zero_init_value firstmember.ftype
+      with
+        (* Union with no members ò.O *)
+        Failure _ -> ValueDomain.Unions.top ()
+      in
+      `Union(v)
+    | TArray (ai, None, _) ->
+      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (zero_init_value ai))
+    | TArray (ai, Some exp, _) ->
+      let l = Cil.isInteger (Cil.constFold true exp) in
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (zero_init_value ai))
+    | TNamed ({ttype=t; _}, _) -> zero_init_value t
     | _ -> `Top
 
   (* run eval_rv from above and keep a result that is bottom *)
@@ -861,9 +889,9 @@ struct
     try
       let r = eval_rv a gs st exp in
       if M.tracing then M.tracel "eval" "eval_rv %a = %a\n" d_exp exp VD.pretty r;
-      if VD.is_bot r then top_value a gs st (typeOf exp) else r
+      if VD.is_bot r then top_value (typeOf exp) else r
     with IntDomain.ArithmeticOnIntegerBot _ ->
-      top_value a gs st (typeOf exp)
+      top_value (typeOf exp)
 
   (* Evaluate an expression containing only locals. This is needed for smart joining the partitioned arrays where ctx is not accessible. *)
   (* This will yield `Top for expressions containing any access to globals, and does not make use of the query system. *)
@@ -1585,7 +1613,7 @@ struct
 
   let set_savetop ?lval_raw ?rval_raw ask (gs:glob_fun) st adr v : store =
     match v with
-    | `Top -> set ask gs st adr (top_value ask gs st (AD.get_type adr)) ?lval_raw ?rval_raw
+    | `Top -> set ask gs st adr (top_value (AD.get_type adr)) ?lval_raw ?rval_raw
     | v -> set ask gs st adr v ?lval_raw ?rval_raw
 
 
@@ -1669,7 +1697,7 @@ struct
           (match Addr.to_var_offset (AD.choose lval_val) with
           | [(x,offs)] ->
             let t = v.vtype in
-            let iv = bot_value ctx.ask ctx.global ctx.local v.vtype in (* correct bottom value for top level variable *)
+            let iv = bot_value v.vtype in (* correct bottom value for top level variable *)
             let nv = VD.update_offset ctx.ask iv offs rval_val (Some  (Lval lval)) lval t in (* do desired update to value *)
             set_savetop ctx.ask ctx.global ctx.local (AD.from_var v) nv (* set top-level variable to updated value *)
           | _ ->
@@ -1743,7 +1771,7 @@ struct
 
   let body ctx f =
     (* First we create a variable-initvalue pair for each variable *)
-    let init_var v = (AD.from_var v, init_value ctx.ask ctx.global ctx.local v.vtype) in
+    let init_var v = (AD.from_var v, init_value v.vtype) in
     (* Apply it to all the locals and then assign them all *)
     let inits = List.map init_var f.slocals in
     set_many ctx.ask ctx.global ctx.local inits

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -611,7 +611,7 @@ struct
     do_splits ctx d !splits;
     if q then raise Deadcode else d
 
-  let zeroinit (ctx:(D.t, G.t, C.t) ctx) v =
+  let zero_init (ctx:(D.t, G.t, C.t) ctx) v =
     let spawns = ref [] in
     let splits = ref [] in
     let sides  = ref [] in
@@ -633,7 +633,7 @@ struct
         ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in assign context (cycles?).")
         }
       in
-      n, repr @@ S.zeroinit ctx' v
+      n, repr @@ S.zero_init ctx' v
     in
     let d, q = map_deadcode f @@ spec_list ctx.local in
     do_sideg ctx !sides;

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -611,6 +611,35 @@ struct
     do_splits ctx d !splits;
     if q then raise Deadcode else d
 
+  let zeroinit (ctx:(D.t, G.t, C.t) ctx) v =
+    let spawns = ref [] in
+    let splits = ref [] in
+    let sides  = ref [] in
+    let f post_all (n,(module S:Spec),d) =
+      let ctx' : (S.D.t, S.G.t, S.C.t) ctx =
+        { local  = obj d
+        ; node   = ctx.node
+        ; prev_node = ctx.prev_node
+        ; control_context = ctx.control_context
+        ; context = (fun () -> ctx.context () |> assoc n |> obj)
+        ; edge   = ctx.edge
+        ; ask    = query ctx
+        ; presub = filter_presubs n ctx.local
+        ; postsub= filter_presubs n post_all
+        ; global = (fun v      -> ctx.global v |> assoc n |> obj)
+        ; spawn  = (fun v d    -> spawns := (v,(n,repr d)) :: !spawns)
+        ; split  = (fun d e tv -> splits := (n,(repr d,e,tv)) :: !splits)
+        ; sideg  = (fun v g    -> sides  := (v, (n, repr g)) :: !sides)
+        ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in assign context (cycles?).")
+        }
+      in
+      n, repr @@ S.zeroinit ctx' v
+    in
+    let d, q = map_deadcode f @@ spec_list ctx.local in
+    do_sideg ctx !sides;
+    do_spawns ctx !spawns;
+    do_splits ctx d !splits;
+    if q then raise Deadcode else d
 
   let vdecl (ctx:(D.t, G.t, C.t) ctx) v =
     let spawns = ref [] in

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -717,14 +717,7 @@ struct
   (* Functions that make us of the configuration flag *)
   let name () = "FlagConfiguredArrayDomain: " ^ if get_bool "exp.partition-arrays.enabled" then P.name () else T.name ()
 
-  let partition_enabled () =
-    if get_bool "exp.partition-arrays.enabled" then
-      if get_bool "exp.fast_global_inits" then
-        failwith "Options 'exp.partition-arrays.enabled' and 'exp.fast_global_inits' are incompatible. Disable at least one of them."
-      else
-        true
-    else
-      false
+  let partition_enabled () = get_bool "exp.partition-arrays.enabled"
 
   let bot () =
     if partition_enabled () then

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -429,16 +429,17 @@ sig
   val call_descr : fundec -> C.t -> string
   val part_access: (D.t, G.t, C.t) ctx -> exp -> varinfo option -> bool -> (Access.LSSSet.t * Access.LSSet.t)
 
-  val sync  : (D.t, G.t, C.t) ctx -> D.t * (varinfo * G.t) list
-  val query : (D.t, G.t, C.t) ctx -> Queries.t -> Queries.Result.t
-  val assign: (D.t, G.t, C.t) ctx -> lval -> exp -> D.t
-  val vdecl : (D.t, G.t, C.t) ctx -> varinfo -> D.t
-  val branch: (D.t, G.t, C.t) ctx -> exp -> bool -> D.t
-  val body  : (D.t, G.t, C.t) ctx -> fundec -> D.t
-  val return: (D.t, G.t, C.t) ctx -> exp option  -> fundec -> D.t
-  val intrpt: (D.t, G.t, C.t) ctx -> D.t
-  val asm   : (D.t, G.t, C.t) ctx -> D.t
-  val skip  : (D.t, G.t, C.t) ctx -> D.t
+  val sync     : (D.t, G.t, C.t) ctx -> D.t * (varinfo * G.t) list
+  val query    : (D.t, G.t, C.t) ctx -> Queries.t -> Queries.Result.t
+  val assign   : (D.t, G.t, C.t) ctx -> lval -> exp -> D.t
+  val zeroinit : (D.t, G.t, C.t) ctx -> varinfo -> D.t
+  val vdecl    : (D.t, G.t, C.t) ctx -> varinfo -> D.t
+  val branch   : (D.t, G.t, C.t) ctx -> exp -> bool -> D.t
+  val body     : (D.t, G.t, C.t) ctx -> fundec -> D.t
+  val return   : (D.t, G.t, C.t) ctx -> exp option  -> fundec -> D.t
+  val intrpt   : (D.t, G.t, C.t) ctx -> D.t
+  val asm      : (D.t, G.t, C.t) ctx -> D.t
+  val skip     : (D.t, G.t, C.t) ctx -> D.t
 
 
   val special : (D.t, G.t, C.t) ctx -> lval option -> varinfo -> exp list -> D.t
@@ -569,6 +570,12 @@ struct
   (* Just ignore. *)
 
   let vdecl ctx _ = ctx.local
+
+  let zeroinit ctx _ = ctx.local
+  (* On a zero initializer, don't do anything. Overwrite this if getting a single assign
+     to the first element of an array to 0 is not enough for intializing global
+     zero-initialized arrays for the purpose of your analysis when running with
+     exp.fast_global_inits                                                               *)
 
   let asm x =
     ignore (M.warn "ASM statement ignored.");

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -432,7 +432,7 @@ sig
   val sync     : (D.t, G.t, C.t) ctx -> D.t * (varinfo * G.t) list
   val query    : (D.t, G.t, C.t) ctx -> Queries.t -> Queries.Result.t
   val assign   : (D.t, G.t, C.t) ctx -> lval -> exp -> D.t
-  val zeroinit : (D.t, G.t, C.t) ctx -> varinfo -> D.t
+  val zero_init : (D.t, G.t, C.t) ctx -> varinfo -> D.t
   val vdecl    : (D.t, G.t, C.t) ctx -> varinfo -> D.t
   val branch   : (D.t, G.t, C.t) ctx -> exp -> bool -> D.t
   val body     : (D.t, G.t, C.t) ctx -> fundec -> D.t
@@ -571,7 +571,7 @@ struct
 
   let vdecl ctx _ = ctx.local
 
-  let zeroinit ctx _ = ctx.local
+  let zero_init ctx _ = ctx.local
   (* On a zero initializer, don't do anything. Overwrite this if getting a single assign
      to the first element of an array to 0 is not enough for intializing global
      zero-initialized arrays for the purpose of your analysis when running with

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -52,8 +52,8 @@ struct
   let assign ctx lv e =
     D.lift @@ S.assign (conv ctx) lv e
 
-  let zeroinit ctx v =
-    D.lift @@ S.zeroinit (conv ctx) v
+  let zero_init ctx v =
+    D.lift @@ S.zero_init (conv ctx) v
 
   let vdecl ctx v =
     D.lift @@ S.vdecl (conv ctx) v
@@ -133,8 +133,8 @@ struct
   let assign ctx lv e =
     S.assign (conv ctx) lv e
 
-  let zeroinit ctx v =
-    S.zeroinit (conv ctx) v
+  let zero_init ctx v =
+    S.zero_init (conv ctx) v
 
   let vdecl ctx v =
     S.vdecl (conv ctx) v
@@ -238,7 +238,7 @@ struct
 
   let query' ctx q    = lift_fun ctx identity   S.query  ((|>) q)
   let assign ctx lv e = lift_fun ctx (lift ctx) S.assign ((|>) e % (|>) lv)
-  let zeroinit ctx v  = lift_fun ctx (lift ctx) S.zeroinit ((|>) v)
+  let zero_init ctx v = lift_fun ctx (lift ctx) S.zero_init ((|>) v)
   let vdecl ctx v     = lift_fun ctx (lift ctx) S.vdecl  ((|>) v)
   let branch ctx e tv = lift_fun ctx (lift ctx) S.branch ((|>) tv % (|>) e)
   let body ctx f      = lift_fun ctx (lift ctx) S.body   ((|>) f)
@@ -369,7 +369,7 @@ struct
   let sync ctx        = let d, ds = S.sync (conv ctx) in (d, snd ctx.local), ds
   let query ctx       = S.query (conv ctx)
   let assign ctx lv e = lift_fun ctx S.assign ((|>) e % (|>) lv)
-  let zeroinit ctx v  = lift_fun ctx S.zeroinit ((|>) v)
+  let zero_init ctx v = lift_fun ctx S.zero_init ((|>) v)
   let vdecl ctx v     = lift_fun ctx S.vdecl  ((|>) v)
   let branch ctx e tv = lift_fun ctx S.branch ((|>) tv % (|>) e)
   let body ctx f      = lift_fun ctx S.body   ((|>) f)
@@ -420,7 +420,7 @@ struct
   let sync ctx        = let d, ds = S.sync (conv ctx) in (d, snd ctx.local), ds
   let query ctx       = S.query (conv ctx)
   let assign ctx lv e = lift_fun ctx S.assign ((|>) e % (|>) lv)
-  let zeroinit ctx v  = lift_fun ctx S.zeroinit ((|>)v)
+  let zero_init ctx v = lift_fun ctx S.zero_init ((|>)v)
   let vdecl ctx v     = lift_fun ctx S.vdecl  ((|>) v)
   let branch ctx e tv = lift_fun ctx S.branch ((|>) tv % (|>) e)
   let body ctx f      = lift_fun ctx S.body   ((|>) f)
@@ -494,7 +494,7 @@ struct
 
   let query ctx q     = lift_fun ctx identity S.query  ((|>) q)            `Bot
   let assign ctx lv e = lift_fun ctx D.lift   S.assign ((|>) e % (|>) lv) `Bot
-  let zeroinit ctx v  = lift_fun ctx D.lift   S.zeroinit ((|>) v)         `Bot
+  let zero_init ctx v = lift_fun ctx D.lift   S.zero_init ((|>) v)         `Bot
   let vdecl ctx v     = lift_fun ctx D.lift   S.vdecl  ((|>) v)            `Bot
   let branch ctx e tv = lift_fun ctx D.lift   S.branch ((|>) tv % (|>) e) `Bot
   let body ctx f      = lift_fun ctx D.lift   S.body   ((|>) f)            `Bot
@@ -985,7 +985,7 @@ struct
     if D.is_bot d then raise Deadcode else d
 
   let assign ctx l e    = map ctx Spec.assign   (fun h -> h l e )
-  let zeroinit ctx v    = map ctx Spec.zeroinit (fun h -> h v )
+  let zero_init ctx v   = map ctx Spec.zero_init (fun h -> h v )
   let vdecl ctx v       = map ctx Spec.vdecl    (fun h -> h v)
   let body   ctx f      = map ctx Spec.body     (fun h -> h f   )
   let return ctx e f    = map ctx Spec.return   (fun h -> h e f )

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -52,6 +52,9 @@ struct
   let assign ctx lv e =
     D.lift @@ S.assign (conv ctx) lv e
 
+  let zeroinit ctx v =
+    D.lift @@ S.zeroinit (conv ctx) v
+
   let vdecl ctx v =
     D.lift @@ S.vdecl (conv ctx) v
 
@@ -129,6 +132,9 @@ struct
 
   let assign ctx lv e =
     S.assign (conv ctx) lv e
+
+  let zeroinit ctx v =
+    S.zeroinit (conv ctx) v
 
   let vdecl ctx v =
     S.vdecl (conv ctx) v
@@ -232,6 +238,7 @@ struct
 
   let query' ctx q    = lift_fun ctx identity   S.query  ((|>) q)
   let assign ctx lv e = lift_fun ctx (lift ctx) S.assign ((|>) e % (|>) lv)
+  let zeroinit ctx v  = lift_fun ctx (lift ctx) S.zeroinit ((|>) v)
   let vdecl ctx v     = lift_fun ctx (lift ctx) S.vdecl  ((|>) v)
   let branch ctx e tv = lift_fun ctx (lift ctx) S.branch ((|>) tv % (|>) e)
   let body ctx f      = lift_fun ctx (lift ctx) S.body   ((|>) f)
@@ -362,6 +369,7 @@ struct
   let sync ctx        = let d, ds = S.sync (conv ctx) in (d, snd ctx.local), ds
   let query ctx       = S.query (conv ctx)
   let assign ctx lv e = lift_fun ctx S.assign ((|>) e % (|>) lv)
+  let zeroinit ctx v  = lift_fun ctx S.zeroinit ((|>) v)
   let vdecl ctx v     = lift_fun ctx S.vdecl  ((|>) v)
   let branch ctx e tv = lift_fun ctx S.branch ((|>) tv % (|>) e)
   let body ctx f      = lift_fun ctx S.body   ((|>) f)
@@ -412,6 +420,7 @@ struct
   let sync ctx        = let d, ds = S.sync (conv ctx) in (d, snd ctx.local), ds
   let query ctx       = S.query (conv ctx)
   let assign ctx lv e = lift_fun ctx S.assign ((|>) e % (|>) lv)
+  let zeroinit ctx v  = lift_fun ctx S.zeroinit ((|>)v)
   let vdecl ctx v     = lift_fun ctx S.vdecl  ((|>) v)
   let branch ctx e tv = lift_fun ctx S.branch ((|>) tv % (|>) e)
   let body ctx f      = lift_fun ctx S.body   ((|>) f)
@@ -485,6 +494,7 @@ struct
 
   let query ctx q     = lift_fun ctx identity S.query  ((|>) q)            `Bot
   let assign ctx lv e = lift_fun ctx D.lift   S.assign ((|>) e % (|>) lv) `Bot
+  let zeroinit ctx v  = lift_fun ctx D.lift   S.zeroinit ((|>) v)         `Bot
   let vdecl ctx v     = lift_fun ctx D.lift   S.vdecl  ((|>) v)            `Bot
   let branch ctx e tv = lift_fun ctx D.lift   S.branch ((|>) tv % (|>) e) `Bot
   let body ctx f      = lift_fun ctx D.lift   S.body   ((|>) f)            `Bot
@@ -974,15 +984,16 @@ struct
     let d = D.fold h ctx.local (D.empty ()) in
     if D.is_bot d then raise Deadcode else d
 
-  let assign ctx l e    = map ctx Spec.assign  (fun h -> h l e )
-  let vdecl ctx v       = map ctx Spec.vdecl   (fun h -> h v)
-  let body   ctx f      = map ctx Spec.body    (fun h -> h f   )
-  let return ctx e f    = map ctx Spec.return  (fun h -> h e f )
-  let branch ctx e tv   = map ctx Spec.branch  (fun h -> h e tv)
-  let intrpt ctx        = map ctx Spec.intrpt  identity
-  let asm ctx           = map ctx Spec.asm     identity
-  let skip ctx          = map ctx Spec.skip    identity
-  let special ctx l f a = map ctx Spec.special (fun h -> h l f a)
+  let assign ctx l e    = map ctx Spec.assign   (fun h -> h l e )
+  let zeroinit ctx v    = map ctx Spec.zeroinit (fun h -> h v )
+  let vdecl ctx v       = map ctx Spec.vdecl    (fun h -> h v)
+  let body   ctx f      = map ctx Spec.body     (fun h -> h f   )
+  let return ctx e f    = map ctx Spec.return   (fun h -> h e f )
+  let branch ctx e tv   = map ctx Spec.branch   (fun h -> h e tv)
+  let intrpt ctx        = map ctx Spec.intrpt   identity
+  let asm ctx           = map ctx Spec.asm      identity
+  let skip ctx          = map ctx Spec.skip     identity
+  let special ctx l f a = map ctx Spec.special  (fun h -> h l f a)
 
   let fold ctx f g h a =
     let k x a =

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -217,7 +217,7 @@ struct
         ; assign  = (fun ?name _ -> failwith "Global initializers trying to assign.")
         }
       in
-      let zeroinits, edges = MyCFG.getGlobalInits file in
+      let zero_inits, edges = MyCFG.getGlobalInits file in
       if (get_bool "dbg.verbose") then print_endline ("Executing "^string_of_int (List.length edges)^" assigns.");
       let funs = ref [] in
       (*let count = ref 0 in*)
@@ -246,8 +246,8 @@ struct
       let result : Spec.D.t = List.fold_left transfer_func with_externs edges in
       (* For any global variable that was zero intialized, but edges contained one assign, now init the entire thing *)
       (* This happens when exp.fast_global_inits is on *)
-      let zero_init st v = Spec.zeroinit {ctx with local= st} v in
-      let with_zeros  = List.fold_left zero_init result zeroinits in
+      let zero_init st v = Spec.zero_init {ctx with local= st} v in
+      let with_zeros  = List.fold_left zero_init result zero_inits in
       with_zeros, !funs, GHT.to_list gh
     in
 

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -415,11 +415,11 @@ let getGlobalInitEdges (file: file) : (edge * location) list  =
 
 
 let getZeroInitializedGlobals (file:file) =
-  let is_zeroinit = function
+  let is_zero_init = function
     | GVar(v, init, loc) -> if init.init = None then Some v else None
     | _ -> None
   in
-  List.filter_map (is_zeroinit) file.globals
+  List.filter_map (is_zero_init) file.globals
 
 let getGlobalInits (file:file) =
   let init_edges = getGlobalInitEdges file in

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -172,7 +172,7 @@ let _ = ()
       ; reg Experimental "exp.solver.td3.space" "false" "Should the td3 solver only keep values at widening points?"
       ; reg Experimental "exp.solver.td3.space_cache" "true" "Should the td3-space solver cache values?"
       ; reg Experimental "exp.solver.td3.space_restore" "true" "Should the td3-space solver restore values for non-widening-points? Needed for inspecting output!"
-      ; reg Experimental "exp.fast_global_inits" "false" "Only generate 'a[0] = 0' for a zero-initialized array a[n]. This is only sound for our flat array domain! TODO change this once we use others!"
+      ; reg Experimental "exp.fast_global_inits" "true" "Only generate 'a[0] = 0' for a zero-initialized array a[n]. This is only sound for our flat array domain! TODO change this once we use others!"
       ; reg Experimental "exp.uninit-ptr-safe"   "false" "Assume that uninitialized stack-allocated pointers may only point to variables not in the program or null."
       ; reg Experimental "exp.ptr-arith-safe"    "false" "Assume that pointer arithmetic only yields safe addresses."
       ; reg Experimental "exp.witness_path" "'witness.graphml'" "Witness output path"

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -172,7 +172,7 @@ let _ = ()
       ; reg Experimental "exp.solver.td3.space" "false" "Should the td3 solver only keep values at widening points?"
       ; reg Experimental "exp.solver.td3.space_cache" "true" "Should the td3-space solver cache values?"
       ; reg Experimental "exp.solver.td3.space_restore" "true" "Should the td3-space solver restore values for non-widening-points? Needed for inspecting output!"
-      ; reg Experimental "exp.fast_global_inits" "true" "Only generate 'a[0] = 0' for a zero-initialized array a[n]. This is only sound for our flat array domain! TODO change this once we use others!"
+      ; reg Experimental "exp.fast_global_inits" "true" "Only generate one assign 'a[0] = 0' for a zero-initialized array a[n]."
       ; reg Experimental "exp.uninit-ptr-safe"   "false" "Assume that uninitialized stack-allocated pointers may only point to variables not in the program or null."
       ; reg Experimental "exp.ptr-arith-safe"    "false" "Assume that pointer arithmetic only yields safe addresses."
       ; reg Experimental "exp.witness_path" "'witness.graphml'" "Witness output path"

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -328,15 +328,16 @@ struct
     let d = Dom.fold h (fst ctx.local) (Dom.empty ()) in
     if Dom.is_bot d then raise Deadcode else (d, Sync.bot ())
 
-  let assign ctx l e    = map ctx Spec.assign  (fun h -> h l e )
-  let vdecl ctx v       = map ctx Spec.vdecl   (fun h -> h v)
-  let body   ctx f      = map ctx Spec.body    (fun h -> h f   )
-  let return ctx e f    = map ctx Spec.return  (fun h -> h e f )
-  let branch ctx e tv   = map ctx Spec.branch  (fun h -> h e tv)
-  let intrpt ctx        = map ctx Spec.intrpt  identity
-  let asm ctx           = map ctx Spec.asm     identity
-  let skip ctx          = map ctx Spec.skip    identity
-  let special ctx l f a = map ctx Spec.special (fun h -> h l f a)
+  let assign ctx l e    = map ctx Spec.assign    (fun h -> h l e )
+  let zeroinit ctx v    = map ctx Spec.zeroinit  (fun h -> h v   )
+  let vdecl ctx v       = map ctx Spec.vdecl     (fun h -> h v   )
+  let body   ctx f      = map ctx Spec.body      (fun h -> h f   )
+  let return ctx e f    = map ctx Spec.return    (fun h -> h e f )
+  let branch ctx e tv   = map ctx Spec.branch    (fun h -> h e tv)
+  let intrpt ctx        = map ctx Spec.intrpt    identity
+  let asm ctx           = map ctx Spec.asm       identity
+  let skip ctx          = map ctx Spec.skip      identity
+  let special ctx l f a = map ctx Spec.special   (fun h -> h l f a)
 
   let fold ctx f g h a =
     let k x a =

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -329,7 +329,7 @@ struct
     if Dom.is_bot d then raise Deadcode else (d, Sync.bot ())
 
   let assign ctx l e    = map ctx Spec.assign    (fun h -> h l e )
-  let zeroinit ctx v    = map ctx Spec.zeroinit  (fun h -> h v   )
+  let zero_init ctx v   = map ctx Spec.zero_init  (fun h -> h v   )
   let vdecl ctx v       = map ctx Spec.vdecl     (fun h -> h v   )
   let body   ctx f      = map ctx Spec.body      (fun h -> h f   )
   let return ctx e f    = map ctx Spec.return    (fun h -> h e f )

--- a/src/witness/witnessConstraints_deprecated.ml
+++ b/src/witness/witnessConstraints_deprecated.ml
@@ -126,8 +126,8 @@ struct
     let w = step_ctx ctx in
     d, w
 
-  let zeroinit ctx v =
-    let d = S.zeroinit (unlift_ctx ctx) v in
+  let zero_init ctx v =
+    let d = S.zero_init (unlift_ctx ctx) v in
     let w = step_ctx ctx in
     d, w
 

--- a/src/witness/witnessConstraints_deprecated.ml
+++ b/src/witness/witnessConstraints_deprecated.ml
@@ -126,6 +126,11 @@ struct
     let w = step_ctx ctx in
     d, w
 
+  let zeroinit ctx v =
+    let d = S.zeroinit (unlift_ctx ctx) v in
+    let w = step_ctx ctx in
+    d, w
+
   let vdecl ctx v =
     let d = S.vdecl (unlift_ctx ctx) v in
     let w = step_ctx ctx in

--- a/tests/regression/01-cpa/36-interval-branching.c
+++ b/tests/regression/01-cpa/36-interval-branching.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits
+// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc
 #include <stdio.h>
 int main(){
     int i;

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int global;
 
 int main(void)

--- a/tests/regression/22-partitioned_arrays/02-pointers_array.c
+++ b/tests/regression/22-partitioned_arrays/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
+++ b/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
+++ b/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
+++ b/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/22-partitioned_arrays/06-interprocedural.c
+++ b/tests/regression/22-partitioned_arrays/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/07-global_array.c
+++ b/tests/regression/22-partitioned_arrays/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/08-unsupported.c
+++ b/tests/regression/22-partitioned_arrays/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 // This is just to test that the analysis does not cause problems for features that are not explicetly dealt with
 int main(void) {
   callok();

--- a/tests/regression/22-partitioned_arrays/09-one_by_one.c
+++ b/tests/regression/22-partitioned_arrays/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/22-partitioned_arrays/10-array_octagon.c
+++ b/tests/regression/22-partitioned_arrays/10-array_octagon.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/11-was_problematic.c
+++ b/tests/regression/22-partitioned_arrays/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
+++ b/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   int arr[260];

--- a/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
+++ b/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 struct some_struct
 {
     int dir[7];

--- a/tests/regression/22-partitioned_arrays/14-with_def_exc.c
+++ b/tests/regression/22-partitioned_arrays/14-with_def_exc.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.def_exc --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.def_exc  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     // Minimal and maximal in def_exc were broken. They are not directly used, but used in the MayBeLess and MayBeEqual queries, that
     // are in turn used by the partitioning arrays. This is why we run the arrays in combination with def_exc.

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int global;
 
 int main(void)

--- a/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
+++ b/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
+++ b/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
+++ b/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/07-global_array.c
+++ b/tests/regression/23-partitioned_arrays_last/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/08-unsupported.c
+++ b/tests/regression/23-partitioned_arrays_last/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {
   vla();

--- a/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
+++ b/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/23-partitioned_arrays_last/10-array_octagon.c
+++ b/tests/regression/23-partitioned_arrays_last/10-array_octagon.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
+++ b/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
+++ b/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   int arr[260];

--- a/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
+++ b/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
 }

--- a/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
+++ b/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
 }

--- a/tests/regression/24-octagon/01-octagon_simple.c
+++ b/tests/regression/24-octagon/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 void main(void) {
   int X = 0;

--- a/tests/regression/24-octagon/02-octagon_interprocudral.c
+++ b/tests/regression/24-octagon/02-octagon_interprocudral.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 int main(void) {
     f1();
 }

--- a/tests/regression/24-octagon/03-previously_problematic_a.c
+++ b/tests/regression/24-octagon/03-previously_problematic_a.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/04-previously_problematic_b.c
+++ b/tests/regression/24-octagon/04-previously_problematic_b.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 typedef int wchar_t;

--- a/tests/regression/24-octagon/05-previously_problematic_c.c
+++ b/tests/regression/24-octagon/05-previously_problematic_c.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/06-previously_problematic_d.c
+++ b/tests/regression/24-octagon/06-previously_problematic_d.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/07-previously_problematic_e.c
+++ b/tests/regression/24-octagon/07-previously_problematic_e.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/08-previously_problematic_f.c
+++ b/tests/regression/24-octagon/08-previously_problematic_f.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/09-previously_problematic_g.c
+++ b/tests/regression/24-octagon/09-previously_problematic_g.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/10-previously_problematic_h.c
+++ b/tests/regression/24-octagon/10-previously_problematic_h.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/11-previously_problematic_i.c
+++ b/tests/regression/24-octagon/11-previously_problematic_i.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 char buf2[67];

--- a/tests/regression/24-octagon/12-previously_problematic_j.c
+++ b/tests/regression/24-octagon/12-previously_problematic_j.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --disable exp.fast_global_inits --set ana.activated "['base','octagon']"
+// PARAM: --sets solver td3 --set ana.activated "['base','octagon']"
 void main(void) {
   int i = 0;
   int j = i;

--- a/tests/regression/25-vla/01-simple.c
+++ b/tests/regression/25-vla/01-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   int a[40];

--- a/tests/regression/25-vla/02-loop.c
+++ b/tests/regression/25-vla/02-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   example1();

--- a/tests/regression/25-vla/03-calls.c
+++ b/tests/regression/25-vla/03-calls.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 // Variable-sized arrays
 void foo(int n, int a[n]);
 void foo2(int n, int a[30][n]);

--- a/tests/regression/25-vla/04-passing_ptr_to_array.c
+++ b/tests/regression/25-vla/04-passing_ptr_to_array.c
@@ -1,4 +1,4 @@
-//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 
 void foo(int (*a)[40]){
     int x = (*(a + 29))[7];

--- a/tests/regression/25-vla/05-more_passing.c
+++ b/tests/regression/25-vla/05-more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 # include<stdio.h>
 
 void foo(int n, int a[n]) {

--- a/tests/regression/25-vla/06-even_more_passing.c
+++ b/tests/regression/25-vla/06-even_more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 
 void foo2(int n , int (*a)[n] )
 {

--- a/tests/regression/30-fast_global_inits/01-on.c
+++ b/tests/regression/30-fast_global_inits/01-on.c
@@ -1,0 +1,9 @@
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation']"
+// This checks that partitioned arrays and fast_global_inits are no longer incompatible
+int global_array[50];
+
+int main(void) {
+  for(int i =0; i < 50; i++) {
+      assert(global_array[i] == 0);
+  }
+}


### PR DESCRIPTION
By default, we generate `n*m` assign edges for a global array of dimensions `array[n][m]` when dealing with global initializers.

As an improvement, @vogler added the option `exp.fast_global_inits` where, for zero-initialized global arrays, only one assign to zero is generated: `array[0][0] = 0;`. This only works for the flat array domain, so we had to disable it when using the partitioned arrays (which we also do in SVCOMP).

**This PR makes this option compatible with partitioned arrays. To this end, we**

- Introduce `Base.zero_init_value t` to make a zero-initialized abstract value of type `t`.
   -  (In this step, we also remove unused arguments from `Base.init_value`, `Base.top_value`, and `Base.bot_value`)
- Add a new transfer function `zeroinit` that takes a `varinfo`
- Make `MyCFG.getGlobalInits file` return a list of `varinfo` to be zero-initialized on top of a list of edges for initialization
- Make `exp.fast_global_inits` the default and remove `--disable exp.fast_global_inits` from all test explicitly setting it

We chose to still generate the `array[0][0] = 0` edge, even when `exp.fast_global_inits` is enabled, causing `zeroinit array` to be called later.
This is so that it is safe to do nothing on `zeroinit` in all analyses except `base`. They still get the same assignment they got when `fast_global_inits` was implemented in the old way, so if they were sound before this change to `fast_global_inits`, they are still.

**The performance impact is quite big for large arrays:**

```
int global_array[50][200][20];

int main(void) {
  for(int i =0; i < 50; i++) {
      assert(global_array[i][42][7] == 0);
  }
}
```
Without `fast_global_inits`:
```
TOTAL                          157.453 s
  analysis                       157.450 s
    solving                         0.008 s

Memory statistics: total=293813.44MB, max=166.58MB, minor=293798.83MB, major=806.48MB, promoted=791.88MB
    minor collections=140102  major collections=24 compactions=0
```

With `fast_global_inits`:
```
TOTAL                           0.186 s
  analysis                        0.185 s
    solving                         0.009 s

Memory statistics: total=235.24MB, max=4.39MB, minor=233.53MB, major=3.47MB, promoted=1.76MB
    minor collections=112  major collections=3 compactions=0
```

Closes #122 