### PR TITLE
Forbid `sideg` in `query`

### DIFF
--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -336,10 +336,10 @@ struct
     | (n',c')::xs -> if n=n' then (n,c)::xs else (n',c') :: assoc_replace (n,c) xs
 
   (** [assoc_split_eq (=) 1 [(1,a);(1,b);(2,x)] = ([a,b],[(2,x)])] *)
-  let assoc_split_eq (=) (k:'a) (xs:('a * 'b) list) : ('b list) * (('a * 'b) list) =
+  let assoc_split_eq eq (k:'a) (xs:('a * 'b) list) : ('b list) * (('a * 'b) list) =
     let rec f a b = function
       | [] -> a, b
-      | (k',v)::xs when k=k' -> f (v::a) b xs
+      | (k',v)::xs when eq k k' -> f (v::a) b xs
       | x::xs -> f a (x::b) xs
     in
     f [] [] xs

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -541,6 +541,8 @@ struct
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
         ; sideg  = (fun v g    -> failwith "Cannot \"sideg\" in query context.")
+        (* sideg is forbidden in query, because they would bypass sides grouping in other transfer functions.
+           See https://github.com/goblint/analyzer/pull/214. *)
         ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in query context.")
         }
       in

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -525,7 +525,6 @@ struct
     if q then raise Deadcode else d
 
   and query (ctx:(D.t, G.t, C.t) ctx) q =
-    let sides  = ref [] in
     let f a (n,(module S:MCPSpec),d) =
       let ctx' : (S.D.t, S.G.t, S.C.t) ctx =
         { local  = obj d
@@ -541,7 +540,7 @@ struct
         ; global = (fun v      -> ctx.global v |> assoc n |> obj)
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
-        ; sideg  = (fun v g    -> sides  := (v, (n, repr g)) :: !sides)
+        ; sideg  = (fun v g    -> failwith "Cannot \"sideg\" in query context.")
         ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in query context.")
         }
       in
@@ -553,9 +552,7 @@ struct
       ignore (Pretty.printf "Current State:\n%a\n\n" D.pretty ctx.local);
       `Bot
     | _ ->
-      let x = fold_left f `Top @@ spec_list ctx.local in
-      do_sideg ctx !sides;
-      x
+      fold_left f `Top @@ spec_list ctx.local
 
   let assign (ctx:(D.t, G.t, C.t) ctx) l e =
     let spawns = ref [] in


### PR DESCRIPTION
As I mentioned in https://github.com/goblint/analyzer/pull/211#issuecomment-830146609, `MCP2` intends to group side effects from multiple analyses to the same global variable together. I guess the intent is to make one `sideg` call to the solver with all the `DomListLattice` components filled instead of doing multiple `sideg` calls where each one has a `DomListLattice` with just a single non-`bot` component.

### Before
When tracing some #183 things, I noticed that this doesn't seem to be happening. For example on this line with lockset {mutex1}: https://github.com/goblint/analyzer/blob/4feae9f90bc7a483c54103d5bfdc9b1c231624ca/tests/regression/13-privatized/01-priv_nr.c#L13

The solver first gets a side effect from mutex analysis:
```
%%% sol2: side to glob1 on 01-priv_nr.c:4 (wpx: true) from node 5 "assert(glob1 == -10);" on 01-priv_nr.c:14 ## value: [readwrite * write:({mutex1}, {mutex1}),
                                                                                                                        Unit:(),
                                                                                                                        Unit:(),
                                                                                                                        Unit:(),
                                                                                                                        Unit:(),
                                                                                                                        unprotected * protected:(Uninitialized, Uninitialized),
                                                                                                                        Unit:()]
```
After which some "init", "side widen" and "destabilize" take place. And after that the solver gets a separate side effect from base analysis:
```
%%% sol2: side to glob1 on 01-priv_nr.c:4 (wpx: true) from node 5 "assert(glob1 == -10);" on 01-priv_nr.c:14 ## value: [unprotected * protected:((-10), Uninitialized),
                                                                                                                        readwrite * write:(All mutexes, All mutexes),
                                                                                                                        Unit:(),
                                                                                                                        Unit:(),
                                                                                                                        Unit:(),
                                                                                                                        Unit:(),
                                                                                                                        Unit:()]
```

This isn't supposed to be happening because they both happen during the same `MCP2.assign` evaluation: base side effects the unprotected value, mutex side effects the protecting locksets.

### Problem
Mutex analysis side effects the protecting locksets in `part_access`, which is since #162 called by `query`:
https://github.com/goblint/analyzer/blob/4feae9f90bc7a483c54103d5bfdc9b1c231624ca/src/analyses/mutexAnalysis.ml#L78-L87
This query is made in the `ctx` given to mutex analysis's `assign`:
https://github.com/goblint/analyzer/blob/4feae9f90bc7a483c54103d5bfdc9b1c231624ca/src/analyses/mutexAnalysis.ml#L151-L155
The `ctx` for the `assign` of mutex analysis is defined in `MCP2` to do `ask` via `query` in `MCP2`:
https://github.com/goblint/analyzer/blob/4feae9f90bc7a483c54103d5bfdc9b1c231624ca/src/analyses/mCP.ml#L560-L573

As the last snippet of code shows, whatever side effects that `query` makes, they don't get added into the `sides` list in `assign`, which is what is later grouped. That's why the access side effects bypass this grouping. I checked back at #162 and this behavior was present even before that change, so that PR didn't introduce this.

### After
This is easily fixed by forbidding `sideg` in `query` and moving that part of `part_access` around to record the lockset with the `assign`'s `ctx`, not the `query` one. Since access partitioning was refactored in #162, this has been a roundabout way to record the access anyway. No other queries use `sideg` anyway.

After these changes, the two side effects do get properly grouped:
```
%%% sol2: side to glob1 on 01-priv_nr.c:4 (wpx: true) from node 5 "assert(glob1 == -10);" on 01-priv_nr.c:14 ## value: [readwrite * write:({mutex1}, {mutex1}),
                                                                                                                        Unit:(),
                                                                                                                        unprotected * protected:((-10), Uninitialized),
                                                                                                                        Unit:(),
                                                                                                                        Unit:(),
                                                                                                                        Unit:(),
                                                                                                                        Unit:()]
```

I don't know whether this might slightly improve performance due to the solver not having to destabilize the same things multiple times.