### PR TITLE
Use variant type group in `MapDomain.Groupable` with `deriving show`

### DIFF
--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -82,8 +82,8 @@ struct
   let pretty_f sf () x = Pretty.text (sf max_int x)
   let pretty_trace () x = Pretty.dprintf "%s on %a" x.vname ProgLines.pretty x.vdecl
   let get_location x = x.vdecl
-  type group = Temp | Local | Global | Context | Parameter [@@deriving show { with_path = false }, enum]
-  let to_group = function
+  type group = Global | Local | Context | Parameter | Temp [@@deriving show { with_path = false }]
+  let to_group = Option.some @@ function
     | x when x.vglob -> Global
     | x when x.vdecl.line = -1 -> Temp
     | x when x.vdecl.line = -3 -> Parameter
@@ -120,7 +120,7 @@ struct
   let pretty_f sf () x = Pretty.text (sf max_int x)
   let pretty_trace () (x,s) = Pretty.dprintf "%s on %a" x.vname ProgLines.pretty x.vdecl
   let get_location (x,s) = x.vdecl
-  let to_group (x,sx) = match sx with Context -> Variables.Context | _ -> Variables.to_group x
+  let to_group (x,sx) = Option.some @@ match sx with Context -> Variables.Context | _ -> Option.get Variables.to_group x
   let pretty () x = pretty_f short () x
   let name () = "variables"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
@@ -512,7 +512,7 @@ struct
     Pretty.dprintf "%s on %a" name ProgLines.pretty (get_var x).vdecl
 
   let get_location x = (get_var x).vdecl
-  let to_group x = Variables.to_group (get_var x)
+  let to_group x = Option.get Variables.to_group (get_var x)
 
   let pretty () x = pretty_f short () x
   let name () = "variables and fields"

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -83,7 +83,8 @@ struct
   let pretty_trace () x = Pretty.dprintf "%s on %a" x.vname ProgLines.pretty x.vdecl
   let get_location x = x.vdecl
   type group = Global | Local | Context | Parameter | Temp [@@deriving show { with_path = false }]
-  let to_group = Option.some @@ function
+  let (%) = Batteries.(%)
+  let to_group = Option.some % function
     | x when x.vglob -> Global
     | x when x.vdecl.line = -1 -> Temp
     | x when x.vdecl.line = -3 -> Parameter
@@ -120,7 +121,7 @@ struct
   let pretty_f sf () x = Pretty.text (sf max_int x)
   let pretty_trace () (x,s) = Pretty.dprintf "%s on %a" x.vname ProgLines.pretty x.vdecl
   let get_location (x,s) = x.vdecl
-  let to_group (x,sx) = Option.some @@ match sx with Context -> Variables.Context | _ -> Option.get Variables.to_group x
+  let to_group (x,sx) = Option.some @@ match sx with Context -> Some Variables.Context | _ -> Variables.to_group x
   let pretty () x = pretty_f short () x
   let name () = "variables"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
@@ -512,7 +513,7 @@ struct
     Pretty.dprintf "%s on %a" name ProgLines.pretty (get_var x).vdecl
 
   let get_location x = (get_var x).vdecl
-  let to_group x = Option.get Variables.to_group (get_var x)
+  let to_group x = Variables.to_group (get_var x)
 
   let pretty () x = pretty_f short () x
   let name () = "variables and fields"

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -82,7 +82,7 @@ struct
   let pretty_f sf () x = Pretty.text (sf max_int x)
   let pretty_trace () x = Pretty.dprintf "%s on %a" x.vname ProgLines.pretty x.vdecl
   let get_location x = x.vdecl
-  type group = Temp | Local | Global | Context | Parameter [@@deriving show, enum]
+  type group = Temp | Local | Global | Context | Parameter [@@deriving show { with_path = false }, enum]
   let to_group = function
     | x when x.vglob -> Global
     | x when x.vdecl.line = -1 -> Temp

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -82,19 +82,13 @@ struct
   let pretty_f sf () x = Pretty.text (sf max_int x)
   let pretty_trace () x = Pretty.dprintf "%s on %a" x.vname ProgLines.pretty x.vdecl
   let get_location x = x.vdecl
