### PR TITLE
Fixes/calloc

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2065,7 +2065,7 @@ struct
                                   (eval_lv ctx.ask gs st lv, `Address heap_var)]
         | _ -> st
       end
-    | `Calloc size ->
+    | `Calloc (n, size) ->
       begin match lv with
         | Some lv -> (* array length is set to one, as num*size is done when turning into `Calloc *)
           let heap_var = heap_var ctx in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -806,9 +806,9 @@ struct
     try
       let r = eval_rv a gs st exp in
       if M.tracing then M.tracel "eval" "eval_rv %a = %a\n" d_exp exp VD.pretty r;
-      if VD.is_bot r then ValueDomain.Compound.top_value2 (typeOf exp) else r
+      if VD.is_bot r then ValueDomain.Compound.top_value (typeOf exp) else r
     with IntDomain.ArithmeticOnIntegerBot _ ->
-    ValueDomain.Compound.top_value2 (typeOf exp)
+    ValueDomain.Compound.top_value (typeOf exp)
 
   (* Evaluate an expression containing only locals. This is needed for smart joining the partitioned arrays where ctx is not accessible. *)
   (* This will yield `Top for expressions containing any access to globals, and does not make use of the query system. *)
@@ -1544,7 +1544,7 @@ struct
 
   let set_savetop ?lval_raw ?rval_raw ask (gs:glob_fun) st adr v : store =
     match v with
-    | `Top -> set ask gs st adr (ValueDomain.Compound.top_value2 (AD.get_type adr)) ?lval_raw ?rval_raw
+    | `Top -> set ask gs st adr (ValueDomain.Compound.top_value (AD.get_type adr)) ?lval_raw ?rval_raw
     | v -> set ask gs st adr v ?lval_raw ?rval_raw
 
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2197,7 +2197,7 @@ struct
       | TPtr (t, attr), `Address a
         when (not (AD.is_top a))
           && List.length (AD.to_var_may a) = 1
-          && not (ValueDomain.Compound.is_immediate_type t)
+          && not (VD.is_immediate_type t)
         ->
         let cv = List.hd (AD.to_var_may a) in
         "ref " ^ VD.short 26 (CPA.find cv es)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1093,6 +1093,9 @@ struct
      * not include the flag. *)
     let update_one_addr (x, offs) (nst, fl, dep): store =
       let cil_offset = Offs.to_cil_offset offs in
+      let t = match t_override with
+        | Some t -> t
+        | None -> Cil.typeOf (Lval(Var x, cil_offset)) in
       if M.tracing then M.tracel "setosek" ~var:firstvar "update_one_addr: start with '%a' (type '%a') \nstate:%a\n\n" AD.pretty (AD.from_var_offset (x,offs)) d_type x.vtype CPA.pretty st;
       if isFunctionType x.vtype then begin
         if M.tracing then M.tracel "setosek" ~var:firstvar "update_one_addr: returning: '%a' is a function type \n" d_type x.vtype;
@@ -1119,13 +1122,13 @@ struct
           if M.tracing then M.tracel "setosek" ~var:x.vname "update_one_addr: update a global var '%s' ...\n" x.vname;
           (* Here, an effect should be generated, but we add it to the local
            * state, waiting for the sync function to publish it. *)
-          update_variable x (VD.update_offset a (get x nst) offs value (Option.map (fun x -> Lval x) lval_raw) (Var x, cil_offset)) nst, fl, dep
+          update_variable x (VD.update_offset a (get x nst) offs value (Option.map (fun x -> Lval x) lval_raw) (Var x, cil_offset) t) nst, fl, dep
         end
       else begin
         if M.tracing then M.tracel "setosek" ~var:x.vname "update_one_addr: update a local var '%s' ...\n" x.vname;
         (* Normal update of the local state *)
         let lval_raw = (Option.map (fun x -> Lval x) lval_raw) in
-        let new_value = VD.update_offset a (CPA.find x nst) offs value lval_raw ((Var x), cil_offset) in
+        let new_value = VD.update_offset a (CPA.find x nst) offs value lval_raw ((Var x), cil_offset) t in
         (* what effect does changing this local variable have on arrays -
            we only need to do this here since globals are not allowed in the
            expressions for partitioning *)
