### PR TITLE
Make known functions in unknown AD still reachable

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -441,12 +441,12 @@ struct
       match value with
       | `Top ->
         let typ = AD.get_type adr in
-        let warning = "Unknown value in " ^ AD.short 40 adr ^ " could be an escaped pointer address!" in
+        let warning = "Unknown value in " ^ AD.short 800 adr ^ " could be an escaped pointer address!" in
         if VD.is_immediate_type typ then () else M.warn_each warning; empty
       | `Bot -> (*M.debug "A bottom value when computing reachable addresses!";*) empty
       | `Address adrs when AD.is_top adrs ->
-        let warning = "Unknown address in " ^ AD.short 40 adr ^ " has escaped." in
-        M.warn_each warning; empty
+        let warning = "Unknown address in " ^ AD.short 800 adr ^ " has escaped." in
+        M.warn_each warning; adrs (* return known addresses still to be a bit more sane (but still unsound) *)
       (* The main thing is to track where pointers go: *)
       | `Address adrs -> adrs
       (* Unions are easy, I just ingore the type info. *)

--- a/tests/regression/02-base/46-spawn-global-funptrs.c
+++ b/tests/regression/02-base/46-spawn-global-funptrs.c
@@ -2,11 +2,11 @@
 #include <assert.h>
 
 void foo() {
-  assert(1);
+  assert(1); // assert reachable
 }
 
 void bar() {
-  assert(1);
+  assert(1); // assert reachable
 }
 
 void (*funs[2])() = {
@@ -14,19 +14,10 @@ void (*funs[2])() = {
   &bar
 };
 
-
 extern void magic1();
 extern void magic2(void (*funs[])());
 
-void *t_fun(void *arg) {
-  // just for going to multithreaded mode
-  return NULL;
-}
-
 int main() {
-  pthread_t id;
-  pthread_create(&id, NULL, t_fun, NULL); // enter multithreaded mode
-
   magic1(); // invalidate funs a bit
   magic2(funs);
   return 0;

--- a/tests/regression/02-base/46-spawn-global-funptrs.c
+++ b/tests/regression/02-base/46-spawn-global-funptrs.c
@@ -1,0 +1,33 @@
+#include <pthread.h>
+#include <assert.h>
+
+void foo() {
+  assert(1);
+}
+
+void bar() {
+  assert(1);
+}
+
+void (*funs[2])() = {
+  &foo,
+  &bar
+};
+
+
+extern void magic1();
+extern void magic2(void (*funs[])());
+
+void *t_fun(void *arg) {
+  // just for going to multithreaded mode
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL); // enter multithreaded mode
+
+  magic1(); // invalidate funs a bit
+  magic2(funs);
+  return 0;
+}


### PR DESCRIPTION
When determining reachable addresses, e.g. for the purpose of an `extern` unknown function spawning everything given as arguments as threads, there's the case of an unknown address. Previously if the set contained that, nothing was spawned at all! With this change, at least the known addresses would be spawned. Obviously this may still be technically unsound, but it's a bit closer to reasonable behavior.

Code-wise it's a very small change, but the impact might potentially be huge. Therefore instead of quietly changing this, I want to know if anyone sees a problem with this. Or has any idea, why this hasn't been the behavior to far.