### PR TITLE
Fast global inits without adding a new transfer function (See #129)

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -800,10 +800,10 @@ struct
           M.debug ("Failed evaluating "^str^" to lvalue"); do_offs AD.unknown_ptr ofs
       end
 
-  let rec bot_value (t: typ): value =
+  let rec bot_value a (gs:glob_fun) (st: store) (t: typ): value =
     let bot_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let bot_field nstruct fd = ValueDomain.Structs.replace nstruct fd (bot_value fd.ftype) in
+      let bot_field nstruct fd = ValueDomain.Structs.replace nstruct fd (bot_value a gs st fd.ftype) in
       List.fold_left bot_field nstruct compinfo.cfields
     in
     match t with
@@ -812,17 +812,17 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (bot_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.bot ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.bot ()) (bot_value ai))
+      `Array (ValueDomain.CArrays.make (IdxDom.bot ()) (bot_value a gs st ai))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (bot_value ai))
-    | TNamed ({ttype=t; _}, _) -> bot_value t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (bot_value a gs st ai))
+    | TNamed ({ttype=t; _}, _) -> bot_value a gs st t
     | _ -> `Bot
 
-  let rec init_value (t: typ): value = (* TODO why is VD.top_value not used here? *)
+  let rec init_value a (gs:glob_fun) (st: store) (t: typ): value = (* TODO why is VD.top_value not used here? *)
     let init_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (init_value fd.ftype) in
+      let init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (init_value a gs st fd.ftype) in
       List.fold_left init_field nstruct compinfo.cfields
     in
     match t with
@@ -832,17 +832,17 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (init_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.bot ())  (if get_bool "exp.partition-arrays.enabled" then (init_value ai) else (bot_value ai)))
+      `Array (ValueDomain.CArrays.make (IdxDom.bot ())  (if get_bool "exp.partition-arrays.enabled" then (init_value a gs st ai) else (bot_value a gs st ai)))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (if get_bool "exp.partition-arrays.enabled" then (init_value ai) else (bot_value ai)))
-    | TNamed ({ttype=t; _}, _) -> init_value t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (if get_bool "exp.partition-arrays.enabled" then (init_value a gs st ai) else (bot_value a gs st ai)))
+    | TNamed ({ttype=t; _}, _) -> init_value a gs st t
     | _ -> `Top
 
-  let rec top_value (t: typ): value =
+  let rec top_value a (gs:glob_fun) (st: store) (t: typ): value =
     let top_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let top_field nstruct fd = ValueDomain.Structs.replace nstruct fd (top_value fd.ftype) in
+      let top_field nstruct fd = ValueDomain.Structs.replace nstruct fd (top_value a gs st fd.ftype) in
       List.fold_left top_field nstruct compinfo.cfields
     in
     match t with
