### PR TITLE
show widening points

### DIFF
--- a/src/solvers/sLR.ml
+++ b/src/solvers/sLR.ml
@@ -169,6 +169,12 @@ module SLR3 =
       reachability vs;
       stop_event ();
 
+      if GobConfig.get_bool "dbg.print_wpoints" then (
+        Printf.printf "\nWidening points:\n";
+        HM.iter (fun k () -> ignore @@ Pretty.printf "%a\n" S.Var.pretty_trace k) wpoint;
+        print_newline ();
+      );
+
       HM.clear key   ;
       HM.clear wpoint;
       HM.clear stable;
@@ -475,6 +481,12 @@ module Make =
         HM.iter (fun x _ -> if not (HM.mem reachable x) then HM.remove X.vals x) X.vals
       in
       reachability list;
+
+      if GobConfig.get_bool "dbg.print_wpoints" then (
+        Printf.printf "\nWidening points:\n";
+        HM.iter (fun k () -> ignore @@ Pretty.printf "%a\n" S.Var.pretty_trace k) wpoint;
+        print_newline ();
+      );
 
       X.to_list ()
 

--- a/src/solvers/sLRphased.ml
+++ b/src/solvers/sLRphased.ml
@@ -206,6 +206,12 @@ module Make =
       reachability rho1 vs;
       stop_event ();
 
+      if GobConfig.get_bool "dbg.print_wpoints" then (
+        Printf.printf "\nWidening points:\n";
+        HM.iter (fun k () -> ignore @@ Pretty.printf "%a\n" S.Var.pretty_trace k) wpoint;
+        print_newline ();
+      );
+
       HM.clear key   ;
       HM.clear wpoint;
       HM.clear infl  ;

--- a/src/solvers/sLRterm.ml
+++ b/src/solvers/sLRterm.ml
@@ -224,6 +224,12 @@ module SLR3term =
       reachability vs;
       stop_event ();
 
+      if GobConfig.get_bool "dbg.print_wpoints" then (
+        Printf.printf "\nWidening points:\n";
+        HM.iter (fun k () -> ignore @@ Pretty.printf "%a\n" S.Var.pretty_trace k) wpoint;
+        print_newline ();
+      );
+
       HM.clear key   ;
       HM.clear wpoint;
       HM.clear infl  ;

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -359,6 +359,12 @@ module WP =
       stop_event ();
       print_data data "Data after solve completed";
 
+      if GobConfig.get_bool "dbg.print_wpoints" then (
+        Printf.printf "\nWidening points:\n";
+        HM.iter (fun k () -> ignore @@ Pretty.printf "%a\n" S.Var.pretty_trace k) wpoint;
+        print_newline ();
+      );
+
       {st; infl; rho; wpoint; stable}
 
     let solve box st vs =

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -217,6 +217,7 @@ let _ = ()
       ; reg Debugging "dbg.solver-signal"   "'sigusr1'" "Signal to print statistics while solving. Possible values: sigint (Ctrl+C), sigtstp (Ctrl+Z), sigquit (Ctrl+\\), sigusr1, sigusr2, sigalrm, sigprof etc. (see signal_of_string in goblintutil.ml)."
       ; reg Debugging "dbg.backtrace-signal" "'sigusr2'" "Signal to print a raw backtrace on stderr. Possible values: sigint (Ctrl+C), sigtstp (Ctrl+Z), sigquit (Ctrl+\\), sigusr1, sigusr2, sigalrm, sigprof etc. (see signal_of_string in goblintutil.ml)."
       ; reg Debugging "dbg.solver-progress" "false" "Used for debugging. Prints out a symbol on solving a rhs."
+      ; reg Debugging "dbg.print_wpoints"   "false" "Print the widening points after solving (does not include the removed wpoints during solving by the slr solvers). Currently only implemented in: slr*, td3."
       ; reg Debugging "dbg.print_dead_code" "false" "Print information about dead code"
       ; reg Debugging "dbg.slice.on"        "false" "Turn slicer on or off."
       ; reg Debugging "dbg.slice.n"         "10"    "How deep function stack do we analyze."


### PR DESCRIPTION
There's no way to show at which places the solver widened.
This would be good to have in order to see how solvers differ.
For now I added an option `dbg.print_wpoints` which just lists the widening points after solving.
`td3` only adds, but e.g. `slr3` also removes from `wpoint` during solving.
Of course one could add some tracing for it, but ideally this would somehow be indicated in the html output (e.g. by shape of node, color, *).