### PR TITLE
Fix unsound query in path-sensitivity functor

### DIFF
--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -468,6 +468,7 @@ struct
         ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in query context.")
         }
       in
+      (* meet results so that precision from all analyses is combined *)
       Queries.Result.meet a @@ S.query ctx' q
     in
     match q with

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1034,7 +1034,7 @@ struct
     fold' ctx Spec.sync identity (fun (a,b) (a',b') -> D.add a' a, b'@b) (D.empty (), [])
 
   let query ctx q =
-    fold' ctx Spec.query identity (fun x f -> Queries.Result.meet x (f q)) `Top
+    fold' ctx Spec.query identity (fun x f -> Queries.Result.join x (f q)) `Bot
 
   let enter ctx l f a =
     let g xs ys = (List.map (fun (x,y) -> D.singleton x, D.singleton y) ys) @ xs in

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1034,6 +1034,7 @@ struct
     fold' ctx Spec.sync identity (fun (a,b) (a',b') -> D.add a' a, b'@b) (D.empty (), [])
 
   let query ctx q =
+    (* join results so that they are sound for all paths *)
     fold' ctx Spec.query identity (fun x f -> Queries.Result.join x (f q)) `Bot
 
   let enter ctx l f a =

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -403,7 +403,7 @@ struct
         ) (fst ctx.local);
       `Bot
     | _ ->
-      fold' ctx Spec.query identity (fun x _ f -> Queries.Result.meet x (f q)) `Top
+      fold' ctx Spec.query identity (fun x _ f -> Queries.Result.join x (f q)) `Bot
 
   let should_inline f =
     (* (* inline __VERIFIER_error because Control requires the corresponding FunctionEntry node *)

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -403,6 +403,7 @@ struct
         ) (fst ctx.local);
       `Bot
     | _ ->
+      (* join results so that they are sound for all paths *)
       fold' ctx Spec.query identity (fun x _ f -> Queries.Result.join x (f q)) `Bot
 
   let should_inline f =

--- a/tests/regression/01-cpa/46-funptr_path.c
+++ b/tests/regression/01-cpa/46-funptr_path.c
@@ -1,0 +1,30 @@
+extern int __VERIFIER_nondet_int();
+
+#include <assert.h>
+#include <pthread.h>
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void fun1() {
+  assert(0); // FAIL
+}
+
+void fun2() {
+  assert(0); // FAIL
+}
+
+int main() {
+  int x = __VERIFIER_nondet_int();
+
+  void (*fp)();
+
+  if (x) {
+    pthread_mutex_lock(&mutex);
+    fp = fun1;
+  }
+  else {
+    fp = fun2;
+  }
+
+  fp();
+}


### PR DESCRIPTION
While thinking about #148 (which has an experimental fix in the [`thread/path-sens`](https://github.com/goblint/analyzer/tree/thread/path-sens) branch) and comparing the mechanism with normal function call mechanism, I discovered the following unsoundness bug.

If different elements of the path-sensitive set (e.g. made path-sensitive by different mutex sets) have different points-to sets for a function pointer address, then these were previously combined with `meet` in `PathSensitive2` when `FromSpec` uses the query from outside to determine possible functions:
https://github.com/goblint/analyzer/blob/e2a0555f8c30fdb7140cac1258e66b23c93671b5/src/framework/constraints.ml#L676-L679
So the intersection became empty and no functions were called at all! The right thing to do would be to join queries over all paths instead because paths are disjunct unlike multiple analyses which are conjunct.

This obviously isn't as precise as it could be because it forgets which functions may get called from which paths but there's no easy way around that right now. This is due to all the logic being on the top level at `FromSpec` instead of being somehow within `PathSensitive2` where each path could evaluate the function variable separately and handle them only along that path. But that's another story altogether...