@@ -851,39 +851,11 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (top_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (if get_bool "exp.partition-arrays.enabled" then (top_value ai) else (bot_value ai)))
+      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (if get_bool "exp.partition-arrays.enabled" then (top_value a gs st ai) else (bot_value a gs st ai)))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (if get_bool "exp.partition-arrays.enabled" then (top_value ai) else (bot_value ai)))
-    | TNamed ({ttype=t; _}, _) -> top_value t
-    | _ -> `Top
-
-  let rec zero_init_value (t:typ): value =
-    let zero_init_comp compinfo: ValueDomain.Structs.t =
-      let nstruct = ValueDomain.Structs.top () in
-      let zero_init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (zero_init_value fd.ftype) in
-      List.fold_left zero_init_field nstruct compinfo.cfields
-    in
-    match t with
-    | TInt (ikind, _) -> `Int (ID.of_int 0L)
-    | TPtr _ -> `Address AD.null_ptr
-    | TComp ({cstruct=true; _} as ci,_) -> `Struct (zero_init_comp ci)
-    | TComp ({cstruct=false; _} as ci,_) ->
-      let v = try
-        (* C99 6.7.8.10: the first named member is initialized (recursively) according to these rules *)
-        let firstmember = List.hd ci.cfields in
-        `Lifted firstmember, zero_init_value firstmember.ftype
-      with
-        (* Union with no members ò.O *)
-        Failure _ -> ValueDomain.Unions.top ()
-      in
-      `Union(v)
-    | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (zero_init_value ai))
-    | TArray (ai, Some exp, _) ->
-      let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (zero_init_value ai))
-    | TNamed ({ttype=t; _}, _) -> zero_init_value t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (if get_bool "exp.partition-arrays.enabled" then (top_value a gs st ai) else (bot_value a gs st ai)))
+    | TNamed ({ttype=t; _}, _) -> top_value a gs st t
     | _ -> `Top
 
   (* run eval_rv from above and keep a result that is bottom *)
@@ -896,9 +868,9 @@ struct
     try
       let r = eval_rv a gs st exp in
       if M.tracing then M.tracel "eval" "eval_rv %a = %a\n" d_exp exp VD.pretty r;
-      if VD.is_bot r then top_value (typeOf exp) else r
+      if VD.is_bot r then top_value a gs st (typeOf exp) else r
     with IntDomain.ArithmeticOnIntegerBot _ ->
-      top_value (typeOf exp)
+      top_value a gs st (typeOf exp)
 
   (* Evaluate an expression containing only locals. This is needed for smart joining the partitioned arrays where ctx is not accessible. *)
   (* This will yield `Top for expressions containing any access to globals, and does not make use of the query system. *)
@@ -1617,7 +1589,7 @@ struct
 
   let set_savetop ?lval_raw ?rval_raw ask (gs:glob_fun) st adr v : store =
     match v with
-    | `Top -> set ask gs st adr (top_value (AD.get_type adr)) ?lval_raw ?rval_raw
+    | `Top -> set ask gs st adr (top_value ask gs st (AD.get_type adr)) ?lval_raw ?rval_raw
     | v -> set ask gs st adr v ?lval_raw ?rval_raw
 
 
@@ -1700,7 +1672,7 @@ struct
         | `Bot -> (* current value is VD `Bot *)
           (match Addr.to_var_offset (AD.choose lval_val) with
           | [(x,offs)] ->
-            let iv = bot_value v.vtype in (* correct bottom value for top level variable *)
+            let iv = bot_value ctx.ask ctx.global ctx.local v.vtype in (* correct bottom value for top level variable *)
             let nv = VD.update_offset ctx.ask iv offs rval_val (Some  (Lval lval)) lval in (* do desired update to value *)
             set_savetop ctx.ask ctx.global ctx.local (AD.from_var v) nv (* set top-level variable to updated value *)
           | _ ->
@@ -1774,7 +1746,7 @@ struct
 
   let body ctx f =
     (* First we create a variable-initvalue pair for each variable *)
-    let init_var v = (AD.from_var v, init_value v.vtype) in
+    let init_var v = (AD.from_var v, init_value ctx.ask ctx.global ctx.local v.vtype) in
     (* Apply it to all the locals and then assign them all *)
     let inits = List.map init_var f.slocals in
     set_many ctx.ask ctx.global ctx.local inits

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -800,10 +800,10 @@ struct
           M.debug ("Failed evaluating "^str^" to lvalue"); do_offs AD.unknown_ptr ofs
       end
 
-  let rec bot_value a (gs:glob_fun) (st: store) (t: typ): value =
+  let rec bot_value (t: typ): value =
     let bot_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let bot_field nstruct fd = ValueDomain.Structs.replace nstruct fd (bot_value a gs st fd.ftype) in
+      let bot_field nstruct fd = ValueDomain.Structs.replace nstruct fd (bot_value fd.ftype) in
       List.fold_left bot_field nstruct compinfo.cfields
     in
     match t with
@@ -812,17 +812,17 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (bot_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.bot ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.bot ()) (bot_value a gs st ai))
+      `Array (ValueDomain.CArrays.make (IdxDom.bot ()) (bot_value ai))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (bot_value a gs st ai))
-    | TNamed ({ttype=t; _}, _) -> bot_value a gs st t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (bot_value ai))
+    | TNamed ({ttype=t; _}, _) -> bot_value t
     | _ -> `Bot
 