-  let classify x = match x with
-    | x when x.vglob -> 2
-    | x when x.vdecl.line = -1 -> -1
-    | x when x.vdecl.line = -3 -> 5
-    | x when x.vdecl.line = -4 -> 4
-    | _ -> 1
-  let class_name n = match n with
-    |  1 -> "Local"
-    |  2 -> "Global"
-    |  4 -> "Context"
-    |  5 -> "Parameter"
-    | -1 -> "Temp"
-    |  _ -> "None"
+  type group = Temp | Local | Global | Context | Parameter [@@deriving show, enum]
+  let to_group = function
+    | x when x.vglob -> Global
+    | x when x.vdecl.line = -1 -> Temp
+    | x when x.vdecl.line = -3 -> Parameter
+    | x when x.vdecl.line = -4 -> Context
+    | _ -> Local
   let pretty () x = pretty_f short () x
   let name () = "variables"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
@@ -126,8 +120,7 @@ struct
   let pretty_f sf () x = Pretty.text (sf max_int x)
   let pretty_trace () (x,s) = Pretty.dprintf "%s on %a" x.vname ProgLines.pretty x.vdecl
   let get_location (x,s) = x.vdecl
-  let classify (x,sx) = match sx with Context -> 4 | _ -> Variables.classify x
-  let class_name = Variables.class_name
+  let to_group (x,sx) = match sx with Context -> Variables.Context | _ -> Variables.to_group x
   let pretty () x = pretty_f short () x
   let name () = "variables"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
@@ -519,8 +512,7 @@ struct
     Pretty.dprintf "%s on %a" name ProgLines.pretty (get_var x).vdecl
 
   let get_location x = (get_var x).vdecl
-  let classify x = Variables.classify (get_var x)
-  let class_name = Variables.class_name
+  let to_group x = Variables.to_group (get_var x)
 
   let pretty () x = pretty_f short () x
   let name () = "variables and fields"

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -188,9 +188,9 @@ struct
 
   type group = Basetype.Variables.group
   let show_group = Basetype.Variables.show_group
-  let to_group = Option.some @@ function
-    | Addr (x,_) -> Option.get Basetype.Variables.to_group x
-    | _ -> Basetype.Variables.Local
+  let to_group = function
+    | Addr (x,_) -> Basetype.Variables.to_group x
+    | _ -> Some Basetype.Variables.Local
 
   let from_var x = Addr (x, `NoOffset)
   let from_var_offset x = Addr x

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -150,8 +150,6 @@ sig
   val str_ptr: unit -> t
   val is_null: t -> bool
   val get_location: t -> location
-  val classify: t -> int
-  val class_name: int -> string
 
   val from_var: varinfo -> t
   (** Creates an address from variable. *)
@@ -188,11 +186,11 @@ struct
     | Addr (x,_) -> x.vdecl
     | _ -> builtinLoc
 
-  let classify = function
-    | Addr (x,_) -> Basetype.Variables.classify x
-    | _ -> 1
-
-  let class_name = Basetype.Variables.class_name
+  type group = Basetype.Variables.group
+  let show_group, group_to_enum, group_of_enum = Basetype.Variables.(show_group, group_to_enum, group_of_enum)
+  let to_group = function
+    | Addr (x,_) -> Basetype.Variables.to_group x
+    | _ -> Basetype.Variables.Local
 
   let from_var x = Addr (x, `NoOffset)
   let from_var_offset x = Addr x

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -187,9 +187,9 @@ struct
     | _ -> builtinLoc
 
   type group = Basetype.Variables.group
