### PR TITLE
Fix witness generation and HoareMap

### DIFF
--- a/src/domains/domainProperties.ml
+++ b/src/domains/domainProperties.ml
@@ -117,7 +117,14 @@ struct
   include DomainTest (D)
 
   (* TODO: remove this hack *)
-  let has_top = try ignore (D.top ()); true with Failure _ -> false
+  let has_top =
+    try
+      ignore (D.top ());
+      true
+    with
+      | Failure _ (* raised by IntDomain *)
+      | Lattice.Unsupported _ (* raised by MapDomain *) ->
+        false
 
   let top_leq = make ~name:"top leq" (arb) (fun a ->
       assume has_top;

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -948,8 +948,6 @@ module GlobSolverFromIneqSolver (Sol:GenericIneqBoxSolver)
         (l', g')
     end
 
-(* TODO: remove unnecessary *)
-module N = struct let topname = "Top" end
 
 (** Add path sensitivity to a analysis *)
 module PathSensitive2 (Spec:Spec)

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -948,19 +948,20 @@ module GlobSolverFromIneqSolver (Sol:GenericIneqBoxSolver)
         (l', g')
     end
 
+(* TODO: remove unnecessary *)
 module N = struct let topname = "Top" end
 
 (** Add path sensitivity to a analysis *)
 module PathSensitive2 (Spec:Spec)
   : Spec
-    with type D.t = SetDomain.Hoare(Spec.D)(N).t
+    with type D.t = SetDomain.Hoare_NoTop(Spec.D).t
      and module G = Spec.G
      and module C = Spec.C
 =
 struct
   module D =
   struct
-    include SetDomain.Hoare (Spec.D) (N) (* TODO is it really worth it to check every time instead of just using sets and joining later? *)
+    include SetDomain.Hoare_NoTop (Spec.D) (* TODO is it really worth it to check every time instead of just using sets and joining later? *)
     let name () = "PathSensitive (" ^ name () ^ ")"
 
     let pretty_diff () ((s1:t),(s2:t)): Pretty.doc =

--- a/src/maindomaintest.ml
+++ b/src/maindomaintest.ml
@@ -46,6 +46,7 @@ module ArbitraryLattice = FiniteSet (PrintableChar) (
 )
 
 module HoareArbitrary = SetDomain.Hoare (ArbitraryLattice) (struct let topname = "Top" end)
+module HoareArbitrary_NoTop = SetDomain.Hoare_NoTop (ArbitraryLattice)
 
 let domains: (module Lattice.S) list = [
   (* (module IntDomainProperties.IntegerSet); (* TODO: top properties error *) *)
@@ -60,8 +61,9 @@ let domains: (module Lattice.S) list = [
 
   (module ArbitraryLattice);
   (module HoareArbitrary);
-  (* TODO: fix after traces *)
-  (* (module WitnessConstraints.HoareMap (ArbitraryLattice) (HoareArbitrary)) *)
+  (module HoareArbitrary_NoTop);
+  (module WitnessConstraints.HoareMap (ArbitraryLattice) (HoareArbitrary));
+  (module WitnessConstraints.HoareMap (ArbitraryLattice) (HoareArbitrary_NoTop));
 ]
 
 let nonAssocDomains: (module Lattice.S) list = []

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -79,7 +79,12 @@ let createCFG (fileAST: file) =
   (* exp.basic-blocks. This does not matter, as we will not run any analysis anyway, when justcil is enabled.         *)
   if not (get_bool "exp.basic-blocks") && not (get_bool "justcil") then end_basic_blocks fileAST;
   (* Partial.calls_end_basic_blocks fileAST; *)
-  Partial.globally_unique_vids fileAST;
+
+  (* We used to renumber vids but CIL already generates them fresh, so no need.
+   * Renumbering is problematic for using [Cabs2cil.environment], e.g. in witness invariant generation to use original variable names.
+   * See https://github.com/goblint/cil/issues/31#issuecomment-824939793. *)
+  (* Partial.globally_unique_vids fileAST; *)
+
   iterGlobals fileAST (fun glob ->
       match glob with
       | GFun(fd,_) ->

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -192,11 +192,12 @@ struct
         try
           let p t tr = not (mem t tr s2) in
           let (evil, evilr) = choose' (filter' p s1) in
-          let (other, otherr) = choose' s2 in
-          (* dprintf "%s has a problem with %a not leq %a because %a" (name ())
-             Spec.D.pretty evil Spec.D.pretty other
-             Spec.D.pretty_diff (evil,other) *)
-          Spec.D.pretty_diff () (evil,other)
+          let evilr' = R.choose evilr in
+          dprintf "%a -> %a:\n" Spec.D.pretty evil VIEB.pretty evilr'
+          ++
+          fold' (fun other otherr acc ->
+              (dprintf "not leq %a because %a\nand not mem %a because %a\n" Spec.D.pretty other Spec.D.pretty_diff (evil, other) R.pretty otherr R.pretty_diff (R.singleton evilr', otherr)) ++ acc
+            ) s2 nil
         with _ ->
           dprintf "choose failed b/c of empty set s1: %d s2: %d"
           (cardinal s1)

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -177,7 +177,7 @@ struct
   (* Bot is needed for Hoare widen *)
   (* TODO: could possibly rewrite Hoare to avoid introducing bots in widen which get reduced away anyway? *)
   module VIEB = Lattice.LiftBot (VIE)
-  module VIES = SetDomain.Hoare (VIEB) (struct let topname = "VIES top" end)
+  module VIES = SetDomain.Hoare_NoTop (VIEB)
 
   module R = VIES
 
@@ -242,7 +242,7 @@ struct
   (* Additional dependencies component between values before and after sync.
    * This is required because some analyses (e.g. region) do sideg through local domain diff and sync.
    * sync is automatically applied in FromSpec before any transition, so previous values may change (diff is flushed). *)
-  module SyncSet = SetDomain.Hoare (Spec.D) (struct let topname = "Sync Hoare top" end)
+  module SyncSet = SetDomain.Hoare_NoTop (Spec.D)
   module Sync = HoareMap (Spec.D) (SyncSet)
   module D =
   struct

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -60,16 +60,9 @@ struct
     include Printable.Std
     include SpecD
   end
-  module MM = MapDomain.MapBot_LiftTop (SpecDGroupable) (R)
-  include MM
+  include MapDomain.MapBot (SpecDGroupable) (R)
 
   (* TODO: get rid of these value-ignoring set-mimicing hacks *)
-  (* let cardinal (s: t): int = match s with
-    | `Top -> failwith "cardinal"
-    | `Lifted s -> M.lift_f M.M.cardinal s *)
-  (* let choose' (s: t) = match s with
-    | `Top -> failwith "choose"
-    | `Lifted s -> M.lift_f M.M.choose s *)
   let choose' = choose
   let choose (s: t): SpecD.t = fst (choose' s)
   let filter' = filter
@@ -80,70 +73,26 @@ struct
   let for_all (p: key -> bool) (s: t): bool = for_all (fun x _ -> p x) s
   let fold' = fold
   let fold (f: key -> 'a -> 'a) (s: t) (acc: 'a): 'a = fold (fun x _ acc -> f x acc) s acc
-  (* let singleton (x: key) (r: R.t): t = `Lifted (M.lift @@ M.M.singleton x r) *)
-  (* let empty (): t = `Lifted (M.lift @@ M.M.empty) *)
-  (* let add (x: key) (r: R.t) (s: t): t = match s with
-    | `Top -> `Top
-    | `Lifted s -> `Lifted (M.lift_f' (M.M.add x (R.join r (M.find x s))) s) *)
-  let add (x: key) (r: R.t) (s: t): t = add x (R.join r (find x s)) s (* TODO: is this the same? *)
-  (* let map (f: key -> key) (s: t): t = match s with
-    | `Top -> `Top
-    | `Lifted s -> `Lifted (M.fold (fun x v acc -> M.lift_f' (M.M.add (f x) (R.join v (M.find (f x) acc))) acc) s (M.lift @@ M.M.empty)) *)
-  let map (f: key -> key) (s: t): t = fold' (fun x v acc -> add (f x) v acc) s (empty ()) (* TODO: is this the same? *)
+  let add (x: key) (r: R.t) (s: t): t = add x (R.join r (find x s)) s
+  let map (f: key -> key) (s: t): t = fold' (fun x v acc -> add (f x) v acc) s (empty ())
   let map' = map (* HACK: for PathSensitive morphstate *)
   (* TODO: reducing map, like HoareSet *)
 
   module S =
   struct
-    (* let exists (p: key -> bool) (s: M.t): bool = M.lift_f (M.M.exists (fun x _ -> p x)) s *)
     let exists (p: key -> bool) (s: t): bool = exists (fun x _ -> p x) s
-    (* let filter (p: key -> bool) (s: M.t): M.t = M.lift_f' (M.M.filter (fun x _ -> p x)) s *)
     let filter (p: key -> bool) (s: t): t = filter' (fun x _ -> p x) s
-    (* let elements (s: M.t): (key * R.t) list = M.lift_f M.M.bindings s *)
     let elements (s: t): (key * R.t) list = bindings s
-    (* let of_list (l: (key * R.t) list): M.t = List.fold_left (fun acc (x, r) -> M.lift_f' (M.M.add x (R.join r (M.find x acc))) acc) (M.lift @@ M.M.empty) l *)
     let of_list (l: (key * R.t) list): t = List.fold_left (fun acc (x, r) -> add x r acc) (empty ()) l
     let union = long_map2 R.union
   end
 
 
-  (* copied & modified from SetDomain.Hoare *)
-  (* let mem x xr = function
-    | `Top -> true
-    (* | `Lifted s -> S.exists (Spec.D.leq x) s *)
-    (* exists check per previous VIE.t in R.t *)
-    (* seems to be necessary for correct ARG but why? *)
-    (* | `Lifted s -> R.for_all (fun vie -> M.M.exists (fun y yr -> Spec.D.leq x y && R.mem vie yr) s) xr *)
-    (* | `Lifted s -> R.for_all (fun vie -> M.M.exists (fun y yr -> Spec.D.leq x y && R.exists (fun vie' -> VIE.leq vie vie') yr) s) xr *)
-    | `Lifted s -> R.for_all (fun vie -> M.lift_f (M.M.exists (fun y yr -> SpecD.leq x y && R.mem vie yr)) s) xr *)
+  (* copied & modified from SetDomain.Hoare_NoTop *)
   let mem x xr s = R.for_all (fun vie -> exists (fun y yr -> SpecD.leq x y && R.mem vie yr) s) xr
-  (* let leq a b =
-    match a with
-    | `Top -> b = `Top
-    | _ -> for_all' (fun x xr -> mem x xr b) a (* mem uses B.leq! *) *)
   let leq a b = for_all' (fun x xr -> mem x xr b) a (* mem uses B.leq! *)
 
   let le x y = SpecD.leq x y && not (SpecD.equal x y) && not (SpecD.leq y x)
-  (* let reduce = function
-    | `Top -> `Top
-    | `Lifted s -> `Lifted (S.filter (fun x -> not (S.exists (le x) s) && not (SpecD.is_bot x)) s) *)
-  (* let reduce: t -> t = function
-    | `Top -> `Top
-    | `Lifted s ->
-      (* get map with just maximal keys and their ranges *)
-      let maximals = S.filter (fun x -> not (S.exists (le x) s) && not (SpecD.is_bot x)) s in
-      (* join le ranges also *)
-      let maximals =
-        M.mapi (fun x xr ->
-            M.fold (fun y yr acc ->
-                if le y x then
-                  R.join acc yr
-                else
-                  acc
-              ) s xr
-          ) maximals
-      in
-      `Lifted maximals *)
   let reduce (s: t): t =
     (* get map with just maximal keys and their ranges *)
     let maximals = S.filter (fun x -> not (S.exists (le x) s) && not (SpecD.is_bot x)) s in
@@ -159,29 +108,14 @@ struct
         ) maximals
     in
     maximals
-  (* let product_bot op op2 a b = match a,b with
-    | `Top, a | a, `Top -> a
-    | `Lifted a, `Lifted b ->
-      let a,b = S.elements a, S.elements b in
-      List.map (fun (x,xr) -> List.map (fun (y,yr) -> (op x y, op2 xr yr)) b) a |> List.flatten |> fun x -> reduce (`Lifted (S.of_list x)) *)
   let product_bot op op2 a b =
     let a,b = S.elements a, S.elements b in
     List.map (fun (x,xr) -> List.map (fun (y,yr) -> (op x y, op2 xr yr)) b) a |> List.flatten |> fun x -> reduce (S.of_list x)
-  (* let product_bot2 op2 a b = match a,b with
-    | `Top, a | a, `Top -> a
-    | `Lifted a, `Lifted b ->
-      let a,b = S.elements a, S.elements b in
-      List.map (fun (x,xr) -> List.map (fun (y,yr) -> op2 (x, xr) (y, yr)) b) a |> List.flatten |> fun x -> reduce (`Lifted (S.of_list x)) *)
   let product_bot2 op2 a b =
     let a,b = S.elements a, S.elements b in
     List.map (fun (x,xr) -> List.map (fun (y,yr) -> op2 (x, xr) (y, yr)) b) a |> List.flatten |> fun x -> reduce (S.of_list x)
   (* why are type annotations needed for product_widen? *)
-  (* let product_widen op op2 (a:t) (b:t): t = match a,b with (* assumes b to be bigger than a *)
-    | `Top, _ | _, `Top -> `Top
-    | `Lifted a, `Lifted b ->
-      let xs,ys = S.elements a, S.elements b in
-      List.map (fun (x,xr) -> List.map (fun (y,yr) -> (op x y, op2 xr yr)) ys) xs |> List.flatten |> fun x -> reduce (`Lifted (S.union b (S.of_list x))) *)
-  let product_widen op op2 (a:t) (b:t): t =
+  let product_widen op op2 (a:t) (b:t): t = (* assumes b to be bigger than a *)
     let xs,ys = S.elements a, S.elements b in
     List.map (fun (x,xr) -> List.map (fun (y,yr) -> (op x y, op2 xr yr)) ys) xs |> List.flatten |> fun x -> reduce (S.union b (S.of_list x))
   let join a b = join a b |> reduce
@@ -192,9 +126,6 @@ struct
   let widen = product_widen (fun x y -> if SpecD.leq x y then SpecD.widen x y else SpecD.bot ()) R.widen
 
   (* TODO: shouldn't this also reduce? *)
-  (* let apply_list f = function
-    | `Top -> `Top
-    | `Lifted s -> `Lifted (S.elements s |> f |> S.of_list) *)
   let apply_list f s = S.elements s |> f |> S.of_list
 end
 
@@ -300,14 +231,6 @@ struct
     let widen = binop widen
     let narrow = binop narrow
 
-    (* let invariant c s =
-      match s with
-      | `Top -> failwith "invariant Top"
-      | `Lifted s ->
-        (* TODO: optimize indexing, using inner hashcons somehow? *)
-        (* let (d, _) = List.at (S.elements s) c.Invariant.i in *)
-        let (d, _) = List.find (fun (x, _) -> I.to_int x = c.Invariant.i) (S.elements s) in
-        Spec.D.invariant c d *)
     let invariant c s =
       (* TODO: optimize indexing, using inner hashcons somehow? *)
       (* let (d, _) = List.at (S.elements s) c.Invariant.i in *)

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -52,7 +52,6 @@ struct
 end
 
 (* TODO: weaken R to Lattice.S ? *)
-(* TODO: fix after traces, domaintest fails *)
 module HoareMap (SpecD:Lattice.S) (R:SetDomain.S) =
 struct
   module SpecDGroupable =


### PR DESCRIPTION
Closes #195.

1. Remove `globally_unique_vids` which breaks original variable name mapping for witness invariants. See: https://github.com/goblint/cil/issues/31. AFAIK this isn't necessary because CIL already generates unique `vid`s. They just won't be consecutive after merging files, but that's not really important.
2. Use a Hoare domain without top for `PathSensitive2`. `SetDomain.Hoare` is based on `SetDomain.ToppedSet`, but the top isn't really meaningful for the path set. AFAIK there's no way for it to arise since it would mean an infinite number of paths. Removing the unnecessary lifting simplifies the logic.
3. Make `HoareMap` also top-less for `PathSensitive3`. This more or less matches the changes done by #164, because the lifted map domain doesn't expose operations on the inner map domain. The logic simplifies here even more.
4. Re-enable domain tests for `HoareMap`. An additional exclusion is necessary to not test `top`-related properties, since they're no longer valid.