### PR TITLE
Fix PathSensitive3 (HoareMap) narrow to reach fixpoint

### DIFF
--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -65,9 +65,11 @@ struct
   let cardinal (s: t): int = match s with
     | `Top -> failwith "cardinal"
     | `Lifted s -> M.M.cardinal s
-  let choose (s: t): SpecD.t = match s with
+  let choose' (s: t) = match s with
     | `Top -> failwith "choose"
-    | `Lifted s -> fst (M.M.choose s)
+    | `Lifted s -> M.M.choose s
+  let choose (s: t): SpecD.t = fst (choose' s)
+  let filter' = filter
   let filter (p: key -> bool) (s: t): t = filter (fun x _ -> p x) s
   let iter' = iter
   let iter (f: key -> unit) (s: t): unit = iter (fun x _ -> f x) s
@@ -212,9 +214,9 @@ struct
     let pretty_diff () ((s1:t),(s2:t)): Pretty.doc =
       if leq s1 s2 then dprintf "%s (%d and %d paths): These are fine!" (name ()) (cardinal s1) (cardinal s2) else begin
         try
-          let p t = not (MM.mem t s2) in
-          let evil = choose (filter p s1) in
-          let other = choose s2 in
+          let p t tr = not (mem t tr s2) in
+          let (evil, evilr) = choose' (filter' p s1) in
+          let (other, otherr) = choose' s2 in
           (* dprintf "%s has a problem with %a not leq %a because %a" (name ())
              Spec.D.pretty evil Spec.D.pretty other
              Spec.D.pretty_diff (evil,other) *)

--- a/tests/sv-comp/hoare/minepump_spec2_product33.min.c
+++ b/tests/sv-comp/hoare/minepump_spec2_product33.min.c
@@ -1,0 +1,91 @@
+extern void abort(void);
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "minepump_spec2_product33.cil.c", 3, "reach_error"); }
+
+extern int __VERIFIER_nondet_int(void);
+
+int waterLevel  =    1;
+int methaneLevelCritical  =    0;
+void lowerWaterLevel(void)
+{
+  if (waterLevel > 0) {
+    waterLevel = waterLevel - 1;
+  }
+}
+void waterRise(void)
+{
+  if (waterLevel < 2) {
+    waterLevel = waterLevel + 1;
+  }
+}
+void changeMethaneLevel(void)
+{
+  if (methaneLevelCritical) {
+    methaneLevelCritical = 0;
+  } else {
+    methaneLevelCritical = 1;
+  }
+}
+int isHighWaterSensorDry(void)
+{
+  if (waterLevel < 2) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+int isHighWaterLevel(void)
+{
+  if (isHighWaterSensorDry()) {
+    return 0;
+  } else {
+    return 1;
+  }
+}
+
+int pumpRunning  =    0;
+int methAndRunningLastTime = 0;
+
+void __utac_acc__Specification2_spec__2(void)
+{
+  if (methaneLevelCritical) {
+    if (pumpRunning) {
+      if (methAndRunningLastTime) {
+        ERROR: {reach_error();abort();}
+      } else {
+        methAndRunningLastTime = 1;
+      }
+    } else {
+      methAndRunningLastTime = 0;
+    }
+  } else {
+    methAndRunningLastTime = 0;
+  }
+}
+
+void timeShift(void)
+{
+  if (pumpRunning) {
+    lowerWaterLevel();
+  }
+  if (! pumpRunning) {
+    if (isHighWaterLevel()) {
+      pumpRunning = 1;
+    }
+  }
+  __utac_acc__Specification2_spec__2();
+}
+
+int main(void)
+{
+  while (1) {
+    if (__VERIFIER_nondet_int()) {
+      waterRise();
+    }
+    if (__VERIFIER_nondet_int()) {
+      changeMethaneLevel();
+    }
+    timeShift();
+  }
+  return 0;
+}


### PR DESCRIPTION
Closes #139.

The main change is the following:
```diff
-  let narrow = product_bot (fun x y -> if SpecD.leq y x then SpecD.narrow x y else x) R.narrow
+  let narrow = product_bot2 (fun (x, xr) (y, yr) -> if SpecD.leq y x then (SpecD.narrow x y, yr) else (x, xr))
```

Previously `R.narrow` was applied on the predecessor sets even if the path state pair couldn't be narrowed. Now the condition also applies to the predecessor sets. Moreover, instead of narrowing the predecessors it now just chooses the new one, which should correspond to everything being from the last iteration without mixing anything up.

This seems quite weird for a narrowing though, so I'm still running Goblint on SoftwareSystems (and ProductLines) to make sure it doesn't have any bad consequences.