### PR TITLE
Enums: Make comparison functions more precise

### DIFF
--- a/tests/regression/31-ikind-aware-ints/16-enums-compare.c
+++ b/tests/regression/31-ikind-aware-ints/16-enums-compare.c
@@ -9,6 +9,22 @@ int main(){
         x = 0;
     }
 
-    assert(x<2);
+    assert(x < 2);
+    assert(x < 1); // UNKNOWN!
+    assert(x < 0); // FAIL
+
+    assert(x <= 2);
+    assert(x <= 1);
+    assert(x <= 0); // UNKNOWN!
+    assert(x <= -1); //FAIL
+
+    assert(x > -1);
+    assert(x > 0); //UNKNOWN!
+    assert(x > 1); //FAIL
+
+    assert(x >= -1);
+    assert(x >= 0);
+    assert(x >= 1); //UNKNOWN!
+    assert(x >= 2); //FAIL
     return 0;
 }

--- a/tests/regression/31-ikind-aware-ints/16-enums-compare.c
+++ b/tests/regression/31-ikind-aware-ints/16-enums-compare.c
@@ -1,0 +1,14 @@
+//PARAM: --enable ana.int.enums --disable ana.int.def_exc
+int main(){
+    int top = rand();
+    int x,y;
+
+    if(top){
+        x = 1;
+    } else{
+        x = 0;
+    }
+
+    assert(x<2);
+    return 0;
+}

--- a/tests/regression/31-ikind-aware-ints/16-enums-compare.c
+++ b/tests/regression/31-ikind-aware-ints/16-enums-compare.c
@@ -1,12 +1,19 @@
 //PARAM: --enable ana.int.enums --disable ana.int.def_exc
 int main(){
     int top = rand();
+    int top2 = rand();
     int x,y;
 
     if(top){
         x = 1;
     } else{
         x = 0;
+    }
+
+    if(top2){
+        y = 1;
+    } else{
+        y = 0;
     }
 
     assert(x < 2);
@@ -26,5 +33,24 @@ int main(){
     assert(x >= 0);
     assert(x >= 1); //UNKNOWN!
     assert(x >= 2); //FAIL
+
+    assert(x == y); // UNKNOWN
+    assert(x == 1); // UNKNOWN
+    assert(x == 2); // FAIL
+
+    assert(x != y); // UNKNOWN
+    assert(x != 1); // UNKNOWN
+    assert(x != 2);
+
+    int z = rand();
+    y = 3;
+    if(z==3){
+        assert(y==z);
+        assert(y!=z); //FAIL
+    } else {
+        assert(y==z); //FAIL
+        assert(y!=z);
+    }
+
     return 0;
 }


### PR DESCRIPTION
This PR fixes the issue that the abstract comparison functions for `Enums` could only deliver exact results when both operands were singleton sets (see #226).

`lt`, `le` now look at the minium and maximum values of both abstract values to compute the result. `gt` is defined using `lt` with swapped arguments, analogous for `ge` and `le`.

Additionally, Enums now raises an `ArithmeticOnIntegerBot` exception, when exactly one of the operands of a binary arithmetic or logical operation is bottom. This behavior has already been implemented for `Interval` and `DefExc`. 