@@ -1686,8 +1689,9 @@ struct
         | `Bot -> (* current value is VD `Bot *)
           (match Addr.to_var_offset (AD.choose lval_val) with
           | [(x,offs)] ->
+            let t = v.vtype in
             let iv = bot_value ctx.ask ctx.global ctx.local v.vtype in (* correct bottom value for top level variable *)
-            let nv = VD.update_offset ctx.ask iv offs rval_val (Some  (Lval lval)) lval in (* do desired update to value *)
+            let nv = VD.update_offset ctx.ask iv offs rval_val (Some  (Lval lval)) lval t in (* do desired update to value *)
             set_savetop ctx.ask ctx.global ctx.local (AD.from_var v) nv (* set top-level variable to updated value *)
           | _ ->
             set_savetop ctx.ask ctx.global ctx.local lval_val rval_val ~lval_raw:lval ~rval_raw:rval

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2119,7 +2119,7 @@ struct
             else heap_var !Tracing.current_loc
           in
           (* ignore @@ printf "malloc will allocate %a bytes\n" ID.pretty (eval_int ctx.ask gs st size); *)
-          set_many ctx.ask gs st [(heap_var, `Blob (VD.bot (), eval_int ctx.ask gs st size, `Lifted "Malloc"));
+          set_many ctx.ask gs st [(heap_var, `Blob (VD.bot (), eval_int ctx.ask gs st size, true));
                                   (eval_lv ctx.ask gs st lv, `Address heap_var)]
         | _ -> st
       end
@@ -2127,7 +2127,7 @@ struct
       begin match lv with
         | Some lv -> (* array length is set to one, as num*size is done when turning into `Calloc *)
           let heap_var = BaseDomain.get_heap_var !Tracing.current_loc in (* TODO calloc can also fail and return NULL *)
-          set_many ctx.ask gs st [(AD.from_var heap_var, `Array (CArrays.make (IdxDom.of_int Int64.one) (`Blob (VD.bot (), eval_int ctx.ask gs st size, `Lifted "Calloc")))); (* TODO why? should be zero-initialized *)
+          set_many ctx.ask gs st [(AD.from_var heap_var, `Array (CArrays.make (IdxDom.of_int Int64.one) (`Blob (VD.bot (), eval_int ctx.ask gs st size, false)))); (* TODO why? should be zero-initialized *)
                                   (eval_lv ctx.ask gs st lv, `Address (AD.from_var_offset (heap_var, `Index (IdxDom.of_int 0L, `NoOffset))))]
         | _ -> st
       end

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -800,10 +800,10 @@ struct
           M.debug ("Failed evaluating "^str^" to lvalue"); do_offs AD.unknown_ptr ofs
       end
 
-  let rec bot_value a (gs:glob_fun) (st: store) (t: typ): value =
+  let rec bot_value (t: typ): value =
     let bot_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let bot_field nstruct fd = ValueDomain.Structs.replace nstruct fd (bot_value a gs st fd.ftype) in
+      let bot_field nstruct fd = ValueDomain.Structs.replace nstruct fd (bot_value fd.ftype) in
       List.fold_left bot_field nstruct compinfo.cfields
     in
     match t with
@@ -812,17 +812,17 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (bot_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.bot ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.bot ()) (bot_value a gs st ai))
+      `Array (ValueDomain.CArrays.make (IdxDom.bot ()) (bot_value ai))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (bot_value a gs st ai))
-    | TNamed ({ttype=t; _}, _) -> bot_value a gs st t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (bot_value ai))
+    | TNamed ({ttype=t; _}, _) -> bot_value t
     | _ -> `Bot
 
-  let rec init_value a (gs:glob_fun) (st: store) (t: typ): value = (* TODO why is VD.top_value not used here? *)
+  let rec init_value (t: typ): value = (* TODO why is VD.top_value not used here? *)
     let init_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (init_value a gs st fd.ftype) in
+      let init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (init_value fd.ftype) in
       List.fold_left init_field nstruct compinfo.cfields
     in
     match t with
@@ -832,17 +832,17 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (init_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.bot ())  (if get_bool "exp.partition-arrays.enabled" then (init_value a gs st ai) else (bot_value a gs st ai)))
+      `Array (ValueDomain.CArrays.make (IdxDom.bot ())  (if get_bool "exp.partition-arrays.enabled" then (init_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (if get_bool "exp.partition-arrays.enabled" then (init_value a gs st ai) else (bot_value a gs st ai)))
-    | TNamed ({ttype=t; _}, _) -> init_value a gs st t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.bot ()) l) (if get_bool "exp.partition-arrays.enabled" then (init_value ai) else (bot_value ai)))
+    | TNamed ({ttype=t; _}, _) -> init_value t
     | _ -> `Top
 
-  let rec top_value a (gs:glob_fun) (st: store) (t: typ): value =
+  let rec top_value (t: typ): value =
     let top_comp compinfo: ValueDomain.Structs.t =
       let nstruct = ValueDomain.Structs.top () in
-      let top_field nstruct fd = ValueDomain.Structs.replace nstruct fd (top_value a gs st fd.ftype) in
+      let top_field nstruct fd = ValueDomain.Structs.replace nstruct fd (top_value fd.ftype) in
       List.fold_left top_field nstruct compinfo.cfields
     in
     match t with
@@ -851,11 +851,39 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (top_comp ci)
     | TComp ({cstruct=false; _},_) -> `Union (ValueDomain.Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (if get_bool "exp.partition-arrays.enabled" then (top_value a gs st ai) else (bot_value a gs st ai)))
