### PR TITLE
Invalidate memory reachable from structs and unions passed to unknown functions.

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1739,8 +1739,8 @@ struct
    * Function calls
    **************************************************************************)
 
-    (** From a list of expressions, collect a list of addresses that they might point to, or contain pointers to. *)
-    let collect_funargs ask ?(warn=false) (gs:glob_fun) (st:store) (exps: exp list) =
+  (** From a list of expressions, collect a list of addresses that they might point to, or contain pointers to. *)
+  let collect_funargs ask ?(warn=false) (gs:glob_fun) (st:store) (exps: exp list) =
     let rec do_value v e =
       match v with
       | `Address a when AD.equal a AD.null_ptr -> []

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1750,7 +1750,9 @@ struct
           M.trace "collect_funargs" "%a = %a\n" AD.pretty a (d_list ", " AD.pretty) rble;
         rble
       | `Struct s -> ValueDomain.Structs.fold (fun f v a -> List.append (do_value v None) a) s []
-      | `Union (f, v) -> do_value v None
+      | `Union (_, v)
+      | `Blob (v, _,_ ) -> do_value v None
+      | `Array a -> CArrays.fold_left (fun a v -> List.append (do_value v None) a) [] a
       | `Int _ -> []
       | _ ->
         if warn then begin

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1738,8 +1738,9 @@ struct
   (**************************************************************************
    * Function calls
    **************************************************************************)
-  (* Variation of the above for yet another purpose, uhm, code reuse? *)
-  let collect_funargs ask ?(warn=false) (gs:glob_fun) (st:store) (exps: exp list) =
+
+    (** From a list of expressions, collect a list of addresses that they might point to, or contain pointers to. *)
+    let collect_funargs ask ?(warn=false) (gs:glob_fun) (st:store) (exps: exp list) =
     let rec do_value v e =
       match v with
       | `Address a when AD.equal a AD.null_ptr -> []
@@ -1749,6 +1750,7 @@ struct
           M.trace "collect_funargs" "%a = %a\n" AD.pretty a (d_list ", " AD.pretty) rble;
         rble
       | `Struct s -> ValueDomain.Structs.fold (fun f v a -> List.append (do_value v None) a) s []
+      | `Union (f, v) -> do_value v None
       | `Int _ -> []
       | _ ->
         if warn then begin

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1752,10 +1752,10 @@ struct
       | `Int _ -> []
       | _ ->
         if warn then begin
-          let warning = "Failed to invalidate unknown address" ^
+          let warning = "Failed to invalidate unknown address: " ^
             (match e with
-              | Some e -> ": " ^ sprint d_exp e
-              | None -> "." ^ sprint VD.pretty v)
+              | Some e -> sprint d_exp e
+              | None -> sprint VD.pretty v)
           in
           M.warn_each warning
         end;

--- a/tests/regression/02-base/48-unknown-func.c
+++ b/tests/regression/02-base/48-unknown-func.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+
+typedef struct list {
+    int val;
+    struct list *next;
+} list_t;
+
+// void mutate_list(list_t n){
+//     list_t *next = n.next;
+//     next->val = 42;
+// }
+
+int main(){
+    list_t first;
+    list_t second;
+
+    first.next = &second;
+    first.val = 1;
+    second.next = NULL;
+    second.val = 2;
+
+    // When passing a struct to an unknown function, reachable memory should be invalidated
+    mutate_list(first);
+    assert(second.val == 2); //UNKNOWN!
+
+    // Passing a pointer to the struct here.
+    mutate_list2(&first);
+    assert(second.val == 2); //UNKNOWN!
+}

--- a/tests/regression/02-base/48-unknown_func_struct.c
+++ b/tests/regression/02-base/48-unknown_func_struct.c
@@ -28,4 +28,5 @@ int main(){
     // Passing a pointer to the struct here.
     mutate_list2(&first);
     assert(second.val == 2); //UNKNOWN!
+    return 0;
 }

--- a/tests/regression/02-base/49-unknown_func_union.c
+++ b/tests/regression/02-base/49-unknown_func_union.c
@@ -1,0 +1,37 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+
+typedef struct list {
+    int val;
+    struct list *next;
+} list_t;
+
+
+typedef union either {
+    int value;
+    struct list node;
+} either_t;
+
+// void mutate_either(either_t e){
+//     list_t *next = e.node.next;
+//     next->val = 42;
+// }
+
+int main(){
+    list_t first;
+    list_t second;
+
+    first.next = &second;
+    first.val = 1;
+    second.next = NULL;
+    second.val = 2;
+
+    either_t e;
+    e.node = first;
+
+    // When passing a union to an unknown function, reachable memory should be invalidated
+    mutate_either(e);
+    assert(second.val == 2); //UNKNOWN!
+    return 0;
+}

--- a/tests/regression/02-base/50-unknown_func_array.c
+++ b/tests/regression/02-base/50-unknown_func_array.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+
+#define LENGTH 10
+
+typedef struct arr {
+    int *ptrs[LENGTH];
+} arr_t;
+
+// int mutate_array(arr_t a){
+//     int t = rand();
+//     for(int i=0; i<LENGTH; i++) {
+//         *(a.ptrs[i]) = t;
+//     }
+// }
+
+int main(){
+    arr_t a;
+    int xs[LENGTH];
+
+    for(int i=0; i<LENGTH; i++){
+        xs[i] = 0;
+        a.ptrs[i] = &xs[0];
+    }
+
+    // When passing an arrays to an unknown function, reachable memory should be invalidated
+    mutate_array(a);
+    assert(xs[0] == 0); //UNKNOWN!
+    return 0;
+}


### PR DESCRIPTION
This PR fixes the issue described in #222, i.e. that memory that is reachable from pointers contained in structs (and unions) is not invalidated after they were passed as arguments to an unknown function.

closes #222