### PR TITLE
add option exp.no-globals-context

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -373,7 +373,12 @@ struct
             | x -> (if M.tracing then M.tracec "get" "Using privatized version.\n"; x)
           else begin
             if M.tracing then M.tracec "get" "Singlethreaded mode.\n";
-            CPA.find x st
+            (* assert (CPA.mem x st); *)
+            if not (CPA.mem x st) then (
+              ignore @@ Pretty.eprintf "Base.get Not_found (bot) for %a\n" Basetype.Variables.pretty x;
+              `Top
+            ) else
+              CPA.find x st
           end
         in
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -523,6 +523,8 @@ struct
 
   let drop_interval = CPA.map (function `Int x -> `Int (ID.no_interval x) | x -> x)
 
+  let drop_globals = CPA.filter (fun k v -> neg V.is_global k)
+
   let context (cpa,dep) =
     let f t f (cpa,dep) = if t then f cpa, dep else cpa, dep in
     (cpa,dep) |>
@@ -530,6 +532,7 @@ struct
     %> f (get_bool "exp.addr-context") drop_non_ptrs
     %> f (get_bool "exp.no-int-context") drop_ints
     %> f (get_bool "exp.no-interval-context") drop_interval
+    %> f (get_bool "exp.no-globals-context") drop_globals
 
   let context_cpa (cpa,dep) = fst @@ context (cpa,dep)
 

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -154,6 +154,7 @@ let _ = ()
       ; reg Experimental "exp.addr-context"      "false" "Ignore non-address values in function contexts."
       ; reg Experimental "exp.no-int-context"    "false" "Ignore all integer values in function contexts."
       ; reg Experimental "exp.no-interval-context" "false" "Ignore integer values of the Interval domain in function contexts."
+      ; reg Experimental "exp.no-globals-context" "false" "Ignore global variables in function contexts."
       ; reg Experimental "exp.malloc.fail"       "false" "Consider the case where malloc or calloc fails."
       ; reg Experimental "exp.malloc.wrappers"   "['kmalloc','__kmalloc','usb_alloc_urb','__builtin_alloca','kzalloc']"  "Loads a list of known malloc wrapper functions." (* When something new that maps to malloc or calloc is added to libraryFunctions.ml, it should also be added here.*)
       ; reg Experimental "exp.volatiles_are_top" "true"  "volatile and extern keywords set variables permanently to top"


### PR DESCRIPTION
For `base` this removes globals from `CPA` in `context`.
Since `exp.earlyglobs` is still convoluted (#177), this is a simpler option to reason about and similar to the `no-*-context` we already have.

For `exp.full-context` this is still unsound since `Base.get` will result in `Bot` if no global invariant is used.