### PR TITLE
Fix var_eq analysis not invalidating escaped variable

### DIFF
--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -394,7 +394,7 @@ let invalidate_actions = ref [
     "dev_driver_string", readsAll;
     "__spin_lock_init", writes [1];
     "kmem_cache_create", readsAll;
-    "pthread_create", writes [1;4];
+    "pthread_create", onlyWrites [1];
     "__builtin_prefetch", readsAll;
     "idr_pre_get", readsAll;
     "zil_replay", writes [1;2;3;5];

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -394,7 +394,7 @@ let invalidate_actions = ref [
     "dev_driver_string", readsAll;
     "__spin_lock_init", writes [1];
     "kmem_cache_create", readsAll;
-    "pthread_create", onlyWrites [1];
+    "pthread_create", writes [1;4];
     "__builtin_prefetch", readsAll;
     "idr_pre_get", readsAll;
     "zil_replay", writes [1;2;3;5];

--- a/tests/regression/06-symbeq/24-escape_rc.c
+++ b/tests/regression/06-symbeq/24-escape_rc.c
@@ -1,0 +1,26 @@
+// PARAM: --set ana.activated[+] "'var_eq'"
+// Copy of 04/45 with var_eq enabled
+#include <pthread.h>
+#include <stdio.h>
+
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  int *p = (int *) arg;
+  pthread_mutex_lock(&mutex1);
+  (*p)++;
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  int i = 0;
+  pthread_create(&id, NULL, t_fun, (void *) &i);
+  pthread_mutex_lock(&mutex2);
+  assert(i == 0); // UNKNOWN!
+  pthread_mutex_unlock(&mutex2);
+  pthread_join (id, NULL);
+  return 0;
+}


### PR DESCRIPTION
This is the source of unsoundness for SV-COMP goblint-regression/28-race_reach_45-escape_racing.yml (issue #141), which is actually from our regression suite. There it doesn't fail because it's run without `var_eq`.

`var_eq` keeps the equality `i == 0` after `i` escapes through the 4th argument of `pthread_create`. Changing `LibraryFunctions` to invalidate that argument also fixes this test, but breaks 05/17. Because of this I'm not sure if this is the right fix or maybe there's something better to do.

I suspect not because our invalidation and `var_eq` are quite ignorant about passing pointers. In one case `&i` is passed, in the other only `p`. The thing is that the argument (which is a pointer) itself wouldn't be changed by such `pthread_create` but only whatever the argument points to.

Another oddity is that `base` also doesn't invalidate `i` in that example. But only later when it is read (for the assertion), the global invariant is used instead because according to `escape` it has escaped.