### PR TITLE
Support for checking NoOverflows property of SV-COMP

### DIFF
--- a/conf/svcomp21.json
+++ b/conf/svcomp21.json
@@ -28,6 +28,7 @@
     "partition-arrays": {
       "enabled": true
     },
+    "lower-constants" : false,
     "region-offsets": true,
     "malloc": {
       "wrappers": [

--- a/conf/svcomp21.json
+++ b/conf/svcomp21.json
@@ -28,7 +28,6 @@
     "partition-arrays": {
       "enabled": true
     },
-    "lower-constants" : false,
     "region-offsets": true,
     "malloc": {
       "wrappers": [

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -632,7 +632,7 @@ struct
       | Some x -> x
       | None ->
         (* query functions were no help ... now try with values*)
-        match constFold true exp with
+        match (if get_bool "exp.lower-constants" then constFold true exp else exp) with
         (* Integer literals *)
         (* seems like constFold already converts CChr to CInt64 *)
         | Const (CChr x) -> eval_rv a gs st (Const (charConstToInt x)) (* char becomes int, see Cil doc/ISO C 6.4.4.4.10 *)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -492,9 +492,13 @@ struct
     | Some (a, b) ->
       if a = b && b = i then `Eq else if Ints_t.compare a i <= 0 && Ints_t.compare i b <=0 then `Top else `Neq
 
+  let set_overflow_flag ik =
+    if Cil.isSigned ik && !GU.in_verifying_stage then
+      Goblintutil.did_overflow := true
+
   let norm ik = function None -> None | Some (x,y) ->
-    if Ints_t.compare x y > 0 then None
-    else if Ints_t.compare (min_int ik) x > 0 || Ints_t.compare (max_int ik) y < 0 then top_of ik
+    if Ints_t.compare x y > 0 then (set_overflow_flag ik; None)
+    else if Ints_t.compare (min_int ik) x > 0 || Ints_t.compare (max_int ik) y < 0 then (set_overflow_flag ik; top_of ik)
     else Some (x,y)
 
   let leq (x:t) (y:t) =

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -497,7 +497,7 @@ struct
       Goblintutil.did_overflow := true
 
   let norm ik = function None -> None | Some (x,y) ->
-    if Ints_t.compare x y > 0 then (set_overflow_flag ik; None)
+    if Ints_t.compare x y > 0 then None
     else if Ints_t.compare (min_int ik) x > 0 || Ints_t.compare (max_int ik) y < 0 then (set_overflow_flag ik; top_of ik)
     else Some (x,y)
 
@@ -611,6 +611,16 @@ struct
       | Some x, Some y -> (try norm ik (of_int ik (f ik x y)) with Division_by_zero -> top_of ik)
       | _              -> top_of ik
 
+  let bitcomp f ik i1 i2 =
+    match is_bot i1, is_bot i2 with
+    | true, true -> bot_of ik
+    | true, _
+    | _   , true -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (short 80 i1) (short 80 i2)))
+    | _ ->
+      match to_int i1, to_int i2 with
+      | Some x, Some y -> (try norm ik (of_int ik (f ik x y)) with Division_by_zero -> top_of ik)
+      | _              -> (set_overflow_flag ik;  top_of ik)
+
   let bitxor = bit (fun _ik -> Ints_t.logxor)
   let bitand = bit (fun _ik -> Ints_t.logand)
   let bitor  = bit (fun _ik -> Ints_t.logor)
@@ -624,8 +634,8 @@ struct
       | _      -> top_of ik
 
   let bitnot = bit1 (fun _ik -> Ints_t.lognot)
-  let shift_right = bit (fun _ik x y -> Ints_t.shift_right x (Ints_t.to_int y))
-  let shift_left  = bit (fun _ik x y -> Ints_t.shift_left  x (Ints_t.to_int y))
+  let shift_right = bitcomp (fun _ik x y -> Ints_t.shift_right x (Ints_t.to_int y))
+  let shift_left  = bitcomp (fun _ik x y -> Ints_t.shift_left  x (Ints_t.to_int y))
 
   let neg ik = function None -> None | Some (x,y) -> norm ik @@ Some (Ints_t.neg y, Ints_t.neg x)
 

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -220,6 +220,7 @@ let createCFG (file: file) =
           let start_id = 10_000_000_000 in (* TODO get max_sid? *)
           let sid = Hashtbl.hash loc in (* Need pure sid instead of Cil.new_sid for incremental, similar to vid in Goblintutil.create_var. We only add one return stmt per loop, so the location hash should be unique. *)
           newst.sid <- if sid < start_id then sid + start_id else sid;
+          Hashtbl.add stmt_index_hack newst.sid fd;
           let newst_node = Statement newst in
           addCfg (Function fd.svar) (Ret (None,fd), newst_node);
           newst_node

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -216,7 +216,7 @@ let createCFG (file: file) =
         (* Return node to be used for infinite loop connection to end of function
          * lazy, so it's only added when actually needed *)
         let pseudo_return = lazy (
-          let newst = mkStmt (Return (None, locUnknown)) in
+          let newst = mkStmt (Return (None, loc)) in
           let start_id = 10_000_000_000 in (* TODO get max_sid? *)
           let sid = Hashtbl.hash loc in (* Need pure sid instead of Cil.new_sid for incremental, similar to vid in Goblintutil.create_var. We only add one return stmt per loop, so the location hash should be unique. *)
           newst.sid <- if sid < start_id then sid + start_id else sid;

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -433,7 +433,13 @@ let main =
         Stats.reset Stats.SoftwareTimer;
         parse_arguments ();
         check_arguments ();
+
+        (* Cil.lowerConstants assumes wrap-around behavior for signed intger types, which conflicts with checking
+          for overflows, as this will replace potential overflows with constants after wrap-around *)
+        (if GobConfig.get_bool "ana.sv-comp.enabled" && Svcomp.Specification.of_option () = NoOverflow then
+          set_bool "exp.lower-constants" false);
         Cilfacade.init ();
+
         handle_extraspecials ();
         create_temp_dir ();
         handle_flags ();

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -431,9 +431,9 @@ let main =
       main_running := true;
       try
         Stats.reset Stats.SoftwareTimer;
-        Cilfacade.init ();
         parse_arguments ();
         check_arguments ();
+        Cilfacade.init ();
         handle_extraspecials ();
         create_temp_dir ();
         handle_flags ();

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -10,6 +10,7 @@ module GU = Goblintutil
 
 let init () =
   initCIL ();
+  lowerConstants := GobConfig.get_bool "exp.lower-constants";
   Mergecil.ignore_merge_conflicts := true;
   (* lineDirectiveStyle := None; *)
   Rmtmps.keepUnused := true;

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -143,6 +143,7 @@ let _ = ()
 
 (* {4 category [Experimental]} *)
 let _ = ()
+      ; reg Experimental "exp.lower-constants"   "true"  "Use Cil.lowerConstants to simplify some constant? (assumes wrap-around for signed int)"
       ; reg Experimental "exp.privatization"     "true"  "Use privatization?"
       ; reg Experimental "exp.cfgdot"            "false" "Output CFG to dot files"
       ; reg Experimental "exp.mincfg"            "false" "Try to minimize the number of CFG nodes."

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -57,6 +57,8 @@ let has_otherfuns = ref false
     This is set to true in control.ml before we verify the result (or already before solving if dbg.earlywarn) *)
 let should_warn = ref false
 
+let did_overflow = ref false
+
 (** hack to use a special integer to denote synchronized array-based locking *)
 let inthack = Int64.of_int (-19012009) (* TODO do we still need this? *)
 

--- a/src/witness/svcomp.ml
+++ b/src/witness/svcomp.ml
@@ -6,6 +6,7 @@ struct
   type t =
     | UnreachCall of string
     | NoDataRace
+    | NoOverflow
 
   let of_string s =
     let s = String.strip s in
@@ -14,6 +15,8 @@ struct
       let global_not = Str.matched_group 1 s in
       if global_not = "data-race" then
         NoDataRace
+      else if global_not = "overflow" then
+        NoOverflow
       else
         let call_regex = Str.regexp "call(\\(.*\\)())" in
         if Str.string_match call_regex global_not 0 then
@@ -39,6 +42,7 @@ struct
     let global_not = match spec with
       | UnreachCall f -> "call(" ^ f ^ "())"
       | NoDataRace -> "data-race"
+      | NoOverflow -> "overflow"
     in
     "CHECK( init(main()), LTL(G ! " ^ global_not ^ ") )"
 end
@@ -92,6 +96,7 @@ struct
     | False (Some spec) ->
       let result_spec = match spec with
         | UnreachCall _ -> "unreach-call"
+        | NoOverflow -> "overflow"
         | NoDataRace -> "no-data-race" (* not yet in SV-COMP/Benchexec *)
       in
       "false(" ^ result_spec ^ ")"

--- a/src/witness/svcomp.ml
+++ b/src/witness/svcomp.ml
@@ -96,7 +96,7 @@ struct
     | False (Some spec) ->
       let result_spec = match spec with
         | UnreachCall _ -> "unreach-call"
-        | NoOverflow -> "overflow"
+        | NoOverflow -> "no-overflow"
         | NoDataRace -> "no-data-race" (* not yet in SV-COMP/Benchexec *)
       in
       "false(" ^ result_spec ^ ")"

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -551,6 +551,37 @@ struct
         in
         (module TaskResult:WitnessTaskResult)
       )
+    | NoOverflow ->
+      let module TrivialArg =
+      struct
+        include Arg
+        let next _ = []
+      end
+      in
+      if not !Goblintutil.did_overflow then
+        let module TaskResult =
+        struct
+          module Arg = TrivialArg
+          let result = Result.True
+          let invariant _ = Invariant.none
+          let is_violation _ = false
+          let is_sink _ = false
+        end
+        in
+        (module TaskResult:WitnessTaskResult)
+      else (
+        let module TaskResult =
+        struct
+          module Arg = TrivialArg
+          let result = Result.Unknown
+          let invariant _ = Invariant.none
+          let is_violation _ = false
+          let is_sink _ = false
+        end
+        in
+        (module TaskResult:WitnessTaskResult)
+      )
+
 
   let write lh gh entrystates =
     let module Task = (val (BatOption.get !task)) in

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -561,9 +561,9 @@ struct
       if not !Goblintutil.did_overflow then
         let module TaskResult =
         struct
-          module Arg = TrivialArg
+          module Arg = Arg
           let result = Result.True
-          let invariant _ = Invariant.none
+          let invariant = find_invariant
           let is_violation _ = false
           let is_sink _ = false
         end

--- a/sv-comp/sv-comp-run-no-overflow.py
+++ b/sv-comp/sv-comp-run-no-overflow.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+import sys
+import glob
+import subprocess
+import re
+import collections
+import os.path
+import shlex
+import yaml # pip3 install pyyaml
+from timeit import default_timer as timer
+
+
+OVERVIEW = False # with True Goblint isn't executed
+# TODO: don't hard-code specification
+GOBLINT_COMMAND = "./goblint --conf conf/svcomp21.json --sets ana.specification ./tests/sv-comp/no-overflow.prp --sets exp.witness_path {witness_filename} {code_filename} -v"
+TIMEOUT = 10 # with some int that's Goblint timeout for single execution
+START = 1
+EXIT_ON_ERROR = True
+WITNESS_ROOT = "./witnesses/"
+
+
+if WITNESS_ROOT:
+    os.makedirs(WITNESS_ROOT, exist_ok=True)
+
+
+def error_exit(code=1):
+    if EXIT_ON_ERROR:
+        sys.exit(code)
+
+
+def str2bool(s):
+    return {
+        "true": True,
+        "false": False
+    }[s]
+
+def extract_bool(p, s):
+    m = re.search(p, s)
+    return str2bool(m.group(1)) if m else None
+
+
+stats = collections.defaultdict(int)
+total_time = 0
+points = 0
+points_must = 0
+try:
+    inp = sys.argv[1]
+    task_filenames = []
+    if inp.endswith('.yml'):
+        task_filenames.append(inp)
+    elif inp.endswith('.set'):
+        with open(inp) as set_file:
+            for pattern in set_file:
+                pattern = pattern.strip()
+                if pattern:
+                    pattern = os.path.join(os.path.dirname(inp), pattern)
+                    for task_filename in glob.iglob(pattern):
+                        task_filenames.append(task_filename)
+    else:
+        print('Call script on .yml or .set file') # TODO also allow .c to just call goblint on with above options?
+
+    for task_i, task_filename in list(enumerate(sorted(task_filenames)))[START - 1:]:
+        print(f"{task_i + 1}/{len(task_filenames)}: {task_filename}: ", end="", flush=True)
+
+        if task_filename.endswith(".yml"):
+            with open(task_filename) as task_file:
+                y = yaml.safe_load(task_file)
+
+                code_filename = y["input_files"]
+                code_filename = os.path.join(os.path.dirname(task_filename), code_filename)
+
+                expected = None
+                for y_property in y["properties"]:
+                    if y_property["property_file"] == "../properties/no-overflow.prp":
+                        expected = y_property["expected_verdict"]
+        else:
+            code_filename = task_filename
+            expected = extract_bool(r"_(false|true)-unreach-call", task_filename)
+
+        if OVERVIEW:
+            result = None
+            task_time = None
+        else:
+            if WITNESS_ROOT:
+                taskname, _ = os.path.splitext(os.path.basename(task_filename))
+                witness_filename = os.path.join(WITNESS_ROOT, taskname + ".graphml")
+            else:
+                witness_filename = "witness.graphml"
+
+            start_time = timer()
+            try:
+                p = subprocess.run(shlex.split(GOBLINT_COMMAND.format(witness_filename=witness_filename, code_filename=code_filename)), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8", timeout=TIMEOUT)
+                if "Fatal error: exception " in p.stdout:
+                    print(p.stdout)
+                    error_exit(1)
+                result = extract_bool(r"SV-COMP (?:\(unreach-call\)|result): (false|true)", p.stdout)
+            except subprocess.TimeoutExpired:
+                result = "timeout"
+            finally:
+                end_time = timer()
+                task_time = end_time - start_time
+                total_time += task_time
+
+        if "p" in locals(): # sometimes on timeout p is declared, sometimes isn't
+            missing_funcs = False
+            for m in re.finditer(r"Function definition missing for (__VERIFIER_\S+)", p.stdout):
+                missing_funcs = True
+                print(f"MISSING FUNC {m.group(1)}")
+
+            if missing_funcs:
+                error_exit(2)
+
+        text = None
+        if expected is None:
+            text = f"NONE {result}, no expected_verdict for no-overflow"
+        elif result == expected:
+            text = f"CORRECT {expected}"
+            points += 2 if result else 1
+            points_must += 2 if result else 0
+        elif result == "timeout" or result is None:
+            text = f"UNKNOWN {result}, expected {expected}"
+        else:
+            text = f"INCORRECT {result}, expected {expected}"
+            points -= 32 if result else 16
+            points_must -= 32 if result else 0
+
+        time_text = f" ({task_time:.2f} s)" if task_time is not None else ""
+        print(text + time_text)
+        stats[text] += 1
+
+except KeyboardInterrupt:
+    pass
+finally:
+    print()
+    print("-" * 80)
+    print("For each .yml we compare with expected_verdict for 'c/properties/unreach-call.prp':")
+    print("CHECK( init(main()), LTL(G ! call(__VERIFIER_error())) )")
+    print("-> True means for all paths __VERIFIER_error is never called (__VERIFIER_assert always true) ")
+    print("-> False means there exists a path where __VERIFIER_error could be called (__VERIFIER_assert can be false)")
+    print("We will often report False for may-reach because we have no must-reach, just must-not-reach (bot).")
+    print("-" * 80)
+    for text, count in sorted(stats.items()):
+        print(f"{text}: {count}")
+    print("-" * 80)
+    print("points: CORRECT{ True: 2, False: 1 }, INCORRECT{ True: -32, False: -16 }")
+    print(f"total points: {points} (assuming witnesses are correct)")
+    print(f"total points_must: {points_must} (assuming witnesses are correct, only counting true-unreach (could return UNKNOWN for may-info))")
+    print(f"total time: {total_time:.2f} s")

--- a/tests/sv-comp/no-overflow.prp
+++ b/tests/sv-comp/no-overflow.prp
@@ -1,0 +1,2 @@
+CHECK( init(main()), LTL(G ! overflow) )
+


### PR DESCRIPTION
This is an experimental first steps towards supporting NoOverflows for SV-COMP.

To do this, we extend Julian's sound arithmetic such that when we invoke the Overflow handling for something of signed type during the verifying phase, we set a bool from true to false. If this bool is true after verifying, the were no overflows during re-evaluation of all right-hand sides, and therefore no overflow.

TODO:

- [x] Test-run (w/ witness verification)
- [x] Investigate unsoundness
- [x] Fix witness generation
- [x] Figure out correct configuration for this property

