### PR TITLE
Use fast_global_inits also for non-zero initialized global arrays

### DIFF
--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -295,7 +295,7 @@ struct
 
   let set_with_length length (ask:Q.ask) ((e, (xl, xm, xr)) as x) (i,_) a =
     if i = `Lifted MyCFG.all_array_index_exp then
-      (assert !Goblintutil.global_initialization; (* just joining with xr here assumes that all values will be set, which is guaranteed during inits *)
+      (assert !Goblintutil.global_initialization; (* just joining with xm here assumes that all values will be set, which is guaranteed during inits *)
       let r =  Val.join xm a in
       (Expp.top(), (r, r, r)))
     else

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -295,7 +295,8 @@ struct
 
   let set_with_length length (ask:Q.ask) ((e, (xl, xm, xr)) as x) (i,_) a =
     if i = `Lifted MyCFG.all_array_index_exp then
-      (Expp.top(), (a, a, a))
+      let r =  Val.join (join_of_all_parts x) a in
+      (Expp.top(), (r, r, r))
     else
       normalize @@
       let use_last = get_string "exp.partition-arrays.keep-expr" = "last" in

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -295,8 +295,9 @@ struct
 
   let set_with_length length (ask:Q.ask) ((e, (xl, xm, xr)) as x) (i,_) a =
     if i = `Lifted MyCFG.all_array_index_exp then
-      let r =  Val.join (join_of_all_parts x) a in
-      (Expp.top(), (r, r, r))
+      (assert !Goblintutil.global_initialization; (* just joining with xr here assumes that all values will be set, which is guaranteed during inits *)
+      let r =  Val.join xm a in
+      (Expp.top(), (r, r, r)))
     else
       normalize @@
       let use_last = get_string "exp.partition-arrays.keep-expr" = "last" in

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -386,9 +386,9 @@ let getGlobalInits (file: file) : (edge * location) list  =
     match init with
     | SingleInit exp ->
       let assign lval = Assign (lval, exp), loc in
-      (* This is an optimization so that we don't get n*m assigns for a zero-initialized array a[n][m]
-         TODO This is only sound for our flat array domain. Change this once we use others. *)
-      if (not fast_global_inits) || (not is_zero) then
+      (* This is an optimization so that we don't get n*m assigns for an array a[n][m].
+         Instead, we get one assign for each distinct value in the array *)
+      if not fast_global_inits then
         Hashtbl.add inits (assign lval) ()
       else if not (Hashtbl.mem inits (assign (all_index lval))) then
         Hashtbl.add inits (assign (all_index lval)) ()

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -174,7 +174,7 @@ let _ = ()
       ; reg Experimental "exp.solver.td3.space" "false" "Should the td3 solver only keep values at widening points?"
       ; reg Experimental "exp.solver.td3.space_cache" "true" "Should the td3-space solver cache values?"
       ; reg Experimental "exp.solver.td3.space_restore" "true" "Should the td3-space solver restore values for non-widening-points? Needed for inspecting output!"
-      ; reg Experimental "exp.fast_global_inits" "true" "Only generate 'a[MyCFG.all_array_index_exp] = 0' for a zero-initialized array a[n]."
+      ; reg Experimental "exp.fast_global_inits" "true" "Only generate one 'a[MyCFG.all_array_index_exp] = x' for all assignments a[...] = x for a global array a[n]."
       ; reg Experimental "exp.uninit-ptr-safe"   "false" "Assume that uninitialized stack-allocated pointers may only point to variables not in the program or null."
       ; reg Experimental "exp.ptr-arith-safe"    "false" "Assume that pointer arithmetic only yields safe addresses."
       ; reg Experimental "exp.witness_path" "'witness.graphml'" "Witness output path"

--- a/tests/regression/30-fast_global_inits/04-non-zero.c
+++ b/tests/regression/30-fast_global_inits/04-non-zero.c
@@ -1,0 +1,25 @@
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled --enable exp.fast_global_inits
+// This checks that partitioned arrays and fast_global_inits are no longer incompatible
+int global_array[5] = {9, 0, 3, 42, 11};
+int global_array_multi[2][5] =  {{9, 0, 3, 42, 11}, {9, 0, 3, 42, 11}};
+
+int main(void) {
+  assert(global_array[0] == 9);  //UNKNOWN
+  assert(global_array[1] == 0);  //UNKNOWN
+  assert(global_array[2] == 3);  //UNKNOWN
+  assert(global_array[3] == 42); //UNKNOWN
+  assert(global_array[3] == 11); //UNKNOWN
+
+  assert(global_array_multi[0][0] == 9);  //UNKNOWN
+  assert(global_array_multi[0][1] == 0);  //UNKNOWN
+  assert(global_array_multi[0][2] == 3);  //UNKNOWN
+  assert(global_array_multi[0][3] == 42); //UNKNOWN
+  assert(global_array_multi[0][3] == 11); //UNKNOWN
+
+
+  assert(global_array_multi[1][0] == 9);  //UNKNOWN
+  assert(global_array_multi[1][1] == 0);  //UNKNOWN
+  assert(global_array_multi[1][2] == 3);  //UNKNOWN
+  assert(global_array_multi[1][3] == 42); //UNKNOWN
+  assert(global_array_multi[1][3] == 11); //UNKNOWN
+}

--- a/tests/regression/30-fast_global_inits/04-non-zero.c
+++ b/tests/regression/30-fast_global_inits/04-non-zero.c
@@ -9,17 +9,19 @@ int main(void) {
   assert(global_array[2] == 3);  //UNKNOWN
   assert(global_array[3] == 42); //UNKNOWN
   assert(global_array[3] == 11); //UNKNOWN
+  assert(global_array[1] == -1); //FAIL
 
   assert(global_array_multi[0][0] == 9);  //UNKNOWN
   assert(global_array_multi[0][1] == 0);  //UNKNOWN
   assert(global_array_multi[0][2] == 3);  //UNKNOWN
   assert(global_array_multi[0][3] == 42); //UNKNOWN
   assert(global_array_multi[0][3] == 11); //UNKNOWN
-
+  assert(global_array_multi[0][1] == -1); //FAIL
 
   assert(global_array_multi[1][0] == 9);  //UNKNOWN
   assert(global_array_multi[1][1] == 0);  //UNKNOWN
   assert(global_array_multi[1][2] == 3);  //UNKNOWN
   assert(global_array_multi[1][3] == 42); //UNKNOWN
   assert(global_array_multi[1][3] == 11); //UNKNOWN
+  assert(global_array_multi[1][1] == -1); //FAIL
 }

--- a/tests/regression/30-fast_global_inits/05-non-zero-performance.c
+++ b/tests/regression/30-fast_global_inits/05-non-zero-performance.c
@@ -1,0 +1,24 @@
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled --enable exp.fast_global_inits
+int global_array[10000] = {9, 0, 3, 42, 11 }; // All non-specified ones will be zero
+int global_array_multi[2][10000] =  {{9, 0, 3, 42, 11}, {9, 0, 3, 42, 11}};  // All non-specified ones will be zero
+
+int main(void) {
+  assert(global_array[0] == 9);  //UNKNOWN
+  assert(global_array[1] == 0);  //UNKNOWN
+  assert(global_array[2] == 3);  //UNKNOWN
+  assert(global_array[3] == 42); //UNKNOWN
+  assert(global_array[3] == 11); //UNKNOWN
+
+  assert(global_array_multi[0][0] == 9);  //UNKNOWN
+  assert(global_array_multi[0][1] == 0);  //UNKNOWN
+  assert(global_array_multi[0][2] == 3);  //UNKNOWN
+  assert(global_array_multi[0][3] == 42); //UNKNOWN
+  assert(global_array_multi[0][3] == 11); //UNKNOWN
+
+
+  assert(global_array_multi[1][0] == 9);  //UNKNOWN
+  assert(global_array_multi[1][1] == 0);  //UNKNOWN
+  assert(global_array_multi[1][2] == 3);  //UNKNOWN
+  assert(global_array_multi[1][3] == 42); //UNKNOWN
+  assert(global_array_multi[1][3] == 11); //UNKNOWN
+}


### PR DESCRIPTION
I looked again at where we waste time before we start the actual solving: The only significant amount of time is spent computing the initial state (i.e. handling of global initializers).

As an improvement, in this PR we use `fast_global_inits` also for non-zero initialized arrays. This is faster whenever the same value is contained in an array multiple times. The only added costs are more lookups in the hash table.

For some of the `sv-comp` tests, this leads to a big decrease of the time spent doing global initializers. 
The most noticable drop was going **from >17000 assign edges to < 3500, and ~140s to ~13s spent on global initialization** for [this](https://github.com/sosy-lab/sv-benchmarks/blob/25191159b7ff6bb205f4107be9f83c0163073c1b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-saa7134-saa7134.cil.c) program. There are no examples where we are considerably slower.

**Downside** of this change is that we no longer know the exact value of the array at index zero.

~~~C
int global_array[5] = {0,0,0,0,42};
int main(void) {
  assert(global_array[0] == 0); // This will succeed without fast_global_inits and fail with it
}
~~~

On the other hand, this means that the array is unpartitioned after the global inits, so it might become partitioned somewhere else in the program, which could positively affect precision there.