### PR TITLE
Cleanup: Only have one query for must-equality between expressions

### DIFF
--- a/src/analyses/arinc.ml
+++ b/src/analyses/arinc.ml
@@ -636,7 +636,7 @@ struct
       if Pri.is_int d.pri then
         `Int (Option.get @@ Pri.to_int d.pri)
       else if Pri.is_top d.pri then `Top else `Bot
-    (* | Queries.IsPublic _ -> *)
+    (* | Queries.MayBePublic _ -> *)
     (*   `Bool ((PrE.to_int d.pre = Some 0L || PrE.to_int d.pre = None) && (not (mode_is_init d.pmo))) *)
     | _ -> Queries.Result.top ()
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -19,7 +19,7 @@ module CArrays = ValueDomain.CArrays
 module BI = IntOps.BigIntOps
 
 let is_global (a: Q.ask) (v: varinfo): bool =
-  v.vglob || match a (Q.MayEscape v) with `Bool tv -> tv | _ -> false
+  v.vglob || match a (Q.MayEscape v) with `MayBool tv -> tv | _ -> false
 
 let is_static (v:varinfo): bool = v.vstorage == Static
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -30,7 +30,7 @@ let privatization = ref false
 let is_private (a: Q.ask) (_,_) (v: varinfo): bool =
   !privatization &&
   (not (ThreadFlag.is_multi a) && is_precious_glob v ||
-   match a (Q.IsPublic v) with `Bool tv -> not tv | _ ->
+   match a (Q.MayBePublic v) with `MayBool tv -> not tv | _ ->
    if M.tracing then M.tracel "osek" "isPrivate yields top(!!!!)";
    false)
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -287,7 +287,7 @@ struct
     let binop op e1 e2 =
       let equality () =
         match ask (Q.MustBeEqual (e1,e2)) with
-        | `MustHold true ->
+        | `MustBool true ->
           if M.tracing then M.tracel "query" "MustBeEqual (%a, %a) = %b\n" d_exp e1 d_exp e2 true;
           Some true
         | _ -> None
@@ -946,10 +946,10 @@ struct
         match e1_val, e2_val with
         | `Int i1, `Int i2 -> begin
             match ID.to_int i1, ID.to_int i2 with
-            | Some i1', Some i2' when i1' = i2' -> `MustHold true
-            | _ -> `MustHold false
+            | Some i1', Some i2' when i1' = i2' -> `MustBool true
+            | _ -> `MustBool false
             end