-  let show_group, group_to_enum, group_of_enum = Basetype.Variables.(show_group, group_to_enum, group_of_enum)
-  let to_group = function
-    | Addr (x,_) -> Basetype.Variables.to_group x
+  let show_group = Basetype.Variables.show_group
+  let to_group = Option.some @@ function
+    | Addr (x,_) -> Option.get Basetype.Variables.to_group x
     | _ -> Basetype.Variables.Local
 
   let from_var x = Addr (x, `NoOffset)

--- a/src/cdomains/shapeDomain.ml
+++ b/src/cdomains/shapeDomain.ml
@@ -31,9 +31,9 @@ struct
   let pretty = pretty_f short
 
   type group = Variables | Values [@@deriving show { with_path = false }]
-  let to_group = Option.some @@ function
-    | `Left  v -> Variables
-    | `Right v -> Values
+  let to_group = function
+    | `Left  v -> Some Variables
+    | `Right v -> Some Values
   let isSimple _ = true
 end
 

--- a/src/cdomains/shapeDomain.ml
+++ b/src/cdomains/shapeDomain.ml
@@ -30,13 +30,10 @@ struct
 
   let pretty = pretty_f short
 
-  let classify = function
-    | `Left  v -> 1
-    | `Right v -> 2
-  let class_name = function
-    | 1 -> "Variables"
-    | 2 -> "Values"
-    | _ -> "Sadness"
+  type group = Variables | Values [@@deriving show, enum]
+  let to_group = function
+    | `Left  v -> Variables
+    | `Right v -> Values
   let isSimple _ = true
 end
 

--- a/src/cdomains/shapeDomain.ml
+++ b/src/cdomains/shapeDomain.ml
@@ -30,7 +30,7 @@ struct
 
   let pretty = pretty_f short
 
-  type group = Variables | Values [@@deriving show, enum]
+  type group = Variables | Values [@@deriving show { with_path = false }, enum]
   let to_group = function
     | `Left  v -> Variables
     | `Right v -> Values

--- a/src/cdomains/shapeDomain.ml
+++ b/src/cdomains/shapeDomain.ml
@@ -30,8 +30,8 @@ struct
 
   let pretty = pretty_f short
 
-  type group = Variables | Values [@@deriving show { with_path = false }, enum]
-  let to_group = function
+  type group = Variables | Values [@@deriving show { with_path = false }]
+  let to_group = Option.some @@ function
     | `Left  v -> Variables
     | `Right v -> Values
   let isSimple _ = true

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -162,7 +162,7 @@ struct
     let pretty_group  map () = fold f map nil in
     let pretty_groups rest map =
       match (fst map) with
-      | 0 ->  rest ++ pretty_group (snd map) ()
+      | -1 ->  rest ++ pretty_group (snd map) ()
       | a -> rest ++ dprintf "@[%t {\n  @[%t@]}@]\n" (group_name (Domain.group_of_enum a |> Option.get)) (pretty_group (snd map)) in
     let content () = List.fold_left pretty_groups nil groups in
     dprintf "@[%s {\n  @[%t@]}@]" (short 60 mapping) content

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -58,7 +58,7 @@ end
 module type Groupable =
 sig
   include Printable.S
-  type group (* use [@@deriving show, enum] *)
+  type group (* use [@@deriving show { with_path = false }, enum] *)
   val show_group: group -> string
   val group_to_enum: group -> int
   val group_of_enum: int -> group option

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -63,7 +63,7 @@ sig
   val group_to_enum: group -> int
   val group_of_enum: int -> group option
   val to_group: t -> group
-  val trace_enabled: bool
+  val trace_enabled: bool (* Just a global hack for tracing individual variables. *)
 end
 
 module PMap (Domain: Groupable) (Range: Lattice.S) : PS with

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -60,7 +60,7 @@ sig
   include Printable.S
   type group (* use [@@deriving show { with_path = false }] *)
   val show_group: group -> string
-  val to_group: (t -> group) option
+  val to_group: t -> group option
   val trace_enabled: bool (* Just a global hack for tracing individual variables. *)
 end
 
@@ -142,8 +142,7 @@ struct
   let pretty_f short () mapping =
     let groups =
       let h = Hashtbl.create 13 in
-      let opt_apply k = Option.bind Domain.to_group (fun to_group -> Some (to_group k)) in
-      iter (fun k v -> BatHashtbl.modify_def M.empty (opt_apply k) (M.add k v) h) mapping;
+      iter (fun k v -> BatHashtbl.modify_def M.empty (Domain.to_group k) (M.add k v) h) mapping;
       let cmpBy f a b = Stdlib.compare (f a) (f b) in
       (* sort groups (order of constructors in type group)  *)
       BatHashtbl.to_list h |> List.sort (cmpBy fst)
@@ -166,6 +165,9 @@ struct
     dprintf "@[%s {\n  @[%t@]}@]" (short 60 mapping) content
 
   let pretty () x = pretty_f short () x
+
+  (* uncomment to easily check pretty's grouping during a normal run, e.g. ./regtest 01 01: *)
+  (* let add k v m = let _ = Pretty.printf "%a\n" pretty m in M.add k v m *)
 
   let pretty_diff () ((x:t),(y:t)): Pretty.doc =
     Pretty.dprintf "PMap: %a not leq %a" pretty x pretty y

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -66,14 +66,6 @@ sig
   val trace_enabled: bool
 end
 
-module StripClasses (G: Groupable) =
-struct
-  include G
-  let to_group _ = 0
-end
-
-(* Just a global hack for tracing individual variables. *)
-
 module PMap (Domain: Groupable) (Range: Lattice.S) : PS with
   type key = Domain.t and
   type value = Range.t =

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -40,10 +40,16 @@ module Std =
 struct
   (*  let equal = Util.equals
       let hash = Hashtbl.hash*)
-  let classify _ = 0
-  let class_name _ = "None"
   let name () = "std"
+
+  (* start MapDomain.Groupable *)
+  type group = unit
+  let show_group () = "None"
+  let group_to_enum () = 0
+  let group_of_enum _ = Some () (* None would not lead to type error if we forgot to override *)
+  let to_group _ = ()
   let trace_enabled = false
+  (* end MapDomain.Groupable *)
 
   let invariant _ _ = Invariant.none
   let tag _ = failwith "Std: no tag"

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -43,9 +43,9 @@ struct
   let name () = "std"
 
   (* start MapDomain.Groupable *)
-  type group = unit
-  let show_group () = "None"
-  let to_group = None
+  type group = |
+  let show_group (x: group)= match x with _ -> .
+  let to_group _ = None
   let trace_enabled = false
   (* end MapDomain.Groupable *)
 

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -45,9 +45,7 @@ struct
   (* start MapDomain.Groupable *)
   type group = unit
   let show_group () = "None"
-  let group_to_enum () = -1
-  let group_of_enum _ = Some () (* None would not lead to type error if we forgot to override *)
-  let to_group _ = ()
+  let to_group = None
   let trace_enabled = false
   (* end MapDomain.Groupable *)
 

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -45,7 +45,7 @@ struct
   (* start MapDomain.Groupable *)
   type group = unit
   let show_group () = "None"
-  let group_to_enum () = 0
+  let group_to_enum () = -1
   let group_of_enum _ = Some () (* None would not lead to type error if we forgot to override *)
   let to_group _ = ()
   let trace_enabled = false


### PR DESCRIPTION
Follow up of comments in https://github.com/goblint/analyzer/commit/0d818dcf34b1630812d1e8ee9ca90ab21f506921.
Instead of `int` this uses a `type group` with [ppx_deriving](https://github.com/ocaml-ppx/ppx_deriving).

Old:
~~~ocaml
let classify x = match x with
  | x when x.vglob -> 2
  | x when x.vdecl.line = -1 -> -1
  | x when x.vdecl.line = -3 -> 5
  | x when x.vdecl.line = -4 -> 4
  | _ -> 1
let class_name n = match n with
  |  1 -> "Local"
  |  2 -> "Global"
  |  4 -> "Context"
  |  5 -> "Parameter"
  | -1 -> "Temp"
  |  _ -> "None"
~~~
New:
~~~ocaml
type group = Temp | Local | Global | Context | Parameter [@@deriving show { with_path = false }]
let to_group = Option.some @@ function
  | x when x.vglob -> Global
  | x when x.vdecl.line = -1 -> Temp
  | x when x.vdecl.line = -3 -> Parameter
  | x when x.vdecl.line = -4 -> Context
  | _ -> Local
~~~

Since it's in `Groupable`, I got rid of the `class*` names. Also, easier to search for `to_group` since there are many `LibraryFunctions.classify` which have nothing to do with this.

Tests pass, but I don't know if this changed some output in a wrong way.
I assume in the worst case, some things might not be grouped anymore.
However, with `include Printable.Std` it should complain if something is only overridden partially.