### PR TITLE
Add __VERIFIER_atomic_* support

### DIFF
--- a/conf/svcomp21.json
+++ b/conf/svcomp21.json
@@ -1,6 +1,9 @@
 {
   "ana": {
-    "sv-comp": true,
+    "sv-comp": {
+      "enabled": true,
+      "functions": true
+    },
     "int": {
       "def_exc": true,
       "enums": false,

--- a/includes/sv-comp.c
+++ b/includes/sv-comp.c
@@ -33,5 +33,6 @@ __VERIFIER_nondet2(unsigned short, ushort)
 // void* __VERIFIER_nondet_pointer() { void* val; return val; }
 __VERIFIER_nondet2(void*, pointer)
 
-void __VERIFIER_atomic_begin() { } // TODO: use atomic marker in Goblint
-void __VERIFIER_atomic_end() { } // TODO: use atomic marker in Goblint
+// atomics are now special in Goblint
+// void __VERIFIER_atomic_begin() { }
+// void __VERIFIER_atomic_end() { }

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -398,7 +398,10 @@ let invalidate_actions = ref [
     "__builtin_prefetch", readsAll;
     "idr_pre_get", readsAll;
     "zil_replay", writes [1;2;3;5];
-    "__VERIFIER_nondet_int", readsAll (* no args, declare invalidate actions to prevent invalidating globals when extern in regression tests *)
+    "__VERIFIER_nondet_int", readsAll; (* no args, declare invalidate actions to prevent invalidating globals when extern in regression tests *)
+    (* no args, declare invalidate actions to prevent invalidating globals *)
+    "__VERIFIER_atomic_begin", readsAll;
+    "__VERIFIER_atomic_end", readsAll
   ]
 let add_invalidate_actions xs = invalidate_actions := xs @ !invalidate_actions
 

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -197,14 +197,14 @@ struct
       | None -> ()
     end;
     (* deprecated but still valid SV-COMP convention for atomic block *)
-    if String.starts_with fundec.svar.vname "__VERIFIER_atomic_" then
+    if get_bool "ana.sv-comp.functions" && String.starts_with fundec.svar.vname "__VERIFIER_atomic_" then
       Lockset.remove (verifier_atomic, true) ctx.local
     else
       ctx.local
 
   let body ctx f : D.t =
     (* deprecated but still valid SV-COMP convention for atomic block *)
-    if String.starts_with f.svar.vname "__VERIFIER_atomic_" then
+    if get_bool "ana.sv-comp.functions" && String.starts_with f.svar.vname "__VERIFIER_atomic_" then
       Lockset.add (verifier_atomic, true) ctx.local
     else
       ctx.local
@@ -260,9 +260,9 @@ struct
       Lockset.remove (console_sem,true) ctx.local
     | _, "__builtin_prefetch" | _, "misc_deregister" ->
       ctx.local
-    | _, "__VERIFIER_atomic_begin" ->
+    | _, "__VERIFIER_atomic_begin" when get_bool "ana.sv-comp.functions" ->
       Lockset.add (verifier_atomic, true) ctx.local
-    | _, "__VERIFIER_atomic_end" ->
+    | _, "__VERIFIER_atomic_end" when get_bool "ana.sv-comp.functions" ->
       Lockset.remove (verifier_atomic, true) ctx.local
     | _, x ->
       let arg_acc act =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -193,13 +193,21 @@ struct
 
   let return ctx exp fundec : D.t =
     begin match exp with
-      | Some exp ->
-        access_one_top ctx false false exp;
-        ctx.local
-      | None -> ctx.local
-    end
+      | Some exp -> access_one_top ctx false false exp
+      | None -> ()
+    end;
+    (* deprecated but still valid SV-COMP convention for atomic block *)
+    if String.starts_with fundec.svar.vname "__VERIFIER_atomic_" then
+      Lockset.remove (verifier_atomic, true) ctx.local
+    else
+      ctx.local
 
-  let body ctx f : D.t = ctx.local
+  let body ctx f : D.t =
+    (* deprecated but still valid SV-COMP convention for atomic block *)
+    if String.starts_with f.svar.vname "__VERIFIER_atomic_" then
+      Lockset.add (verifier_atomic, true) ctx.local
+    else
+      ctx.local
 
   let special ctx lv f arglist : D.t =
     let remove_rw x st = Lockset.remove (x,true) (Lockset.remove (x,false) st) in

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -161,10 +161,13 @@ struct
     | Queries.IsPublic _ when Lockset.is_bot ctx.local -> `Bool false
     | Queries.IsPublic v ->
       let held_locks = Lockset.export_locks (Lockset.filter snd ctx.local) in
-      let lambda_v = ctx.global v in
-      let intersect = Mutexes.inter held_locks lambda_v in
-      let tv = Mutexes.is_empty intersect in
-      `Bool (tv)
+      if Mutexes.mem verifier_atomic held_locks then
+        `Bool false
+      else
+        let lambda_v = ctx.global v in
+        let intersect = Mutexes.inter held_locks lambda_v in
+        let tv = Mutexes.is_empty intersect in
+        `Bool tv
     | _ -> Queries.Result.top ()
 
   let may_race (ctx1,ac1) (ctx,ac2) =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -29,6 +29,7 @@ let get_flag (state: (string * Obj.t) list) : BaseDomain.Flag.t =
 
 let big_kernel_lock = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType))
 let console_sem = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[console semaphore]" intType))
+let verifier_atomic = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[__VERIFIER_atomic]" intType))
 
 module type SpecParam =
 sig
@@ -248,6 +249,10 @@ struct
       Lockset.remove (console_sem,true) ctx.local
     | _, "__builtin_prefetch" | _, "misc_deregister" ->
       ctx.local
+    | _, "__VERIFIER_atomic_begin" ->
+      Lockset.add (verifier_atomic, true) ctx.local
+    | _, "__VERIFIER_atomic_end" ->
+      Lockset.remove (verifier_atomic, true) ctx.local
     | _, x ->
       let arg_acc act =
         match LF.get_threadsafe_inv_ac x with

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -18,10 +18,10 @@ let get_spec () : (module SpecHC) =
             |> lift (get_bool "exp.widen-context" && get_bool "exp.full-context") (module WidenContextLifter)
             |> lift (get_bool "exp.widen-context" && neg get_bool "exp.full-context") (module WidenContextLifterSide)
             (* hashcons before witness to reduce duplicates, because witness re-uses contexts in domain and requires tag for PathSensitive3 *)
-            |> lift (get_bool "ana.opt.hashcons" || get_bool "ana.sv-comp") (module HashconsContextLifter)
-            |> lift (get_bool "ana.sv-comp") (module HashconsLifter)
-            |> lift (get_bool "ana.sv-comp") (module WitnessConstraints.PathSensitive3)
-            |> lift (not (get_bool "ana.sv-comp")) (module PathSensitive2)
+            |> lift (get_bool "ana.opt.hashcons" || get_bool "ana.sv-comp.enabled") (module HashconsContextLifter)
+            |> lift (get_bool "ana.sv-comp.enabled") (module HashconsLifter)
+            |> lift (get_bool "ana.sv-comp.enabled") (module WitnessConstraints.PathSensitive3)
+            |> lift (not (get_bool "ana.sv-comp.enabled")) (module PathSensitive2)
             |> lift true (module DeadCodeLifter)
             |> lift (get_bool "dbg.slice.on") (module LevelSliceLifter)
             |> lift (get_int "dbg.limit.widen" > 0) (module LimitLifter)
@@ -256,7 +256,7 @@ struct
     in
 
     (* real beginning of the [analyze] function *)
-    if get_bool "ana.sv-comp" then
+    if get_bool "ana.sv-comp.enabled" then
       WResult.init file; (* TODO: move this out of analyze_loop *)
 
     GU.global_initialization := true;
@@ -399,7 +399,7 @@ struct
         Vrfyr.verify lh gh;
       );
 
