### PR TITLE
Add a [-] option to constants from arrays in the configuration

### DIFF
--- a/src/util/gobConfig.ml
+++ b/src/util/gobConfig.ml
@@ -239,13 +239,13 @@ struct
         o := Array (ref (!a @ [ref (create_new v pth)]))      
       | Array a, Index (Rem, pth) ->
         let original_list = !a in 
+        let excluded_elem = create_new v pth in
         let filtered_list = 
           List.filter (fun ref_elem ->
             let elem = !ref_elem in
-            let excluded_elem = create_new v pth in
             match (elem, excluded_elem) with
             | (String s1, String s2) -> not (String.equal s1 s2)
-            | (_, _) -> false 
+            | (_, _) -> failwith "At the moment it's only possible to remove a string from an array."
             ) original_list in
         o := Array (ref filtered_list)
       | Array _, Index (New, pth) ->

--- a/src/util/gobConfig.ml
+++ b/src/util/gobConfig.ml
@@ -6,6 +6,7 @@
            | . <field-name> path'  (* field access *)
            | [ <index-nr> ] path'  (* array index access *)
            | [ + ] path'           (* cons to array *)
+           | [ - ] path'           (* cons away from array *)
            | [ * ] path'           (* reset array *)
 
   path ::==              path'     (*  *)
@@ -99,7 +100,8 @@ struct
 
   (** Type of the index *)
   type index = Int of int  (** and integer *)
-             | App        (** prepend to the list *)
+             | App         (** prepend to the list *)
+             | Rem         (** remove from the list *)
              | New         (** create a new list *)
 
   (** Type of the path *)
@@ -113,6 +115,7 @@ struct
     | Select (s,p)    -> fprintf ch ".%s%a"  s print_path' p
     | Index (Int i,p) -> fprintf ch "[%d]%a" i print_path' p
     | Index (App ,p) -> fprintf ch "[+]%a"    print_path' p
+    | Index (Rem ,p) -> fprintf ch "[-]%a"    print_path' p
     | Index (New  ,p) -> fprintf ch "[*]%a"    print_path' p
 
   (** Path printing where you can ignore the first dot. *)
@@ -138,6 +141,7 @@ struct
   let parse_index s =
     try if s = "+" then App
       else if s = "*" then New
+      else if s = "-" then Rem
       else Int (int_of_string s)
     with Failure _ -> raise PathParseError
 
@@ -232,7 +236,18 @@ struct
       | Array a, Index (Int i, pth) ->
         set_value v (List.at !a i) pth
       | Array a, Index (App, pth) ->
-        o := Array (ref (!a @ [ref (create_new v pth)]))
+        o := Array (ref (!a @ [ref (create_new v pth)]))      
+      | Array a, Index (Rem, pth) ->
+        let original_list = !a in 
+        let filtered_list = 
+          List.filter (fun ref_elem ->
+            let elem = !ref_elem in
+            let excluded_elem = create_new v pth in
+            match (elem, excluded_elem) with
+            | (String s1, String s2) -> not (String.equal s1 s2)
+            | (_, _) -> false 
+            ) original_list in
+        o := Array (ref filtered_list)
       | Array _, Index (New, pth) ->
         o := Array (ref [ref (create_new v pth)])
       | Null, _ ->


### PR DESCRIPTION
Until now, we had a [+] option to add a constant to the arrays in the configuration. For example to add an extra analysis to the default array of active analyses for a specific regression test. 

An option to remove a constant from an array would also be useful, so it's suggested by this pull request. It would be used like this:
_// PARAM: --set ana.activated[-] "'mallocWrapper'"_