### PR TITLE
Fix unsoundness when thread escape analysis is disabled 

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -19,7 +19,7 @@ module CArrays = ValueDomain.CArrays
 module BI = IntOps.BigIntOps
 
 let is_global (a: Q.ask) (v: varinfo): bool =
-  v.vglob || match a (Q.MayEscape v) with `MayBool tv -> tv | _ -> false
+  v.vglob || ThreadEscape.has_escaped a v
 
 let is_static (v:varinfo): bool = v.vstorage == Static
 

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -6,12 +6,16 @@ open Analyses
 module M = Messages
 
 let has_escaped (ask: Queries.ask) (v: varinfo): bool =
-  match ask (Queries.MayEscape v) with
-  | `MayBool b -> b
-  | `Top ->
-    M.warn "Without thread escape analysis all variables are considered escaped, i.e. global";
-    true
-  | _ -> failwith "ThreadEscape.has_escaped"
+  assert (not v.vglob);
+  if not v.vaddrof then
+    false (* Cannot have escaped without taking address. Override provides extra precision for degenerate ask in base eval_exp used for partitioned arrays. *)
+  else
+    match ask (Queries.MayEscape v) with
+    | `MayBool b -> b
+    | `Top ->
+      M.warn "Without thread escape analysis all variables are considered escaped, i.e. global";
+      true
+    | _ -> failwith "ThreadEscape.has_escaped"
 
 
 module Spec =

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -5,6 +5,15 @@ open Analyses
 
 module M = Messages
 
+let has_escaped (ask: Queries.ask) (v: varinfo): bool =
+  match ask (Queries.MayEscape v) with
+  | `MayBool b -> b
+  | `Top ->
+    M.warn "Without thread escape analysis all variables are considered escaped, i.e. global";
+    true
+  | _ -> failwith "ThreadEscape.has_escaped"
+
+
 module Spec =
 struct
   include Analyses.DefaultSpec

--- a/tests/regression/02-base/09-ambigpointer.c
+++ b/tests/regression/02-base/09-ambigpointer.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','mallocWrapper']"
+// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mallocWrapper']"
 #include<pthread.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/47-no-threadescape.c
+++ b/tests/regression/02-base/47-no-threadescape.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','mallocWrapper','threadflag']"
+// PARAM: --sets ana.activated[-] escape
 #include <pthread.h>
 int g = 10;
 

--- a/tests/regression/02-base/47-no-threadescape.c
+++ b/tests/regression/02-base/47-no-threadescape.c
@@ -1,0 +1,20 @@
+// PARAM: --set ana.activated "['base','mallocWrapper','threadflag']"
+#include <pthread.h>
+int g = 10;
+
+void* t(void *v) {
+  int* p = (int*) v;
+  *p = 4711;
+}
+
+
+int main(void){
+  int l = 42;
+
+  pthread_t tid;
+  pthread_create(&tid, NULL, t, (void *)&l);
+  pthread_join(tid, NULL);
+
+  assert(l==42); //UNKNOWN!
+  return 0;
+}

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 int global;
 
 int main(void)

--- a/tests/regression/22-partitioned_arrays/02-pointers_array.c
+++ b/tests/regression/22-partitioned_arrays/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
+++ b/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
+++ b/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
+++ b/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/22-partitioned_arrays/06-interprocedural.c
+++ b/tests/regression/22-partitioned_arrays/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 int main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/10-array_octagon.c
+++ b/tests/regression/22-partitioned_arrays/10-array_octagon.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','octagon','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','octagon','mallocWrapper']"
 void main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 int global;
 
 int main(void)

--- a/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
+++ b/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
+++ b/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
+++ b/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 int main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/10-array_octagon.c
+++ b/tests/regression/23-partitioned_arrays_last/10-array_octagon.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','expRelation','octagon','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --sets exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','octagon','mallocWrapper']"
 void main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
+++ b/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval  --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.enabled --set ana.activated "['base','threadid','threadflag','expRelation','octagon','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval  --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.enabled --set ana.activated "['base','threadid','threadflag','escape','expRelation','octagon','mallocWrapper']"
 void main(void) {
   example1();
 }

--- a/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
+++ b/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled --sets exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 int main(void) {
   example1();
 }

--- a/tests/regression/25-vla/02-loop.c
+++ b/tests/regression/25-vla/02-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+// PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 int main(void)
 {
   example1();

--- a/tests/regression/25-vla/04-passing_ptr_to_array.c
+++ b/tests/regression/25-vla/04-passing_ptr_to_array.c
@@ -1,4 +1,4 @@
-//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 
 void foo(int (*a)[40]){
     int x = (*(a + 29))[7];

--- a/tests/regression/25-vla/05-more_passing.c
+++ b/tests/regression/25-vla/05-more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 # include<stdio.h>
 
 void foo(int n, int a[n]) {

--- a/tests/regression/25-vla/06-even_more_passing.c
+++ b/tests/regression/25-vla/06-even_more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']"
+//PARAM: --sets solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']"
 
 void foo2(int n , int (*a)[n] )
 {

--- a/tests/regression/31-ikind-aware-ints/04-ptrdiff.c
+++ b/tests/regression/31-ikind-aware-ints/04-ptrdiff.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --enable exp.partition-arrays.enabled --set ana.activated "['base', 'mallocWrapper', 'expRelation', 'var_eq']"
+// PARAM: --enable ana.int.interval --enable exp.partition-arrays.enabled --set ana.activated "['base', 'mallocWrapper', 'escape', 'expRelation', 'var_eq']"
 int *tmp;
 
 int main ()


### PR DESCRIPTION
It was discovered during the review of #183 that `is_global` handles escaped local variables unsoundly when escape analysis is disabled: https://github.com/goblint/analyzer/pull/183#pullrequestreview-638795674.

The fix attempts from there have been cherry-picked to this PR, since some things seem to rely on this unsound behavior. Probably within degenerate `ctx`s.