-      if get_bool "ana.sv-comp" then (
+      if get_bool "ana.sv-comp.enabled" then (
         (* prune already here so local_xml and thus HTML are also pruned *)
         let module Reach = Reachability (EQSys) (LHT) (GHT) in
         Reach.prune lh gh startvars'
@@ -491,7 +491,7 @@ struct
         fun _ -> true (* TODO: warn about conflicting options *)
     in
 
-    if get_bool "ana.sv-comp" then
+    if get_bool "ana.sv-comp.enabled" then
       WResult.write lh gh entrystates;
 
     if get_bool "exp.cfgdot" then

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -229,7 +229,7 @@ let preprocess_files () =
   if get_bool "custom_libc" then
     cFileNames := (Filename.concat include_dir "lib.c") :: !cFileNames;
 
-  if get_bool "ana.sv-comp" then
+  if get_bool "ana.sv-comp.functions" then
     cFileNames := (Filename.concat include_dir "sv-comp.c") :: !cFileNames;
 
   (* If we analyze a kernel module, some special includes are needed. *)

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -131,7 +131,8 @@ let _ = ()
       ; reg Analyses "ana.opt.equal"       "true"  "First try physical equality (==) before {D,G,C}.equal (only done if hashcons is disabled since it basically does the same via its tags)."
       ; reg Analyses "ana.restart_count"   "1"     "How many times SLR4 is allowed to switch from restarting iteration to increasing iteration."
       ; reg Analyses "ana.mutex.disjoint_types" "true" "Do not propagate basic type writes to all struct fields"
-      ; reg Analyses "ana.sv-comp"         "false" "SV-COMP mode"
+      ; reg Analyses "ana.sv-comp.enabled" "false" "SV-COMP mode"
+      ; reg Analyses "ana.sv-comp.functions" "false" "SV-COMP functions"
       ; reg Analyses "ana.specification"   "" "SV-COMP specification (path or string)"
       ; reg Analyses "ana.wp"              "false" "Weakest precondition feasibility analysis for SV-COMP violations"
 

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -132,7 +132,7 @@ let _ = ()
       ; reg Analyses "ana.restart_count"   "1"     "How many times SLR4 is allowed to switch from restarting iteration to increasing iteration."
       ; reg Analyses "ana.mutex.disjoint_types" "true" "Do not propagate basic type writes to all struct fields"
       ; reg Analyses "ana.sv-comp.enabled" "false" "SV-COMP mode"
-      ; reg Analyses "ana.sv-comp.functions" "false" "SV-COMP functions"
+      ; reg Analyses "ana.sv-comp.functions" "false" "Handle SV-COMP __VERIFIER* functions"
       ; reg Analyses "ana.specification"   "" "SV-COMP specification (path or string)"
       ; reg Analyses "ana.wp"              "false" "Weakest precondition feasibility analysis for SV-COMP violations"
 

--- a/tests/regression/29-svcomp/15-atomic_nr.c
+++ b/tests/regression/29-svcomp/15-atomic_nr.c
@@ -1,0 +1,23 @@
+#include <pthread.h>
+
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
+
+int myglobal;
+
+void *t_fun(void *arg) {
+  __VERIFIER_atomic_begin();
+  myglobal=myglobal+1; // NORACE
+  __VERIFIER_atomic_end();
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  __VERIFIER_atomic_begin();
+  myglobal=myglobal+1; // NORACE
+  __VERIFIER_atomic_end();
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/29-svcomp/15-atomic_nr.c
+++ b/tests/regression/29-svcomp/15-atomic_nr.c
@@ -1,3 +1,4 @@
+// PARAM: --enable ana.sv-comp.functions
 #include <pthread.h>
 
 extern void __VERIFIER_atomic_begin();

--- a/tests/regression/29-svcomp/16-atomic_priv.c
+++ b/tests/regression/29-svcomp/16-atomic_priv.c
@@ -1,0 +1,26 @@
+#include <pthread.h>
+#include <assert.h>
+
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
+
+int myglobal = 5;
+
+void *t_fun(void *arg) {
+  __VERIFIER_atomic_begin();
+  assert(myglobal == 5);
+  myglobal++;
+  assert(myglobal == 6);
+  myglobal--;
+  assert(myglobal == 5);
+  __VERIFIER_atomic_end();
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  assert(myglobal == 5);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/29-svcomp/16-atomic_priv.c
+++ b/tests/regression/29-svcomp/16-atomic_priv.c
@@ -1,3 +1,4 @@
+// PARAM: --enable ana.sv-comp.functions
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/29-svcomp/16-atomic_priv.c
+++ b/tests/regression/29-svcomp/16-atomic_priv.c
@@ -20,7 +20,9 @@ void *t_fun(void *arg) {
 int main(void) {
   pthread_t id;
   pthread_create(&id, NULL, t_fun, NULL);
+  // __VERIFIER_atomic_begin();
   assert(myglobal == 5);
+  // __VERIFIER_atomic_end();
   pthread_join (id, NULL);
   return 0;
 }

--- a/tests/regression/29-svcomp/17-atomic_fun_nr.c
+++ b/tests/regression/29-svcomp/17-atomic_fun_nr.c
@@ -1,0 +1,21 @@
+#include <pthread.h>
+
+int myglobal;
+
+// atomic by function name prefix
+void __VERIFIER_atomic_fun() {
+  myglobal=myglobal+1; // NORACE
+}
+
+void *t_fun(void *arg) {
+  __VERIFIER_atomic_fun();
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  __VERIFIER_atomic_fun();
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/29-svcomp/17-atomic_fun_nr.c
+++ b/tests/regression/29-svcomp/17-atomic_fun_nr.c
@@ -1,3 +1,4 @@
+// PARAM: --enable ana.sv-comp.functions
 #include <pthread.h>
 
 int myglobal;

--- a/tests/regression/29-svcomp/18-atomic_fun_priv.c
+++ b/tests/regression/29-svcomp/18-atomic_fun_priv.c
@@ -1,0 +1,28 @@
+#include <pthread.h>
+#include <assert.h>
+
+int myglobal = 5;
+
+// atomic by function name prefix
+void __VERIFIER_atomic_fun() {
+  assert(myglobal == 5);
+  myglobal++;
+  assert(myglobal == 6);
+  myglobal--;
+  assert(myglobal == 5);
+}
+
+void *t_fun(void *arg) {
+  __VERIFIER_atomic_fun();
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  // __VERIFIER_atomic_begin();
+  assert(myglobal == 5);
+  // __VERIFIER_atomic_end();
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/29-svcomp/18-atomic_fun_priv.c
+++ b/tests/regression/29-svcomp/18-atomic_fun_priv.c
@@ -1,3 +1,4 @@
+// PARAM: --enable ana.sv-comp.functions
 #include <pthread.h>
 #include <assert.h>
 


### PR DESCRIPTION
Closes #113.

Besides `__VERIFIER_atomic_begin` and `__VERIFIER_atomic_end`, it also implements the deprecated but still valid form of SV-COMP atomics by function name beginning with `__VERIFIER_atomic_`.