+      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (if get_bool "exp.partition-arrays.enabled" then (top_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = Cil.isInteger (Cil.constFold true exp) in
-      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (if get_bool "exp.partition-arrays.enabled" then (top_value a gs st ai) else (bot_value a gs st ai)))
-    | TNamed ({ttype=t; _}, _) -> top_value a gs st t
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (if get_bool "exp.partition-arrays.enabled" then (top_value ai) else (bot_value ai)))
+    | TNamed ({ttype=t; _}, _) -> top_value t
+    | _ -> `Top
+
+  let rec zero_init_value (t:typ): value =
+    let zero_init_comp compinfo: ValueDomain.Structs.t =
+      let nstruct = ValueDomain.Structs.top () in
+      let zero_init_field nstruct fd = ValueDomain.Structs.replace nstruct fd (zero_init_value fd.ftype) in
+      List.fold_left zero_init_field nstruct compinfo.cfields
+    in
+    match t with
+    | TInt (ikind, _) -> `Int (ID.of_int 0L)
+    | TPtr _ -> `Address AD.null_ptr
+    | TComp ({cstruct=true; _} as ci,_) -> `Struct (zero_init_comp ci)
+    | TComp ({cstruct=false; _} as ci,_) ->
+      let v = try
+        (* C99 6.7.8.10: the first named member is initialized (recursively) according to these rules *)
+        let firstmember = List.hd ci.cfields in
+        `Lifted firstmember, zero_init_value firstmember.ftype
+      with
+        (* Union with no members ò.O *)
+        Failure _ -> ValueDomain.Unions.top ()
+      in
+      `Union(v)
+    | TArray (ai, None, _) ->
+      `Array (ValueDomain.CArrays.make (IdxDom.top ()) (zero_init_value ai))
+    | TArray (ai, Some exp, _) ->
+      let l = Cil.isInteger (Cil.constFold true exp) in
+      `Array (ValueDomain.CArrays.make (BatOption.map_default (IdxDom.of_int) (IdxDom.top ()) l) (zero_init_value ai))
+    | TNamed ({ttype=t; _}, _) -> zero_init_value t
     | _ -> `Top
 
   (* run eval_rv from above and keep a result that is bottom *)
@@ -868,9 +896,9 @@ struct
     try
       let r = eval_rv a gs st exp in
       if M.tracing then M.tracel "eval" "eval_rv %a = %a\n" d_exp exp VD.pretty r;
-      if VD.is_bot r then top_value a gs st (typeOf exp) else r
+      if VD.is_bot r then top_value (typeOf exp) else r
     with IntDomain.ArithmeticOnIntegerBot _ ->
-      top_value a gs st (typeOf exp)
+      top_value (typeOf exp)
 
   (* Evaluate an expression containing only locals. This is needed for smart joining the partitioned arrays where ctx is not accessible. *)
   (* This will yield `Top for expressions containing any access to globals, and does not make use of the query system. *)
@@ -1606,7 +1634,7 @@ struct
 
   let set_savetop ?lval_raw ?rval_raw ask (gs:glob_fun) st adr v : store =
     match v with
-    | `Top -> set ask gs st adr (top_value ask gs st (AD.get_type adr)) ?lval_raw ?rval_raw
+    | `Top -> set ask gs st adr (top_value (AD.get_type adr)) ?lval_raw ?rval_raw
     | v -> set ask gs st adr v ?lval_raw ?rval_raw
 
 