-        | _ -> `MustHold false
+        | _ -> `MustBool false
       end
     | Q.MayBeEqual (e1, e2) -> begin
         (* Printf.printf "---------------------->  may equality check for %s and %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
@@ -964,11 +964,11 @@ struct
             if ID.is_bot (ID.meet (ID.cast_to ik i1) (ID.cast_to ik i2)) then
               begin
                 (* Printf.printf "----------------------> NOPE may equality check for %s and %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
-                `MayHold false
+                `MayBool false
               end
-            else `MayHold true
+            else `MayBool true
           end
-        | _ -> `MayHold true
+        | _ -> `MayBool true
       end
     | Q.MayBeLess (e1, e2) -> begin
         (* Printf.printf "----------------------> may check for %s < %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
@@ -981,12 +981,12 @@ struct
               if i1' >= i2' then
                 begin
                   (* Printf.printf "----------------------> NOPE may check for %s < %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
-                  `MayHold false
+                  `MayBool false
                 end
-              else `MayHold true
-            | _ -> `MayHold true
+              else `MayBool true
+            | _ -> `MayBool true
           end
-        | _ -> `MayHold true
+        | _ -> `MayBool true
       end
     | _ -> Q.Result.top ()
 
@@ -1093,7 +1093,7 @@ struct
           let movement_for_expr l' r' currentE' =
             let are_equal e1 e2 =
               match a (Q.MustBeEqual (e1, e2)) with
-              | `MustHold true -> true
+              | `MustBool true -> true
               | _ -> false
             in
             let ik = Cilfacade.get_ikind (typeOf currentE') in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -287,9 +287,9 @@ struct
     let binop op e1 e2 =
       let equality () =
         match ask (Q.MustBeEqual (e1,e2)) with
-        | `MustHold x ->
-          if M.tracing then M.tracel "query" "MustBeEqual (%a, %a) = %b\n" d_exp e1 d_exp e2 x;
-          Some x
+        | `MustHold true ->
+          if M.tracing then M.tracel "query" "MustBeEqual (%a, %a) = %b\n" d_exp e1 d_exp e2 true;
+          Some true
         | _ -> None
       in
       let ptrdiff_ikind = match !ptrdiffType with TInt (ik,_) -> ik | _ -> assert false in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -287,7 +287,7 @@ struct
     let binop op e1 e2 =
       let equality () =
         match ask (Q.MustBeEqual (e1,e2)) with
-        | `Bool x ->
+        | `MustHold x ->
           if M.tracing then M.tracel "query" "MustBeEqual (%a, %a) = %b\n" d_exp e1 d_exp e2 x;
           Some x
         | _ -> None
@@ -946,10 +946,10 @@ struct
         match e1_val, e2_val with
         | `Int i1, `Int i2 -> begin
             match ID.to_int i1, ID.to_int i2 with
-            | Some i1', Some i2' when i1' = i2' -> `Bool(true)
-            | _ -> Q.Result.top ()
+            | Some i1', Some i2' when i1' = i2' -> `MustHold true
+            | _ -> `MustHold false
             end
-        | _ -> Q.Result.top ()
+        | _ -> `MustHold false
       end
     | Q.MayBeEqual (e1, e2) -> begin
         (* Printf.printf "---------------------->  may equality check for %s and %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
@@ -964,11 +964,11 @@ struct
             if ID.is_bot (ID.meet (ID.cast_to ik i1) (ID.cast_to ik i2)) then
               begin
                 (* Printf.printf "----------------------> NOPE may equality check for %s and %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
-                `Bool(false)
+                `MayHold false
               end
-            else Q.Result.top ()
+            else `MayHold true
           end
-        | _ -> Q.Result.top ()
+        | _ -> `MayHold true
       end
     | Q.MayBeLess (e1, e2) -> begin
         (* Printf.printf "----------------------> may check for %s < %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
@@ -981,12 +981,12 @@ struct
               if i1' >= i2' then
                 begin
                   (* Printf.printf "----------------------> NOPE may check for %s < %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
-                  `Bool(false)
+                  `MayHold false
                 end
-              else Q.Result.top ()
-            | _ -> Q.Result.top ()
+              else `MayHold true
+            | _ -> `MayHold true
           end
-        | _ -> Q.Result.top ()
+        | _ -> `MayHold true
       end
     | _ -> Q.Result.top ()
 
@@ -1093,7 +1093,7 @@ struct
           let movement_for_expr l' r' currentE' =
             let are_equal e1 e2 =
               match a (Q.MustBeEqual (e1, e2)) with
-              | `Bool t -> Q.BD.to_bool t = Some true
+              | `MustHold true -> true
               | _ -> false
             in
             let ik = Cilfacade.get_ikind (typeOf currentE') in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -286,9 +286,9 @@ struct
   let eval_rv_pre (ask: Q.ask) exp pr =
     let binop op e1 e2 =
       let equality () =
-        match ask (Q.ExpEq (e1,e2)) with
+        match ask (Q.MustBeEqual (e1,e2)) with
         | `Bool x ->
-          if M.tracing then M.tracel "query" "ExpEq (%a, %a) = %b\n" d_exp e1 d_exp e2 x;
+          if M.tracing then M.tracel "query" "MustBeEqual (%a, %a) = %b\n" d_exp e1 d_exp e2 x;
           Some x
         | _ -> None
       in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1035,7 +1035,7 @@ struct
       let t = match t_override with
         | Some t -> t
         | None ->
-          let is_heap_var = match a (Q.IsHeapVar x) with `Bool(true) -> true | _ -> false in
+          let is_heap_var = match a (Q.IsHeapVar x) with `MayBool(true) -> true | _ -> false in
           if is_heap_var then
             (* the vtype of heap vars will be TVoid, so we need to trust the pointer we got to this to be of the right type *)
             (* i.e. use the static type of the pointer here *)

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -57,23 +57,23 @@ struct
     | Queries.MustBeEqual (e1, e2) when not (isFloat e1) ->
       begin
         if Expcompare.compareExp (canonize e1) (canonize e2) then
-          `MustHold true
+          `MustBool true
         else
-          `MustHold false
+          `MustBool false
       end
     | Queries.MayBeLess (e1, e2) when not (isFloat e1) ->
       begin
         match e1, e2 with
         | BinOp(PlusA, Lval l1, Const(CInt64(i,_,_)), _), Lval l2 when (lvalsEq l1 l2 && Int64.compare i Int64.zero > 0) ->
-            `MayHold false  (* c > 0 => (! x+c < x) *)
+            `MayBool false  (* c > 0 => (! x+c < x) *)
         | Lval l1, BinOp(PlusA, Lval l2, Const(CInt64(i,_,_)), _) when (lvalsEq l1 l2 && Int64.compare i Int64.zero < 0) ->
-            `MayHold false  (* c < 0 => (! x < x+c )*)
+            `MayBool false  (* c < 0 => (! x < x+c )*)
         | BinOp(MinusA, Lval l1, Const(CInt64(i,_,_)), _), Lval l2 when (lvalsEq l1 l2 && Int64.compare i Int64.zero < 0) ->
-            `MayHold false  (* c < 0 => (! x-c < x) *)
+            `MayBool false  (* c < 0 => (! x-c < x) *)
         | Lval l1, BinOp(MinusA, Lval l2, Const(CInt64(i,_,_)), _) when (lvalsEq l1 l2 && Int64.compare i Int64.zero > 0) ->
-            `MayHold false  (* c < 0 => (! x < x-c) *)
+            `MayBool false  (* c < 0 => (! x < x-c) *)
         | _ ->
-            `MayHold true
+            `MayBool true
       end
     | Queries.MayBeEqual (e1,e2) when not (isFloat e1) ->
       begin
@@ -82,8 +82,8 @@ struct
         | Lval l2, BinOp(PlusA, Lval l1, Const(CInt64(i,_,_)), _)
         | BinOp(MinusA, Lval l1, Const(CInt64(i,_,_)), _), Lval l2
         | Lval l2, BinOp(MinusA, Lval l1, Const(CInt64(i,_,_)), _) when (lvalsEq l1 l2) && Int64.compare i Int64.zero <> 0  ->
-            `MayHold false
-        | _ -> `MayHold true
+            `MayBool false
+        | _ -> `MayBool true
       end
     | _ -> Queries.Result.top ()
 

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -57,23 +57,23 @@ struct
     | Queries.MustBeEqual (e1, e2) when not (isFloat e1) ->
       begin
         if Expcompare.compareExp (canonize e1) (canonize e2) then
-          `Bool (true)
+          `MustHold true
         else
-          Queries.Result.top()
+          `MustHold false
       end
     | Queries.MayBeLess (e1, e2) when not (isFloat e1) ->
       begin
         match e1, e2 with
         | BinOp(PlusA, Lval l1, Const(CInt64(i,_,_)), _), Lval l2 when (lvalsEq l1 l2 && Int64.compare i Int64.zero > 0) ->
-            `Bool(false)   (* c > 0 => (! x+c < x) *)
+            `MayHold false  (* c > 0 => (! x+c < x) *)
         | Lval l1, BinOp(PlusA, Lval l2, Const(CInt64(i,_,_)), _) when (lvalsEq l1 l2 && Int64.compare i Int64.zero < 0) ->
-            `Bool(false)   (* c < 0 => (! x < x+c )*)
+            `MayHold false  (* c < 0 => (! x < x+c )*)
         | BinOp(MinusA, Lval l1, Const(CInt64(i,_,_)), _), Lval l2 when (lvalsEq l1 l2 && Int64.compare i Int64.zero < 0) ->
-            `Bool(false)   (* c < 0 => (! x-c < x) *)
+            `MayHold false  (* c < 0 => (! x-c < x) *)
         | Lval l1, BinOp(MinusA, Lval l2, Const(CInt64(i,_,_)), _) when (lvalsEq l1 l2 && Int64.compare i Int64.zero > 0) ->
-            `Bool(false)   (* c < 0 => (! x < x-c) *)
+            `MayHold false  (* c < 0 => (! x < x-c) *)
         | _ ->
-            Queries.Result.top ()
+            `MayHold true
       end
     | Queries.MayBeEqual (e1,e2) when not (isFloat e1) ->
       begin
@@ -82,8 +82,8 @@ struct
         | Lval l2, BinOp(PlusA, Lval l1, Const(CInt64(i,_,_)), _)
         | BinOp(MinusA, Lval l1, Const(CInt64(i,_,_)), _), Lval l2
         | Lval l2, BinOp(MinusA, Lval l1, Const(CInt64(i,_,_)), _) when (lvalsEq l1 l2) && Int64.compare i Int64.zero <> 0  ->
-            `Bool(false)
-        | _ -> Queries.Result.top ()
+            `MayHold false
+        | _ -> `MayHold true
       end
     | _ -> Queries.Result.top ()
 

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -46,17 +46,22 @@ struct
         end
       | x -> x
 
+  let isFloat e =
+    match Cil.unrollTypeDeep (Cil.typeOf e) with
+    | TFloat _ -> true
+    | _ -> false
+
   let query ctx (q:Queries.t) : Queries.Result.t =
     let lvalsEq l1 l2 = Expcompare.compareExp (Lval l1) (Lval l2) in (* == would be wrong here *)
     match q with
-    | Queries.MustBeEqual (e1, e2) ->
+    | Queries.MustBeEqual (e1, e2) when not (isFloat e1) ->
       begin
         if Expcompare.compareExp (canonize e1) (canonize e2) then
           `Bool (true)
         else
           Queries.Result.top()
       end
-    | Queries.MayBeLess (e1, e2) ->
+    | Queries.MayBeLess (e1, e2) when not (isFloat e1) ->
       begin
         match e1, e2 with
         | BinOp(PlusA, Lval l1, Const(CInt64(i,_,_)), _), Lval l2 when (lvalsEq l1 l2 && Int64.compare i Int64.zero > 0) ->
@@ -70,7 +75,7 @@ struct
         | _ ->
             Queries.Result.top ()
       end
-    | Queries.MayBeEqual (e1,e2) ->
+    | Queries.MayBeEqual (e1,e2) when not (isFloat e1) ->
       begin
         match e1,e2 with
         | BinOp(PlusA, Lval l1, Const(CInt64(i,_,_)), _), Lval l2

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -528,7 +528,7 @@ struct
     in
     let has_escaped g =
       match ctx.ask (Queries.MayEscape g) with
-      | `Bool false -> false
+      | `MayBool false -> false
       | _ -> true
     in
     (* The following function adds accesses to the lval-set ls

--- a/src/analyses/mallocWrapperAnalysis.ml
+++ b/src/analyses/mallocWrapperAnalysis.ml
@@ -75,7 +75,7 @@ struct
       | _ -> MyCFG.getLoc ctx.node in
       `Varinfo (`Lifted (get_heap_var loc))
     | Q.IsHeapVar v ->
-      `Bool (Hashtbl.mem heap_vars v.vid)
+      `MayBool (Hashtbl.mem heap_vars v.vid)
     | _ -> `Top
 
     let init () =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -155,16 +155,16 @@ struct
 
   let query ctx (q:Queries.t) : Queries.Result.t =
     match q with
-    | Queries.IsPublic _ when Lockset.is_bot ctx.local -> `Bool false
-    | Queries.IsPublic v ->
+    | Queries.MayBePublic _ when Lockset.is_bot ctx.local -> `MayBool false
+    | Queries.MayBePublic v ->
       let held_locks = Lockset.export_locks (Lockset.filter snd ctx.local) in
       if Mutexes.mem verifier_atomic held_locks then
-        `Bool false
+        `MayBool false
       else
         let lambda_v = ctx.global v in
         let intersect = Mutexes.inter held_locks lambda_v in
         let tv = Mutexes.is_empty intersect in
-        `Bool tv
+        `MayBool tv
     | _ -> Queries.Result.top ()
 
   let may_race (ctx1,ac1) (ctx,ac2) =

--- a/src/analyses/octagon.ml
+++ b/src/analyses/octagon.ml
@@ -334,10 +334,10 @@ struct
         | _, Some(x) ->
           begin
             match OctagonDomain.INV.to_int x with
-            | (Some i) -> `MustHold (BI.equal BI.zero i)
-            | _ -> `MustHold false
+            | (Some i) -> `MustBool (BI.equal BI.zero i)
+            | _ -> `MustBool false
           end
-        | _ -> `MustHold false
+        | _ -> `MustBool false
       end
     | Queries.MayBeEqual (exp1,exp2) ->
       begin
@@ -345,11 +345,11 @@ struct
         | _, Some(x) ->
           begin
             if OctagonDomain.INV.is_bot (OctagonDomain.INV.meet x (OctagonDomain.INV.of_int oct_ik BI.zero)) then
-              `MayHold false
+              `MayBool false
             else
-              `MayHold true
+              `MayBool true
           end
-        | _ -> `MayHold true
+        | _ -> `MayBool true
       end
     | Queries.MayBeLess (exp1, exp2) ->
       (* TODO: Here the order of arguments actually matters, be careful *)
@@ -359,10 +359,10 @@ struct
           begin
             match OctagonDomain.INV.minimal x with
             | Some i when BI.compare i BI.zero >= 0 ->
-              `MayHold false
-            | _ -> `MayHold true
+              `MayBool false
+            | _ -> `MayBool true
           end
-        | _ -> `MayHold true
+        | _ -> `MayBool true
       end
     | Queries.EvalInt exp ->
       let inv = evaluate_exp ctx.local exp in

--- a/src/analyses/octagon.ml
+++ b/src/analyses/octagon.ml
@@ -364,18 +364,6 @@ struct
           end
         | _ -> Queries.Result.top ()
       end
-    | Queries.ExpEq (exp1, exp2) ->                           (* TODO: We want to leverage all the additional information we have here *)
-      let inv1, inv2 = evaluate_exp ctx.local exp1,           (* Also, what does ExpEq actually do? Is it must or may equality?        *)
-                       evaluate_exp ctx.local exp2 in
-      if INV.is_int inv1 then
-        if INV.is_bot (INV.meet inv1 inv2) then
-          `Bool false
-        else if INV.compare inv1 inv2 = 0 then
-          `Bool true
-        else
-          `Top
-      else
-        `Top
     | Queries.EvalInt exp ->
       let inv = evaluate_exp ctx.local exp in
       if INV.is_int inv

--- a/src/analyses/octagon.ml
+++ b/src/analyses/octagon.ml
@@ -369,15 +369,6 @@ struct
       if INV.is_int inv
       then `Int(INV.to_int inv |> Option.get |> BI.to_int64)
       else `Top
-    | Queries.InInterval (exp, inv) ->
-      let linv = evaluate_exp ctx.local exp in
-      let min, max = Tuple2.mapn (BI.of_int64 |> Option.map) (IntDomain.Interval32.(minimal inv, maximal inv)) in
-      (match min, max with
-        | None, _ -> `Bool false
-        | _, None -> `Bool false
-        | Some min, Some max ->
-            let inv = INV.of_interval oct_ik (min, max) in
-            `Bool (INV.leq linv inv))
     | _ -> Queries.Result.top ()
 
   let threadspawn ctx lval f args fctx = D.bot ()

--- a/src/analyses/octagon.ml
+++ b/src/analyses/octagon.ml
@@ -334,10 +334,10 @@ struct
         | _, Some(x) ->
           begin
             match OctagonDomain.INV.to_int x with
-            | (Some i) -> `Bool (BI.equal BI.zero i)
-            | _ -> Queries.Result.top ()
+            | (Some i) -> `MustHold (BI.equal BI.zero i)
+            | _ -> `MustHold false
           end
-        | _ -> Queries.Result.top ()
+        | _ -> `MustHold false
       end
     | Queries.MayBeEqual (exp1,exp2) ->
       begin
@@ -345,11 +345,11 @@ struct
         | _, Some(x) ->
           begin
             if OctagonDomain.INV.is_bot (OctagonDomain.INV.meet x (OctagonDomain.INV.of_int oct_ik BI.zero)) then
-              `Bool (false)
+              `MayHold false
             else
-              Queries.Result.top ()
+              `MayHold true
           end
-        | _ -> Queries.Result.top ()
+        | _ -> `MayHold true
       end
     | Queries.MayBeLess (exp1, exp2) ->
       (* TODO: Here the order of arguments actually matters, be careful *)
@@ -359,10 +359,10 @@ struct
           begin
             match OctagonDomain.INV.minimal x with
             | Some i when BI.compare i BI.zero >= 0 ->
-              `Bool(false)
-            | _ -> Queries.Result.top ()
+              `MayHold false
+            | _ -> `MayHold true
           end
-        | _ -> Queries.Result.top ()
+        | _ -> `MayHold true
       end
     | Queries.EvalInt exp ->
       let inv = evaluate_exp ctx.local exp in

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -570,10 +570,10 @@ struct
       let pry = resourceset_to_priority (List.map names (Mutex.Lockset.ReverseAddrSet.elements ctx.local)) in
       `Int (Int64.of_int pry)
     | Queries.Priority vname -> begin try `Int (Int64.of_int (Hashtbl.find offensivepriorities vname) ) with _ -> Queries.Result.top() end
-    | Queries.IsPublic v ->
+    | Queries.MayBePublic v ->
       let pry = resourceset_to_priority (List.map names (Mutex.Lockset.ReverseAddrSet.elements ctx.local)) in
       if pry = min_int then
-        `Bool false
+        `MayBool false
       else
         let off =
           (*         if !FlagModes.Spec.flag_list = [] then begin *)
@@ -585,7 +585,7 @@ struct
           (*             let flagstate = get_flags ctx.presub in *)
           (*             offpry_flags flagstate v *)
           (*           end *)
-        in `Bool (off > pry)
+        in `MayBool (off > pry)
     | _ -> Queries.Result.top ()
 
   let rec conv_offset x =

--- a/src/analyses/poly.ml
+++ b/src/analyses/poly.ml
@@ -134,8 +134,8 @@ struct
         | _ -> `Top
       end
     | MustBeEqual (e1, e2) ->
-      if D.cil_exp_equals d e1 e2 then `MustHold true
-      else `MustHold false
+      if D.cil_exp_equals d e1 e2 then `MustBool true
+      else `MustBool false
     | _ -> Result.top ()
 end
 

--- a/src/analyses/poly.ml
+++ b/src/analyses/poly.ml
@@ -133,7 +133,7 @@ struct
         | _, Some s -> `Interval (IntDomain.Interval.ending s)
         | _ -> `Top
       end
-    | ExpEq (e1, e2) ->
+    | MustBeEqual (e1, e2) ->
       if D.cil_exp_equals d e1 e2 then `Bool (Queries.BD.of_bool true)
       else Result.top ()
     | _ -> Result.top ()

--- a/src/analyses/poly.ml
+++ b/src/analyses/poly.ml
@@ -134,8 +134,8 @@ struct
         | _ -> `Top
       end
     | MustBeEqual (e1, e2) ->
-      if D.cil_exp_equals d e1 e2 then `Bool (Queries.BD.of_bool true)
-      else Result.top ()
+      if D.cil_exp_equals d e1 e2 then `MustHold true
+      else `MustHold false
     | _ -> Result.top ()
 end
 

--- a/src/analyses/spec.ml
+++ b/src/analyses/spec.ml
@@ -226,6 +226,8 @@ struct
     | `ExpTriples x -> "`ExpTriples"
     | `TypeSet x -> "`TypeSet"
     | `Varinfo x -> "`Varinfo"
+    | `MustHold x -> "`MustHold"
+    | `MayHold x -> "`MayHold"
     | `Bot -> "`Bot"
 
 

--- a/src/analyses/spec.ml
+++ b/src/analyses/spec.ml
@@ -226,8 +226,8 @@ struct
     | `ExpTriples x -> "`ExpTriples"
     | `TypeSet x -> "`TypeSet"
     | `Varinfo x -> "`Varinfo"
-    | `MustHold x -> "`MustHold"
-    | `MayHold x -> "`MayHold"
+    | `MustBool x -> "`MustBool"
+    | `MayBool x -> "`MayBool"
     | `Bot -> "`Bot"
 
 

--- a/src/analyses/spec.ml
+++ b/src/analyses/spec.ml
@@ -220,7 +220,6 @@ struct
     | `Interval x -> "`Interval"
     | `IntSet x -> "`IntSet"
     | `Str x -> "`Str"
-    | `Bool x -> "`Bool"
     | `LvalSet x -> "`LvalSet"
     | `ExprSet x -> "`ExprSet"
     | `ExpTriples x -> "`ExpTriples"
@@ -310,7 +309,6 @@ struct
        (match Queries.ID.to_bool i with
         | Some b when b<>tv -> M.debug_each "EvalInt: `Int bool" (* D.remove k m TODO where to get the key?? *)
         | _ -> M.debug_each "EvalInt: `Int no bool")
-     | `Bool b -> M.debug_each "EvalInt: `Bool"
      | x -> M.debug_each @@ "OTHER RESULT: "^dump_query_result x
     );
     let check a b tv =

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -64,7 +64,7 @@ struct
   let same_unknown_index ask exp slocks =
     let uk_index_equal i1 i2 =
       match ask (Queries.MustBeEqual (i1, i2)) with
-      | `Bot | `MustHold true -> true
+      | `Bot | `MustBool true -> true
       | _ -> false
     in
     let lock_index ei ee x xs =

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -63,7 +63,7 @@ struct
 
   let same_unknown_index ask exp slocks =
     let uk_index_equal i1 i2 =
-      match ask (Queries.ExpEq (i1, i2)) with
+      match ask (Queries.MustBeEqual (i1, i2)) with
       | `Bot | `Bool true -> true
       | _ -> false
     in

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -64,7 +64,7 @@ struct
   let same_unknown_index ask exp slocks =
     let uk_index_equal i1 i2 =
       match ask (Queries.MustBeEqual (i1, i2)) with
-      | `Bot | `Bool true -> true
+      | `Bot | `MustHold true -> true
       | _ -> false
     in
     let lock_index ei ee x xs =

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -73,11 +73,11 @@ struct
 
   let query ctx (q: Queries.t) =
     match q with
-    | Queries.IsNotUnique -> begin
+    | Queries.MayBeNotUnique -> begin
         let tid = ThreadId.get_current ctx.ask in
         match tid with
-        | `Lifted tid -> `Bool (is_not_unique ctx tid)
-        | _ -> `Bool (true)
+        | `Lifted tid -> `MayBool (is_not_unique ctx tid)
+        | _ -> `MayBool (true)
       end
     | Queries.NotSingleThreaded -> begin
         let tid = ThreadId.get_current ctx.ask in

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -79,11 +79,11 @@ struct
         | `Lifted tid -> `MayBool (is_not_unique ctx tid)
         | _ -> `MayBool (true)
       end
-    | Queries.MayBeNotSingleThreaded -> begin
+    | Queries.MustBeSingleThreaded -> begin
         let tid = ThreadId.get_current ctx.ask in
         match tid with
-        | `Lifted {vname="main"; _} -> `MayBool (not (D.is_empty ctx.local))
-        | _ -> `MayBool (true)
+        | `Lifted {vname="main"; _} -> `MustBool (D.is_empty ctx.local)
+        | _ -> `MustBool (false)
       end
     | _ -> Queries.Result.top ()
 

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -79,11 +79,11 @@ struct
         | `Lifted tid -> `MayBool (is_not_unique ctx tid)
         | _ -> `MayBool (true)
       end
-    | Queries.NotSingleThreaded -> begin
+    | Queries.MayBeNotSingleThreaded -> begin
         let tid = ThreadId.get_current ctx.ask in
         match tid with
-        | `Lifted {vname="main"; _} -> `Bool (not (D.is_empty ctx.local))
-        | _ -> `Bool (true)
+        | `Lifted {vname="main"; _} -> `MayBool (not (D.is_empty ctx.local))
+        | _ -> `MayBool (true)
       end
     | _ -> Queries.Result.top ()
 

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -73,17 +73,17 @@ struct
 
   let query ctx (q: Queries.t) =
     match q with
-    | Queries.MayBeNotUnique -> begin
+    | Queries.MustBeUniqueThread -> begin
         let tid = ThreadId.get_current ctx.ask in
         match tid with
-        | `Lifted tid -> `MayBool (is_not_unique ctx tid)
-        | _ -> `MayBool (true)
+        | `Lifted tid -> `MustBool (not (is_not_unique ctx tid))
+        | _ -> `MustBool false
       end
     | Queries.MustBeSingleThreaded -> begin
         let tid = ThreadId.get_current ctx.ask in
         match tid with
         | `Lifted {vname="main"; _} -> `MustBool (D.is_empty ctx.local)
-        | _ -> `MustBool (false)
+        | _ -> `MustBool false
       end
     | _ -> Queries.Result.top ()
 

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -17,7 +17,7 @@ struct
   (* queries *)
   let query ctx (q:Queries.t) : Queries.Result.t =
     match q with
-    | Queries.MayEscape v -> `Bool (D.mem v ctx.local)
+    | Queries.MayEscape v -> `MayBool (D.mem v ctx.local)
     | _ -> Queries.Result.top ()
 
   (* transfer functions *)

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -62,7 +62,7 @@ struct
     match x with
     | Queries.SingleThreaded -> `Bool (Queries.BD.of_bool (not (Flag.is_multi ctx.local)))
     | Queries.NotSingleThreaded -> `Bool (Queries.BD.of_bool (Flag.is_multi ctx.local))
-    | Queries.IsNotUnique -> `Bool (Flag.is_bad ctx.local)
+    | Queries.MayBeNotUnique -> `MayBool (Flag.is_bad ctx.local)
     (* This used to be in base but also commented out. *)
     (* | Queries.MayBePublic _ -> `MayBool (Flag.is_multi ctx.local) *)
     | _ -> `Top

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -7,8 +7,8 @@ open Prelude.Ana
 open Analyses
 
 let is_multi (ask: Queries.ask): bool =
-  match ask Queries.MayBeNotSingleThreaded with
-  | `MayBool b -> b
+  match ask Queries.MustBeSingleThreaded with
+  | `MustBool x -> not x
   | `Top -> true
   | _ -> failwith "ThreadFlag.is_multi"
 
@@ -61,7 +61,6 @@ struct
   let query ctx x =
     match x with
     | Queries.MustBeSingleThreaded -> `MustBool (Queries.BD.of_bool (not (Flag.is_multi ctx.local)))
-    | Queries.MayBeNotSingleThreaded -> `MayBool (Queries.BD.of_bool (Flag.is_multi ctx.local))
     | Queries.MayBeNotUnique -> `MayBool (Flag.is_bad ctx.local)
     (* This used to be in base but also commented out. *)
     (* | Queries.MayBePublic _ -> `MayBool (Flag.is_multi ctx.local) *)

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -60,7 +60,7 @@ struct
 
   let query ctx x =
     match x with
-    | Queries.MustBeSingleThreaded -> `MustBool (Queries.BD.of_bool (not (Flag.is_multi ctx.local)))
+    | Queries.MustBeSingleThreaded -> `MustBool (not (Flag.is_multi ctx.local))
     | Queries.MayBeNotUnique -> `MayBool (Flag.is_bad ctx.local)
     (* This used to be in base but also commented out. *)
     (* | Queries.MayBePublic _ -> `MayBool (Flag.is_multi ctx.local) *)

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -60,7 +60,7 @@ struct
 
   let query ctx x =
     match x with
-    | Queries.SingleThreaded -> `Bool (Queries.BD.of_bool (not (Flag.is_multi ctx.local)))
+    | Queries.MustBeSingleThreaded -> `MustBool (Queries.BD.of_bool (not (Flag.is_multi ctx.local)))
     | Queries.MayBeNotSingleThreaded -> `MayBool (Queries.BD.of_bool (Flag.is_multi ctx.local))
     | Queries.MayBeNotUnique -> `MayBool (Flag.is_bad ctx.local)
     (* This used to be in base but also commented out. *)

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -64,7 +64,7 @@ struct
     | Queries.NotSingleThreaded -> `Bool (Queries.BD.of_bool (Flag.is_multi ctx.local))
     | Queries.IsNotUnique -> `Bool (Flag.is_bad ctx.local)
     (* This used to be in base but also commented out. *)
-    (* | Queries.IsPublic _ -> `Bool (Flag.is_multi ctx.local) *)
+    (* | Queries.MayBePublic _ -> `MayBool (Flag.is_multi ctx.local) *)
     | _ -> `Top
 
   let part_access ctx e v w =

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -7,8 +7,8 @@ open Prelude.Ana
 open Analyses
 
 let is_multi (ask: Queries.ask): bool =
-  match ask Queries.NotSingleThreaded with
-  | `Bool b -> b
+  match ask Queries.MayBeNotSingleThreaded with
+  | `MayBool b -> b
   | `Top -> true
   | _ -> failwith "ThreadFlag.is_multi"
 
@@ -61,7 +61,7 @@ struct
   let query ctx x =
     match x with
     | Queries.SingleThreaded -> `Bool (Queries.BD.of_bool (not (Flag.is_multi ctx.local)))
-    | Queries.NotSingleThreaded -> `Bool (Queries.BD.of_bool (Flag.is_multi ctx.local))
+    | Queries.MayBeNotSingleThreaded -> `MayBool (Queries.BD.of_bool (Flag.is_multi ctx.local))
     | Queries.MayBeNotUnique -> `MayBool (Flag.is_bad ctx.local)
     (* This used to be in base but also commented out. *)
     (* | Queries.MayBePublic _ -> `MayBool (Flag.is_multi ctx.local) *)

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -61,7 +61,7 @@ struct
   let query ctx x =
     match x with
     | Queries.MustBeSingleThreaded -> `MustBool (not (Flag.is_multi ctx.local))
-    | Queries.MayBeNotUnique -> `MayBool (Flag.is_bad ctx.local)
+    | Queries.MustBeUniqueThread -> `MustBool (not (Flag.is_bad ctx.local))
     (* This used to be in base but also commented out. *)
     (* | Queries.MayBePublic _ -> `MayBool (Flag.is_multi ctx.local) *)
     | _ -> `Top

--- a/src/analyses/threadId.ml
+++ b/src/analyses/threadId.ml
@@ -70,8 +70,8 @@ struct
     | _ -> `Top
 
   let is_unique ctx =
-    match ctx.ask Queries.MayBeNotUnique with
-    | `MayBool false -> true
+    match ctx.ask Queries.MustBeUniqueThread with
+    | `MustBool true -> true
     | _ -> false
 
   let part_access ctx e v w =

--- a/src/analyses/threadId.ml
+++ b/src/analyses/threadId.ml
@@ -70,8 +70,8 @@ struct
     | _ -> `Top
 
   let is_unique ctx =
-    match ctx.ask Queries.IsNotUnique with
-    | `Bool false -> true
+    match ctx.ask Queries.MayBeNotUnique with
+    | `MayBool false -> true
     | _ -> false
 
   let part_access ctx e v w =

--- a/src/analyses/threadReturn.ml
+++ b/src/analyses/threadReturn.ml
@@ -4,8 +4,8 @@ open Prelude.Ana
 open Analyses
 
 let is_current (ask: Queries.ask): bool =
-  match ask Queries.IsThreadReturn with
-  | `Bool b -> b
+  match ask Queries.MayBeThreadReturn with
+  | `MayBool b -> b
   | `Top -> true
   | _ -> failwith "ThreadReturn.is_current"
 
@@ -48,7 +48,7 @@ struct
 
   let query ctx x =
     match x with
-    | Queries.IsThreadReturn -> `Bool ctx.local
+    | Queries.MayBeThreadReturn -> `MayBool ctx.local
     | _ -> `Top
 end
 

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -584,7 +584,7 @@ struct
   let query ctx x =
     match x with
     | Queries.MustBeEqual (e1,e2) when query_exp_equal ctx.ask e1 e2 ctx.global ctx.local ->
-      `Bool (Queries.BD.of_bool true)
+      `MustHold true
     | Queries.EqualSet e ->
       let r = eq_set_clos e ctx.local in
       (*          Messages.report ("equset of "^(sprint 80 (d_exp () e))^" is "^(Queries.ES.short 80 r));  *)

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -584,7 +584,7 @@ struct
   let query ctx x =
     match x with
     | Queries.MustBeEqual (e1,e2) when query_exp_equal ctx.ask e1 e2 ctx.global ctx.local ->
-      `MustHold true
+      `MustBool true
     | Queries.EqualSet e ->
       let r = eq_set_clos e ctx.local in
       (*          Messages.report ("equset of "^(sprint 80 (d_exp () e))^" is "^(Queries.ES.short 80 r));  *)

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -1,4 +1,4 @@
-(** Variable equalities neccessary for per-element patterns. *)
+(** Variable equalities necessary for per-element patterns. *)
 
 module M = Messages
 module GU = Goblintutil
@@ -583,7 +583,7 @@ struct
 
   let query ctx x =
     match x with
-    | Queries.ExpEq (e1,e2) when query_exp_equal ctx.ask e1 e2 ctx.global ctx.local ->
+    | Queries.MustBeEqual (e1,e2) when query_exp_equal ctx.ask e1 e2 ctx.global ctx.local ->
       `Bool (Queries.BD.of_bool true)
     | Queries.EqualSet e ->
       let r = eq_set_clos e ctx.local in

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -143,19 +143,19 @@ struct
     | `Lifted e', `Lifted i' ->
       begin
         let isEqual = match ask (Q.MustBeEqual (e',i')) with
-          | `Bool true -> true
+          | `MustHold true -> true
           | _ -> false in
         if isEqual then xm
         else
           begin
             let contributionLess = match ask (Q.MayBeLess (i', e')) with        (* (may i < e) ? xl : bot *)
-            | `Bool false -> Val.bot ()
+            | `MayHold false -> Val.bot ()
             | _ -> xl in
             let contributionEqual = match ask (Q.MayBeEqual (i', e')) with      (* (may i = e) ? xm : bot *)
-            | `Bool false -> Val.bot ()
+            | `MayHold false -> Val.bot ()
             | _ -> xm in
             let contributionGreater =  match ask (Q.MayBeLess (e', i')) with    (* (may i > e) ? xr : bot *)
-            | `Bool false -> Val.bot ()
+            | `MayHold false -> Val.bot ()
             | _ -> xr in
             Val.join (Val.join contributionLess contributionEqual) contributionGreater
           end
@@ -267,7 +267,7 @@ struct
                   | Some i ->
                     begin
                       match ask (Q.MayBeLess (exp, Cil.kinteger64 Cil.IInt (IntOps.BigIntOps.to_int64 i))) with
-                      | `Bool false -> true (* !(e <_{may} length) => e >=_{must} length *)
+                      | `MayHold false -> true (* !(e <_{may} length) => e >=_{must} length *)
                       | _ -> false
                     end
                   | None -> false
@@ -276,7 +276,7 @@ struct
             in
             let e_must_less_zero =
               match ask (Q.MayBeLess (Cil.mone, exp)) with
-              | `Bool false -> true (* !(-1 <_{may} e) => e <=_{must} -1 *)
+              | `MayHold false -> true (* !(-1 <_{may} e) => e <=_{must} -1 *)
               | _ -> false
             in
             if e_must_bigger_max_index then
@@ -333,7 +333,7 @@ struct
           (i, (l, a, r))
       else
         let isEqual e' i' = match ask (Q.MustBeEqual (e',i')) with
-          | `Bool true -> true
+          | `MustHold true -> true
           | _ -> false
         in
         match e, i with
@@ -341,15 +341,15 @@ struct
             let default =
               let left =
                 match ask (Q.MayBeLess (i', e')) with     (* (may i < e) ? xl : bot *)
-                | `Bool false -> xl
+                | `MayHold false -> xl
                 | _ -> lubIfNotBot xl in
               let middle =
                 match ask (Q.MayBeEqual (i', e')) with    (* (may i = e) ? xm : bot *)
-                | `Bool false -> xm
+                | `MayHold false -> xm
                 | _ -> Val.join xm a in
               let right =
                 match ask (Q.MayBeLess (e', i')) with     (* (may i > e) ? xr : bot *)
-                | `Bool false -> xr
+                | `MayHold false -> xr
                 | _ -> lubIfNotBot xr in
               (e, (left, middle, right))
             in
@@ -380,33 +380,33 @@ struct
           else
             let left = if equals_zero i then Val.bot () else Val.join xl @@ Val.join
               (match ask (Q.MayBeEqual (e', i')) with
-              | `Bool false -> Val.bot()
+              | `MayHold false -> Val.bot()
               | _ -> xm) (* if e' may be equal to i', but e' may not be smaller than i' then we only need xm *)
               (
                 let ik = Cilfacade.get_ikind (Cil.typeOf e') in
                 match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik 1, Cil.typeOf e'),i')) with
-                | `Bool true -> xm
+                | `MustHold true -> xm
                 | _ ->
                   begin
                     match ask (Q.MayBeLess (e', i')) with
-                    | `Bool false -> Val.bot()
+                    | `MayHold false-> Val.bot()
                     | _ -> Val.join xm xr (* if e' may be less than i' then we also need xm for sure *)
                   end
               )
             in
             let right = if equals_maxIndex i then Val.bot () else  Val.join xr @@  Val.join
               (match ask (Q.MayBeEqual (e', i')) with
-              | `Bool false -> Val.bot()
+              | `MayHold false -> Val.bot()
               | _ -> xm)
 
               (
                 let ik = Cilfacade.get_ikind (Cil.typeOf e') in
                 match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik (-1), Cil.typeOf e'),i')) with
-                | `Bool true -> xm
+                | `MustHold true -> xm
                 | _ ->
                   begin
                     match ask (Q.MayBeLess (i', e')) with
-                    | `Bool false -> Val.bot()
+                    | `MayHold false -> Val.bot()
                     | _ -> Val.join xl xm (* if e' may be less than i' then we also need xm for sure *)
                   end
               )

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -143,19 +143,19 @@ struct
     | `Lifted e', `Lifted i' ->
       begin
         let isEqual = match ask (Q.MustBeEqual (e',i')) with
-          | `MustHold true -> true
+          | `MustBool true -> true
           | _ -> false in
         if isEqual then xm
         else
           begin
             let contributionLess = match ask (Q.MayBeLess (i', e')) with        (* (may i < e) ? xl : bot *)
-            | `MayHold false -> Val.bot ()
+            | `MayBool false -> Val.bot ()
             | _ -> xl in
             let contributionEqual = match ask (Q.MayBeEqual (i', e')) with      (* (may i = e) ? xm : bot *)
-            | `MayHold false -> Val.bot ()
+            | `MayBool false -> Val.bot ()
             | _ -> xm in
             let contributionGreater =  match ask (Q.MayBeLess (e', i')) with    (* (may i > e) ? xr : bot *)
-            | `MayHold false -> Val.bot ()
+            | `MayBool false -> Val.bot ()
             | _ -> xr in
             Val.join (Val.join contributionLess contributionEqual) contributionGreater
           end
@@ -267,7 +267,7 @@ struct
                   | Some i ->
                     begin
                       match ask (Q.MayBeLess (exp, Cil.kinteger64 Cil.IInt (IntOps.BigIntOps.to_int64 i))) with
-                      | `MayHold false -> true (* !(e <_{may} length) => e >=_{must} length *)
+                      | `MayBool false -> true (* !(e <_{may} length) => e >=_{must} length *)
                       | _ -> false
                     end
                   | None -> false
@@ -276,7 +276,7 @@ struct
             in
             let e_must_less_zero =
               match ask (Q.MayBeLess (Cil.mone, exp)) with
-              | `MayHold false -> true (* !(-1 <_{may} e) => e <=_{must} -1 *)
+              | `MayBool false -> true (* !(-1 <_{may} e) => e <=_{must} -1 *)
               | _ -> false
             in
             if e_must_bigger_max_index then
@@ -333,7 +333,7 @@ struct
           (i, (l, a, r))
       else
         let isEqual e' i' = match ask (Q.MustBeEqual (e',i')) with
-          | `MustHold true -> true
+          | `MustBool true -> true
           | _ -> false
         in
         match e, i with
@@ -341,15 +341,15 @@ struct
             let default =
               let left =
                 match ask (Q.MayBeLess (i', e')) with     (* (may i < e) ? xl : bot *)
-                | `MayHold false -> xl
+                | `MayBool false -> xl
                 | _ -> lubIfNotBot xl in
               let middle =
                 match ask (Q.MayBeEqual (i', e')) with    (* (may i = e) ? xm : bot *)
-                | `MayHold false -> xm
+                | `MayBool false -> xm
                 | _ -> Val.join xm a in
               let right =
                 match ask (Q.MayBeLess (e', i')) with     (* (may i > e) ? xr : bot *)
-                | `MayHold false -> xr
+                | `MayBool false -> xr
                 | _ -> lubIfNotBot xr in
               (e, (left, middle, right))
             in
@@ -380,33 +380,33 @@ struct
           else
             let left = if equals_zero i then Val.bot () else Val.join xl @@ Val.join
               (match ask (Q.MayBeEqual (e', i')) with
-              | `MayHold false -> Val.bot()
+              | `MayBool false -> Val.bot()
               | _ -> xm) (* if e' may be equal to i', but e' may not be smaller than i' then we only need xm *)
               (
                 let ik = Cilfacade.get_ikind (Cil.typeOf e') in
                 match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik 1, Cil.typeOf e'),i')) with
-                | `MustHold true -> xm
+                | `MustBool true -> xm
                 | _ ->
                   begin
                     match ask (Q.MayBeLess (e', i')) with
-                    | `MayHold false-> Val.bot()
+                    | `MayBool false-> Val.bot()
                     | _ -> Val.join xm xr (* if e' may be less than i' then we also need xm for sure *)
                   end
               )
             in
             let right = if equals_maxIndex i then Val.bot () else  Val.join xr @@  Val.join
               (match ask (Q.MayBeEqual (e', i')) with
-              | `MayHold false -> Val.bot()
+              | `MayBool false -> Val.bot()
               | _ -> xm)
 
               (
                 let ik = Cilfacade.get_ikind (Cil.typeOf e') in
                 match ask (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik (-1), Cil.typeOf e'),i')) with
-                | `MustHold true -> xm
+                | `MustBool true -> xm
                 | _ ->
                   begin
                     match ask (Q.MayBeLess (i', e')) with
-                    | `MayHold false -> Val.bot()
+                    | `MayBool false -> Val.bot()
                     | _ -> Val.join xl xm (* if e' may be less than i' then we also need xm for sure *)
                   end
               )

--- a/src/cdomains/shapeDomain.ml
+++ b/src/cdomains/shapeDomain.ml
@@ -74,8 +74,8 @@ let is_private ask (lp:ListPtr.t) =
     match ask Queries.SingleThreaded with
     | `Bot | `Bool true -> true
     | _ ->
-      match ask (Queries.IsPublic v)  with
-      | `Bot | `Bool false -> true
+      match ask (Queries.MayBePublic v)  with
+      | `Bot | `MayBool false -> true
       | _ -> false
   in
   match lp with

--- a/src/cdomains/shapeDomain.ml
+++ b/src/cdomains/shapeDomain.ml
@@ -71,8 +71,8 @@ end
 
 let is_private ask (lp:ListPtr.t) =
   let check v =
-    match ask Queries.SingleThreaded with
-    | `Bot | `Bool true -> true
+    match ask Queries.MustBeSingleThreaded with
+    | `Bot | `MustBool true -> true
     | _ ->
       match ask (Queries.MayBePublic v)  with
       | `Bot | `MayBool false -> true

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -42,7 +42,7 @@ type t = EqualSet of exp
        | Priority of string
        | MayBePublic of varinfo
        | MustBeSingleThreaded
-       | MayBeNotUnique
+       | MustBeUniqueThread
        | CurrentThreadId
        | MayBeThreadReturn
        | EvalFunvar of exp

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -76,8 +76,8 @@ type result = [
   | `ExpTriples of PS.t
   | `TypeSet of TS.t
   | `Varinfo of VI.t
-  | `MustHold of bool  (* true \leq false *)
-  | `MayHold of bool   (* false \leq true *)
+  | `MustBool of bool  (* true \leq false *)
+  | `MayBool of bool   (* false \leq true *)
   | `Bot
 ] [@@deriving to_yojson]
 
@@ -133,8 +133,8 @@ struct
       | `IntSet _ -> 8
       | `TypeSet _ -> 9
       | `Varinfo _ -> 10
-      | `MustHold _ -> 11
-      | `MayHold _ -> 12
+      | `MustBool _ -> 11
+      | `MayBool _ -> 12
       | `Top -> 100
     in match x,y with
     | `Int x, `Int y -> ID.compare x y
@@ -156,8 +156,8 @@ struct
     | `ExpTriples n ->  PS.pretty () n
     | `TypeSet n -> TS.pretty () n
     | `Varinfo n -> VI.pretty () n
-    | `MustHold n -> text (string_of_bool n)
-    | `MayHold n -> text (string_of_bool n)
+    | `MustBool n -> text (string_of_bool n)
+    | `MayBool n -> text (string_of_bool n)
     | `Bot -> text bot_name
     | `Top -> text top_name
 
@@ -171,8 +171,8 @@ struct
     | `ExpTriples n ->  PS.short w n
     | `TypeSet n -> TS.short w n
     | `Varinfo n -> VI.short w n
-    | `MustHold n -> string_of_bool n
-    | `MayHold n -> string_of_bool n
+    | `MustBool n -> string_of_bool n
+    | `MayBool n -> string_of_bool n
     | `Bot -> bot_name
     | `Top -> top_name
 
@@ -203,8 +203,8 @@ struct
     | (`ExpTriples x, `ExpTriples y) -> PS.leq x y
     | (`TypeSet x, `TypeSet y) -> TS.leq x y
     | (`Varinfo x, `Varinfo y) -> VI.leq x y
-    | (`MustHold x, `MustHold y) -> x == y || x
-    | (`MayHold x, `MayHold y) -> x == y || y
+    | (`MustBool x, `MustBool y) -> x == y || x
+    | (`MayBool x, `MayBool y) -> x == y || y
     | _ -> false
 
   let join x y =
@@ -220,8 +220,8 @@ struct
       | (`ExpTriples x, `ExpTriples y) -> `ExpTriples (PS.join x y)
       | (`TypeSet x, `TypeSet y) -> `TypeSet (TS.join x y)
       | (`Varinfo x, `Varinfo y) -> `Varinfo (VI.join x y)
-      | (`MustHold x, `MustHold y) -> `MustHold (x && y)
-      | (`MayHold x, `MayHold y) -> `MayHold (x || y)
+      | (`MustBool x, `MustBool y) -> `MustBool (x && y)
+      | (`MayBool x, `MayBool y) -> `MayBool (x || y)
       | _ -> `Top
     with IntDomain.Unknown -> `Top
 
@@ -238,8 +238,8 @@ struct
       | (`ExpTriples x, `ExpTriples y) -> `ExpTriples (PS.meet x y)
       | (`TypeSet x, `TypeSet y) -> `TypeSet (TS.meet x y)
       | (`Varinfo x, `Varinfo y) -> `Varinfo (VI.meet x y)
-      | (`MustHold x, `MustHold y) -> `MustHold (x || y)
-      | (`MayHold x, `MayHold y) -> `MayHold (x && y)
+      | (`MustBool x, `MustBool y) -> `MustBool (x || y)
+      | (`MayBool x, `MayBool y) -> `MayBool (x && y)
       | _ -> `Bot
     with IntDomain.Error -> `Bot
 
@@ -256,8 +256,8 @@ struct
       | (`ExpTriples x, `ExpTriples y) -> `ExpTriples (PS.widen x y)
       | (`TypeSet x, `TypeSet y) -> `TypeSet (TS.widen x y)
       | (`Varinfo x, `Varinfo y) -> `Varinfo (VI.widen x y)
-      | (`MustHold x, `MustHold y) -> `MustHold (x && y)
-      | (`MayHold x, `MayHold y) -> `MustHold (x || y)
+      | (`MustBool x, `MustBool y) -> `MustBool (x && y)
+      | (`MayBool x, `MayBool y) -> `MustBool (x || y)
       | _ -> `Top
     with IntDomain.Unknown -> `Top
 

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -42,7 +42,7 @@ type t = EqualSet of exp
        | MayEscape of varinfo
        | Priority of string
        | MayBePublic of varinfo
-       | SingleThreaded
+       | MustBeSingleThreaded
        | MayBeNotSingleThreaded
        | MayBeNotUnique
        | CurrentThreadId

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -69,7 +69,6 @@ type result = [
   | `Top
   | `Int of ID.t
   | `Str of string
-  | `Bool of BD.t
   | `LvalSet of LS.t
   | `ExprSet of ES.t
   | `ExpTriples of PS.t
@@ -101,7 +100,7 @@ struct
     | (`Top, `Top) -> true
     | (`Bot, `Bot) -> true
     | (`Int x, `Int y) -> ID.equal x y
-    | (`Bool x, `Bool y) -> BD.equal x y
+
     | (`LvalSet x, `LvalSet y) -> LS.equal x y
     | (`ExprSet x, `ExprSet y) -> ES.equal x y
     | (`ExpTriples x, `ExpTriples y) -> PS.equal x y
@@ -112,7 +111,6 @@ struct
   let hash (x:t) =
     match x with
     | `Int n -> ID.hash n
-    | `Bool n -> BD.hash n
     | `LvalSet n -> LS.hash n
     | `ExprSet n -> ES.hash n
     | `ExpTriples n -> PS.hash n
@@ -124,20 +122,18 @@ struct
     let constr_to_int x = match x with
       | `Bot -> 0
       | `Int _ -> 1
-      | `Bool _ -> 2
-      | `LvalSet _ -> 3
-      | `ExprSet _ -> 4
-      | `ExpTriples _ -> 5
-      | `Str _ -> 6
-      | `IntSet _ -> 8
-      | `TypeSet _ -> 9
-      | `Varinfo _ -> 10
-      | `MustBool _ -> 11
-      | `MayBool _ -> 12
+      | `LvalSet _ -> 2
+      | `ExprSet _ -> 3
+      | `ExpTriples _ -> 4
+      | `Str _ -> 5
+      | `IntSet _ -> 6
+      | `TypeSet _ -> 7
+      | `Varinfo _ -> 8
+      | `MustBool _ -> 9
+      | `MayBool _ -> 10
       | `Top -> 100
     in match x,y with
     | `Int x, `Int y -> ID.compare x y
-    | `Bool x, `Bool y -> BD.compare x y
     | `LvalSet x, `LvalSet y -> LS.compare x y
     | `ExprSet x, `ExprSet y -> ES.compare x y
     | `ExpTriples x, `ExpTriples y -> PS.compare x y
@@ -149,7 +145,6 @@ struct
     match state with
     | `Int n ->  ID.pretty () n
     | `Str s ->  text s
-    | `Bool n ->  BD.pretty () n
     | `LvalSet n ->  LS.pretty () n
     | `ExprSet n ->  ES.pretty () n
     | `ExpTriples n ->  PS.pretty () n
@@ -164,7 +159,6 @@ struct
     match state with
     | `Int n ->  ID.short w n
     | `Str s ->  s
-    | `Bool n ->  BD.short w n
     | `LvalSet n ->  LS.short w n
     | `ExprSet n ->  ES.short w n
     | `ExpTriples n ->  PS.short w n
@@ -178,7 +172,6 @@ struct
   let isSimple x =
     match x with
     | `Int n ->  ID.isSimple n
-    | `Bool n ->  BD.isSimple n
     | `LvalSet n ->  LS.isSimple n
     | `ExprSet n ->  ES.isSimple n
     | `ExpTriples n ->  PS.isSimple n
@@ -196,7 +189,6 @@ struct
     | (`Bot, _) -> true
     | (_, `Bot) -> false
     | (`Int x, `Int y) -> ID.leq x y
-    | (`Bool x, `Bool y) -> BD.leq x y
     | (`LvalSet x, `LvalSet y) -> LS.leq x y
     | (`ExprSet x, `ExprSet y) -> ES.leq x y
     | (`ExpTriples x, `ExpTriples y) -> PS.leq x y
@@ -213,7 +205,6 @@ struct
       | (`Bot, x)
       | (x, `Bot) -> x
       | (`Int x, `Int y) -> `Int (ID.join x y)
-      | (`Bool x, `Bool y) -> `Bool (BD.join x y)
       | (`LvalSet x, `LvalSet y) -> `LvalSet (LS.join x y)
       | (`ExprSet x, `ExprSet y) -> `ExprSet (ES.join x y)
       | (`ExpTriples x, `ExpTriples y) -> `ExpTriples (PS.join x y)
@@ -231,7 +222,6 @@ struct
       | (`Top, x)
       | (x, `Top) -> x
       | (`Int x, `Int y) -> `Int (ID.meet x y)
-      | (`Bool x, `Bool y) -> `Bool (BD.meet x y)
       | (`LvalSet x, `LvalSet y) -> `LvalSet (LS.meet x y)
       | (`ExprSet x, `ExprSet y) -> `ExprSet (ES.meet x y)
       | (`ExpTriples x, `ExpTriples y) -> `ExpTriples (PS.meet x y)
@@ -249,7 +239,6 @@ struct
       | (`Bot, x)
       | (x, `Bot) -> x
       | (`Int x, `Int y) -> `Int (ID.widen x y)
-      | (`Bool x, `Bool y) -> `Bool (BD.widen x y)
       | (`LvalSet x, `LvalSet y) -> `LvalSet (LS.widen x y)
       | (`ExprSet x, `ExprSet y) -> `ExprSet (ES.widen x y)
       | (`ExpTriples x, `ExpTriples y) -> `ExpTriples (PS.widen x y)
@@ -263,7 +252,6 @@ struct
   let narrow x y =
     match (x,y) with
     | (`Int x, `Int y) -> `Int (ID.narrow x y)
-    | (`Bool x, `Bool y) -> `Bool (BD.narrow x y)
     | (`LvalSet x, `LvalSet y) -> `LvalSet (LS.narrow x y)
     | (`ExprSet x, `ExprSet y) -> `ExprSet (ES.narrow x y)
     | (`ExpTriples x, `ExpTriples y) -> `ExpTriples (PS.narrow x y)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -34,8 +34,7 @@ let iterprevvar_to_yojson _ = `Null
 type itervar = int -> unit
 let itervar_to_yojson _ = `Null
 
-type t = ExpEq of exp * exp
-       | EqualSet of exp
+type t = EqualSet of exp
        | MayPointTo of exp
        | ReachableFrom of exp
        | ReachableUkTypes of exp

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -43,7 +43,6 @@ type t = EqualSet of exp
        | Priority of string
        | MayBePublic of varinfo
        | MustBeSingleThreaded
-       | MayBeNotSingleThreaded
        | MayBeNotUnique
        | CurrentThreadId
        | MayBeThreadReturn

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -44,7 +44,7 @@ type t = EqualSet of exp
        | MayBePublic of varinfo
        | SingleThreaded
        | NotSingleThreaded
-       | IsNotUnique
+       | MayBeNotUnique
        | CurrentThreadId
        | IsThreadReturn
        | EvalFunvar of exp

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -57,7 +57,6 @@ type t = EqualSet of exp
        | Access of exp * bool * bool * int
        | IterPrevVars of iterprevvar
        | IterVars of itervar
-       | InInterval of exp * IntDomain.Interval32.t
        | MustBeEqual of exp * exp (* are two expression known to must-equal ? *)
        | MayBeEqual of exp * exp (* may two expressions be equal? *)
        | MayBeLess of exp * exp (* may exp1 < exp2 ? *)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -46,7 +46,7 @@ type t = EqualSet of exp
        | MayBeNotSingleThreaded
        | MayBeNotUnique
        | CurrentThreadId
-       | IsThreadReturn
+       | MayBeThreadReturn
        | EvalFunvar of exp
        | EvalInt of exp
        | EvalStr of exp

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -43,7 +43,7 @@ type t = EqualSet of exp
        | Priority of string
        | MayBePublic of varinfo
        | SingleThreaded
-       | NotSingleThreaded
+       | MayBeNotSingleThreaded
        | MayBeNotUnique
        | CurrentThreadId
        | IsThreadReturn

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -41,7 +41,7 @@ type t = EqualSet of exp
        | Regions of exp
        | MayEscape of varinfo
        | Priority of string
-       | IsPublic of varinfo
+       | MayBePublic of varinfo
        | SingleThreaded
        | NotSingleThreaded
        | IsNotUnique

--- a/tests/regression/22-partitioned_arrays/15-var_eq.c
+++ b/tests/regression/22-partitioned_arrays/15-var_eq.c
@@ -1,0 +1,29 @@
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','var_eq']"
+int global;
+
+int main(void)
+{
+    example1();
+    example2();
+    example3();
+    example4();
+    example5();
+    example6();
+    example7();
+    example8();
+    example9();
+    example10();
+    return 0;
+}
+
+// Simple example
+void example1(void)
+{
+    int top;
+    int top2;
+    int arr[10];
+
+    arr[top] = 42;
+    top2 = top;
+    assert(arr[top2] == 42);
+}


### PR DESCRIPTION
We currently have two different queries for must equality of expressions:

- `ExpEq` (answered by `var_eq` and `octagon` and used in `base`)
- `MustBeEqual` (answered by `base`, `expRelation`, and `octagon` and used in `base` and for arrays)

 (I am to blame here, I introduced the second one in my Master's thesis).

With this PR:
- We use `MustBeEqual` everywhere where `ExpEq` was used 
- Fix `expRelation` to always answer `top` for floats (see #141)

This means that we use all analyses to answer the question whether to expressions must be equal, rather than different ones in different scenarios.