-  let rec init_value a (gs:glob_fun) (st: store) (t: typ): value = (* TODO why is VD.top_value not used here? *)
+  let rec init_value (t: typ): value = (* TODO why is VD.top_value not used here? *)
     let init_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (init_value a gs st fd.ftype) in
+      let init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (init_value fd.ftype) in
       List.fold_left init_field nstruct compinfo.cfields
     in
     match t with
@@ -832,17 +832,17 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (init_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.bot ())  (if get_bool "exp.partition-arrays.enabled" then (init_value a gs st ai) else (bot_value a gs st ai)))
+      `Array (ValueDomain.CArrays.make (IdxDom.bot ())  (if get_bool "exp.partition-arrays.enabled" then (init_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (if get_bool "exp.partition-arrays.enabled" then (init_value a gs st ai) else (bot_value a gs st ai)))
-    | TNamed ({ttype=t; _}, _) -> init_value a gs st t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (if get_bool "exp.partition-arrays.enabled" then (init_value ai) else (bot_value ai)))
+    | TNamed ({ttype=t; _}, _) -> init_value t
     | _ -> `Top
 
-  let rec top_value a (gs:glob_fun) (st: store) (t: typ): value =
+  let rec top_value (t: typ): value =
     let top_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let top_field nstruct fd = ValueDomain.Structs.replace nstruct fd (top_value a gs st fd.ftype) in
+      let top_field nstruct fd = ValueDomain.Structs.replace nstruct fd (top_value fd.ftype) in
       List.fold_left top_field nstruct compinfo.cfields
     in
     match t with
@@ -851,11 +851,39 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (top_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (if get_bool "exp.partition-arrays.enabled" then (top_value a gs st ai) else (bot_value a gs st ai)))
+      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (if get_bool "exp.partition-arrays.enabled" then (top_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (if get_bool "exp.partition-arrays.enabled" then (top_value a gs st ai) else (bot_value a gs st ai)))
-    | TNamed ({ttype=t; _}, _) -> top_value a gs st t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (if get_bool "exp.partition-arrays.enabled" then (top_value ai) else (bot_value ai)))
+    | TNamed ({ttype=t; _}, _) -> top_value t
+    | _ -> `Top
+
+  let rec zero_init_value (t:typ): value =
+    let zero_init_comp compinfo: ValueDomain.Structs.t =
+      let nstruct = ValueDomain.Structs.top () in
+      let zero_init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (zero_init_value fd.ftype) in
+      List.fold_left zero_init_field nstruct compinfo.cfields
+    in
+    match t with
+    | TInt (ikind, _) -> `Int (ID.of_int 0L)
+    | TPtr _ -> `Address AD.null_ptr
+    | TComp ({cstruct=true; _} as ci,_) -> `Struct (zero_init_comp ci)
+    | TComp ({cstruct=false; _} as ci,_) ->
+      let v = try
+        (* C99 6.7.8.10: the first named member is initialized (recursively) according to these rules *)
+        let firstmember = List.hd ci.cfields in
+        `Lifted firstmember, zero_init_value firstmember.ftype
+      with
+        (* Union with no members ò.O *)
+        Failure _ -> ValueDomain.Unions.top ()
+      in
+      `Union(v)
+    | TArray (ai, None, _) ->
+      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (zero_init_value ai))
+    | TArray (ai, Some exp, _) ->
+      let l = Cil.isInteger (Cil.constFold true exp) in
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (zero_init_value ai))
+    | TNamed ({ttype=t; _}, _) -> zero_init_value t
     | _ -> `Top
 
   (* run eval_rv from above and keep a result that is bottom *)
@@ -868,9 +896,9 @@ struct
     try
       let r = eval_rv a gs st exp in
       if M.tracing then M.tracel "eval" "eval_rv %a = %a\n" d_exp exp VD.pretty r;
-      if VD.is_bot r then top_value a gs st (typeOf exp) else r
+      if VD.is_bot r then top_value (typeOf exp) else r
     with IntDomain.ArithmeticOnIntegerBot _ ->
-      top_value a gs st (typeOf exp)
+      top_value (typeOf exp)
 
   (* Evaluate an expression containing only locals. This is needed for smart joining the partitioned arrays where ctx is not accessible. *)
   (* This will yield `Top for expressions containing any access to globals, and does not make use of the query system. *)
