### PR TITLE
Fix var_eq from keeping equalities with pointers to globals

### DIFF
--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -98,24 +98,6 @@ struct
     in
     cv e
 
-  let rec is_global_var x =
-    match x with
-    | SizeOf _
-    | SizeOfE _
-    | SizeOfStr _
-    | AlignOf _
-    | AlignOfE _
-    | UnOp _
-    | BinOp _ -> None
-    | Const _ -> Some false
-    | Lval (Var v,_) -> Some v.vglob
-    | Lval (Mem e,_) -> is_global_var e
-    | CastE (t,e) -> is_global_var e
-    | AddrOf lval -> Some false
-    | StartOf lval -> Some false
-    | Question _ -> failwith "Logical operations should be compiled away by CIL."
-    | _ -> failwith "Unmatched pattern."
-
   let rec conv_offs (offs:(fieldinfo,exp) Lval.offs) : offset =
     match offs with
     | `NoOffset -> NoOffset

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -118,7 +118,8 @@ let escape (x:string):string =
   Str.global_replace (Str.regexp ">") "&gt;" |>
   Str.global_replace (Str.regexp "\"") "&quot;" |>
   Str.global_replace (Str.regexp "'") "&apos;" |>
-  Str.global_replace (Str.regexp "\x0b") "" (* g2html just cannot handle \v from some kernel benchmarks, even when escaped... *)
+  Str.global_replace (Str.regexp "\x0b") "" |> (* g2html just cannot handle \v from some kernel benchmarks, even when escaped... *)
+  Str.global_replace (Str.regexp "\001") "" (* g2html just cannot handle \v from some kernel benchmarks, even when escaped... *)
 
 let trim (x:string): string =
   let len = String.length x in

--- a/tests/regression/06-symbeq/22-var_eq_types.c
+++ b/tests/regression/06-symbeq/22-var_eq_types.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'" 
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"
 #include <stdio.h>
 
 extern short * anShortPlease();
@@ -38,7 +38,7 @@ extern void f(int *);
 extern struct s ** get_s();
 
 int t17(){
-	int i = i % 6;
+	int i = i % 6; // WTF?
 	struct s ss[6], *ps;
 
 	ps = &ss[i];
@@ -54,9 +54,9 @@ int t16(){
 	int i;
 	struct t tt, *pt, tt2;
 	struct s ss,ss2;
-
+	// UB: deref uninit ptr pt
 	pt->ss->i = i;
-	assert(pt->ss->i == i);
+	assert(pt->ss->i == i); // UNKNOWN?
 
 	tt = tt2;
 	assert(pt->ss->i == i); // UNKNOWN
@@ -71,9 +71,9 @@ int t15(){
 
 //	pt = &tt;
 	tt.ss = &ss;
-
+	// UB: deref uninit ptr pt
 	pt->ss->i = i;
-	assert(pt->ss->i == i);
+	assert(pt->ss->i == i); // UNKNOWN?
 
 	ss = ss2;
 	assert(pt->ss->i == i); // UNKNOWN
@@ -88,9 +88,9 @@ int t14(){
 
 //	pt = &tt;
 //	tt.ss = &ss;
-
+	// UB: deref uninit ptr pt
 	pt->ss->i = i;
-	assert(pt->ss->i == i);
+	assert(pt->ss->i == i); // UNKNOWN?
 	ss.i = 1;
 	assert(pt->ss->i == i); // UNKNOWN
 

--- a/tests/regression/06-symbeq/25-ptr_global.c
+++ b/tests/regression/06-symbeq/25-ptr_global.c
@@ -1,0 +1,29 @@
+// PARAM: --set ana.activated[+] "'var_eq'"
+// Own version of 29/20
+// Somehow has NullPtr and UnknownPtr for global instead of Addr like the original. How???
+#include <pthread.h>
+#include <stdio.h>
+#include <assert.h>
+
+int *global;
+
+void *t_fun(void *arg) {
+  int *p = global;
+  *p = 2;
+  assert(*p == 2); // UNKNOWN!
+  return NULL;
+}
+
+int main(void) {
+  global = malloc(sizeof(int));
+  int *p = global;
+
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  *p = 1;
+  assert(*p == 1); // UNKNOWN!
+
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/06-symbeq/25-ptr_global.c
+++ b/tests/regression/06-symbeq/25-ptr_global.c
@@ -1,8 +1,7 @@
 // PARAM: --set ana.activated[+] "'var_eq'"
 // Own version of 29/20
-// Somehow has NullPtr and UnknownPtr for global instead of Addr like the original. How???
 #include <pthread.h>
-#include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 
 int *global;

--- a/tests/regression/29-svcomp/20-char_generic_nvram.c
+++ b/tests/regression/29-svcomp/20-char_generic_nvram.c
@@ -2,29 +2,7 @@
 // Minimized from pthread-driver-races/char_generic_nvram_read_nvram_write_nvram.i
 // Somehow global whoop_loff_t may not point to NULL in the original, but it may in this one. How???
 #include <pthread.h>
-
-extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 24, __extension__ __PRETTY_FUNCTION__); })); }
-extern void abort(void);
-void assume_abort_if_not(int cond) {
-  if(!cond) {abort();}
-}
-void __VERIFIER_assert(int cond) {
-  if (!(cond)) {
-    ERROR: {reach_error();abort();}
-  }
-  return;
-}
+#include <assert.h>
 
 typedef long long loff_t;
 
@@ -32,13 +10,13 @@ void read_nvram(loff_t *ppos)
 {
  unsigned int i;
  *ppos = i;
- __VERIFIER_assert(*ppos == i);
+ assert(*ppos == i); // UNKNOWN!
 }
 void write_nvram(loff_t *ppos)
 {
  unsigned int i;
  *ppos = i;
- __VERIFIER_assert(*ppos == i);
+ assert(*ppos == i); // UNKNOWN!
 }
 loff_t *whoop_loff_t;
 void *whoop_wrapper_write_nvram(void* args)

--- a/tests/regression/29-svcomp/20-char_generic_nvram.c
+++ b/tests/regression/29-svcomp/20-char_generic_nvram.c
@@ -1,7 +1,7 @@
 // PARAM: --set ana.activated[+] "'var_eq'"
 // Minimized from pthread-driver-races/char_generic_nvram_read_nvram_write_nvram.i
-// Somehow global whoop_loff_t may not point to NULL in the original, but it may in this one. How???
 #include <pthread.h>
+#include <stdlib.h>
 #include <assert.h>
 
 typedef long long loff_t;

--- a/tests/regression/29-svcomp/20-char_generic_nvram.c
+++ b/tests/regression/29-svcomp/20-char_generic_nvram.c
@@ -1,0 +1,63 @@
+// PARAM: --set ana.activated[+] "'var_eq'"
+// Minimized from pthread-driver-races/char_generic_nvram_read_nvram_write_nvram.i
+// Somehow global whoop_loff_t may not point to NULL in the original, but it may in this one. How???
+#include <pthread.h>
+
+extern void abort(void);
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 24, __extension__ __PRETTY_FUNCTION__); })); }
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: {reach_error();abort();}
+  }
+  return;
+}
+
+typedef long long loff_t;
+
+void read_nvram(loff_t *ppos)
+{
+ unsigned int i;
+ *ppos = i;
+ __VERIFIER_assert(*ppos == i);
+}
+void write_nvram(loff_t *ppos)
+{
+ unsigned int i;
+ *ppos = i;
+ __VERIFIER_assert(*ppos == i);
+}
+loff_t *whoop_loff_t;
+void *whoop_wrapper_write_nvram(void* args)
+{
+ write_nvram(whoop_loff_t);
+ return ((void *)0);
+}
+void *whoop_wrapper_read_nvram(void* args)
+{
+ read_nvram(whoop_loff_t);
+ return ((void *)0);
+}
+int main(void)
+{
+ whoop_loff_t = (loff_t *) malloc(sizeof(loff_t));
+ pthread_t pthread_t_write_nvram;
+ pthread_t pthread_t_read_nvram;
+ pthread_create(&pthread_t_write_nvram, ((void *)0), whoop_wrapper_write_nvram, ((void *)0));
+ pthread_create(&pthread_t_read_nvram, ((void *)0), whoop_wrapper_read_nvram, ((void *)0));
+ pthread_join(pthread_t_write_nvram, ((void *)0));
+ pthread_join(pthread_t_read_nvram, ((void *)0));
+}


### PR DESCRIPTION
See https://github.com/goblint/analyzer/issues/141#issuecomment-732080297.