@@ -1690,7 +1718,7 @@ struct
           (match Addr.to_var_offset (AD.choose lval_val) with
           | [(x,offs)] ->
             let t = v.vtype in
-            let iv = bot_value ctx.ask ctx.global ctx.local v.vtype in (* correct bottom value for top level variable *)
+            let iv = bot_value v.vtype in (* correct bottom value for top level variable *)
             let nv = VD.update_offset ctx.ask iv offs rval_val (Some  (Lval lval)) lval t in (* do desired update to value *)
             set_savetop ctx.ask ctx.global ctx.local (AD.from_var v) nv (* set top-level variable to updated value *)
           | _ ->
@@ -1764,7 +1792,7 @@ struct
 
   let body ctx f =
     (* First we create a variable-initvalue pair for each variable *)
-    let init_var v = (AD.from_var v, init_value ctx.ask ctx.global ctx.local v.vtype) in
+    let init_var v = (AD.from_var v, init_value v.vtype) in
     (* Apply it to all the locals and then assign them all *)
     let inits = List.map init_var f.slocals in
     set_many ctx.ask ctx.global ctx.local inits

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -376,7 +376,7 @@ struct
           end
         in
 
-        let v = VD.eval_offset a (fun x -> get a gs (st,fl,dep) x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) in
+        let v = VD.eval_offset a (fun x -> get a gs (st,fl,dep) x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
         if M.tracing then M.tracec "get" "var = %a, %a = %a\n" VD.pretty var AD.pretty (AD.from_var_offset (x, offs)) VD.pretty v;
         if full then v else match v with
           | `Blob (c,s,_) -> c
@@ -690,7 +690,7 @@ struct
           in
           let v' = VD.cast t v in (* cast to the expected type (the abstract type might be something other than t since we don't change addresses upon casts!) *)
           M.tracel "cast" "Ptr-Deref: cast %a to %a = %a!\n" VD.pretty v d_type t VD.pretty v';
-          let v' = VD.eval_offset a (fun x -> get a gs st x (Some exp)) v' (convert_offset a gs st ofs) (Some exp) None in (* handle offset *)
+          let v' = VD.eval_offset a (fun x -> get a gs st x (Some exp)) v' (convert_offset a gs st ofs) (Some exp) None t in (* handle offset *)
           let v' = do_offs v' ofs in (* handle blessed fields? *)
           v'
         (* Binary operators *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -673,21 +673,17 @@ struct
             let cast_ok = function
               | Addr a ->
                 begin
-                  if Cil.isVoidType (get_type_addr a) then
-                    (* If the variable has void type, it was something we allocated via malloc / calloc *)
-                    true
-                  else
-                    match Cil.isInteger (sizeOf t), Cil.isInteger (sizeOf (get_type_addr a)) with
-                    | Some i1, Some i2 -> Int64.compare i1 i2 <= 0
-                    | _ ->
-                      if contains_vla t || contains_vla (get_type_addr a) then
-                        begin
-                          (* TODO: Is this ok? *)
-                          M.warn "Casting involving a VLA is assumed to work";
-                          true
-                        end
-                      else
-                        false
+                  match Cil.isInteger (sizeOf t), Cil.isInteger (sizeOf (get_type_addr a)) with
+                  | Some i1, Some i2 -> Int64.compare i1 i2 <= 0
+                  | _ ->
+                    if contains_vla t || contains_vla (get_type_addr a) then
+                      begin
+                        (* TODO: Is this ok? *)
+                        M.warn "Casting involving a VLA is assumed to work";
+                        true
+                      end
+                    else
+                      false
                 end
               | _ -> false
             in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -673,17 +673,21 @@ struct
             let cast_ok = function
               | Addr a ->
                 begin
-                  match Cil.isInteger (sizeOf t), Cil.isInteger (sizeOf (get_type_addr a)) with
-                  | Some i1, Some i2 -> Int64.compare i1 i2 <= 0
-                  | _ ->
-                    if contains_vla t || contains_vla (get_type_addr a) then
-                      begin
-                        (* TODO: Is this ok? *)
-                        M.warn "Casting involving a VLA is assumed to work";
-                        true
-                      end
-                    else
-                      false
+                  if Cil.isVoidType (get_type_addr a) then
+                    (* If the variable has void type, it was something we allocated via malloc / calloc *)
+                    true
+                  else
+                    match Cil.isInteger (sizeOf t), Cil.isInteger (sizeOf (get_type_addr a)) with
+                    | Some i1, Some i2 -> Int64.compare i1 i2 <= 0
+                    | _ ->
+                      if contains_vla t || contains_vla (get_type_addr a) then
+                        begin
+                          (* TODO: Is this ok? *)
+                          M.warn "Casting involving a VLA is assumed to work";
+                          true
+                        end
+                      else
+                        false
                 end
               | _ -> false
             in

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -7,7 +7,7 @@ module M = Messages
 
 type categories = [
   | `Malloc       of exp
-  | `Calloc       of exp
+  | `Calloc       of exp * exp
   | `Realloc      of exp * exp
   | `Assert       of exp
   | `Lock         of bool * bool * bool  (* try? * write? * return  on success *)
@@ -37,12 +37,12 @@ let classify' fn exps =
     end
   | "kzalloc" ->
     begin match exps with
-      | size::_ -> `Calloc size
+      | size::_ -> `Calloc (Cil.one, size)
       | _ -> M.bailwith (fn^" arguments are strange!")
     end
   | "calloc" ->
     begin match exps with
-      | n::size::_ -> `Calloc Cil.(BinOp (Mult, n, size, typeOf one))
+      | n::size::_ -> `Calloc (n, size)
       | _ -> M.bailwith (fn^" arguments are strange!")
     end
   | "realloc" ->

--- a/src/analyses/libraryFunctions.mli
+++ b/src/analyses/libraryFunctions.mli
@@ -4,7 +4,7 @@ open Prelude.Ana
 
 type categories = [
   | `Malloc       of exp
-  | `Calloc       of exp
+  | `Calloc       of exp * exp
   | `Realloc      of exp * exp
   | `Assert       of exp
   | `Lock         of bool * bool * bool (* try? * write? *)

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -34,7 +34,7 @@ let is_atomic lval =
 
 let is_ignorable lval =
   (*  ignore (printf "Var %a\n" d_lval lval);*)
-  try Base.is_immediate_type (Cilfacade.typeOfLval lval) || is_atomic lval
+  try ValueDomain.Compound.is_immediate_type (Cilfacade.typeOfLval lval) || is_atomic lval
   with Not_found -> false
 
 module Spec =

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -427,9 +427,9 @@ struct
 
   let make i v =
     if Idx.to_int i = Some Int64.one then
-      (`Lifted (Cil.integer 0), (Val.bot (), v, Val.bot ()))
+      (`Lifted (Cil.integer 0), (v, v, v))
     else if Val.is_bot v then
-      (Expp.top(), (Val.top(), Val.top(), Val.top()))
+      (Expp.top(), (Val.bot(), Val.bot(), Val.bot()))
     else
       (Expp.top(), (v, v, v))
 

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -169,6 +169,28 @@ module Strings: Lattice.S with type t = [`Bot | `Lifted of string | `Top] =
     let bot_name = "-"
   end)
 