@@ -1589,7 +1617,7 @@ struct
 
   let set_savetop ?lval_raw ?rval_raw ask (gs:glob_fun) st adr v : store =
     match v with
-    | `Top -> set ask gs st adr (top_value ask gs st (AD.get_type adr)) ?lval_raw ?rval_raw
+    | `Top -> set ask gs st adr (top_value (AD.get_type adr)) ?lval_raw ?rval_raw
     | v -> set ask gs st adr v ?lval_raw ?rval_raw
 
 
@@ -1672,7 +1700,7 @@ struct
         | `Bot -> (* current value is VD `Bot *)
           (match Addr.to_var_offset (AD.choose lval_val) with
           | [(x,offs)] ->
-            let iv = bot_value ctx.ask ctx.global ctx.local v.vtype in (* correct bottom value for top level variable *)
+            let iv = bot_value v.vtype in (* correct bottom value for top level variable *)
             let nv = VD.update_offset ctx.ask iv offs rval_val (Some  (Lval lval)) lval in (* do desired update to value *)
             set_savetop ctx.ask ctx.global ctx.local (AD.from_var v) nv (* set top-level variable to updated value *)
           | _ ->
@@ -1746,7 +1774,7 @@ struct
 
   let body ctx f =
     (* First we create a variable-initvalue pair for each variable *)
-    let init_var v = (AD.from_var v, init_value ctx.ask ctx.global ctx.local v.vtype) in
+    let init_var v = (AD.from_var v, init_value v.vtype) in
     (* Apply it to all the locals and then assign them all *)
     let inits = List.map init_var f.slocals in
     set_many ctx.ask ctx.global ctx.local inits

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -717,14 +717,7 @@ struct
   (* Functions that make us of the configuration flag *)
   let name () = "FlagConfiguredArrayDomain: " ^ if get_bool "exp.partition-arrays.enabled" then P.name () else T.name ()
 
-  let partition_enabled () =
-    if get_bool "exp.partition-arrays.enabled" then
-      if get_bool "exp.fast_global_inits" then
-        failwith "Options 'exp.partition-arrays.enabled' and 'exp.fast_global_inits' are incompatible. Disable at least one of them."
-      else
-        true
-    else
-      false
+  let partition_enabled () = get_bool "exp.partition-arrays.enabled"
 
   let bot () =
     if partition_enabled () then

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -823,7 +823,12 @@ struct
               let new_value_at_index = do_update_offset ask (CArrays.get ask x' (e,idx)) offs value exp l' o' v in
               let new_array_value = CArrays.set ask x' (e, idx) new_value_at_index in
               `Array new_array_value
-            | `Bot ->  M.warn_each("encountered array bot, made array top"); `Array (CArrays.top ());
+            | `Bot ->
+              let x' = CArrays.bot () in
+              let e = determine_offset ask l o exp (Some v) in
+              let new_value_at_index = do_update_offset ask `Bot offs value exp l' o' v in
+              let new_array_value =  CArrays.set ask x' (e, idx) new_value_at_index in
+              `Array new_array_value
             | `Top -> M.warn "Trying to update an index, but the array is unknown"; top ()
             | x when IndexDomain.to_int idx = Some 0L -> do_update_offset ask x offs value exp l' o' v
             | _ -> M.warn_each ("Trying to update an index, but was not given an array("^short 80 x^")"); top ()

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -110,6 +110,8 @@ let unknown_exp : exp = mkString "__unknown_value__"
 let dummy_func = emptyFunction "__goblint_dummy_init" (* TODO get rid of this? *)
 let dummy_node = FunctionEntry Cil.dummyFunDec.svar
 
+let all_array_index_exp : exp = CastE(TInt(Cilfacade.ptrdiff_ikind (),[]), unknown_exp)
+
 let getLoc (node: node) =
   match node with
   | Statement stmt -> get_stmtLoc stmt.skind
@@ -375,19 +377,23 @@ let getGlobalInits (file: file) : (edge * location) list  =
       doInit (addOffsetLval offs lval) loc init is_zero;
       lval
     in
-    let rec zero_index = function
-      | Index (e,o) -> Index (zero, zero_index o)
-      | Field (f,o) -> Field (f, zero_index o)
+    let rec all_index = function
+      | Index (e,o) -> Index (all_array_index_exp, all_index o)
+      | Field (f,o) -> Field (f, all_index o)
       | NoOffset -> NoOffset
     in
-    let zero_index (lh,offs) = lh, zero_index offs in
+    let all_index (lh,offs) = lh, all_index offs in
     match init with
     | SingleInit exp ->
       let assign lval = Assign (lval, exp), loc in
       (* This is an optimization so that we don't get n*m assigns for a zero-initialized array a[n][m]
          TODO This is only sound for our flat array domain. Change this once we use others. *)
-      if not (fast_global_inits && is_zero && Hashtbl.mem inits (assign (zero_index lval))) then
+      if (not fast_global_inits) || (not is_zero) then
         Hashtbl.add inits (assign lval) ()
+      else if not (Hashtbl.mem inits (assign (all_index lval))) then
+        Hashtbl.add inits (assign (all_index lval)) ()
+      else
+        ()
     | CompoundInit (typ, lst) ->
       let ntyp = match typ, lst with
         | TArray(t, None, attr), [] -> TArray(t, Some zero, attr) (* set initializer type to t[0] for flexible array members of structs that are intialized with {} *)

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -172,7 +172,7 @@ let _ = ()
       ; reg Experimental "exp.solver.td3.space" "false" "Should the td3 solver only keep values at widening points?"
       ; reg Experimental "exp.solver.td3.space_cache" "true" "Should the td3-space solver cache values?"
       ; reg Experimental "exp.solver.td3.space_restore" "true" "Should the td3-space solver restore values for non-widening-points? Needed for inspecting output!"
-      ; reg Experimental "exp.fast_global_inits" "false" "Only generate 'a[0] = 0' for a zero-initialized array a[n]. This is only sound for our flat array domain! TODO change this once we use others!"
+      ; reg Experimental "exp.fast_global_inits" "true" "Only generate 'a[0] = 0' for a zero-initialized array a[n]. This is only sound for our flat array domain! TODO change this once we use others!"
       ; reg Experimental "exp.uninit-ptr-safe"   "false" "Assume that uninitialized stack-allocated pointers may only point to variables not in the program or null."
       ; reg Experimental "exp.ptr-arith-safe"    "false" "Assume that pointer arithmetic only yields safe addresses."
       ; reg Experimental "exp.witness_path" "'witness.graphml'" "Witness output path"

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -172,7 +172,7 @@ let _ = ()
       ; reg Experimental "exp.solver.td3.space" "false" "Should the td3 solver only keep values at widening points?"
       ; reg Experimental "exp.solver.td3.space_cache" "true" "Should the td3-space solver cache values?"
       ; reg Experimental "exp.solver.td3.space_restore" "true" "Should the td3-space solver restore values for non-widening-points? Needed for inspecting output!"
-      ; reg Experimental "exp.fast_global_inits" "true" "Only generate 'a[0] = 0' for a zero-initialized array a[n]. This is only sound for our flat array domain! TODO change this once we use others!"
+      ; reg Experimental "exp.fast_global_inits" "true" "Only generate 'a[MyCFG.all_array_index_exp] = 0' for a zero-initialized array a[n]."
       ; reg Experimental "exp.uninit-ptr-safe"   "false" "Assume that uninitialized stack-allocated pointers may only point to variables not in the program or null."
       ; reg Experimental "exp.ptr-arith-safe"    "false" "Assume that pointer arithmetic only yields safe addresses."
       ; reg Experimental "exp.witness_path" "'witness.graphml'" "Witness output path"

--- a/tests/regression/01-cpa/36-interval-branching.c
+++ b/tests/regression/01-cpa/36-interval-branching.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits
+// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc
 #include <stdio.h>
 int main(){
     int i;

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int global;
 
 int main(void)

--- a/tests/regression/22-partitioned_arrays/02-pointers_array.c
+++ b/tests/regression/22-partitioned_arrays/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
+++ b/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
+++ b/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
+++ b/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/22-partitioned_arrays/06-interprocedural.c
+++ b/tests/regression/22-partitioned_arrays/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/07-global_array.c
+++ b/tests/regression/22-partitioned_arrays/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/08-unsupported.c
+++ b/tests/regression/22-partitioned_arrays/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 // This is just to test that the analysis does not cause problems for features that are not explicetly dealt with
 int main(void) {
   callok();

--- a/tests/regression/22-partitioned_arrays/09-one_by_one.c
+++ b/tests/regression/22-partitioned_arrays/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/22-partitioned_arrays/10-array_octagon.c
+++ b/tests/regression/22-partitioned_arrays/10-array_octagon.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/11-was_problematic.c
+++ b/tests/regression/22-partitioned_arrays/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
+++ b/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   int arr[260];

--- a/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
+++ b/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 struct some_struct
 {
     int dir[7];

--- a/tests/regression/22-partitioned_arrays/14-with_def_exc.c
+++ b/tests/regression/22-partitioned_arrays/14-with_def_exc.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.def_exc --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.def_exc  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void) {
     // Minimal and maximal in def_exc were broken. They are not directly used, but used in the MayBeLess and MayBeEqual queries, that
     // are in turn used by the partitioning arrays. This is why we run the arrays in combination with def_exc.

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int global;
 
 int main(void)

--- a/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
+++ b/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
+++ b/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
+++ b/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/07-global_array.c
+++ b/tests/regression/23-partitioned_arrays_last/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/08-unsupported.c
+++ b/tests/regression/23-partitioned_arrays_last/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {
   vla();

--- a/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
+++ b/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation']"
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/23-partitioned_arrays_last/10-array_octagon.c
+++ b/tests/regression/23-partitioned_arrays_last/10-array_octagon.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
+++ b/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
+++ b/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last"  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   int arr[260];

--- a/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
+++ b/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits  --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation','octagon']"
 void main(void) {
   example1();
 }

--- a/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
+++ b/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','expRelation']"
 int main(void) {
   example1();
 }

--- a/tests/regression/24-octagon/01-octagon_simple.c
+++ b/tests/regression/24-octagon/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 void main(void) {
   int X = 0;

--- a/tests/regression/24-octagon/02-octagon_interprocudral.c
+++ b/tests/regression/24-octagon/02-octagon_interprocudral.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 int main(void) {
     f1();
 }

--- a/tests/regression/24-octagon/03-previously_problematic_a.c
+++ b/tests/regression/24-octagon/03-previously_problematic_a.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/04-previously_problematic_b.c
+++ b/tests/regression/24-octagon/04-previously_problematic_b.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 typedef int wchar_t;

--- a/tests/regression/24-octagon/05-previously_problematic_c.c
+++ b/tests/regression/24-octagon/05-previously_problematic_c.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/06-previously_problematic_d.c
+++ b/tests/regression/24-octagon/06-previously_problematic_d.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval  --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/07-previously_problematic_e.c
+++ b/tests/regression/24-octagon/07-previously_problematic_e.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/08-previously_problematic_f.c
+++ b/tests/regression/24-octagon/08-previously_problematic_f.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/09-previously_problematic_g.c
+++ b/tests/regression/24-octagon/09-previously_problematic_g.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/10-previously_problematic_h.c
+++ b/tests/regression/24-octagon/10-previously_problematic_h.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/11-previously_problematic_i.c
+++ b/tests/regression/24-octagon/11-previously_problematic_i.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation','octagon']"
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 char buf2[67];

--- a/tests/regression/24-octagon/12-previously_problematic_j.c
+++ b/tests/regression/24-octagon/12-previously_problematic_j.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --disable exp.fast_global_inits --set ana.activated "['base','octagon']"
+// PARAM: --sets solver td3 --set ana.activated "['base','octagon']"
 void main(void) {
   int i = 0;
   int j = i;

--- a/tests/regression/25-vla/01-simple.c
+++ b/tests/regression/25-vla/01-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   int a[40];

--- a/tests/regression/25-vla/02-loop.c
+++ b/tests/regression/25-vla/02-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 int main(void)
 {
   example1();

--- a/tests/regression/25-vla/03-calls.c
+++ b/tests/regression/25-vla/03-calls.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 // Variable-sized arrays
 void foo(int n, int a[n]);
 void foo2(int n, int a[30][n]);

--- a/tests/regression/25-vla/04-passing_ptr_to_array.c
+++ b/tests/regression/25-vla/04-passing_ptr_to_array.c
@@ -1,4 +1,4 @@
-//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 
 void foo(int (*a)[40]){
     int x = (*(a + 29))[7];

--- a/tests/regression/25-vla/05-more_passing.c
+++ b/tests/regression/25-vla/05-more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 # include<stdio.h>
 
 void foo(int n, int a[n]) {

--- a/tests/regression/25-vla/06-even_more_passing.c
+++ b/tests/regression/25-vla/06-even_more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --disable exp.fast_global_inits --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
+//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','expRelation']"
 
 void foo2(int n , int (*a)[n] )
 {

--- a/tests/regression/30-fast_global_inits/01-on.c
+++ b/tests/regression/30-fast_global_inits/01-on.c
@@ -1,0 +1,9 @@
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation']"
+// This checks that partitioned arrays and fast_global_inits are no longer incompatible
+int global_array[50];
+
+int main(void) {
+  for(int i =0; i < 50; i++) {
+      assert(global_array[i] == 0);
+  }
+}

--- a/tests/regression/30-fast_global_inits/02-off.c
+++ b/tests/regression/30-fast_global_inits/02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled --set ana.activated "['base','expRelation']" --disable exp.fast_global_inits
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 int global_array[50];
 int global_array_multi[50][2][2];


### PR DESCRIPTION
**This is an alternative to #129 that also solves #122.**

As suggested, for this case we add a new expression 

~~~OCaml
let all_array_index_exp : exp = CastE(TInt(Cilfacade.ptrdiff_ikind (),[]), unknown_exp)`
~~~
 to `MyCFG` (with the semantics that an assign to this special index represents an assignment to all indices of an array) and in the assign in the partitioned array domain check if we are dealing with an assign to this expression.

This means touching less code, but I am not sure if it is nicer than #129. To me, it feels quite hacky. What do y'all think @vogler @sim642 @jerhard @vesalvojdani  ?


**Sidenote:** The diff of `src/cdomains/arrayDomain.ml` appears huge, Github somehow gets confused. The change is adding:

~~~OCaml
if i = `Lifted MyCFG.all_array_index_exp then
   (Expp.top(), (a, a, a))
else
~~~

The rest is indentation changing because of it.