### PR TITLE
Replace part_access transfer function with PartAccess query

### DIFF
--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -488,11 +488,9 @@ struct
     let open Queries in
     let part_access ctx (e:exp) (vo:varinfo option) (w: bool) =
       let open Access in
-      (* TODO: make this be PartAccessResult.top *)
-      let start = (LSSSet.singleton (LSSet.empty ()), LSSet.empty ()) in
       match query ctx (PartAccess {exp=e; var=vo; write=w}) with
       | `PartAccessResult (po, pd) -> (po, pd)
-      | `Top -> start
+      | `Top -> PartAccessResult.top ()
       | _ -> failwith "MCP2.part_access"
     in
     let add_access conf vo oo =

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -484,17 +484,17 @@ struct
       do_sideg ctx !sides;
       x
 
-  and part_access ctx (e:exp) (vo:varinfo option) (w: bool) =
-    let open Access in
-    (* TODO: make this be PartAccessResult.top *)
-    let start = (LSSSet.singleton (LSSet.empty ()), LSSet.empty ()) in
-    match query ctx (Queries.PartAccess {exp=e; var=vo; write=w}) with
-    | `PartAccessResult (po, pd) -> (po, pd)
-    | `Top -> start
-    | _ -> failwith "MCP2.part_access"
-
   and do_access (ctx: (D.t, G.t, C.t) ctx) (w:bool) (reach:bool) (conf:int) (e:exp) =
     let open Queries in
+    let part_access ctx (e:exp) (vo:varinfo option) (w: bool) =
+      let open Access in
+      (* TODO: make this be PartAccessResult.top *)
+      let start = (LSSSet.singleton (LSSet.empty ()), LSSet.empty ()) in
+      match query ctx (PartAccess {exp=e; var=vo; write=w}) with
+      | `PartAccessResult (po, pd) -> (po, pd)
+      | `Top -> start
+      | _ -> failwith "MCP2.part_access"
+    in
     let add_access conf vo oo =
       let (po,pd) = part_access ctx e vo w in
       Access.add e w conf vo oo (po,pd)

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -486,36 +486,8 @@ struct
 
   and part_access ctx (e:exp) (vo:varinfo option) (w: bool) =
     let open Access in
+    (* TODO: make this be PartAccessResult.top *)
     let start = (LSSSet.singleton (LSSet.empty ()), LSSet.empty ()) in
-    (* let sides  = ref [] in
-    let f (po,lo) (n, (module S: Spec), d) : part =
-      let ctx' : (S.D.t, S.G.t, S.C.t) ctx =
-        { local  = obj d
-        ; node   = ctx.node
-        ; prev_node = ctx.prev_node
-        ; control_context = ctx.control_context
-        ; context = (fun () -> ctx.context () |> assoc n |> obj)
-        ; edge   = ctx.edge
-        ; ask    = query ctx
-        ; presub = filter_presubs n ctx.local
-        ; postsub= []
-        ; global = (fun v         -> ctx.global v |> assoc n |> obj)
-        ; spawn  = (fun v d       -> failwith "part_access::spawn")
-        ; split  = (fun d e tv    -> failwith "part_access::split")
-        ; sideg  = (fun v g    -> sides  := (v, (n, repr g)) :: !sides)
-        ; assign = (fun ?name v e -> failwith "part_access::assign")
-        }
-      in
-      let (pd, ld) = S.part_access ctx' e vo w in
-      let ln = LSSet.union lo ld in
-      let mult_po s = LSSSet.union (LSSSet.map (LSSet.union s) po) in
-      let pn = LSSSet.fold mult_po pd (LSSSet.empty ())  in
-      do_sideg ctx !sides;
-      (* printf "e=%a po=%a pd=%a pn=%a\n" d_exp e LSSSet.pretty po LSSSet.pretty pd LSSSet.pretty pn; *)
-      (pn, ln)
-      (* (LSSSet.map (LSSet.add pn) po, LSSet.union lo ln) *)
-    in
-    List.fold_left f start (spec_list ctx.local) *)
     match query ctx (Queries.PartAccess {exp=e; var=vo; write=w}) with
     | `PartAccessResult (po, pd) -> (po, pd)
     | `Top -> start

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -487,7 +487,7 @@ struct
   and part_access ctx (e:exp) (vo:varinfo option) (w: bool) =
     let open Access in
     let start = (LSSSet.singleton (LSSet.empty ()), LSSet.empty ()) in
-    let sides  = ref [] in
+    (* let sides  = ref [] in
     let f (po,lo) (n, (module S: Spec), d) : part =
       let ctx' : (S.D.t, S.G.t, S.C.t) ctx =
         { local  = obj d
@@ -515,7 +515,11 @@ struct
       (pn, ln)
       (* (LSSSet.map (LSSet.add pn) po, LSSet.union lo ln) *)
     in
-    List.fold_left f start (spec_list ctx.local)
+    List.fold_left f start (spec_list ctx.local) *)
+    match query ctx (Queries.PartAccess {exp=e; var=vo; write=w}) with
+    | `PartAccessResult (po, pd) -> (po, pd)
+    | `Top -> start
+    | _ -> failwith "MCP2.part_access"
 
   and do_access (ctx: (D.t, G.t, C.t) ctx) (w:bool) (reach:bool) (conf:int) (e:exp) =
     let open Queries in

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -142,10 +142,80 @@ struct
 
   let arinc_analysis_activated = ref false
 
+  let do_access (ctx: (D.t, G.t, C.t) ctx) (w:bool) (reach:bool) (conf:int) (e:exp) =
+    let open Queries in
+    let part_access ctx (e:exp) (vo:varinfo option) (w: bool) =
+      let open Access in
+      match ctx.ask (PartAccess {exp=e; var=vo; write=w}) with
+      | `PartAccessResult (po, pd) -> (po, pd)
+      | `Top -> PartAccessResult.top ()
+      | _ -> failwith "MutexAnalysis.part_access"
+    in
+    let add_access conf vo oo =
+      let (po,pd) = part_access ctx e vo w in
+      Access.add e w conf vo oo (po,pd)
+    in
+    let add_access_struct conf ci =
+      let (po,pd) = part_access ctx e None w in
+      Access.add_struct e w conf (`Struct (ci,`NoOffset)) None (po,pd)
+    in
+    let has_escaped g =
+      match ctx.ask (Queries.MayEscape g) with
+      | `MayBool false -> false
+      | _ -> true
+    in
+    (* The following function adds accesses to the lval-set ls
+       -- this is the common case if we have a sound points-to set. *)
+    let on_lvals ls includes_uk =
+      let ls = LS.filter (fun (g,_) -> g.vglob || has_escaped g) ls in
+      let conf = if reach then conf - 20 else conf in
+      let conf = if includes_uk then conf - 10 else conf in
+      let f (var, offs) =
+        let coffs = Lval.CilLval.to_ciloffs offs in
+        if var.vid = dummyFunDec.svar.vid then
+          add_access conf None (Some coffs)
+        else
+          add_access conf (Some var) (Some coffs)
+      in
+      LS.iter f ls
+    in
+    let reach_or_mpt = if reach then ReachableFrom e else MayPointTo e in
+    match ctx.ask reach_or_mpt with
+    | `Bot -> ()
+    | `LvalSet ls when not (LS.is_top ls) && not (Queries.LS.mem (dummyFunDec.svar,`NoOffset) ls) ->
+      (* the case where the points-to set is non top and does not contain unknown values *)
+      on_lvals ls false
+    | `LvalSet ls when not (LS.is_top ls) ->
+      (* the case where the points-to set is non top and contains unknown values *)
+      let includes_uk = ref false in
+      (* now we need to access all fields that might be pointed to: is this correct? *)
+      begin match ctx.ask (ReachableUkTypes e) with
+        | `Bot -> ()
+        | `TypeSet ts when Queries.TS.is_top ts ->
+          includes_uk := true
+        | `TypeSet ts ->
+          if Queries.TS.is_empty ts = false then
+            includes_uk := true;
+          let f = function
+            | TComp (ci, _) ->
+              add_access_struct (conf - 50) ci
+            | _ -> ()
+          in
+          Queries.TS.iter f ts
+        | _ ->
+          includes_uk := true
+      end;
+      on_lvals ls !includes_uk
+    | _ ->
+      add_access (conf - 60) None None
+
   let access_one_top ctx write reach exp =
     (* ignore (Pretty.printf "access_one_top %b %b %a:\n" write reach d_exp exp); *)
-    if ThreadFlag.is_multi ctx.ask then
-      ignore(ctx.ask (Queries.Access(exp,write,reach,110)))
+    if ThreadFlag.is_multi ctx.ask then (
+      let conf = 110 in
+      if reach || write then do_access ctx write reach conf exp;
+      Access.distribute_access_exp (do_access ctx) false false conf exp;
+    )
 
   (** We just lift start state, global and dependecy functions: *)
   let startstate v = Lockset.empty ()

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -161,10 +161,13 @@ struct
       if Mutexes.mem verifier_atomic held_locks then
         `MayBool false
       else
+        (* TODO: previous implementation required G=Mutexes, use implementation from traces branch *)
         let lambda_v = ctx.global v in
-        let intersect = Mutexes.inter held_locks lambda_v in
-        let tv = Mutexes.is_empty intersect in
+        let intersect = G.join (P.effect_fun (Lockset.filter snd ctx.local)) lambda_v in
+        let tv = G.is_top intersect in
         `MayBool tv
+    | Queries.PartAccess {exp; var; write} ->
+      `PartAccessResult (part_access ctx exp var write)
     | _ -> Queries.Result.top ()
 
   let may_race (ctx1,ac1) (ctx,ac2) =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -147,7 +147,7 @@ struct
     let open Queries in
     let part_access ctx (e:exp) (vo:varinfo option) (w: bool) =
       let open Access in
-      match ctx.ask (PartAccess {exp=e; var=vo; write=w}) with
+      match ctx.ask (PartAccess {exp=e; var_opt=vo; write=w}) with
       | `PartAccessResult (po, pd) -> (po, pd)
       | `Top -> PartAccessResult.top ()
       | _ -> failwith "MutexAnalysis.part_access"
@@ -236,8 +236,8 @@ struct
       let held_locks: G.t = P.check_fun (Lockset.filter snd ctx.local) in
       if Mutexes.mem verifier_atomic (Lockset.export_locks ctx.local) then `MayBool false
       else non_overlapping held_locks (ctx.global v)
-    | Queries.PartAccess {exp; var; write} ->
-      `PartAccessResult (part_access ctx exp var write)
+    | Queries.PartAccess {exp; var_opt; write} ->
+      `PartAccessResult (part_access ctx exp var_opt write)
     | _ -> Queries.Result.top ()
 
   let may_race (ctx1,ac1) (ctx,ac2) =

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -232,6 +232,7 @@ struct
       let staticprys = List.filter is_task_res prys in
       let pry = resourceset_to_priority staticprys in
       if pry = min_int then `Bot else `Lifted (Int64.of_int pry)
+    let check_fun = effect_fun
   end
 
   module M = Mutex.MakeSpec (MyParam)

--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -78,8 +78,8 @@ struct
       if is_bullet e regpart ctx.local then `Bot else
         let ls = List.fold_right Queries.LS.add (regions e regpart ctx.local) (Queries.LS.empty ()) in
         `LvalSet ls
-    | Queries.PartAccess {exp; var; write} ->
-      `PartAccessResult (part_access ctx exp var write)
+    | Queries.PartAccess {exp; var_opt; write} ->
+      `PartAccessResult (part_access ctx exp var_opt write)
     | _ -> Queries.Result.top ()
 
   (* transfer functions *)

--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -78,6 +78,8 @@ struct
       if is_bullet e regpart ctx.local then `Bot else
         let ls = List.fold_right Queries.LS.add (regions e regpart ctx.local) (Queries.LS.empty ()) in
         `LvalSet ls
+    | Queries.PartAccess {exp; var; write} ->
+      `PartAccessResult (part_access ctx exp var write)
     | _ -> Queries.Result.top ()
 
   (* transfer functions *)

--- a/src/analyses/spec.ml
+++ b/src/analyses/spec.ml
@@ -227,6 +227,7 @@ struct
     | `Varinfo x -> "`Varinfo"
     | `MustBool x -> "`MustBool"
     | `MayBool x -> "`MayBool"
+    | `PartAccessResult x -> "`PartAccessResult"
     | `Bot -> "`Bot"
 
 

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -238,8 +238,8 @@ struct
 
   let query ctx (q:Queries.t) =
     match q with
-    | Queries.PartAccess {exp; var; write} ->
-      `PartAccessResult (part_access ctx exp var write)
+    | Queries.PartAccess {exp; var_opt; write} ->
+      `PartAccessResult (part_access ctx exp var_opt write)
     | _ -> Queries.Result.top ()
 end
 

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -162,10 +162,6 @@ struct
 
     | _ -> true
 
-  let query ctx (q:Queries.t) =
-    match q with
-    | _ -> Queries.Result.top ()
-
   let add_per_element_access ctx e rw =
     let module LSSet = Access.LSSet in
     (* Per-element returns a triple of exps, first are the "element" pointers,
@@ -239,6 +235,12 @@ struct
     let ls = add_per_element_access ctx e false in
     (* ignore (printf "bla %a %a = %a\n" d_exp e D.pretty ctx.local LSSet.pretty ls); *)
     (LSSSet.singleton (LSSet.empty ()), ls)
+
+  let query ctx (q:Queries.t) =
+    match q with
+    | Queries.PartAccess {exp; var; write} ->
+      `PartAccessResult (part_access ctx exp var write)
+    | _ -> Queries.Result.top ()
 end
 
 let _ =

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -58,14 +58,6 @@ struct
   let special ctx lval f args =
     ctx.local
 
-  let query ctx x =
-    match x with
-    | Queries.MustBeSingleThreaded -> `MustBool (not (Flag.is_multi ctx.local))
-    | Queries.MustBeUniqueThread -> `MustBool (not (Flag.is_bad ctx.local))
-    (* This used to be in base but also commented out. *)
-    (* | Queries.MayBePublic _ -> `MayBool (Flag.is_multi ctx.local) *)
-    | _ -> `Top
-
   let part_access ctx e v w =
     let es = Access.LSSet.empty () in
     if is_multi ctx.ask then
@@ -73,6 +65,16 @@ struct
     else
       (* kill access when single threaded *)
       (Access.LSSSet.empty (), es)
+
+  let query ctx x =
+    match x with
+    | Queries.MustBeSingleThreaded -> `MustBool (not (Flag.is_multi ctx.local))
+    | Queries.MustBeUniqueThread -> `MustBool (not (Flag.is_bad ctx.local))
+    (* This used to be in base but also commented out. *)
+    (* | Queries.MayBePublic _ -> `MayBool (Flag.is_multi ctx.local) *)
+    | Queries.PartAccess {exp; var; write} ->
+      `PartAccessResult (part_access ctx exp var write)
+    | _ -> `Top
 
   let threadenter ctx lval f args =
     create_tid f

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -72,8 +72,8 @@ struct
     | Queries.MustBeUniqueThread -> `MustBool (not (Flag.is_bad ctx.local))
     (* This used to be in base but also commented out. *)
     (* | Queries.MayBePublic _ -> `MayBool (Flag.is_multi ctx.local) *)
-    | Queries.PartAccess {exp; var; write} ->
-      `PartAccessResult (part_access ctx exp var write)
+    | Queries.PartAccess {exp; var_opt; write} ->
+      `PartAccessResult (part_access ctx exp var_opt write)
     | _ -> `Top
 
   let threadenter ctx lval f args =

--- a/src/analyses/threadId.ml
+++ b/src/analyses/threadId.ml
@@ -64,11 +64,6 @@ struct
   let special ctx lval f args =
     ctx.local
 
-  let query ctx x =
-    match x with
-    | Queries.CurrentThreadId -> `Varinfo ctx.local
-    | _ -> `Top
-
   let is_unique ctx =
     match ctx.ask Queries.MustBeUniqueThread with
     | `MustBool true -> true
@@ -82,6 +77,13 @@ struct
       (Access.LSSSet.singleton es, Access.LSSet.add ("thread",tid) es)
     else
       (Access.LSSSet.singleton es, es)
+
+  let query ctx x =
+    match x with
+    | Queries.CurrentThreadId -> `Varinfo ctx.local
+    | Queries.PartAccess {exp; var; write} ->
+      `PartAccessResult (part_access ctx exp var write)
+    | _ -> `Top
 
   let threadenter ctx lval f args =
     create_tid f

--- a/src/analyses/threadId.ml
+++ b/src/analyses/threadId.ml
@@ -81,8 +81,8 @@ struct
   let query ctx x =
     match x with
     | Queries.CurrentThreadId -> `Varinfo ctx.local
-    | Queries.PartAccess {exp; var; write} ->
-      `PartAccessResult (part_access ctx exp var write)
+    | Queries.PartAccess {exp; var_opt; write} ->
+      `PartAccessResult (part_access ctx exp var_opt write)
     | _ -> `Top
 
   let threadenter ctx lval f args =

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -60,7 +60,11 @@ struct
   let is_bot x = cardinal x = 1 && LSSet.is_empty (choose x)
   (* top & is_top come from SetDomain.Make *)
 
+  (* Since Queries.PartAccess and PartAccessResult are only used within MCP2,
+     these operations are never really called. *)
   let leq _ _ = raise (Lattice.Unsupported "LSSSet.leq")
+  (* meet (i.e. join in PartAccessResult) for PathSensitive query joining
+     isn't needed, because accesses are handled only within MCP2. *)
   let meet _ _ = raise (Lattice.Unsupported "LSSSet.meet")
   let widen _ _ = raise (Lattice.Unsupported "LSSSet.widen")
   let narrow _ _ = raise (Lattice.Unsupported "LSSSet.narrow")

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -48,8 +48,23 @@ struct
   let short _ (x,y) = x^":"^y
   let pretty () x = pretty_f short () x
 end
-module LSSet = SetDomain.Make (LabeledString)
-module LSSSet = SetDomain.Make (LSSet)
+module LSSet =
+struct
+  module S = SetDomain.Make (LabeledString)
+  include S
+  include Lattice.Reverse (S)
+end
+module LSSSet =
+struct
+  module S = SetDomain.Make (LSSet)
+  include S
+  (* TODO: other ops *)
+  let meet po pd =
+    let mult_po s = S.union (S.map (LSSet.union s) po) in
+    S.fold mult_po pd (S.empty ())
+end
+
+module PartAccessResult = Lattice.Prod (LSSSet) (LSSet)
 
 let typeVar  = Hashtbl.create 101
 let typeIncl = Hashtbl.create 101

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -52,11 +52,18 @@ module LSSet = SetDomain.Make (LabeledString)
 module LSSSet =
 struct
   include SetDomain.Make (LSSet)
-  (* TODO: other ops *)
+  (* TODO: is this actually some partition domain? *)
   let join po pd =
     let mult_po s = union (map (LSSet.union s) po) in
     fold mult_po pd (empty ())
   let bot () = singleton (LSSet.empty ())
+  let is_bot x = cardinal x = 1 && LSSet.is_empty (choose x)
+  (* top & is_top come from SetDomain.Make *)
+
+  let leq _ _ = raise (Lattice.Unsupported "LSSSet.leq")
+  let meet _ _ = raise (Lattice.Unsupported "LSSSet.meet")
+  let widen _ _ = raise (Lattice.Unsupported "LSSSet.widen")
+  let narrow _ _ = raise (Lattice.Unsupported "LSSSet.narrow")
 end
 
 (* Reverse because MCP2.query [meet]s. *)

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -48,23 +48,19 @@ struct
   let short _ (x,y) = x^":"^y
   let pretty () x = pretty_f short () x
 end
-module LSSet =
-struct
-  module S = SetDomain.Make (LabeledString)
-  include S
-  include Lattice.Reverse (S)
-end
+module LSSet = SetDomain.Make (LabeledString)
 module LSSSet =
 struct
-  module S = SetDomain.Make (LSSet)
-  include S
+  include SetDomain.Make (LSSet)
   (* TODO: other ops *)
-  let meet po pd =
-    let mult_po s = S.union (S.map (LSSet.union s) po) in
-    S.fold mult_po pd (S.empty ())
+  let join po pd =
+    let mult_po s = union (map (LSSet.union s) po) in
+    fold mult_po pd (empty ())
+  let bot () = singleton (LSSet.empty ())
 end
 
-module PartAccessResult = Lattice.Prod (LSSSet) (LSSet)
+(* Reverse because MCP2.query [meet]s. *)
+module PartAccessResult = Lattice.Reverse (Lattice.Prod (LSSSet) (LSSet))
 
 let typeVar  = Hashtbl.create 101
 let typeIncl = Hashtbl.create 101

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -52,7 +52,6 @@ type t = EqualSet of exp
        | BlobSize of exp (* size of a dynamically allocated `Blob pointed to by exp *)
        | PrintFullState
        | CondVars of exp