+  module RawBools: Printable.S with type t = bool =
+  struct
+    include Printable.Std
+    open Pretty
+    type t = bool [@@deriving to_yojson]
+    let hash (x:t) = Hashtbl.hash x
+    let equal (x:t) (y:t) = x=y
+    let isSimple _ = true
+    let short _ (x:t) =  if x then "\" true \"" else "\" false \""
+    let pretty_f sf () x = text (if x then "true" else "false")
+    let pretty () x = text (short () x)
+    let name () = "raw bools"
+    let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
+    let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (short () x)
+  end
+  
+  module Bools: Lattice.S with type t = [`Bot | `Lifted of bool | `Top] =
+    Lattice.Flat (RawBools) (struct
+      let top_name = "?"
+      let bot_name = "-"
+    end)
+
 module CilExp =
 struct
   include Printable.Std

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -257,8 +257,8 @@ struct
           end
     in
     let one_addr = let open Addr in function
-        | Addr ({ vtype = TVoid _; _} as v, `NoOffset) -> (* we had no information about the type (e.g. malloc), so we add it TODO what about offsets? *)
-          Addr ({ v with vtype = t }, `NoOffset)
+        | Addr ({ vtype = TVoid _; _} as v, offs) -> (* we had no information about the type (e.g. malloc), so we add it *)
+          Addr ({ v with vtype = t }, offs)
         | Addr (v, o) as a ->
           begin try Addr (v, (adjust_offs v o None)) (* cast of one address by adjusting the abstract offset *)
             with CastError s -> (* don't know how to handle this cast :( *)

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -51,8 +51,8 @@ end
 
 module AllocOrigin = IntDomain.MakeBooleans (
   struct
-    let truename = "MallocOrigin"
-    let falsename = "CallocOrigin"
+    let truename = "Malloc"
+    let falsename = "Calloc"
   end)
 
 module Blob (Value: S) (Size: IntDomain.S)=

--- a/tests/regression/02-base/35-calloc_array.c
+++ b/tests/regression/02-base/35-calloc_array.c
@@ -1,11 +1,19 @@
+// PARAM: --set ana.int.interval true
+
 #include<stdlib.h>
 #include<assert.h>
 
 int main(void) {
     int *r = calloc(5,sizeof(int));
+
+    assert(r[0] == 0); //UNKNOWN 
+    
     r[0] = 3;
+
+    assert(r[0] == 3); //UNKNOWN 
 
     int z = r[1];
 
     assert(z == 0); //UNKNOWN 
+    assert(z != 365);
 }

--- a/tests/regression/02-base/35-calloc_array.c
+++ b/tests/regression/02-base/35-calloc_array.c
@@ -6,7 +6,7 @@
 int main(void) {
     int *r = calloc(5,sizeof(int));
 
-    assert(r[0] == 0); //UNKNOWN 
+    assert(r[0] == 0); 
     
     r[0] = 3;
 

--- a/tests/regression/02-base/35-calloc_array.c
+++ b/tests/regression/02-base/35-calloc_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true
+// PARAM: --set ana.int.interval true --enable exp.partition-arrays.enabled
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/35-calloc_int.c
+++ b/tests/regression/02-base/35-calloc_int.c
@@ -1,0 +1,11 @@
+#include<stdlib.h>
+#include<assert.h>
+int main(void) {
+    int *r = calloc(5,sizeof(int));
+    //r[3] = 4;
+    r[0] = 3;
+
+    int z = r[1];
+
+    assert(z == 0); 
+}

--- a/tests/regression/02-base/35-calloc_int.c
+++ b/tests/regression/02-base/35-calloc_int.c
@@ -1,11 +1,11 @@
 #include<stdlib.h>
 #include<assert.h>
+
 int main(void) {
     int *r = calloc(5,sizeof(int));
-    //r[3] = 4;
     r[0] = 3;
 
     int z = r[1];
 
-    assert(z == 0); 
+    assert(z == 0); //UNKNOWN 
 }

--- a/tests/regression/02-base/36-calloc_struct.c
+++ b/tests/regression/02-base/36-calloc_struct.c
@@ -1,0 +1,40 @@
+#include<stdlib.h>
+#include<assert.h>
+
+typedef struct {
+  int x;
+  int y;
+} data;
+
+data *d;
+
+int main(void) {
+    d = calloc(1,sizeof(data));
+    d -> x = 0;
+    d -> y = 0;
+
+    data e = {.x = 0, .y = 0};
+
+    assert(d->x == e.x);
+    assert(d->y == e.y);
+
+    int a = d -> x;
+    int b = d -> y;
+
+    assert(a != 3); 
+    assert(b != 4); 
+
+    d -> x = 3;
+    d -> y = 4;
+
+    data f = {.x = 3, .y = 3};
+
+    assert(d->x == f.x); //UNKNOWN 
+    assert(d->y == f.y); //UNKNOWN 
+
+    a = d -> x;
+    b = d -> y;
+
+    assert(a == 3); //UNKNOWN 
+    assert(b == 4); //UNKNOWN 
+}

--- a/tests/regression/02-base/36-calloc_struct.c
+++ b/tests/regression/02-base/36-calloc_struct.c
@@ -1,3 +1,5 @@
+// PARAM: --set ana.int.interval true --enable exp.partition-arrays.enabled
+
 #include<stdlib.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/37-calloc_glob.c
+++ b/tests/regression/02-base/37-calloc_glob.c
@@ -1,0 +1,27 @@
+// Made after 02 22 
+
+// PARAM: --set ana.int.interval true
+
+#include <stdlib.h>
+#include <assert.h>
+
+int *x;
+int *y;
+
+int main() {
+  int *p;
+  x = calloc(1, sizeof(int));
+  y = calloc(1, sizeof(int));
+
+  *x = 0;
+  *y = 1;
+
+  assert(*x == 0);
+  assert(*y == 1); //UNKNOWN
+
+  p = x; x = y; y = p;
+  assert(*x == 1); //UNKNOWN
+  assert(*y == 0);
+
+  return 0;
+}

--- a/tests/regression/02-base/37-calloc_glob.c
+++ b/tests/regression/02-base/37-calloc_glob.c
@@ -1,6 +1,6 @@
 // Made after 02 22 
 
-// PARAM: --set ana.int.interval true
+// PARAM: --set ana.int.interval true --enable exp.partition-arrays.enabled
 
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/regression/02-base/38-calloc_int.c
+++ b/tests/regression/02-base/38-calloc_int.c
@@ -1,0 +1,20 @@
+// PARAM: --set ana.int.interval true
+
+#include<stdlib.h>
+#include<assert.h>
+
+int main(void) {
+    int *r = calloc(1,sizeof(int));
+
+    r[0] = 0;
+
+    assert(r[0] != 5);
+    assert(r[0] == 0);
+
+    r[0] = 5;
+
+    assert(r[0] == 5); //UNKNOWN 
+    assert(r[0] != 0); //UNKNOWN
+    assert(r[0] != -10);
+    assert(r[0] != 100);
+}

--- a/tests/regression/02-base/38-calloc_int.c
+++ b/tests/regression/02-base/38-calloc_int.c
@@ -1,5 +1,4 @@
-// PARAM: --set ana.int.interval true
-
+// PARAM: --set ana.int.interval true --enable exp.partition-arrays.enabled
 #include<stdlib.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/39-calloc_matrix.c
+++ b/tests/regression/02-base/39-calloc_matrix.c
@@ -1,0 +1,28 @@
+#include<stdlib.h>
+#include<assert.h>
+
+struct h {
+    int a[2]; 
+    int b;
+};
+
+int main(void) {
+    int *ro = calloc(2,sizeof(int));
+    ro[0] = 3;
+    assert(ro[1] != 3); //UNKNOWN
+
+    struct h *m = calloc(3,sizeof(int));
+
+    struct h *a = calloc(10,sizeof(struct horst));
+
+    struct h *b = a+1;
+    a->a[1] = 3;
+    int* ptr = &(b->a[1]);
+    assert(*ptr == 3); //UNKNOWN
+
+    int (*r)[5] = calloc(2, sizeof(int[5]));
+    r[0][1] = 3;
+    int* z = &r[0][1];
+
+    assert(*z == 3); //UNKNOWN
+}

--- a/tests/regression/02-base/39-calloc_matrix.c
+++ b/tests/regression/02-base/39-calloc_matrix.c
@@ -1,25 +1,9 @@
+// PARAM: --enable exp.partition-arrays.enabled
+
 #include<stdlib.h>
 #include<assert.h>
 
-struct h {
-    int a[2]; 
-    int b;
-};
-
 int main(void) {
-    int *ro = calloc(2,sizeof(int));
-    ro[0] = 3;
-    assert(ro[1] != 3); //UNKNOWN
-
-    struct h *m = calloc(3,sizeof(int));
-
-    struct h *a = calloc(10,sizeof(struct horst));
-
-    struct h *b = a+1;
-    a->a[1] = 3;
-    int* ptr = &(b->a[1]);
-    assert(*ptr == 3); //UNKNOWN
-
     int (*r)[5] = calloc(2, sizeof(int[5]));
     r[0][1] = 3;
     int* z = &r[0][1];

--- a/tests/regression/02-base/40-calloc_loop.c
+++ b/tests/regression/02-base/40-calloc_loop.c
@@ -1,4 +1,5 @@
 // Made after 02 21
+// PARAM: --set ana.int.interval true --enable exp.partition-arrays.enabled
 
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/regression/02-base/40-calloc_loop.c
+++ b/tests/regression/02-base/40-calloc_loop.c
@@ -1,0 +1,18 @@
+// Made after 02 21
+
+#include <stdlib.h>
+#include <assert.h>
+
+int main() {
+  int* x[10];
+  int i = 0;
+
+  while (i < 10)
+    x[i++] = calloc(1, sizeof(int));
+
+  *x[3] = 50;
+  *x[7] = 100;
+  assert(*x[8] == 100); // UNKNOWN
+
+  return 0;
+}

--- a/tests/regression/02-base/41-calloc_globmt.c
+++ b/tests/regression/02-base/41-calloc_globmt.c
@@ -1,0 +1,32 @@
+// PARAM: --set ana.activated "['base','escape', 'mallocWrapper']"
+#include <stdlib.h>
+#include <pthread.h>
+#include <assert.h>
+
+int *x;
+int *y;
+
+void *t_fun(void *arg) {
+  *x = 3;
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+
+  x = calloc(1, sizeof(int));
+  y = calloc(1, sizeof(int));
+
+  *x = 0;
+  *y = 1;
+
+  assert(*x == 0);
+  assert(*y == 1); // UNKNOWN
+
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  assert(*x == 0); // UNKNOWN
+  assert(*y == 1); // UNKNOWN
+
+  return 0;
+}

--- a/tests/regression/02-base/41-calloc_globmt.c
+++ b/tests/regression/02-base/41-calloc_globmt.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','escape', 'mallocWrapper']"
+// PARAM: --set ana.activated "['base','escape', 'mallocWrapper']" --set ana.int.interval true --enable exp.partition-arrays.enabled
 #include <stdlib.h>
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/02-base/42-calloc_zero_init.c
+++ b/tests/regression/02-base/42-calloc_zero_init.c
@@ -1,0 +1,13 @@
+// PARAM: --enable exp.partition-arrays.enabled
+
+#include<stdlib.h>
+#include<assert.h>
+
+int main(void) {
+    int *ro = calloc(2,sizeof(int));
+    assert(ro[0] == 0);
+    assert(ro[1] == 0);
+
+    ro[0] = 3;
+    assert(ro[1] != 3); //UNKNOWN 
+}

--- a/tests/regression/02-base/42-calloc_zero_init.c
+++ b/tests/regression/02-base/42-calloc_zero_init.c
@@ -1,4 +1,4 @@
-// PARAM: --enable exp.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --enable exp.partition-arrays.enabled
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/43-calloc_struct_array.c
+++ b/tests/regression/02-base/43-calloc_struct_array.c
@@ -1,0 +1,20 @@
+// PARAM: --enable exp.partition-arrays.enabled
+
+#include<stdlib.h>
+#include<assert.h>
+
+struct h {
+    int a[2]; 
+    int b;
+};
+
+int main(void) {
+    struct h *m = calloc(3,sizeof(int));
+
+    struct h *a = calloc(10,sizeof(struct h));
+
+    struct h *b = a+1;
+    a->a[1] = 3;
+    int* ptr = &(b->a[1]);
+    assert(*ptr == 3); //UNKNOWN
+}

--- a/tests/regression/02-base/43-calloc_struct_array.c
+++ b/tests/regression/02-base/43-calloc_struct_array.c
@@ -1,4 +1,4 @@
-// PARAM: --enable exp.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --enable exp.partition-arrays.enabled
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/44-malloc_array.c
+++ b/tests/regression/02-base/44-malloc_array.c
@@ -8,7 +8,7 @@ int main(void) {
     r[3] = 2;
 
     assert(r[4] == 2); 
-    (* Here we only test our implementation. Concretely, accessing the uninitialised r[4] is undefined behavior.
+    /* Here we only test our implementation. Concretely, accessing the uninitialised r[4] is undefined behavior.
     In our implementation we keep the whole memory allocated by malloc as one Blob and the whole Blob contains 2 after it was assigned to r[3].
-    This is more useful than keeping the Blob unknown. *)
+    This is more useful than keeping the Blob unknown. */
 }

--- a/tests/regression/02-base/44-malloc_array.c
+++ b/tests/regression/02-base/44-malloc_array.c
@@ -1,12 +1,11 @@
 // PARAM: --set ana.int.interval true --enable exp.partition-arrays.enabled
-
 #include<stdlib.h>
 #include<assert.h>
 
 int main(void) {
-    int (*r)[5] = calloc(2, sizeof(int[5]));
-    r[0][1] = 3;
-    int* z = &r[0][1];
+    int *r = malloc(5 * sizeof(int));
 
-    assert(*z == 3); //UNKNOWN
+    r[3] = 2;
+
+    assert(r[4] == 2);
 }

--- a/tests/regression/02-base/44-malloc_array.c
+++ b/tests/regression/02-base/44-malloc_array.c
@@ -7,5 +7,8 @@ int main(void) {
 
     r[3] = 2;
 
-    assert(r[4] == 2);
+    assert(r[4] == 2); 
+    (* Here we only test our implementation. Concretely, accessing the uninitialised r[4] is undefined behavior.
+    In our implementation we keep the whole memory allocated by malloc as one Blob and the whole Blob contains 2 after it was assigned to r[3].
+    This is more useful than keeping the Blob unknown. *)
 }


### PR DESCRIPTION
This should fix #135:
- The created Blobs keep track of their creator (so-called `origin`, which can be either `Calloc` or `Malloc`)
- The idea is to know that the Blob created by `calloc`, which has a value `Bot` is actually supposed to be 0, because `calloc` zero-initializes the allocated place
- The type argument was returned to the signature of the `update_offset` function from the value domain because it's necessary to know the type of the zero which is produced by `calloc`
- `Calloc` used to take only one argument `n * size` and now those two are separated so `calloc` takes `n` and `size`
- Tests for `calloc` have been added
- Type was added as parameter to the `eval _offset `function of the value domain to make possible to read 0 when something was allocated by `calloc` and is not initialized yet
- Functions `bot_value`, `init_vaue` and `top_value` have been moved from `base` analysis to `valueDomain`. There a `top_value` function already existed and now, not to keep two `top_value` functions, a combination is kept in the `valueDomain` only (it resembles more to the one from the base analysis, which was more specific about arrays). The functions `is_mutex_type` and `is_immediate_type` have been moved together because they were only used by the functions that now went to the value domain.
- Partition arrays parameter has been added to the `calloc` tests.