-       | Access of exp * bool * bool * int
        | PartAccess of {exp: exp; var: varinfo option; write: bool}
        | IterPrevVars of iterprevvar
        | IterVars of itervar

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -52,7 +52,7 @@ type t = EqualSet of exp
        | BlobSize of exp (* size of a dynamically allocated `Blob pointed to by exp *)
        | PrintFullState
        | CondVars of exp
-       | PartAccess of {exp: exp; var: varinfo option; write: bool}
+       | PartAccess of {exp: exp; var_opt: varinfo option; write: bool}
        | IterPrevVars of iterprevvar
        | IterVars of itervar
        | MustBeEqual of exp * exp (* are two expression known to must-equal ? *)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -53,6 +53,7 @@ type t = EqualSet of exp
        | PrintFullState
        | CondVars of exp
        | Access of exp * bool * bool * int
+       | PartAccess of {exp: exp; var: varinfo option; write: bool}
        | IterPrevVars of iterprevvar
        | IterVars of itervar
        | MustBeEqual of exp * exp (* are two expression known to must-equal ? *)
@@ -62,6 +63,8 @@ type t = EqualSet of exp
        | HeapVar
        | IsHeapVar of varinfo
 [@@deriving to_yojson]
+
+module PartAccessResult = Access.PartAccessResult
 
 type result = [
   | `Top
@@ -74,6 +77,7 @@ type result = [
   | `Varinfo of VI.t
   | `MustBool of bool  (* true \leq false *)
   | `MayBool of bool   (* false \leq true *)
+  | `PartAccessResult of PartAccessResult.t
   | `Bot
 ] [@@deriving to_yojson]
 
@@ -105,6 +109,7 @@ struct
     | (`Varinfo x, `Varinfo y) -> VI.equal x y
     | (`MustBool x, `MustBool y) -> Bool.equal x y
     | (`MayBool x, `MayBool y) -> Bool.equal x y
+    | (`PartAccessResult x, `PartAccessResult y) -> PartAccessResult.equal x y
     | _ -> false
 
   let hash (x:t) =
@@ -115,6 +120,7 @@ struct
     | `ExpTriples n -> PS.hash n
     | `TypeSet n -> TS.hash n
     | `Varinfo n -> VI.hash n
+    | `PartAccessResult n -> PartAccessResult.hash n
     (* `MustBool and `MayBool should work by the following *)
     | _ -> Hashtbl.hash x
 
@@ -131,6 +137,7 @@ struct
       | `Varinfo _ -> 8
       | `MustBool _ -> 9
       | `MayBool _ -> 10
+      | `PartAccessResult _ -> 11
       | `Top -> 100
     in match x,y with
     | `Int x, `Int y -> ID.compare x y
@@ -141,6 +148,7 @@ struct
     | `Varinfo x, `Varinfo y -> VI.compare x y
     | `MustBool x, `MustBool y -> Bool.compare x y
     | `MayBool x, `MayBool y -> Bool.compare x y
+    | `PartAccessResult x, `PartAccessResult y -> PartAccessResult.compare x y
     | _ -> Stdlib.compare (constr_to_int x) (constr_to_int y)
 
   let pretty_f s () state =
@@ -154,6 +162,7 @@ struct
     | `Varinfo n -> VI.pretty () n
     | `MustBool n -> text (string_of_bool n)
     | `MayBool n -> text (string_of_bool n)
+    | `PartAccessResult n -> PartAccessResult.pretty () n
     | `Bot -> text bot_name
     | `Top -> text top_name
 
@@ -168,6 +177,7 @@ struct
     | `Varinfo n -> VI.short w n
     | `MustBool n -> string_of_bool n
     | `MayBool n -> string_of_bool n
+    | `PartAccessResult n -> PartAccessResult.short w n
     | `Bot -> bot_name
     | `Top -> top_name
 
@@ -179,6 +189,7 @@ struct
     | `ExpTriples n ->  PS.isSimple n
     | `TypeSet n -> TS.isSimple n
     | `Varinfo n -> VI.isSimple n
+    | `PartAccessResult n -> PartAccessResult.isSimple n
     (* `MustBool and `MayBool should work by the following *)
     | _ -> true
 
@@ -200,6 +211,7 @@ struct
     (* TODO: should these be more like IntDomain.Booleans? *)
     | (`MustBool x, `MustBool y) -> x == y || x
     | (`MayBool x, `MayBool y) -> x == y || y
+    | (`PartAccessResult x, `PartAccessResult y) -> PartAccessResult.leq x y
     | _ -> false
 
   let join x y =
@@ -216,6 +228,7 @@ struct
       | (`Varinfo x, `Varinfo y) -> `Varinfo (VI.join x y)
       | (`MustBool x, `MustBool y) -> `MustBool (x && y)
       | (`MayBool x, `MayBool y) -> `MayBool (x || y)
+      | (`PartAccessResult x, `PartAccessResult y) -> `PartAccessResult (PartAccessResult.join x y)
       | _ -> `Top
     with IntDomain.Unknown -> `Top
 
@@ -233,6 +246,7 @@ struct
       | (`Varinfo x, `Varinfo y) -> `Varinfo (VI.meet x y)
       | (`MustBool x, `MustBool y) -> `MustBool (x || y)
       | (`MayBool x, `MayBool y) -> `MayBool (x && y)
+      | (`PartAccessResult x, `PartAccessResult y) -> `PartAccessResult (PartAccessResult.meet x y)
       | _ -> `Bot
     with IntDomain.Error -> `Bot
 
@@ -250,6 +264,7 @@ struct
       | (`Varinfo x, `Varinfo y) -> `Varinfo (VI.widen x y)
       | (`MustBool x, `MustBool y) -> `MustBool (x && y)
       | (`MayBool x, `MayBool y) -> `MustBool (x || y)
+      | (`PartAccessResult x, `PartAccessResult y) -> `PartAccessResult (PartAccessResult.widen x y)
       | _ -> `Top
     with IntDomain.Unknown -> `Top
 
@@ -263,6 +278,7 @@ struct
     | (`Varinfo x, `Varinfo y) -> `Varinfo (VI.narrow x y)
     | (`MustBool x, `MustBool y) -> `MustBool (x || y)
     | (`MayBool x, `MayBool y) -> `MayBool (x && y)
+    | (`PartAccessResult x, `PartAccessResult y) -> `PartAccessResult (PartAccessResult.narrow x y)
     | (x,_) -> x
 
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>%s\n</data>\n</value>\n" (Goblintutil.escape (short 800 x))

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -426,7 +426,6 @@ sig
   val val_of  : C.t -> D.t
   val context : D.t -> C.t
   val call_descr : fundec -> C.t -> string
-  val part_access: (D.t, G.t, C.t) ctx -> exp -> varinfo option -> bool -> (Access.LSSSet.t * Access.LSSet.t)
 
   val sync  : (D.t, G.t, C.t) ctx -> D.t * (varinfo * G.t) list
   val query : (D.t, G.t, C.t) ctx -> Queries.t -> Queries.Result.t
@@ -592,8 +591,4 @@ struct
 
   let val_of x = x
   (* Assume that context is same as local domain. *)
-
-  let part_access _ _ _ _ =
-    (Access.LSSSet.singleton (Access.LSSet.empty ()), Access.LSSet.empty ())
-    (* No partitioning on accesses and not locks *)
 end

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -80,9 +80,6 @@ struct
   let combine ctx r fe f args fc es =
     D.lift @@ S.combine (conv ctx) r fe f args fc (D.unlift es)
 
-  let part_access _ _ _ _ =
-    (Access.LSSSet.singleton (Access.LSSet.empty ()), Access.LSSet.empty ())
-
   let threadenter ctx lval f args =
     D.lift @@ S.threadenter (conv ctx) lval f args
 
@@ -162,9 +159,6 @@ struct
 
   let combine ctx r fe f args fc es =
     S.combine (conv ctx) r fe f args (C.unlift fc) es
-
-  let part_access _ _ _ _ =
-    (Access.LSSSet.singleton (Access.LSSet.empty ()), Access.LSSet.empty ())
 
   let threadenter ctx lval f args =
     S.threadenter (conv ctx) lval f args
@@ -290,9 +284,6 @@ struct
       else
         query' ctx (Queries.EvalFunvar e)
     | q -> query' ctx q
-
-  let part_access _ _ _ _ =
-    (Access.LSSSet.singleton (Access.LSSet.empty ()), Access.LSSet.empty ())
 end
 
 
@@ -394,9 +385,6 @@ struct
     S.enter (conv ctx) r f args |> List.map (fun (c,v) -> (c,m), d' v)
 
   let combine ctx r fe f args fc es = lift_fun ctx S.combine (fun p -> p r fe f args (fst fc) (fst es))
-
-  let part_access _ _ _ _ =
-    (Access.LSSSet.singleton (Access.LSSet.empty ()), Access.LSSet.empty ())
 end
 
 
@@ -509,9 +497,6 @@ struct
 
   let threadenter ctx lval f args = lift_fun ctx D.lift S.threadenter ((|>) args % (|>) f % (|>) lval) `Bot
   let threadspawn ctx lval f args fctx = lift_fun ctx D.lift S.threadspawn ((|>) (conv fctx) % (|>) args % (|>) f % (|>) lval) `Bot
-
-  let part_access _ _ _ _ =
-    (Access.LSSSet.singleton (Access.LSSet.empty ()), Access.LSSet.empty ())
 end
 
 module type Increment =
@@ -1050,9 +1035,6 @@ struct
     in
     let d = D.fold k d (D.bot ()) in
     if D.is_bot d then raise Deadcode else d
-
-  let part_access _ _ _ _ =
-    (Access.LSSSet.singleton (Access.LSSet.empty ()), Access.LSSet.empty ())
 end
 
 module Compare

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -447,7 +447,4 @@ struct
     in
     let d = Dom.fold k (fst d) (Dom.bot ()) in
     if Dom.is_bot d then raise Deadcode else (d, Sync.bot ())
-
-  let part_access _ _ _ _ =
-    (Access.LSSSet.singleton (Access.LSSet.empty ()), Access.LSSet.empty ())
 end

--- a/src/witness/witnessConstraints_deprecated.ml
+++ b/src/witness/witnessConstraints_deprecated.ml
@@ -96,7 +96,6 @@ struct
         ); *)
       split = (fun d e tv -> ctx.split (d, w) e tv)
     }
-  let part_access ctx = S.part_access (unlift_ctx ctx)
 
   let sync ctx =
     let (d, l) = S.sync (unlift_ctx ctx) in


### PR DESCRIPTION
This PR makes the following changes:
1. **Replaces the `part_access` transfer function with `PartAccess` query.**
    This simplifies the `Spec` signature and allows removing dummy `part_access` implementations from `Spec` lifting functors. Especially as anything outside of `MCP2` doesn't influence access partitioning anyway. The `meet` of the new query result is chosen to coincide with the old `part_access` combination logic in `MCP2`, giving exactly the same behavior.
2. **Moves access handling out of `MCP2`.**
    It doesn't need to be there at all and mutex analysis is a suitable place for it anyway, considering it is the one to invoke the `Access` queries in the first place.
3. **Removes `Access` query.**
    Since mutex analysis can directly partition accesses using `PartAccess` query, the `Access` query, which was previously used to signal `MCP2`, is now unnecessary.

It could be also argued that the whole accessing logic doesn't really belong to mutex analysis either and could be extracted out to a separate analysis, but I thought I won't go that far immediately.