### PR TITLE
Extract `Printable` implementations for CIL types into separate `CilType` module

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2089,8 +2089,8 @@ struct
           match LF.get_invalidate_action f.vname with
           | Some fnc -> invalidate ~ctx ctx.ask gs st (fnc `Write  args)
           | None -> (
-              (if f.vid <> dummyFunDec.svar.vid  && not (LF.use_special f.vname) then M.warn_each ("Function definition missing for " ^ f.vname));
-              (if f.vid = dummyFunDec.svar.vid then M.warn_each ("Unknown function ptr called"));
+              (if not (CilType.Varinfo.equal f dummyFunDec.svar) && not (LF.use_special f.vname) then M.warn_each ("Function definition missing for " ^ f.vname));
+              (if CilType.Varinfo.equal f dummyFunDec.svar then M.warn_each ("Unknown function ptr called"));
               let addrs =
                 if get_bool "sem.unknown_function.invalidate.globals" then (
                   M.warn_each "INVALIDATING ALL GLOBALS!";

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -236,7 +236,7 @@ struct
             in
             if AD.is_definite p1 && AD.is_definite p2 then
               match Addr.to_var_offset (AD.choose p1), Addr.to_var_offset (AD.choose p2) with
-              | [x, xo], [y, yo] when x.vid = y.vid ->
+              | [x, xo], [y, yo] when CilType.Varinfo.equal x y ->
                 calculateDiffFromOffset xo yo
               | _ ->
                 `Int (ID.top_of result_ik)
@@ -1576,7 +1576,7 @@ struct
     let is_list_init () =
       match lval, rval with
       | (Var a, Field (fi,NoOffset)), AddrOf((Var b, NoOffset))
-        when !GU.global_initialization && a.vid = b.vid
+        when !GU.global_initialization && CilType.Varinfo.equal a b
              && fi.fcomp.cname = "list_head"
              && (fi.fname = "prev" || fi.fname = "next") -> Some a
       | _ -> None

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -230,7 +230,7 @@ struct
                   | Some z -> `Int(ID.of_int ik z)
                   | _ -> `Int (ID.top_of ik)
                 end
-              | `Index (xi, xo), `Index(yi, yo) when xi = yi -> (* ID.equal? *)
+              | `Index (xi, xo), `Index(yi, yo) when xi = yi -> (* TODO: ID.equal? *)
                 calculateDiffFromOffset xo yo
               | _ -> `Int (ID.top_of result_ik)
             in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -220,7 +220,7 @@ struct
             let rec calculateDiffFromOffset x y =
               match x, y with
               | `Field ((xf:Cil.fieldinfo), xo), `Field((yf:Cil.fieldinfo), yo)
-                when  xf.floc = yf.floc && xf.fname = yf.fname && Cil.typeSig xf.ftype = Cil.typeSig yf.ftype && xf.fbitfield = yf.fbitfield && xf.fattr = yf.fattr ->
+                when CilType.Fieldinfo.equal xf yf ->
                 calculateDiffFromOffset xo yo
               | `Index (i, `NoOffset), `Index(j, `NoOffset) ->
                 begin
@@ -230,7 +230,7 @@ struct
                   | Some z -> `Int(ID.of_int ik z)
                   | _ -> `Int (ID.top_of ik)
                 end
-              | `Index (xi, xo), `Index(yi, yo) when xi = yi ->
+              | `Index (xi, xo), `Index(yi, yo) when xi = yi -> (* ID.equal? *)
                 calculateDiffFromOffset xo yo
               | _ -> `Int (ID.top_of result_ik)
             in

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -52,11 +52,12 @@ struct
     | _ -> false
 
   let query ctx (q:Queries.t) : Queries.Result.t =
-    let lvalsEq l1 l2 = Basetype.CilExp.compareExp (Lval l1) (Lval l2) = 0 in (* == would be wrong here *)
+    (* TODO: CilType.Lval.equal *)
+    let lvalsEq l1 l2 = Basetype.CilExp.equal (Lval l1) (Lval l2) in (* == would be wrong here *)
     match q with
     | Queries.MustBeEqual (e1, e2) when not (isFloat e1) ->
       begin
-        if Basetype.CilExp.compareExp (canonize e1) (canonize e2) = 0 then
+        if Basetype.CilExp.equal (canonize e1) (canonize e2) then
           `MustBool true
         else
           `MustBool false

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -52,8 +52,7 @@ struct
     | _ -> false
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
-    (* TODO: CilType.Lval.equal *)
-    let lvalsEq l1 l2 = Basetype.CilExp.equal (Lval l1) (Lval l2) in (* == would be wrong here *)
+    let lvalsEq l1 l2 = CilType.Lval.equal l1 l2 in (* == would be wrong here *)
     match q with
     | Queries.MustBeEqual (e1, e2) when not (isFloat e1) ->
       Basetype.CilExp.equal (canonize e1) (canonize e2)

--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -39,7 +39,7 @@ struct
       | (`Field (f1, o1), `Field (f2,o2)) -> f1 == f2 && is_offs_prefix_of o1 o2
       | (_, _) -> false
     in
-    (v1.vid == v2.vid) && is_offs_prefix_of ofs1 ofs2
+    CilType.Varinfo.equal v1 v2 && is_offs_prefix_of ofs1 ofs2
 
   (* We just had to dereference an lval --- warn if it was null *)
   let warn_lval (st:D.t) (v :varinfo * (Addr.field,Addr.idx) Lval.offs) : unit =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -69,9 +69,9 @@ struct
 
   let rec replace_elem (v,o) q ex =
     match ex with
-    | AddrOf  (Mem e,_) when Basetype.CilExp.compareExp e q = 0 ->v, Offs.from_offset (conv_offset o)
-    | StartOf (Mem e,_) when Basetype.CilExp.compareExp e q = 0 ->v, Offs.from_offset (conv_offset o)
-    | Lval    (Mem e,_) when Basetype.CilExp.compareExp e q = 0 ->v, Offs.from_offset (conv_offset o)
+    | AddrOf  (Mem e,_) when Basetype.CilExp.equal e q ->v, Offs.from_offset (conv_offset o)
+    | StartOf (Mem e,_) when Basetype.CilExp.equal e q ->v, Offs.from_offset (conv_offset o)
+    | Lval    (Mem e,_) when Basetype.CilExp.equal e q ->v, Offs.from_offset (conv_offset o)
     | CastE (_,e)           -> replace_elem (v,o) q e
     | _ -> v, Offs.from_offset (conv_offset o)
 
@@ -150,7 +150,7 @@ struct
             ctx.sideg v el
         | None -> M.warn "Write to unknown address: privatization is unsound."
       end;
-      
+
       (*partitions & locks*)
       let open Access in
       match ctx.ask (PartAccess {exp=e; var_opt=vo; write=w}) with

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -179,7 +179,7 @@ struct
       let conf = if includes_uk then conf - 10 else conf in
       let f (var, offs) =
         let coffs = Lval.CilLval.to_ciloffs offs in
-        if var.vid = dummyFunDec.svar.vid then
+        if CilType.Varinfo.equal var dummyFunDec.svar then
           add_access conf None (Some coffs)
         else
           add_access conf (Some var) (Some coffs)

--- a/src/analyses/uninit.ml
+++ b/src/analyses/uninit.ml
@@ -107,7 +107,7 @@ struct
     let rec is_offs_prefix_of pr os =
       match (pr, os) with
       | (`NoOffset, _) -> true
-      | (`Field (f1, o1), `Field (f2,o2)) -> f1.fname = f2.fname && is_offs_prefix_of o1 o2
+      | (`Field (f1, o1), `Field (f2,o2)) -> CilType.Fieldinfo.equal f1 f2 && is_offs_prefix_of o1 o2
       | (_, _) -> false
     in
     CilType.Varinfo.equal v1 v2 && is_offs_prefix_of ofs1 ofs2

--- a/src/analyses/uninit.ml
+++ b/src/analyses/uninit.ml
@@ -154,9 +154,9 @@ struct
     in
     let rec bothstruct (t:fieldinfo list) (tf:fieldinfo) (o:fieldinfo list) (no:lval_offs)  : var_offs list =
       match t, o with
-      | x::xs, y::ys when x.fcomp.ckey = tf.fcomp.ckey && x.fname = tf.fname ->
+      | x::xs, y::ys when CilType.Fieldinfo.equal x tf ->
         get_pfx v (`Field (y, cx)) no x.ftype y.ftype
-      | x::xs, y::ys when CilType.Typ.equal x.ftype y.ftype ->
+      | x::xs, y::ys when CilType.Typ.equal x.ftype y.ftype -> (* different fields, same type? *)
         bothstruct xs tf ys no
       | x::xs, y::ys ->
         [] (* found a mismatch *)

--- a/src/analyses/uninit.ml
+++ b/src/analyses/uninit.ml
@@ -110,7 +110,7 @@ struct
       | (`Field (f1, o1), `Field (f2,o2)) -> f1.fname = f2.fname && is_offs_prefix_of o1 o2
       | (_, _) -> false
     in
-    (v1.vid == v2.vid) && is_offs_prefix_of ofs1 ofs2
+    CilType.Varinfo.equal v1 v2 && is_offs_prefix_of ofs1 ofs2
 
 
   (* Does it contain non-initialized variables? *)

--- a/src/analyses/uninit.ml
+++ b/src/analyses/uninit.ml
@@ -156,7 +156,7 @@ struct
       match t, o with
       | x::xs, y::ys when x.fcomp.ckey = tf.fcomp.ckey && x.fname = tf.fname ->
         get_pfx v (`Field (y, cx)) no x.ftype y.ftype
-      | x::xs, y::ys when Basetype.CilExp.compareType x.ftype y.ftype = 0 ->
+      | x::xs, y::ys when CilType.Typ.equal x.ftype y.ftype ->
         bothstruct xs tf ys no
       | x::xs, y::ys ->
         [] (* found a mismatch *)

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -79,7 +79,7 @@ struct
     | TArray (t1,d1,_), TArray (t2,d2,_) -> option_eq exp_equal d1 d2 && typ_equal t1 t2
     | TFun (rt1, arg1, _,  b1), TFun (rt2, arg2, _, b2) -> b1 = b2 && typ_equal rt1 rt2 && option_eq (for_all2 args_eq) arg1 arg2
     | TNamed (ti1, _), TNamed (ti2, _) -> ti1.tname = ti2.tname && typ_equal ti1.ttype ti2.ttype
-    | TComp (c1,_), TComp (c2,_) -> c1.ckey = c2.ckey
+    | TComp (c1,_), TComp (c2,_) -> CilType.Compinfo.equal c1 c2
     | TEnum (e1,_), TEnum (e2,_) -> e1.ename = e2.ename && for_all2 eitem_eq e1.eitems e2.eitems
     | TBuiltin_va_list _, TBuiltin_va_list _ -> true
     | _ -> false

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -94,7 +94,7 @@ struct
     in
     offs_equal o1 o2
     && match l1, l2 with
-    | Var v1, Var v2 -> v1.vid = v2.vid && (match Cil.unrollTypeDeep v1.vtype with | TArray(TFloat _,_,_) | TFloat  _-> false | _ -> true)
+    | Var v1, Var v2 -> CilType.Varinfo.equal v1 v2 && (match Cil.unrollTypeDeep v1.vtype with | TArray(TFloat _,_,_) | TFloat  _-> false | _ -> true)
     | Mem m1, Mem m2 -> exp_equal m1 m2
     | _ -> false
 
@@ -288,7 +288,7 @@ struct
         in
         if Queries.LS.is_top als
         then false
-        else Queries.LS.exists (fun (u,s) ->  v.vid = u.vid && oleq o s) als
+        else Queries.LS.exists (fun (u,s) -> CilType.Varinfo.equal v u && oleq o s) als
       in
       let (als, test) =
         match addrOfExp a with
@@ -427,7 +427,7 @@ struct
       in
       let has_reachable_prefix v1 ofs =
         let suitable_prefix (v2,ofs2) =
-          v1.vid = v2.vid
+          CilType.Varinfo.equal v1 v2
           && is_prefix ofs ofs2
         in
         Queries.LS.exists suitable_prefix r

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -88,7 +88,7 @@ struct
     let rec offs_equal o1 o2 =
       match o1, o2 with
       | NoOffset, NoOffset -> true
-      | Field (f1, o1), Field (f2,o2) -> f1.fcomp.ckey = f2.fcomp.ckey && f1.fname = f2.fname && (match Cil.unrollType f1.ftype with | TArray(TFloat _,_,_) | TFloat _ -> false | _ -> true)  &&offs_equal o1 o2
+      | Field (f1, o1), Field (f2,o2) -> CilType.Fieldinfo.equal f1 f2 && (match Cil.unrollType f1.ftype with | TArray(TFloat _,_,_) | TFloat _ -> false | _ -> true)  &&offs_equal o1 o2
       | Index (i1,o1), Index (i2,o2) -> exp_equal i1 i2 && offs_equal o1 o2
       | _ -> false
     in
@@ -282,7 +282,7 @@ struct
         let rec oleq o s =
           match o, s with
           | `NoOffset, _ -> true
-          | `Field (f1,o), `Field (f2,s) when f1.fname = f2.fname -> oleq o s
+          | `Field (f1,o), `Field (f2,s) when CilType.Fieldinfo.equal f1 f2 -> oleq o s
           | `Index (i1,o), `Index (i2,s) when exp_equal i1 i2     -> oleq o s
           | _ -> false
         in
@@ -421,7 +421,7 @@ struct
       let rec is_prefix x1 x2 =
         match x1, x2 with
         | _, `NoOffset -> true
-        | Field (f1,o1), `Field (f2,o2) when f1.fname = f2.fname -> is_prefix o1 o2
+        | Field (f1,o1), `Field (f2,o2) when CilType.Fieldinfo.equal f1 f2 -> is_prefix o1 o2
         | Index (_,o1), `Index (_,o2) -> is_prefix o1 o2
         | _ -> false
       in

--- a/src/cdomains/apronDomain.ml
+++ b/src/cdomains/apronDomain.ml
@@ -83,7 +83,7 @@ struct
   let show x =
     A.print Legacy.Format.str_formatter x;
     Legacy.Format.flush_str_formatter ()
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let pretty () (x:t) = text (show x)
   let pretty_diff () (x,y) = text "pretty_diff"
 

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -466,7 +466,7 @@ struct
         let over_all_x2 = op (op xl2 xm2) xr2 in
         let e1e_in_state_of_x2 = x2_eval_int e1e in
         let e2e_in_state_of_x1 = x1_eval_int e2e in
-        let e1e_is_better = (not (Cil.isConstant e1e) && Cil.isConstant e2e) || Basetype.CilExp.compareExp e1e e2e < 0 in
+        let e1e_is_better = (not (Cil.isConstant e1e) && Cil.isConstant e2e) || Basetype.CilExp.compare e1e e2e < 0 in (* TODO: why does this depend on exp comparison? *)
         if e1e_is_better then (* first try if the result can be partitioned by e1e *)
           if must_be_zero e1e_in_state_of_x2  then
             (e1, (xl1, op xm1 over_all_x2, op xr1 over_all_x2))

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -601,7 +601,7 @@ struct
   let update_length newl (x, l) = (x, newl)
 
   let printXml f (x,y) =
-    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (Goblintutil.escape (Base.name ())) Base.printXml x "length" Idx.printXml y
+    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (XmlUtil.escape (Base.name ())) Base.printXml x "length" Idx.printXml y
 end
 
 
@@ -645,7 +645,7 @@ struct
   let update_length newl (x, l) = (x, newl)
 
   let printXml f (x,y) =
-    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (Goblintutil.escape (Base.name ())) Base.printXml x "length" Idx.printXml y
+    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (XmlUtil.escape (Base.name ())) Base.printXml x "length" Idx.printXml y
 end
 
 module FlagConfiguredArrayDomain(Val: LatticeWithSmartOps) (Idx:IntDomain.Z):S with type value = Val.t and type idx = Idx.t =

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -449,7 +449,7 @@ struct
         let over_all_x2 = op (op xl2 xm2) xr2 in
         let e1e_in_state_of_x2 = x2_eval_int e1e in
         let e2e_in_state_of_x1 = x1_eval_int e2e in
-        let e1e_is_better = (not (Cil.isConstant e1e) && Cil.isConstant e2e) || Basetype.CilExp.compare e1e e2e < 0 in (* TODO: why does this depend on exp comparison? *)
+        let e1e_is_better = (not (Cil.isConstant e1e) && Cil.isConstant e2e) || Basetype.CilExp.compare e1e e2e < 0 in (* TODO: why does this depend on exp comparison? probably to use "simpler" expression according to constructor order in compare *)
         if e1e_is_better then (* first try if the result can be partitioned by e1e *)
           if must_be_zero e1e_in_state_of_x2  then
             (e1, (xl1, op xm1 over_all_x2, op xr1 over_all_x2))

--- a/src/cdomains/baseDomain.ml
+++ b/src/cdomains/baseDomain.ml
@@ -98,7 +98,7 @@ struct
     ++ text ")"
 
   let printXml f r =
-    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (Goblintutil.escape (CPA.name ())) CPA.printXml r.cpa (Goblintutil.escape (PartDeps.name ())) PartDeps.printXml r.deps (Goblintutil.escape (PrivD.name ())) PrivD.printXml r.priv
+    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (XmlUtil.escape (CPA.name ())) CPA.printXml r.cpa (XmlUtil.escape (PartDeps.name ())) PartDeps.printXml r.deps (XmlUtil.escape (PrivD.name ())) PrivD.printXml r.priv
 
   let name () = CPA.name () ^ " * " ^ PartDeps.name () ^ " * " ^ PrivD.name ()
 

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -305,15 +305,8 @@ end
 
 module CilType =
 struct
-  include Printable.Std
-  type t = typ [@@deriving to_yojson]
-  let compare x y = compare (Cil.typeSig x) (Cil.typeSig y)
-  let equal x y = Util.equals (Cil.typeSig x) (Cil.typeSig y)
-  let hash (x:typ) = Hashtbl.hash x
-  let show x = sprint ~width:max_int (d_type () x)
-  let pretty () x = d_type () x
+  include CilType.Typ
 
   let name () = "types"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
 end

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -16,7 +16,7 @@ struct
   let pretty () x = text (show x)
   let name () = "proglines"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module ProgLocation : Printable.S with type t = location =
@@ -36,7 +36,7 @@ struct
   let pretty () x = text (show x)
   let name () = "proglines_byte"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module ProgLinesFun: Printable.S with type t = location * MyCFG.node * fundec =
@@ -57,7 +57,7 @@ struct
   let pretty () x = text (show x)
   let name () = "proglinesfun"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module Variables =
@@ -86,7 +86,7 @@ struct
   let description n = sprint 80 (pretty_trace () n)
   let context () _ = Pretty.nil
   let loopSep _ = true
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let var_id _ = "globals"
   let node _ = MyCFG.Function Cil.dummyFunDec.svar
 
@@ -104,7 +104,7 @@ struct
   let pretty () x = text (show x)
   let name () = "raw strings"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module Strings: Lattice.S with type t = [`Bot | `Lifted of string | `Top] =
@@ -216,7 +216,7 @@ struct
 
   let name () = "expressions"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module CilFun: Printable.S with type t = varinfo =
@@ -248,7 +248,7 @@ struct
   let pretty () x = Pretty.text (show x)
   let name () = "field"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module FieldVariables =
@@ -296,7 +296,7 @@ struct
 
   let name () = "variables and fields"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 
 end
 

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -62,15 +62,10 @@ end
 
 module Variables =
 struct
-  include Printable.Std
-  type t = varinfo [@@deriving to_yojson]
-  let relift x = x
+  include CilType.Varinfo
   let trace_enabled = true
   let is_global v = v.vglob
   let copy x = x
-  let equal x y = x.vid = y.vid
-  let compare x y = compare x.vid y.vid
-  let hash x = x.vid - 4773
   let show x = GU.demangle x.vname
   let pretty () x = Pretty.text (show x)
   let pretty_trace () x = Pretty.dprintf "%s on %a" x.vname ProgLines.pretty x.vdecl

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -371,17 +371,10 @@ end
 
 module CilFun: Printable.S with type t = varinfo =
 struct
-  include Printable.Std
+  include CilType.Varinfo
   let copy x = x
-  type t = varinfo [@@deriving to_yojson]
-  let compare x y = compare x.vid y.vid
-  let equal x y = x.vid = y.vid
-  let hash x = Hashtbl.hash x.vid
-  let show x = x.vname
-  let pretty () x = Pretty.text (show x)
   let name () = "functions"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
 end
 
 module CilFundec =

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -200,8 +200,6 @@ struct
     | Lval (Var v, _) -> [v]
     | Lval (Mem e',_) -> (get_vars e')
 
-  let compareExp = compare (* TODO: inline *)
-
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
 end
 

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -201,7 +201,6 @@ struct
     | Lval (Mem e',_) -> (get_vars e')
 
   let compareExp = compare (* TODO: inline *)
-  let compareType a b = Stdlib.compare (typeSig a) (typeSig b) (* TODO: CilType.Typ *)
 
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
 end

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -134,13 +134,8 @@ module Bools: Lattice.S with type t = [`Bot | `Lifted of bool | `Top] =
 
 module CilExp =
 struct
-  include Printable.Std
-  type t = exp [@@deriving to_yojson]
+  include CilType.Exp
   let copy x = x
-  let equal x y = Util.equals x y
-  let hash x = Hashtbl.hash x
-  let show x = sprint ~width:max_int (d_exp () x)
-  let pretty () x = d_exp () x
 
   let name () = "expressions"
 
@@ -205,152 +200,10 @@ struct
     | Lval (Var v, _) -> [v]
     | Lval (Mem e',_) -> (get_vars e')
 
+  let compareExp = compare (* TODO: inline *)
+  let compareType a b = Stdlib.compare (typeSig a) (typeSig b) (* TODO: CilType.Typ *)
+
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
-
-  (* Need custom compare because normal compare on CIL Exp might not terminate *)
-  let rec compareExp a b =
-    let order x = match x with
-      | Const _ -> 0
-      | Lval _ -> 1
-      | SizeOf _ -> 2
-      | SizeOfE _ -> 3
-      | SizeOfStr _ -> 4
-      | AlignOf _ -> 5
-      | AlignOfE _ -> 6
-      | UnOp _ -> 7
-      | BinOp _ -> 9
-      | CastE _ -> 10
-      | AddrOf _ -> 11
-      | StartOf _ -> 12
-      | Question _ -> 13
-      | AddrOfLabel _ -> 14
-      | Real _ -> 15
-      | Imag _ -> 16
-    in
-    if a == b || Expcompare.compareExp a b then
-      0
-    else if order a <> order b then
-      (order a) - (order b)
-    else
-      match a,b with
-      | Const c1, Const c2 -> compareConst c1 c2
-      | AddrOf l1, AddrOf l2
-      | StartOf l1, StartOf l2
-      | Lval l1, Lval l2 -> compareLval l1 l2
-      | AlignOf t1, AlignOf t2
-      | SizeOf t1, SizeOf t2 -> compareType t1 t2
-      | AlignOfE e1, AlignOfE e2
-      | SizeOfE e1, SizeOfE e2 -> compareExp e1 e2
-      | SizeOfStr s1, SizeOfStr s2 -> compare s1 s2
-      | UnOp (op1, e1, t1), UnOp (op2, e2, t2) ->
-        let r = compare op1 op2 in
-        if r <> 0 then
-          r
-        else
-          let r = compareType t1 t2 in
-          if r <> 0 then
-            r
-          else
-            compareExp e1 e2
-      | BinOp (op1, e1a, e1b, t1), BinOp (op2, e2a, e2b, t2) ->
-        let r = compare op1 op2 in
-        if r <> 0 then
-          r
-        else
-          let r = compareType t1 t2 in
-          if r <> 0 then
-            r
-          else
-            let r = compareExp e1a e2a in
-            if r <> 0 then
-              r
-            else
-              compareExp e1b e2b
-      | CastE (t1, e1), CastE (t2, e2) ->
-        let r = compareType t1 t2 in
-        if r <> 0 then
-          r
-        else
-          compareExp e1 e2
-      | AddrOfLabel s1, AddrOfLabel s2 -> compare s1 s2
-      | Question (e1a, e1b, e1c, t1), Question (e2a, e2b, e2c, t2) ->
-        let r = compareType t1 t2 in
-        if r <> 0 then
-          r
-        else
-          let r = compareExp e1a e2a in
-          if r <> 0 then
-            r
-          else
-            let r = compareExp e1b e2b in
-            if r <> 0 then
-              r
-            else
-              compareExp e1c e2c
-      | _ -> failwith "CilExp.compareExp unknown type of expression"
-  and compareConst a b =
-    match a,b with
-    | CEnum (ea, sa, ia), CEnum (eb, sb, ib) ->
-      let r = compareExp ea eb in
-      if r <> 0 then
-        r
-      else
-        compare (sa, ia) (sb, ib)
-    | _ ->
-      compare a b
-  and compareLval a b =
-    match a, b with
-    | (Var v1, o1), (Var v2, o2) ->
-      let r = compare v1.vid v2.vid in
-      if r <> 0 then
-        r
-      else
-        compareOffset o1 o2
-    | (Mem e1, o1), (Mem e2, o2) ->
-      let r = compareExp e1 e2 in
-      if r <> 0 then
-        r
-      else
-        compareOffset o1 o2
-    | (Var _, _), (Mem _, _) -> -1
-    | (Mem _, _), (Var _, _) -> 1
-  and compareOffset a b =
-    let order x =
-      match x with
-      | NoOffset -> 0
-      | Field _ -> 1
-      | Index _ -> 2
-    in
-      if order a <> order b then
-        (order a) - (order b)
-      else
-        match a, b with
-        | NoOffset, NoOffset -> 0
-        | Field (f1, o1), Field(f2, o2) ->
-          let r = compareFieldinfo f1 f2 in
-          if r <> 0 then
-            r
-          else
-            compareOffset o1 o2
-        | Index (e1, o1), Index(e2, o2) ->
-          let r = compareExp e1 e2 in
-          if r <> 0 then
-            r
-          else
-            compareOffset o1 o2
-        | _ -> failwith "CilExp.compareOffset unknown type of expression"
-  and compareFieldinfo a b =
-    let r = compareType a.ftype b.ftype in
-    if r <> 0 then
-      r
-    else
-      compare (a.fname, a.fbitfield, a.fattr, a.floc) (b.fname, b.fbitfield, b.fattr, b.floc)
-  and compareType a b =
-    compare (typeSig a) (typeSig b) (* call to typeSig here is necessary, otherwise compare might not terminate *)
-
-  let compare = compareExp
-  let equal a b = compare a b = 0
 end
 
 module CilStmt: Printable.S with type t = stmt =

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -46,7 +46,7 @@ struct
   let copy x = x
   let equal (x,a,_) (y,b,_) = ProgLines.equal x y && MyCFG.Node.equal a b (* ignores fundec component *)
   let compare (x,a,_) (y,b,_) = match ProgLines.compare x y with 0 -> MyCFG.node_compare a b | x -> x (* ignores fundec component *)
-  let hash (x,a,f) = ProgLines.hash x * f.svar.vid * MyCFG.Node.hash a (* FIXME: doesn't agree with equal, considers fundec component *)
+  let hash (x,a,f) = ProgLines.hash x * MyCFG.Node.hash a (* ignores fundec component *)
   let pretty_node () (l,x) =
     match x with
     | MyCFG.Statement     s -> dprintf "statement \"%a\" at %a" dn_stmt s ProgLines.pretty l

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -379,18 +379,11 @@ end
 
 module CilFundec =
 struct
-  include Printable.Std
+  include CilType.Fundec
   let copy x = x
-  type t = fundec [@@deriving to_yojson]
-  let compare x y = compare x.svar.vid y.svar.vid
-  let equal x y = x.svar.vid = y.svar.vid
-  let hash x = x.svar.vid * 3
-  let show x = x.svar.vname
-  let pretty () x = CilFun.pretty () x.svar
   let name () = "function decs"
   let dummy = dummyFunDec
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
 end
 
 module CilField =

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -238,17 +238,12 @@ end
 
 module CilField =
 struct
-  include Printable.Std
+  include Printable.Std (* for default MapDomain.Groupable *)
+  include CilType.Fieldinfo
   let copy x = x
-  type t = fieldinfo [@@deriving to_yojson]
-  let compare x y = compare (x.fname, compFullName x.fcomp)  (y.fname, compFullName y.fcomp)
-  let equal x y = x.fname = y.fname && compFullName x.fcomp = compFullName y.fcomp
-  let hash x = Hashtbl.hash (x.fname, compFullName x.fcomp)
-  let show x = x.fname
-  let pretty () x = Pretty.text (show x)
+
   let name () = "field"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module FieldVariables =

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -46,7 +46,7 @@ struct
   let copy x = x
   let equal (x,a,_) (y,b,_) = ProgLines.equal x y && MyCFG.Node.equal a b (* ignores fundec component *)
   let compare (x,a,_) (y,b,_) = match ProgLines.compare x y with 0 -> MyCFG.node_compare a b | x -> x (* ignores fundec component *)
-  let hash (x,a,f) = ProgLines.hash x * f.svar.vid * MyCFG.Node.hash a
+  let hash (x,a,f) = ProgLines.hash x * f.svar.vid * MyCFG.Node.hash a (* FIXME: doesn't agree with equal, considers fundec component *)
   let pretty_node () (l,x) =
     match x with
     | MyCFG.Statement     s -> dprintf "statement \"%a\" at %a" dn_stmt s ProgLines.pretty l

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -279,7 +279,7 @@ struct
                   (*"("^string_of_int (get_var x).vid ^")"^*)
                   (apply_field (fun x->"::"^x.fname) "" x)
 
-  let compare x y = let cmp = compare (get_var x).vid (get_var y).vid in
+  let compare x y = let cmp = CilType.Varinfo.compare (get_var x) (get_var y) in
     if cmp = 0 then
       compare (apply_field (fun v->v.fname) "" x) (apply_field (fun v->v.fname) "" y)
     else

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -355,12 +355,8 @@ end
 
 module CilStmt: Printable.S with type t = stmt =
 struct
-  include Printable.Std
-  type t = stmt [@@deriving to_yojson]
+  include CilType.Stmt
   let copy x = x
-  let compare x y = compare x.sid y.sid
-  let equal x y = x.sid = y.sid
-  let hash x = Hashtbl.hash (x.sid) * 97
   let show x = "<stmt>"
   let pretty () x =
     match x.skind with

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -273,7 +273,7 @@ struct
 
   let is_global v = (get_var v).vglob
   let copy x = x
-  let equal x y = (get_var x).vid = (get_var y).vid && (apply_field (fun v->v.fname) "" x)=(apply_field (fun v->v.fname) "" y)
+  let equal x y = CilType.Varinfo.equal (get_var x) (get_var y) && (apply_field (fun v->v.fname) "" x)=(apply_field (fun v->v.fname) "" y)
 
   let show x = GU.demangle (get_var x).vname^
                   (*"("^string_of_int (get_var x).vid ^")"^*)

--- a/src/cdomains/containDomain.ml
+++ b/src/cdomains/containDomain.ml
@@ -1127,10 +1127,10 @@ struct
     let vars = get_vars exp in
     let res = List.fold_left
         (fun ags v->
-           let tmp = ArgSet.filter (fun x->(FieldVars.get_var x).vid!=v.vid) ags
+           let tmp = ArgSet.filter (fun x-> not (CilType.Varinfo.equal (FieldVars.get_var x) v)) ags
            in
            let args2 = Danger.find v st in
-           ArgSet.filter (fun x->ArgSet.fold (fun q v-> (FieldVars.get_var x).vid!=(FieldVars.get_var q).vid && v ) args2 true) tmp
+           ArgSet.filter (fun x->ArgSet.fold (fun q v-> not (CilType.Varinfo.equal (FieldVars.get_var x) (FieldVars.get_var q)) && v ) args2 true) tmp
         )
         args vars in
     (*    report ("filter "^(sprint 160 (d_exp () exp))^" , "^sprint 160 (ArgSet.pretty () (args))^" = "^sprint 160 (ArgSet.pretty () (res)));*)

--- a/src/cdomains/containDomain.ml
+++ b/src/cdomains/containDomain.ml
@@ -341,11 +341,11 @@ struct
 *)
   let remove_formals sformals (fd, st,df) =
     let f k s st =
-      let p y = List.exists (fun x -> x.vid = y.vid) sformals in
+      let p y = List.exists (fun x -> CilType.Varinfo.equal x y) sformals in
       if p k
       then st
       else
-        let ns = ArgSet.filter (fun x ->  ( (k.vid=return_var.vid || not (FieldVars.has_field x)) && not (p (FieldVars.get_var x)))) s in
+        let ns = ArgSet.filter (fun x ->  ( (CilType.Varinfo.equal k return_var || not (FieldVars.has_field x)) && not (p (FieldVars.get_var x)))) s in
         if ArgSet.is_bot ns
         then st
         else Danger.add k ns st
@@ -886,7 +886,7 @@ struct
           (*dbg_report("danger.prop_non_this "^v.vname^" -> "^(sprint 160 (FieldVars.pretty () fv))^" = "^sprint 160 (ArgSet.pretty () args));*)
           ArgSet.fold (fun x y->if
                         (*dbg_report("check "^var.vname^" -> "^(FieldVars.get_var x).vname^" == "^(FieldVars.get_var fv).vname);*)
-                        not ((FieldVars.get_var x).vglob)&& not (var.vglob) &&not ((FieldVars.get_var x).vid=var.vid)
+                        not ((FieldVars.get_var x).vglob)&& not (var.vglob) &&not (CilType.Varinfo.equal (FieldVars.get_var x) var)
                         (*&&(FieldVars.get_var x).vid=(FieldVars.get_var fv).vid*)
                         && FieldVars.equal x fv
                         (*&& not (must_be_constructed_from_this st (Lval (Var (FieldVars.get_var x),NoOffset)))*)
@@ -944,7 +944,7 @@ struct
   let is_bad_reachable v st =
     let args = Danger.find v st in
     if not (ArgSet.is_bot args) then
-      ArgSet.fold (fun x y -> y || (FieldVars.get_var x).vid=v.vid) args false
+      ArgSet.fold (fun x y -> y || CilType.Varinfo.equal (FieldVars.get_var x) v) args false
     else false
 
   (*analog to may_be_.._global, prints warnings*)

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -242,7 +242,7 @@ struct
     | CastE (t,e) -> one_unknown_array_index e
     | _ -> None
 
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module LockingPattern =

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -4,19 +4,13 @@ open Deriving.Cil
 
 module Exp =
 struct
-  (* TODO: use CilType.Exp *)
-  type t = exp [@@deriving to_yojson]
-  include Printable.Std
+  include CilType.Exp
 
-  let equal = Basetype.CilExp.equal
-  let compare = Basetype.CilExp.compare
-  let hash = Hashtbl.hash
   let name () = "Cil expressions"
 
-  let pretty = d_exp
-  let show s = sprint ~width:max_int (d_exp () s)
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
 
+  (* TODO: what does interesting mean? *)
   let rec interesting x =
     match x with
     | SizeOf _
@@ -132,7 +126,7 @@ struct
     | Field (f1, o1), Field (f2, o2) -> CilType.Fieldinfo.equal f1 f2 && off_eq o1 o2
     | Index (e1, o1), Index (e2, o2) -> simple_eq e1 e2 && off_eq o1 o2
     | _ -> false
-  and simple_eq x y =
+  and simple_eq x y = (* TODO: is this necessary instead of equal? *)
     match x, y with
     | Const c1, Const c2 -> eq_const c1 c2
     | Lval (Var v1,o1)   , Lval (Var v2,o2)
@@ -241,8 +235,6 @@ struct
     | StartOf (Mem e, NoOffset) -> one_unknown_array_index e
     | CastE (t,e) -> one_unknown_array_index e
     | _ -> None
-
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module LockingPattern =

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -72,7 +72,7 @@ struct
     let rec offs_contains o =
       match o with
       | NoOffset -> false
-      | Field (f',o) -> f.fname = f'.fname
+      | Field (f',o) -> CilType.Fieldinfo.equal f f'
       | Index (e,o) -> cv e || offs_contains o
     and cv e =
       match e with
@@ -129,7 +129,7 @@ struct
   let rec off_eq x y =
     match x, y with
     | NoOffset, NoOffset -> true
-    | Field (f1, o1), Field (f2, o2) -> f1.fname = f2.fname && off_eq o1 o2
+    | Field (f1, o1), Field (f2, o2) -> CilType.Fieldinfo.equal f1 f2 && off_eq o1 o2
     | Index (e1, o1), Index (e2, o2) -> simple_eq e1 e2 && off_eq o1 o2
     | _ -> false
   and simple_eq x y =

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -57,11 +57,11 @@ struct
       | StartOf (Mem e,o)
       | Lval    (Mem e,o) -> cv true e || offs_contains o
       | CastE (_,e)           -> cv deref e
-      | Lval    (Var v2,o) -> v.vid = v2.vid || offs_contains o
+      | Lval    (Var v2,o) -> CilType.Varinfo.equal v v2 || offs_contains o
       | AddrOf  (Var v2,o)
       | StartOf (Var v2,o) ->
         if deref
-        then v.vid = v2.vid || offs_contains o
+        then CilType.Varinfo.equal v v2 || offs_contains o
         else offs_contains o
       | Question _ -> failwith "Logical operations should be compiled away by CIL."
       | _ -> failwith "Unmatched pattern."
@@ -138,7 +138,7 @@ struct
     | Lval (Var v1,o1)   , Lval (Var v2,o2)
     | AddrOf (Var v1,o1) , AddrOf (Var v2,o2)
     | StartOf (Var v1,o1), StartOf (Var v2,o2)
-      -> v1.vid = v2.vid && off_eq o1 o2
+      -> CilType.Varinfo.equal v1 v2 && off_eq o1 o2
     | Lval (Mem e1,o1)   , Lval (Mem e2,o2)
     | AddrOf (Mem e1,o1) , AddrOf (Mem e2,o2)
     | StartOf (Mem e1,o1), StartOf (Mem e2,o2)
@@ -264,7 +264,7 @@ struct
 
   let ee_equal x y =
     match x, y with
-    | EVar v1, EVar v2 -> v1.vid = v2.vid
+    | EVar v1, EVar v2 -> CilType.Varinfo.equal v1 v2
     | EAddr, EAddr -> true
     | EDeref, EDeref -> true
     | EField f1, EField f2 -> f1.fname = f2.fname

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -4,11 +4,12 @@ open Deriving.Cil
 
 module Exp =
 struct
+  (* TODO: use CilType.Exp *)
   type t = exp [@@deriving to_yojson]
   include Printable.Std
 
-  let equal a b = Basetype.CilExp.compareExp a b = 0
-  let compare = Basetype.CilExp.compareExp
+  let equal = Basetype.CilExp.equal
+  let compare = Basetype.CilExp.compare
   let hash = Hashtbl.hash
   let name () = "Cil expressions"
 

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -267,7 +267,7 @@ struct
     | EVar v1, EVar v2 -> CilType.Varinfo.equal v1 v2
     | EAddr, EAddr -> true
     | EDeref, EDeref -> true
-    | EField f1, EField f2 -> f1.fname = f2.fname
+    | EField f1, EField f2 -> CilType.Fieldinfo.equal f1 f2
     | EIndex e1, EIndex e2 -> Exp.simple_eq e1 e2
     | _ -> false
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1542,7 +1542,7 @@ module Enums : S with type int_t = BigInt.t = struct
     include SetDomain.Make(I)
     let is_singleton s = cardinal s = 1
   end
-  type t = Inc of ISet.t | Exc of ISet.t * R.t [@@deriving eq, to_yojson] (* inclusion/exclusion set *)
+  type t = Inc of ISet.t | Exc of ISet.t * R.t [@@deriving eq, ord, to_yojson] (* inclusion/exclusion set *)
 
   type int_t = BI.t
   let name () = "enums"
@@ -1560,17 +1560,6 @@ module Enums : S with type int_t = BigInt.t = struct
     | Exc (xs,r) -> "not {" ^ (String.concat ", " (List.map I.show (ISet.elements xs))) ^ "} " ^ "("^R.show r^")"
 
   include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
-
-  let compare a b =
-    let value c =
-      match c with Inc _ -> 0 | Exc _ -> 1
-    in
-    match a, b with
-    | Inc x, Inc y -> ISet.compare x y
-    | Exc (x,r), Exc (y, s) ->
-        let comp_sets = ISet.compare x y in
-        if comp_sets = 0 then R.compare r s else comp_sets
-    | _, _ -> compare (value a) (value b)
 
   let hash = function
     | Inc x -> ISet.hash x

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -56,7 +56,7 @@ struct
   let rec may_be_same_offset of1 of2 =
     match of1, of2 with
     | `NoOffset , `NoOffset -> true
-    | `Field (x1,y1) , `Field (x2,y2) -> x1.fcomp.ckey = x2.fcomp.ckey && may_be_same_offset y1 y2
+    | `Field (x1,y1) , `Field (x2,y2) -> CilType.Compinfo.equal x1.fcomp x2.fcomp && may_be_same_offset y1 y2 (* TODO: why not fieldinfo equal? *)
     | `Index (x1,y1) , `Index (x2,y2)
       -> (not (IdxDom.is_int x1) || not (IdxDom.is_int x2))
          || IdxDom.equal x1 x2 && may_be_same_offset y1 y2

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -70,8 +70,8 @@ struct
   let remove (addr,rw) set =
     let collect_diff_varinfo_with (vi,os) (addr,rw) =
       match (Addr.to_var_offset addr) with
-      | [(v,o)] when vi.vid == v.vid -> not (may_be_same_offset o os)
-      | [(v,o)] when vi.vid != v.vid -> true
+      | [(v,o)] when CilType.Varinfo.equal vi v -> not (may_be_same_offset o os)
+      | [(v,o)] -> true
       | _ -> false
     in
     match (Addr.to_var_offset addr) with

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -84,6 +84,7 @@ struct
     | `Index (i1,o1) -> `Index (i1,add_offset o1 o2)
 
   let rec compare o1 o2 = match o1, o2 with
+    (* FIXME: forgets to check cmp_zero_offset like equal *)
     | `NoOffset, `NoOffset -> 0
     | `Field (f1,o1), `Field (f2,o2) ->
       let c = Stdlib.compare f1.fname f2.fname in

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -46,7 +46,7 @@ struct
     | `NoOffset , `NoOffset -> true
     | `NoOffset, x
     | x, `NoOffset -> cmp_zero_offset x = `MustZero
-    | `Field (f1,o1), `Field (f2,o2) when f1.fname = f2.fname -> equal o1 o2
+    | `Field (f1,o1), `Field (f2,o2) when CilType.Fieldinfo.equal f1 f2 -> equal o1 o2
     | `Index (i1,o1), `Index (i2,o2) when Idx.equal i1 i2 -> equal o1 o2
     | _ -> false
 
@@ -86,7 +86,7 @@ struct
     (* FIXME: forgets to check cmp_zero_offset like equal *)
     | `NoOffset, `NoOffset -> 0
     | `Field (f1,o1), `Field (f2,o2) ->
-      let c = Stdlib.compare f1.fname f2.fname in
+      let c = CilType.Fieldinfo.compare f1 f2 in
       if c=0 then compare o1 o2 else c
     | `Index (i1,o1), `Index (i2,o2) ->
       let c = Idx.compare i1 i2 in
@@ -102,7 +102,7 @@ struct
     | `NoOffset, x -> cmp_zero_offset x <> `MustNonzero
     | x, `NoOffset -> cmp_zero_offset x = `MustZero
     | `Index (i1,o1), `Index (i2,o2) when Idx.leq i1 i2 -> leq o1 o2
-    | `Field (f1,o1), `Field (f2,o2) when f1.fname = f2.fname -> leq o1 o2
+    | `Field (f1,o1), `Field (f2,o2) when CilType.Fieldinfo.equal f1 f2 -> leq o1 o2
     | _ -> false
 
   let rec merge cop x y =
@@ -114,7 +114,7 @@ struct
       | (`Join | `Widen), (`MustZero | `MayZero) -> x
       | (`Meet | `Narrow), (`MustZero | `MayZero) -> `NoOffset
       | _ -> raise Lattice.Uncomparable)
-    | `Field (x1,y1), `Field (x2,y2) when x1.fname = x2.fname -> `Field (x1, merge cop y1 y2)
+    | `Field (x1,y1), `Field (x2,y2) when CilType.Fieldinfo.equal x1 x2 -> `Field (x1, merge cop y1 y2)
     | `Index (x1,y1), `Index (x2,y2) -> `Index (op x1 x2, merge cop y1 y2)
     | _ -> raise Lattice.Uncomparable
 
@@ -535,7 +535,7 @@ struct
       match a,b with
       | `NoOffset , `NoOffset -> 0
       | `Field (f1,o1), `Field (f2,o2) ->
-        let r = String.compare f1.fname f2.fname in
+        let r = CilType.Fieldinfo.compare f1 f2 in
         if r <>0 then r else
           compare o1 o2
       | `Index (i1,o1), `Index (i2,o2) ->

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -29,8 +29,7 @@ struct
   type t = (fieldinfo, Idx.t) offs [@@deriving to_yojson]
   include Printable.Std
 
-  let eq_field x y = compFullName x.fcomp ^ x.fname = compFullName y.fcomp ^ y.fname
-  let is_first_field x = try eq_field (List.hd x.fcomp.cfields) x with _ -> false
+  let is_first_field x = try CilType.Fieldinfo.equal (List.hd x.fcomp.cfields) x with _ -> false
 
   let rec cmp_zero_offset : t -> [`MustZero | `MustNonzero | `MayZero] = function
     | `NoOffset -> `MustZero
@@ -514,7 +513,7 @@ struct
     let rec eq a b =
       match a,b with
       | `NoOffset , `NoOffset -> true
-      | `Field (f1,o1), `Field (f2,o2) when f1.fname = f2.fname -> eq o1 o2
+      | `Field (f1,o1), `Field (f2,o2) when CilType.Fieldinfo.equal f1 f2 -> eq o1 o2
       | `Index (i1,o1), `Index (i2,o2) when Basetype.CilExp.equal i1 i2 -> eq o1 o2
       | _ -> false
     in

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -287,7 +287,7 @@ struct
           else
             match (x, y) with
             | Addr (v, o), Addr (u, p) ->
-              let vc = compare v.vid u.vid in
+              let vc = CilType.Varinfo.compare v u in
               if vc <> 0
                 then vc
                 else Offs.compare o p
@@ -544,7 +544,7 @@ struct
           compare o1 o2
       | _ -> failwith "unexpected tag"
     in
-    let r = x1.vid - x2.vid in
+    let r = CilType.Varinfo.compare x1 x2 in
     if r <> 0 then r else compare o1 o2
 
   let class_tag (v,o) =

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -263,7 +263,7 @@ struct
   let is_zero_offset x = Offs.cmp_zero_offset x = `MustZero
 
   let equal x y = match x, y with
-    | Addr (v,o), Addr (u,p) -> v.vid = u.vid && Offs.equal o p
+    | Addr (v,o), Addr (u,p) -> CilType.Varinfo.equal v u && Offs.equal o p
     | StrPtr a  , StrPtr b -> a=b (* TODO problematic if the same literal appears more than once *)
     | UnknownPtr, UnknownPtr
     | SafePtr   , SafePtr
@@ -341,7 +341,7 @@ struct
   let leq x y = match x, y with
     | SafePtr, UnknownPtr    -> true
     | StrPtr a  , StrPtr b   -> a = b
-    | Addr (x,o), Addr (y,u) -> x.vid = y.vid && Offs.leq o u
+    | Addr (x,o), Addr (y,u) -> CilType.Varinfo.equal x y && Offs.leq o u
     | _                      -> x = y
 
   let drop_ints = function
@@ -356,7 +356,7 @@ struct
     | NullPtr   , NullPtr -> NullPtr
     | SafePtr   , SafePtr -> SafePtr
     | StrPtr a  , StrPtr b when a=b -> StrPtr a
-    | Addr (x,o), Addr (y,u) when x.vid = y.vid -> Addr (x, Offs.merge cop o u)
+    | Addr (x,o), Addr (y,u) when CilType.Varinfo.equal x y -> Addr (x, Offs.merge cop o u)
     | _ -> raise Lattice.Uncomparable
 
   let join = merge `Join
@@ -517,7 +517,7 @@ struct
       | `Index (i1,o1), `Index (i2,o2) when Basetype.CilExp.equal i1 i2 -> eq o1 o2
       | _ -> false
     in
-    x1.vid=x2.vid && eq o1 o2
+    CilType.Varinfo.equal x1 x2 && eq o1 o2
 
   let hash    = Hashtbl.hash
   let name () = "simplified lval"

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -514,7 +514,7 @@ struct
       match a,b with
       | `NoOffset , `NoOffset -> true
       | `Field (f1,o1), `Field (f2,o2) when f1.fname = f2.fname -> eq o1 o2
-      | `Index (i1,o1), `Index (i2,o2) when Basetype.CilExp.compareExp i1 i2 = 0 -> eq o1 o2
+      | `Index (i1,o1), `Index (i2,o2) when Basetype.CilExp.equal i1 i2 -> eq o1 o2
       | _ -> false
     in
     x1.vid=x2.vid && eq o1 o2
@@ -539,7 +539,7 @@ struct
         if r <>0 then r else
           compare o1 o2
       | `Index (i1,o1), `Index (i2,o2) ->
-        let r = Basetype.CilExp.compareExp i1 i2 in
+        let r = Basetype.CilExp.compare i1 i2 in
         if r <> 0 then r else
           compare o1 o2
       | _ -> failwith "unexpected tag"

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -45,7 +45,7 @@ struct
     match x, y with
     | `NoOffset , `NoOffset -> true
     | `NoOffset, x
-    | x, `NoOffset -> cmp_zero_offset x = `MustZero
+    | x, `NoOffset -> cmp_zero_offset x = `MustZero (* cannot derive due to this special case *)
     | `Field (f1,o1), `Field (f2,o2) when CilType.Fieldinfo.equal f1 f2 -> equal o1 o2
     | `Index (i1,o1), `Index (i2,o2) when Idx.equal i1 i2 -> equal o1 o2
     | _ -> false
@@ -83,7 +83,7 @@ struct
     | `Index (i1,o1) -> `Index (i1,add_offset o1 o2)
 
   let rec compare o1 o2 = match o1, o2 with
-    (* FIXME: forgets to check cmp_zero_offset like equal *)
+    (* FIXME: forgets to check cmp_zero_offset like equal, cannot derive due to this special case *)
     | `NoOffset, `NoOffset -> 0
     | `Field (f1,o1), `Field (f2,o2) ->
       let c = CilType.Fieldinfo.compare f1 f2 in

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -134,7 +134,7 @@ struct
     | `Field (x, o) -> `Field (x, drop_ints o)
     | `NoOffset -> `NoOffset
 
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module type S =
@@ -324,7 +324,7 @@ struct
     | `Index (i,o) -> `Index (i, remove_offset o)
     | `Field (f,o) -> `Field (f, remove_offset o)
 
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 
   let arbitrary () = QCheck.always UnknownPtr (* S TODO: non-unknown *)
 end
@@ -364,7 +364,7 @@ struct
   let meet = merge `Meet
   let narrow = merge `Narrow
 
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module Stateless (Idx: Printable.S) =
@@ -388,7 +388,7 @@ struct
   let pretty_diff () (x,y) =
     dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
 
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
 module Fields =
@@ -588,5 +588,5 @@ struct
   let pretty () x = text (show x)
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
 
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end

--- a/src/cdomains/regionDomain.ml
+++ b/src/cdomains/regionDomain.ml
@@ -16,7 +16,7 @@ struct
   let pretty () x = Pretty.text (show x)
 
   let printXml f (v,fi) =
-    BatPrintf.fprintf f "<value>\n<data>\n%s%a\n</data>\n</value>\n" (Goblintutil.escape (V.show v)) F.printInnerXml fi
+    BatPrintf.fprintf f "<value>\n<data>\n%s%a\n</data>\n</value>\n" (XmlUtil.escape (V.show v)) F.printInnerXml fi
 
   (* Indicates if the two var * offset pairs should collapse or not. *)
   let collapse (v1,f1) (v2,f2) = V.equal v1 v2 && F.collapse f1 f2

--- a/src/cdomains/shapeDomain.ml
+++ b/src/cdomains/shapeDomain.ml
@@ -524,10 +524,10 @@ let sync_one ask gl upd (sm:SHMap.t) : SHMap.t * ((varinfo * bool) list) * ((var
       in
       let dead lp' =
         let lpv' = ListPtr.get_var lp' in
-        lpv'.vid = lpv.vid ||
+        CilType.Varinfo.equal lpv' lpv ||
         (blab (not (lpv'.vglob)) (fun () -> Pretty.printf "global %s is never dead\n" lpv'.vname) &&
          let killer = ref dummyFunDec.svar in
-         blab (if Usedef.VS.exists (fun x -> if lpv'.vid = x.vid then (killer := x; true) else false) alive
+         blab (if Usedef.VS.exists (fun x -> if CilType.Varinfo.equal lpv' x then (killer := x; true) else false) alive
                then ((*ignore (Messages.report ("List "^ListPtr.short 80 lp^" totally destroyed by "^(!killer).vname));*)false)
                else true) (fun () -> Pretty.printf "%s in alive list\n" lpv'.vname ))
       in

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -669,7 +669,7 @@ struct
         | `LvalSet v when Q.LS.cardinal v = 1 && not (Q.LS.is_top v) ->
           begin
           match Q.LS.choose v with
-          | (var,`Index (i,`NoOffset)) when Basetype.CilExp.compareExp i Cil.zero = 0 && var.vid = arr_start_var.vid ->
+          | (var,`Index (i,`NoOffset)) when Basetype.CilExp.compare i Cil.zero = 0 && var.vid = arr_start_var.vid ->
             (* The idea here is that if a must(!) point to arr and we do sth like a[i] we don't want arr to be partitioned according to (arr+i)-&a but according to i instead  *)
             add
           | _ -> BinOp(MinusPP, exp, StartOf start_of_array_lval, !ptrdiffType)

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -58,7 +58,7 @@ struct
   type size = Size.t
   type origin = ZeroInit.t
   let printXml f (x, y, z) =
-    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\nsize\n</key>\n%a<key>\norigin\n</key>\n%a</map>\n</value>\n" (Goblintutil.escape (Value.name ())) Value.printXml x Size.printXml y ZeroInit.printXml z
+    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\nsize\n</key>\n%a<key>\norigin\n</key>\n%a</map>\n</value>\n" (XmlUtil.escape (Value.name ())) Value.printXml x Size.printXml y ZeroInit.printXml z
 
   let make v s = v, s, true
   let value (a, b, c) = a

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -669,7 +669,7 @@ struct
         | v when Q.LS.cardinal v = 1 && not (Q.LS.is_top v) ->
           begin
           match Q.LS.choose v with
-          | (var,`Index (i,`NoOffset)) when Basetype.CilExp.compare i Cil.zero = 0 && CilType.Varinfo.equal var arr_start_var ->
+          | (var,`Index (i,`NoOffset)) when Basetype.CilExp.equal i Cil.zero && CilType.Varinfo.equal var arr_start_var ->
             (* The idea here is that if a must(!) point to arr and we do sth like a[i] we don't want arr to be partitioned according to (arr+i)-&a but according to i instead  *)
             add
           | _ -> BinOp(MinusPP, exp, StartOf start_of_array_lval, !ptrdiffType)

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -669,7 +669,7 @@ struct
         | `LvalSet v when Q.LS.cardinal v = 1 && not (Q.LS.is_top v) ->
           begin
           match Q.LS.choose v with
-          | (var,`Index (i,`NoOffset)) when Basetype.CilExp.compare i Cil.zero = 0 && var.vid = arr_start_var.vid ->
+          | (var,`Index (i,`NoOffset)) when Basetype.CilExp.compare i Cil.zero = 0 && CilType.Varinfo.equal var arr_start_var ->
             (* The idea here is that if a must(!) point to arr and we do sth like a[i] we don't want arr to be partitioned according to (arr+i)-&a but according to i instead  *)
             add
           | _ -> BinOp(MinusPP, exp, StartOf start_of_array_lval, !ptrdiffType)

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -97,7 +97,7 @@ let rec compareOffset (off1: offset) (off2: offset) : bool =
   | Field (fld1, off1'), Field (fld2, off2') ->
     fld1.fcomp.ckey = fld2.fcomp.ckey && fld1.fname = fld2.fname && compareOffset off1' off2'
   | Index (e1, off1'), Index (e2, off2') ->
-    Basetype.CilExp.compareExp e1 e2 = 0 && compareOffset off1' off2'
+    Basetype.CilExp.equal e1 e2 && compareOffset off1' off2'
   | NoOffset, NoOffset -> true
   | _ -> false
 

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -259,7 +259,7 @@ struct
   type t = (varinfo * offs) option
   let equal (x:t) (y:t) =
     match x, y with
-    | Some (v1,o1), Some (v2,o2) -> v1.vid = v2.vid && offs_eq o1 o2
+    | Some (v1,o1), Some (v2,o2) -> CilType.Varinfo.equal v1 v2 && offs_eq o1 o2
     | None, None -> true
     | _ -> false
   let hash = function

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -91,15 +91,6 @@ let init (f:file) =
   in
   List.iter visit_glob f.globals
 
-(* from cil *)
-let rec compareOffset (off1: offset) (off2: offset) : bool =
-  match off1, off2 with
-  | Field (fld1, off1'), Field (fld2, off2') ->
-    CilType.Fieldinfo.equal fld1 fld2 && compareOffset off1' off2'
-  | Index (e1, off1'), Index (e2, off2') ->
-    Basetype.CilExp.equal e1 e2 && compareOffset off1' off2'
-  | NoOffset, NoOffset -> true
-  | _ -> false
 
 type offs = [`NoOffset | `Index of 't | `Field of fieldinfo * 't] as 't
 

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -220,7 +220,7 @@ struct
   let equal (x:t) y =
     match x, y with
     | `Type t, `Type v -> Basetype.CilType.equal t v
-    | `Struct (c1,o1), `Struct (c2,o2) -> c1.ckey = c2.ckey && equal_offs o1 o2
+    | `Struct (c1,o1), `Struct (c2,o2) -> CilType.Compinfo.equal c1 c2 && equal_offs o1 o2
     | _ -> false
   let hash = function
     | `Type t -> Basetype.CilType.hash t

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -110,7 +110,7 @@ let rec d_offs () : offs -> doc = function
   | `Index o -> dprintf "[?]%a" d_offs o
   | `Field (f,o) -> dprintf ".%s%a" f.fname d_offs o
 
-type acc_typ = [ `Type of typ | `Struct of compinfo * offs ]
+type acc_typ = [ `Type of CilType.Typ.t | `Struct of CilType.Compinfo.t * offs ] [@@deriving eq]
 
 let d_acct () = function
   | `Type t -> dprintf "(%a)" d_type t
@@ -216,12 +216,7 @@ end
 module Acc_typHashable
   : Hashtbl.HashedType with type t = acc_typ =
 struct
-  type t = acc_typ
-  let equal (x:t) y =
-    match x, y with
-    | `Type t, `Type v -> Basetype.CilType.equal t v
-    | `Struct (c1,o1), `Struct (c2,o2) -> CilType.Compinfo.equal c1 c2 && equal_offs o1 o2
-    | _ -> false
+  type t = acc_typ [@@deriving eq]
   let hash = function
     | `Type t -> Basetype.CilType.hash t
     | `Struct (c,o) -> Hashtbl.hash (c.ckey, o)

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -33,7 +33,7 @@ struct
     dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let printXml f x =
     BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n"
-      (Goblintutil.escape (show x))
+      (XmlUtil.escape (show x))
 end
 
 module LabeledString =

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -116,7 +116,7 @@ let rec offs_eq x y =
   match x, y with
   | `NoOffset, `NoOffset -> true
   | `Index x, `Index y -> offs_eq x y
-  | `Field (f,x), `Field (g,y) -> f.fcomp.ckey = g.fcomp.ckey && f.fname = g.fname && offs_eq x y
+  | `Field (f,x), `Field (g,y) -> CilType.Fieldinfo.equal f g && offs_eq x y
   | _ -> false
 
 let rec remove_idx : offset -> offs  = function

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -156,7 +156,7 @@ let rec get_type (fb: typ) : exp -> acc_typ = function
   | Question (_,b,c,t) ->
     begin match get_type fb b, get_type fb c with
       | `Struct (s1,o1), `Struct (s2,o2)
-        when s1.ckey = s2.ckey && equal_offs o1 o2 ->
+        when CilType.Compinfo.equal s1 s2 && equal_offs o1 o2 ->
         `Struct (s1, o1)
       | _ -> `Type t
     end

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -231,12 +231,7 @@ module TypeHash = HtF (Acc_typHashable)
 module LvalOptHashable
   : Hashtbl.HashedType with type t = (varinfo * offs) option =
 struct
-  type t = (varinfo * offs) option
-  let equal (x:t) (y:t) =
-    match x, y with
-    | Some (v1,o1), Some (v2,o2) -> CilType.Varinfo.equal v1 v2 && equal_offs o1 o2
-    | None, None -> true
-    | _ -> false
+  type t = (CilType.Varinfo.t * offs) option [@@deriving eq]
   let hash = function
     | None -> 435
     | Some (x,y) -> Hashtbl.hash (x.vid, Hashtbl.hash y)

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -95,7 +95,7 @@ let init (f:file) =
 let rec compareOffset (off1: offset) (off2: offset) : bool =
   match off1, off2 with
   | Field (fld1, off1'), Field (fld2, off2') ->
-    fld1.fcomp.ckey = fld2.fcomp.ckey && fld1.fname = fld2.fname && compareOffset off1' off2'
+    CilType.Fieldinfo.equal fld1 fld2 && compareOffset off1' off2'
   | Index (e1, off1'), Index (e2, off2') ->
     Basetype.CilExp.equal e1 e2 && compareOffset off1' off2'
   | NoOffset, NoOffset -> true
@@ -106,7 +106,7 @@ type offs = [`NoOffset | `Index of 't | `Field of fieldinfo * 't] as 't
 let rec compareOffs (off1: offs) (off2: offs) : bool =
   match off1, off2 with
   | `Field (fld1, off1'), `Field (fld2, off2') ->
-    fld1.fcomp.ckey = fld2.fcomp.ckey && fld1.fname = fld2.fname && compareOffs off1' off2'
+    CilType.Fieldinfo.equal fld1 fld2 && compareOffs off1' off2'
   | `Index off1', `Index off2' ->
     compareOffs off1' off2'
   | `NoOffset, `NoOffset -> true

--- a/src/domains/invariantCil.ml
+++ b/src/domains/invariantCil.ml
@@ -49,7 +49,7 @@ let var_find_fundec vi = VM.find vi (Lazy.force var_fundecs)
 let var_is_in_scope scope vi =
   match var_find_fundec vi with
   | None -> true
-  | Some fd -> fd.svar.vid = scope.svar.vid (* equal fundec *)
+  | Some fd -> CilType.Fundec.equal fd scope
 
 class exp_is_in_scope_visitor (scope: fundec) (acc: bool ref) = object
   inherit nopCilVisitor

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -169,7 +169,7 @@ struct
     Pretty.dprintf "PMap: %a not leq %a" pretty x pretty y
   let printXml f xs =
     let print_one k v =
-      BatPrintf.fprintf f "<key>\n%s</key>\n%a" (Goblintutil.escape (Domain.show k)) Range.printXml v
+      BatPrintf.fprintf f "<key>\n%s</key>\n%a" (XmlUtil.escape (Domain.show k)) Range.printXml v
     in
     BatPrintf.fprintf f "<value>\n<map>\n";
     iter print_one xs;

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -164,7 +164,7 @@ end
 
 module HashCached (M: S) =
 struct
-  module LazyHash = Goblintutil.LazyEval (struct type t = M.t type result = int let eval = M.hash end)
+  module LazyHash = LazyEval.Make (struct type t = M.t type result = int let eval = M.hash end)
 
   let name () = "HashCached " ^ M.name ()
 

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -86,7 +86,7 @@ struct
   let pretty () x = text (P.show x)
   let pretty_diff () (x,y) =
     dprintf "%s: %a not leq %a" (P.name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (P.show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (P.show x))
 end
 
 
@@ -101,7 +101,7 @@ struct
   let name () = "Unit"
   let pretty_diff () (x,y) =
     dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f () = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape N.name)
+  let printXml f () = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape N.name)
 
   let arbitrary () = QCheck.unit
   let relift x = x
@@ -226,8 +226,8 @@ struct
   let name () = "lifted " ^ Base.name ()
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let printXml f = function
-    | `Bot      -> BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape N.bot_name)
-    | `Top      -> BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape N.top_name)
+    | `Bot      -> BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape N.bot_name)
+    | `Top      -> BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape N.top_name)
     | `Lifted x -> Base.printXml f x
 
   let invariant c = function
@@ -354,7 +354,7 @@ struct
       text (show (x,y))
 
   let printXml f (x,y) =
-    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (Goblintutil.escape (Base1.name ())) Base1.printXml x (Goblintutil.escape (Base2.name ())) Base2.printXml y
+    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (XmlUtil.escape (Base1.name ())) Base1.printXml x (XmlUtil.escape (Base2.name ())) Base2.printXml y
 
   let pretty_diff () ((x1,x2:t),(y1,y2:t)): Pretty.doc =
     if Base1.equal x1 y1 then
@@ -397,7 +397,7 @@ struct
     ++ text ")"
 
   let printXml f (x,y,z) =
-    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (Goblintutil.escape (Base1.name ())) Base1.printXml x (Goblintutil.escape (Base2.name ())) Base2.printXml y (Goblintutil.escape (Base3.name ())) Base3.printXml z
+    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (XmlUtil.escape (Base1.name ())) Base1.printXml x (XmlUtil.escape (Base2.name ())) Base2.printXml y (XmlUtil.escape (Base3.name ())) Base3.printXml z
 
   let name () = Base1.name () ^ " * " ^ Base2.name () ^ " * " ^ Base3.name ()
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -229,5 +229,5 @@ struct
     | (`PartAccessResult x, `PartAccessResult y) -> `PartAccessResult (PartAccessResult.narrow x y)
     | (x,_) -> x
 
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -148,7 +148,7 @@ struct
     | tb -> tb
 
   let printXml f = function
-    | `Top -> BatPrintf.fprintf f "<value>%s</value>" (Goblintutil.escape top_name)
+    | `Top -> BatPrintf.fprintf f "<value>%s</value>" (XmlUtil.escape top_name)
     | `Bot -> ()
     | `Lifted x -> LD.printXml f x
 end

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -623,7 +623,7 @@ struct
   let tf_ret var edge prev_node ret fd getl sidel getg sideg d =
     let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
     let d =
-      if (fd.svar.vid = MyCFG.dummy_func.svar.vid ||
+      if (CilType.Fundec.equal fd MyCFG.dummy_func ||
           List.mem fd.svar.vname (List.map Json.string (get_list "mainfun"))) &&
          (get_bool "kernel" || get_string "ana.osek.oil" <> "")
       then toplevel_kernel_return ret fd ctx sideg

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -177,7 +177,7 @@ struct
     let make_global_fast_xml f g =
       let open Printf in
       let print_globals k v =
-        fprintf f "\n<glob><key>%s</key>%a</glob>" (Goblintutil.escape (Basetype.Variables.show k)) Spec.G.printXml v;
+        fprintf f "\n<glob><key>%s</key>%a</glob>" (XmlUtil.escape (Basetype.Variables.show k)) Spec.G.printXml v;
       in
       GHT.iter print_globals g
     in

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -327,10 +327,10 @@ let print cfg  =
     | FunctionEntry f -> Pretty.dprintf "fun%d" f.vid
   in
   let dn_exp () e =
-    text (Goblintutil.escape (sprint 800 (dn_exp () e)))
+    text (XmlUtil.escape (sprint 800 (dn_exp () e)))
   in
   let dn_lval () l =
-    text (Goblintutil.escape (sprint 800 (dn_lval () l)))
+    text (XmlUtil.escape (sprint 800 (dn_lval () l)))
   in
   let p_edge () = function
     | Test (exp, b) -> if b then Pretty.dprintf "Pos(%a)" dn_exp exp else Pretty.dprintf "Neg(%a)" dn_exp exp
@@ -494,10 +494,10 @@ let printFun (module Cfg : CfgBidir) live fd out =
     | FunctionEntry f -> Pretty.dprintf "fun%d" f.vid
   in
   let dn_exp () e =
-    text (Goblintutil.escape (sprint 800 (dn_exp () e)))
+    text (XmlUtil.escape (sprint 800 (dn_exp () e)))
   in
   let dn_lval () l =
-    text (Goblintutil.escape (sprint 800 (dn_lval () l)))
+    text (XmlUtil.escape (sprint 800 (dn_lval () l)))
   in
   let p_edge () = function
     | Test (exp, b) -> if b then Pretty.dprintf "Pos(%a)" dn_exp exp else Pretty.dprintf "Neg(%a)" dn_exp exp

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -41,7 +41,7 @@ let compare_node = node_compare
 
 let equal_node x y =
   match x,y with
-  | Statement s1, Statement s2 -> s1.sid = s2.sid
+  | Statement s1, Statement s2 -> CilType.Stmt.equal s1 s2
   | Function f1, Function f2 -> CilType.Varinfo.equal f1 f2
   | FunctionEntry f1, FunctionEntry f2 -> CilType.Varinfo.equal f1 f2
   | _ -> false

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -42,8 +42,8 @@ let compare_node = node_compare
 let equal_node x y =
   match x,y with
   | Statement s1, Statement s2 -> s1.sid = s2.sid
-  | Function f1, Function f2 -> f1.vid = f2.vid
-  | FunctionEntry f1, FunctionEntry f2 -> f1.vid = f2.vid
+  | Function f1, Function f2 -> CilType.Varinfo.equal f1 f2
+  | FunctionEntry f1, FunctionEntry f2 -> CilType.Varinfo.equal f1 f2
   | _ -> false
 
 let print doc =

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -16,7 +16,7 @@ let empty_change_info () : change_info = {added = []; removed = []; changed = []
 
 type global_type = Fun | Decl | Var | Other
 
-type global_identifier = {name: string ; global_t: global_type}
+and global_identifier = {name: string ; global_t: global_type} [@@deriving ord]
 
 let identifier_of_global glob =
   match glob with
@@ -42,12 +42,7 @@ let check_file_changed (old_commit_dir: string) (current_commit_dir: string) =
   print_endline @@ "CIL-file " ^ (if old_file = current_file then "did not change." else "changed.")
 
 module GlobalMap = Map.Make(struct
-    type t = global_identifier
-    let compare a b =
-      let c = compare a.name b.name in
-      if c <> 0
-      then c
-      else compare a.global_t b.global_t
+    type t = global_identifier [@@deriving ord]
   end)
 
 let eq_list eq xs ys =

--- a/src/solvers/sLR.ml
+++ b/src/solvers/sLR.ml
@@ -505,7 +505,7 @@ module PrintInfluence =
       let f k _ =
         let q = if HM.mem S1.wpoint k then " shape=box style=rounded" else "" in
         let s = Pretty.sprint 80 (S.Var.pretty_trace () k) ^ " " ^ string_of_int (try HM.find S1.X.keys k with Not_found -> 0) in
-        ignore (Pretty.fprintf ch "%d [label=\"%s\"%s];\n" (S.Var.hash k) (Goblintutil.escape s) q);
+        ignore (Pretty.fprintf ch "%d [label=\"%s\"%s];\n" (S.Var.hash k) (XmlUtil.escape s) q);
         let f y =
           if try HM.find S1.X.keys k > HM.find S1.X.keys y with Not_found -> false then
             ignore (Pretty.fprintf ch "%d -> %d [arrowhead=box style=dashed];\n" (S.Var.hash k) (S.Var.hash y))

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -5,6 +5,7 @@ open Pretty
 module type S =
 sig
   include Printable.S
+  (* include MapDomain.Groupable *) (* FIXME: dependency cycle *)
 end
 
 module Std =
@@ -253,6 +254,27 @@ struct
   (* Output *)
   let pretty () x = d_type () x
   let show x = sprint ~width:max_int (pretty () x)
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
+  let to_yojson x = `String (show x)
+end
+
+module Fieldinfo: S with type t = fieldinfo =
+struct
+  include Std
+
+  type t = fieldinfo
+
+  let name () = "fieldinfo"
+
+  (* Identity *)
+  (* TODO: why compFullName, not ckey? *)
+  let equal x y = x.fname = y.fname && compFullName x.fcomp = compFullName y.fcomp
+  let compare x y = compare (x.fname, compFullName x.fcomp) (y.fname, compFullName y.fcomp)
+  let hash x = Hashtbl.hash (x.fname, compFullName x.fcomp)
+
+  (* Output *)
+  let show x = x.fname
+  let pretty () x = Pretty.text (show x)
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String (show x)
 end

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -217,7 +217,7 @@ struct
               r
             else
               compare e1c e2c
-      | _ -> failwith "CilExp.compareExp unknown type of expression"
+      | _ -> failwith "CilType.Exp.compare: mismatching exps"
   let equal a b = compare a b = 0
   let hash x = Hashtbl.hash x (* TODO: is this right? *)
 
@@ -261,7 +261,7 @@ struct
           r
         else
           compare o1 o2
-      | _ -> failwith "CilExp.compareOffset unknown type of expression" (* FIXME: don't fail *)
+      | _ -> failwith "CilType.Offset.compare: mismatching offsets"
   let equal x y = compare x y = 0
   let hash x = Hashtbl.hash x (* TODO: is this right? *)
 

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -97,6 +97,26 @@ struct
   let to_yojson x = `String (show x)
 end
 
+module Compinfo: S with type t = compinfo =
+struct
+  include Std
+
+  type t = compinfo
+
+  let name () = "compinfo"
+
+  (* Identity *)
+  let equal x y = x.ckey = y.ckey
+  let compare x y = compare x.ckey y.ckey
+  let hash x = Hashtbl.hash x.ckey
+
+  (* Output *)
+  let show x = compFullName x
+  let pretty () x = Pretty.text (show x)
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
+  let to_yojson x = `String (show x)
+end
+
 module Fieldinfo: S with type t = fieldinfo =
 struct
   include Std

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -27,6 +27,7 @@ struct
   let equal x y = x.vid = y.vid
   let compare x y = compare x.vid y.vid
   let hash x = x.vid - 4773
+  (* let hash x = Hashtbl.hash x.vid *)
 
   (* Output *)
   let show x = x.vname

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -113,6 +113,12 @@ struct
   (* let equal fld1 fld2 = fld1.fcomp.ckey = fld2.fcomp.ckey && fld1.fname = fld2.fname *) (* TODO: use this *)
   (* let equal xf yf = xf.floc = yf.floc && xf.fname = yf.fname && Cil.typeSig xf.ftype = Cil.typeSig yf.ftype && xf.fbitfield = yf.fbitfield && xf.fattr = yf.fattr *)
   let compare x y = compare (x.fname, compFullName x.fcomp) (y.fname, compFullName y.fcomp)
+  (* let compare a b =
+    let r = Typ.compare a.ftype b.ftype in
+    if r <> 0 then
+      r
+    else
+      compare (a.fname, a.fbitfield, a.fattr, a.floc) (b.fname, b.fbitfield, b.fattr, b.floc) *)
   let hash x = Hashtbl.hash (x.fname, compFullName x.fcomp)
 
   (* Output *)
@@ -252,7 +258,7 @@ struct
         match a, b with
         | NoOffset, NoOffset -> 0
         | Field (f1, o1), Field(f2, o2) ->
-          let r = compareFieldinfo f1 f2 in
+          let r = Fieldinfo.compare f1 f2 in
           if r <> 0 then
             r
           else
@@ -264,12 +270,6 @@ struct
           else
             compareOffset o1 o2
         | _ -> failwith "CilExp.compareOffset unknown type of expression"
-  and compareFieldinfo a b = (* TODO: Fieldinfo *)
-    let r = Typ.compare a.ftype b.ftype in
-    if r <> 0 then
-      r
-    else
-      compare (a.fname, a.fbitfield, a.fattr, a.floc) (b.fname, b.fbitfield, b.fattr, b.floc)
 
   let compare = compareExp
   let equal a b = compare a b = 0

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -64,8 +64,8 @@ struct
   let name () = "fundec"
 
   (* Identity *)
-  let equal x y = x.svar.vid = y.svar.vid
-  let compare x y = compare x.svar.vid y.svar.vid
+  let equal x y = Varinfo.equal x.svar y.svar
+  let compare x y = Varinfo.compare x.svar y.svar
   let hash x = x.svar.vid * 3
 
   (* Output *)
@@ -179,7 +179,7 @@ struct
   and compareLval a b = (* TODO: Lval *)
     match a, b with
     | (Var v1, o1), (Var v2, o2) ->
-      let r = compare v1.vid v2.vid in
+      let r = Varinfo.compare v1 v2 in
       if r <> 0 then
         r
       else

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -269,6 +269,10 @@ struct
   (* Identity *)
   (* TODO: why compFullName, not ckey? *)
   let equal x y = x.fname = y.fname && compFullName x.fcomp = compFullName y.fcomp
+  (* let equal f1 f2 = f1.fname = f2.fname *)
+  (* let equal x y = compFullName x.fcomp ^ x.fname = compFullName y.fcomp ^ y.fname *)
+  (* let equal fld1 fld2 = fld1.fcomp.ckey = fld2.fcomp.ckey && fld1.fname = fld2.fname *) (* TODO: use this *)
+  (* let equal xf yf = xf.floc = yf.floc && xf.fname = yf.fname && Cil.typeSig xf.ftype = Cil.typeSig yf.ftype && xf.fbitfield = yf.fbitfield && xf.fattr = yf.fattr *)
   let compare x y = compare (x.fname, compFullName x.fcomp) (y.fname, compFullName y.fcomp)
   let hash x = Hashtbl.hash (x.fname, compFullName x.fcomp)
 

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -34,3 +34,23 @@ struct
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
   let to_yojson x = `String x.vname
 end
+
+module Stmt: S with type t = stmt =
+struct
+  include Std
+
+  type t = stmt
+
+  let name () = "stmt"
+
+  (* Identity *)
+  let equal x y = x.sid = y.sid
+  let compare x y = compare x.sid y.sid
+  let hash x = Hashtbl.hash x.sid * 97
+
+  (* Output *)
+  let pretty () x = dn_stmt () x
+  let show x = Pretty.sprint ~width:max_int (pretty () x)
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let to_yojson x = `String (show x)
+end

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -76,6 +76,51 @@ struct
   let to_yojson x = `String (show x)
 end
 
+module Typ: S with type t = typ =
+struct
+  include Std
+
+  type t = typ
+
+  let name () = "typ"
+
+  (* Identity *)
+  let equal x y = Util.equals (Cil.typeSig x) (Cil.typeSig y)
+  let compare x y = compare (Cil.typeSig x) (Cil.typeSig y)
+  let hash (x:typ) = Hashtbl.hash x
+
+  (* Output *)
+  let pretty () x = d_type () x
+  let show x = sprint ~width:max_int (pretty () x)
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
+  let to_yojson x = `String (show x)
+end
+
+module Fieldinfo: S with type t = fieldinfo =
+struct
+  include Std
+
+  type t = fieldinfo
+
+  let name () = "fieldinfo"
+
+  (* Identity *)
+  (* TODO: why compFullName, not ckey? *)
+  let equal x y = x.fname = y.fname && compFullName x.fcomp = compFullName y.fcomp
+  (* let equal f1 f2 = f1.fname = f2.fname *)
+  (* let equal x y = compFullName x.fcomp ^ x.fname = compFullName y.fcomp ^ y.fname *)
+  (* let equal fld1 fld2 = fld1.fcomp.ckey = fld2.fcomp.ckey && fld1.fname = fld2.fname *) (* TODO: use this *)
+  (* let equal xf yf = xf.floc = yf.floc && xf.fname = yf.fname && Cil.typeSig xf.ftype = Cil.typeSig yf.ftype && xf.fbitfield = yf.fbitfield && xf.fattr = yf.fattr *)
+  let compare x y = compare (x.fname, compFullName x.fcomp) (y.fname, compFullName y.fcomp)
+  let hash x = Hashtbl.hash (x.fname, compFullName x.fcomp)
+
+  (* Output *)
+  let show x = x.fname
+  let pretty () x = Pretty.text (show x)
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
+  let to_yojson x = `String (show x)
+end
+
 module Exp: S with type t = exp =
 struct
   include Std
@@ -234,51 +279,6 @@ struct
   (* Output *)
   let pretty () x = dn_exp () x
   let show x = Pretty.sprint ~width:max_int (pretty () x)
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
-  let to_yojson x = `String (show x)
-end
-
-module Typ: S with type t = typ =
-struct
-  include Std
-
-  type t = typ
-
-  let name () = "typ"
-
-  (* Identity *)
-  let equal x y = Util.equals (Cil.typeSig x) (Cil.typeSig y)
-  let compare x y = compare (Cil.typeSig x) (Cil.typeSig y)
-  let hash (x:typ) = Hashtbl.hash x
-
-  (* Output *)
-  let pretty () x = d_type () x
-  let show x = sprint ~width:max_int (pretty () x)
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
-  let to_yojson x = `String (show x)
-end
-
-module Fieldinfo: S with type t = fieldinfo =
-struct
-  include Std
-
-  type t = fieldinfo
-
-  let name () = "fieldinfo"
-
-  (* Identity *)
-  (* TODO: why compFullName, not ckey? *)
-  let equal x y = x.fname = y.fname && compFullName x.fcomp = compFullName y.fcomp
-  (* let equal f1 f2 = f1.fname = f2.fname *)
-  (* let equal x y = compFullName x.fcomp ^ x.fname = compFullName y.fcomp ^ y.fname *)
-  (* let equal fld1 fld2 = fld1.fcomp.ckey = fld2.fcomp.ckey && fld1.fname = fld2.fname *) (* TODO: use this *)
-  (* let equal xf yf = xf.floc = yf.floc && xf.fname = yf.fname && Cil.typeSig xf.ftype = Cil.typeSig yf.ftype && xf.fbitfield = yf.fbitfield && xf.fattr = yf.fattr *)
-  let compare x y = compare (x.fname, compFullName x.fcomp) (y.fname, compFullName y.fcomp)
-  let hash x = Hashtbl.hash (x.fname, compFullName x.fcomp)
-
-  (* Output *)
-  let show x = x.fname
-  let pretty () x = Pretty.text (show x)
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String (show x)
 end

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -138,8 +138,7 @@ struct
 
   (* Identity *)
   (* Need custom compare because normal compare on CIL Exp might not terminate *)
-  (* TODO: rename to compare *)
-  let rec compareExp a b =
+  let rec compare a b =
     let order x = match x with
       | Const _ -> 0
       | Lval _ -> 1
@@ -171,10 +170,10 @@ struct
       | AlignOf t1, AlignOf t2
       | SizeOf t1, SizeOf t2 -> Typ.compare t1 t2
       | AlignOfE e1, AlignOfE e2
-      | SizeOfE e1, SizeOfE e2 -> compareExp e1 e2
-      | SizeOfStr s1, SizeOfStr s2 -> compare s1 s2
+      | SizeOfE e1, SizeOfE e2 -> compare e1 e2
+      | SizeOfStr s1, SizeOfStr s2 -> String.compare s1 s2
       | UnOp (op1, e1, t1), UnOp (op2, e2, t2) ->
-        let r = compare op1 op2 in
+        let r = Stdlib.compare op1 op2 in
         if r <> 0 then
           r
         else
@@ -182,9 +181,9 @@ struct
           if r <> 0 then
             r
           else
-            compareExp e1 e2
+            compare e1 e2
       | BinOp (op1, e1a, e1b, t1), BinOp (op2, e2a, e2b, t2) ->
-        let r = compare op1 op2 in
+        let r = Stdlib.compare op1 op2 in
         if r <> 0 then
           r
         else
@@ -192,35 +191,33 @@ struct
           if r <> 0 then
             r
           else
-            let r = compareExp e1a e2a in
+            let r = compare e1a e2a in
             if r <> 0 then
               r
             else
-              compareExp e1b e2b
+              compare e1b e2b
       | CastE (t1, e1), CastE (t2, e2) ->
         let r = Typ.compare t1 t2 in
         if r <> 0 then
           r
         else
-          compareExp e1 e2
-      | AddrOfLabel s1, AddrOfLabel s2 -> compare s1 s2
+          compare e1 e2
+      | AddrOfLabel s1, AddrOfLabel s2 -> Stdlib.compare s1 s2 (* TODO: is this right? *)
       | Question (e1a, e1b, e1c, t1), Question (e2a, e2b, e2c, t2) ->
         let r = Typ.compare t1 t2 in
         if r <> 0 then
           r
         else
-          let r = compareExp e1a e2a in
+          let r = compare e1a e2a in
           if r <> 0 then
             r
           else
-            let r = compareExp e1b e2b in
+            let r = compare e1b e2b in
             if r <> 0 then
               r
             else
-              compareExp e1c e2c
+              compare e1c e2c
       | _ -> failwith "CilExp.compareExp unknown type of expression"
-
-  let compare = compareExp
   let equal a b = compare a b = 0
   let hash x = Hashtbl.hash x (* TODO: is this right? *)
 

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -237,3 +237,23 @@ struct
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
   let to_yojson x = `String (show x)
 end
+
+module Typ: S with type t = typ =
+struct
+  include Std
+
+  type t = typ
+
+  let name () = "typ"
+
+  (* Identity *)
+  let equal x y = Util.equals (Cil.typeSig x) (Cil.typeSig y)
+  let compare x y = compare (Cil.typeSig x) (Cil.typeSig y)
+  let hash (x:typ) = Hashtbl.hash x
+
+  (* Output *)
+  let pretty () x = d_type () x
+  let show x = sprint ~width:max_int (pretty () x)
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let to_yojson x = `String (show x)
+end

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -165,6 +165,7 @@ struct
   (* Identity *)
   (* Need custom compare because normal compare on CIL Exp might not terminate *)
   let rec compare a b =
+    (* ArrayDomain seems to rely on this constructor order for "simpler" expressions *)
     let order x = match x with
       | Const _ -> 0
       | Lval _ -> 1

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -126,20 +126,26 @@ struct
   let name () = "fieldinfo"
 
   (* Identity *)
-  (* TODO: why compFullName, not ckey? *)
-  let equal x y = x.fname = y.fname && compFullName x.fcomp = compFullName y.fcomp
+  let equal x y = x.fname = y.fname && Compinfo.equal x.fcomp y.fcomp
+  (* let equal x y = x.fname = y.fname && compFullName x.fcomp = compFullName y.fcomp *)
   (* let equal f1 f2 = f1.fname = f2.fname *)
   (* let equal x y = compFullName x.fcomp ^ x.fname = compFullName y.fcomp ^ y.fname *)
-  (* let equal fld1 fld2 = fld1.fcomp.ckey = fld2.fcomp.ckey && fld1.fname = fld2.fname *) (* TODO: use this *)
+  (* let equal fld1 fld2 = fld1.fcomp.ckey = fld2.fcomp.ckey && fld1.fname = fld2.fname *)
   (* let equal xf yf = xf.floc = yf.floc && xf.fname = yf.fname && Cil.typeSig xf.ftype = Cil.typeSig yf.ftype && xf.fbitfield = yf.fbitfield && xf.fattr = yf.fattr *)
-  let compare x y = compare (x.fname, compFullName x.fcomp) (y.fname, compFullName y.fcomp)
+  let compare x y =
+    let r = String.compare x.fname y.fname in
+    if r <> 0 then
+      r
+    else
+      Compinfo.compare x.fcomp y.fcomp
+  (* let compare x y = compare (x.fname, compFullName x.fcomp) (y.fname, compFullName y.fcomp) *)
   (* let compare a b =
     let r = Typ.compare a.ftype b.ftype in
     if r <> 0 then
       r
     else
       compare (a.fname, a.fbitfield, a.fattr, a.floc) (b.fname, b.fbitfield, b.fattr, b.floc) *)
-  let hash x = Hashtbl.hash (x.fname, compFullName x.fcomp)
+  let hash x = Hashtbl.hash (x.fname, Compinfo.hash x.fcomp)
 
   (* Output *)
   let show x = x.fname

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -55,3 +55,23 @@ struct
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
   let to_yojson x = `String (show x)
 end
+
+module Fundec: S with type t = fundec =
+struct
+  include Std
+
+  type t = fundec
+
+  let name () = "fundec"
+
+  (* Identity *)
+  let equal x y = x.svar.vid = y.svar.vid
+  let compare x y = compare x.svar.vid y.svar.vid
+  let hash x = x.svar.vid * 3
+
+  (* Output *)
+  let show x = x.svar.vname
+  let pretty () x = Pretty.text (show x)
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let to_yojson x = `String (show x)
+end

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -1,0 +1,36 @@
+module GU = Goblintutil
+open Cil
+open Deriving.Cil
+open Pretty
+
+module type S =
+sig
+  include Printable.S
+end
+
+module Std =
+struct
+  include Printable.Std
+
+  let pretty_diff () (_, _) = nil
+end
+
+module Varinfo: S with type t = varinfo =
+struct
+  include Std
+
+  type t = varinfo
+
+  let name () = "varinfo"
+
+  (* Identity *)
+  let equal x y = x.vid = y.vid
+  let compare x y = compare x.vid y.vid
+  let hash x = x.vid - 4773
+
+  (* Output *)
+  let show x = x.vname
+  let pretty () x = Pretty.text (show x)
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let to_yojson x = `String x.vname
+end

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -75,3 +75,165 @@ struct
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
   let to_yojson x = `String (show x)
 end
+
+module Exp: S with type t = exp =
+struct
+  include Std
+
+  type t = exp
+
+  let name () = "exp"
+
+  (* Identity *)
+  (* Need custom compare because normal compare on CIL Exp might not terminate *)
+  (* TODO: rename to compare *)
+  let rec compareExp a b =
+    let order x = match x with
+      | Const _ -> 0
+      | Lval _ -> 1
+      | SizeOf _ -> 2
+      | SizeOfE _ -> 3
+      | SizeOfStr _ -> 4
+      | AlignOf _ -> 5
+      | AlignOfE _ -> 6
+      | UnOp _ -> 7
+      | BinOp _ -> 9
+      | CastE _ -> 10
+      | AddrOf _ -> 11
+      | StartOf _ -> 12
+      | Question _ -> 13
+      | AddrOfLabel _ -> 14
+      | Real _ -> 15
+      | Imag _ -> 16
+    in
+    if a == b || Expcompare.compareExp a b then
+      0
+    else if order a <> order b then
+      (order a) - (order b)
+    else
+      match a,b with
+      | Const c1, Const c2 -> compareConst c1 c2
+      | AddrOf l1, AddrOf l2
+      | StartOf l1, StartOf l2
+      | Lval l1, Lval l2 -> compareLval l1 l2
+      | AlignOf t1, AlignOf t2
+      | SizeOf t1, SizeOf t2 -> compareType t1 t2
+      | AlignOfE e1, AlignOfE e2
+      | SizeOfE e1, SizeOfE e2 -> compareExp e1 e2
+      | SizeOfStr s1, SizeOfStr s2 -> compare s1 s2
+      | UnOp (op1, e1, t1), UnOp (op2, e2, t2) ->
+        let r = compare op1 op2 in
+        if r <> 0 then
+          r
+        else
+          let r = compareType t1 t2 in
+          if r <> 0 then
+            r
+          else
+            compareExp e1 e2
+      | BinOp (op1, e1a, e1b, t1), BinOp (op2, e2a, e2b, t2) ->
+        let r = compare op1 op2 in
+        if r <> 0 then
+          r
+        else
+          let r = compareType t1 t2 in
+          if r <> 0 then
+            r
+          else
+            let r = compareExp e1a e2a in
+            if r <> 0 then
+              r
+            else
+              compareExp e1b e2b
+      | CastE (t1, e1), CastE (t2, e2) ->
+        let r = compareType t1 t2 in
+        if r <> 0 then
+          r
+        else
+          compareExp e1 e2
+      | AddrOfLabel s1, AddrOfLabel s2 -> compare s1 s2
+      | Question (e1a, e1b, e1c, t1), Question (e2a, e2b, e2c, t2) ->
+        let r = compareType t1 t2 in
+        if r <> 0 then
+          r
+        else
+          let r = compareExp e1a e2a in
+          if r <> 0 then
+            r
+          else
+            let r = compareExp e1b e2b in
+            if r <> 0 then
+              r
+            else
+              compareExp e1c e2c
+      | _ -> failwith "CilExp.compareExp unknown type of expression"
+  and compareConst a b = (* TODO: Constant *)
+    match a,b with
+    | CEnum (ea, sa, ia), CEnum (eb, sb, ib) ->
+      let r = compareExp ea eb in
+      if r <> 0 then
+        r
+      else
+        compare (sa, ia) (sb, ib)
+    | _ ->
+      compare a b
+  and compareLval a b = (* TODO: Lval *)
+    match a, b with
+    | (Var v1, o1), (Var v2, o2) ->
+      let r = compare v1.vid v2.vid in
+      if r <> 0 then
+        r
+      else
+        compareOffset o1 o2
+    | (Mem e1, o1), (Mem e2, o2) ->
+      let r = compareExp e1 e2 in
+      if r <> 0 then
+        r
+      else
+        compareOffset o1 o2
+    | (Var _, _), (Mem _, _) -> -1
+    | (Mem _, _), (Var _, _) -> 1
+  and compareOffset a b = (* TODO: Offset *)
+    let order x =
+      match x with
+      | NoOffset -> 0
+      | Field _ -> 1
+      | Index _ -> 2
+    in
+      if order a <> order b then
+        (order a) - (order b)
+      else
+        match a, b with
+        | NoOffset, NoOffset -> 0
+        | Field (f1, o1), Field(f2, o2) ->
+          let r = compareFieldinfo f1 f2 in
+          if r <> 0 then
+            r
+          else
+            compareOffset o1 o2
+        | Index (e1, o1), Index(e2, o2) ->
+          let r = compareExp e1 e2 in
+          if r <> 0 then
+            r
+          else
+            compareOffset o1 o2
+        | _ -> failwith "CilExp.compareOffset unknown type of expression"
+  and compareFieldinfo a b = (* TODO: Fieldinfo *)
+    let r = compareType a.ftype b.ftype in
+    if r <> 0 then
+      r
+    else
+      compare (a.fname, a.fbitfield, a.fattr, a.floc) (b.fname, b.fbitfield, b.fattr, b.floc)
+  and compareType a b = (* TODO: Typ *)
+    compare (typeSig a) (typeSig b) (* call to typeSig here is necessary, otherwise compare might not terminate *)
+
+  let compare = compareExp
+  let equal a b = compare a b = 0
+  let hash x = Hashtbl.hash x (* TODO: is this right? *)
+
+  (* Output *)
+  let pretty () x = dn_exp () x
+  let show x = Pretty.sprint ~width:max_int (pretty () x)
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let to_yojson x = `String (show x)
+end

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -85,6 +85,7 @@ struct
   let name () = "typ"
 
   (* Identity *)
+  (* call to typeSig here is necessary, otherwise compare might not terminate *)
   let equal x y = Util.equals (Cil.typeSig x) (Cil.typeSig y)
   let compare x y = compare (Cil.typeSig x) (Cil.typeSig y)
   let hash (x:typ) = Hashtbl.hash x
@@ -162,7 +163,7 @@ struct
       | StartOf l1, StartOf l2
       | Lval l1, Lval l2 -> compareLval l1 l2
       | AlignOf t1, AlignOf t2
-      | SizeOf t1, SizeOf t2 -> compareType t1 t2
+      | SizeOf t1, SizeOf t2 -> Typ.compare t1 t2
       | AlignOfE e1, AlignOfE e2
       | SizeOfE e1, SizeOfE e2 -> compareExp e1 e2
       | SizeOfStr s1, SizeOfStr s2 -> compare s1 s2
@@ -171,7 +172,7 @@ struct
         if r <> 0 then
           r
         else
-          let r = compareType t1 t2 in
+          let r = Typ.compare t1 t2 in
           if r <> 0 then
             r
           else
@@ -181,7 +182,7 @@ struct
         if r <> 0 then
           r
         else
-          let r = compareType t1 t2 in
+          let r = Typ.compare t1 t2 in
           if r <> 0 then
             r
           else
@@ -191,14 +192,14 @@ struct
             else
               compareExp e1b e2b
       | CastE (t1, e1), CastE (t2, e2) ->
-        let r = compareType t1 t2 in
+        let r = Typ.compare t1 t2 in
         if r <> 0 then
           r
         else
           compareExp e1 e2
       | AddrOfLabel s1, AddrOfLabel s2 -> compare s1 s2
       | Question (e1a, e1b, e1c, t1), Question (e2a, e2b, e2c, t2) ->
-        let r = compareType t1 t2 in
+        let r = Typ.compare t1 t2 in
         if r <> 0 then
           r
         else
@@ -264,13 +265,11 @@ struct
             compareOffset o1 o2
         | _ -> failwith "CilExp.compareOffset unknown type of expression"
   and compareFieldinfo a b = (* TODO: Fieldinfo *)
-    let r = compareType a.ftype b.ftype in
+    let r = Typ.compare a.ftype b.ftype in
     if r <> 0 then
       r
     else
       compare (a.fname, a.fbitfield, a.fattr, a.floc) (b.fname, b.fbitfield, b.fattr, b.floc)
-  and compareType a b = (* TODO: Typ *)
-    compare (typeSig a) (typeSig b) (* call to typeSig here is necessary, otherwise compare might not terminate *)
 
   let compare = compareExp
   let equal a b = compare a b = 0

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -1,4 +1,3 @@
-module GU = Goblintutil
 open Cil
 open Deriving.Cil
 open Pretty
@@ -32,7 +31,7 @@ struct
   (* Output *)
   let show x = x.vname
   let pretty () x = Pretty.text (show x)
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String x.vname
 end
 
@@ -52,7 +51,7 @@ struct
   (* Output *)
   let pretty () x = dn_stmt () x
   let show x = Pretty.sprint ~width:max_int (pretty () x)
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String (show x)
 end
 
@@ -72,7 +71,7 @@ struct
   (* Output *)
   let show x = x.svar.vname
   let pretty () x = Pretty.text (show x)
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String (show x)
 end
 
@@ -234,7 +233,7 @@ struct
   (* Output *)
   let pretty () x = dn_exp () x
   let show x = Pretty.sprint ~width:max_int (pretty () x)
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String (show x)
 end
 
@@ -254,6 +253,6 @@ struct
   (* Output *)
   let pretty () x = d_type () x
   let show x = sprint ~width:max_int (pretty () x)
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String (show x)
 end

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -438,25 +438,3 @@ let signal_of_string = let open Sys in function
   | s -> failwith ("Unhandled signal " ^ s)
 
 let self_signal signal = Unix.kill (Unix.getpid ()) signal
-
-module LazyEval (M : sig
-  type t
-  type result
-  val eval : t -> result
-end) : sig
-  type t
-  val make : M.t -> t
-  val force : t -> M.result
-end = struct
-  type t = { mutable value : [ `Computed of M.result | `Closure of M.t ] }
-
-  let make arg = { value = `Closure arg }
-
-  let force l =
-    match l.value with
-    | `Closure arg ->
-        let v = M.eval arg in
-        l.value <- `Computed v;
-        v
-    | `Computed v -> v
-end

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -77,14 +77,7 @@ let in_verifying_stage = ref false
 (* None if verification is disabled, Some true if verification succeeded, Some false if verification failed *)
 let verified : bool option ref = ref None
 
-let escape (x:string):string =
-  (* Safe to escape all these everywhere in XML: https://stackoverflow.com/a/1091953/854540 *)
-  Str.global_replace (Str.regexp "&") "&amp;" x |>
-  Str.global_replace (Str.regexp "<") "&lt;" |>
-  Str.global_replace (Str.regexp ">") "&gt;" |>
-  Str.global_replace (Str.regexp "\"") "&quot;" |>
-  Str.global_replace (Str.regexp "'") "&apos;" |>
-  Str.global_replace (Str.regexp "[\x0b\001\x0c\x0f\x0e]") "" (* g2html just cannot handle from some kernel benchmarks, even when escaped... *)
+let escape = XmlUtil.escape (* TODO: inline everywhere *)
 
 let trim (x:string): string =
   let len = String.length x in

--- a/src/util/lazyEval.ml
+++ b/src/util/lazyEval.ml
@@ -1,0 +1,24 @@
+(* Lazy eval extracted here to avoid dependency cycle:
+   Node -> CilType -> Printable -> Goblintutil -> GobConfig -> Tracing -> Node *)
+
+module Make (M : sig
+  type t
+  type result
+  val eval : t -> result
+end) : sig
+  type t
+  val make : M.t -> t
+  val force : t -> M.result
+end = struct
+  type t = { mutable value : [ `Computed of M.result | `Closure of M.t ] }
+
+  let make arg = { value = `Closure arg }
+
+  let force l =
+    match l.value with
+    | `Closure arg ->
+        let v = M.eval arg in
+        l.value <- `Computed v;
+        v
+    | `Computed v -> v
+end

--- a/src/util/xmlUtil.ml
+++ b/src/util/xmlUtil.ml
@@ -1,0 +1,11 @@
+(* XML escape extracted here to avoid dependency cycle:
+   CilType -> Goblintutil -> GobConfig -> Tracing -> Node -> CilType *)
+
+let escape (x:string):string =
+  (* Safe to escape all these everywhere in XML: https://stackoverflow.com/a/1091953/854540 *)
+  Str.global_replace (Str.regexp "&") "&amp;" x |>
+  Str.global_replace (Str.regexp "<") "&lt;" |>
+  Str.global_replace (Str.regexp ">") "&gt;" |>
+  Str.global_replace (Str.regexp "\"") "&quot;" |>
+  Str.global_replace (Str.regexp "'") "&apos;" |>
+  Str.global_replace (Str.regexp "[\x0b\001\x0c\x0f\x0e]") "" (* g2html just cannot handle from some kernel benchmarks, even when escaped... *)

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -238,7 +238,7 @@ let partition_if_next if_next_n =
   in
   (* assert (List.length if_next <= 2); *)
   match test_next true, test_next false with
-  | (Test (e_true, true), if_true_next_n), (Test (e_false, false), if_false_next_n) when Basetype.CilExp.compareExp e_true e_false = 0 ->
+  | (Test (e_true, true), if_true_next_n), (Test (e_false, false), if_false_next_n) when Basetype.CilExp.equal e_true e_false ->
     (e_true, if_true_next_n, if_false_next_n)
   | _, _ -> failwith "partition_if_next: bad branches"
 

--- a/src/witness/violationZ3.ml
+++ b/src/witness/violationZ3.ml
@@ -18,12 +18,7 @@ struct
 
   type var = varinfo
 
-  module Var =
-  struct
-    type t = var
-    let equal x y = CilType.Varinfo.equal x y
-    let compare x y = CilType.Varinfo.compare x y
-  end
+  module Var = CilType.Varinfo
 
   module type Env =
   sig

--- a/src/witness/violationZ3.ml
+++ b/src/witness/violationZ3.ml
@@ -21,7 +21,7 @@ struct
   module Var =
   struct
     type t = var
-    let equal x y = x.vid = y.vid
+    let equal x y = CilType.Varinfo.equal x y
     let compare x y = compare x.vid y.vid
   end
 

--- a/src/witness/violationZ3.ml
+++ b/src/witness/violationZ3.ml
@@ -22,7 +22,7 @@ struct
   struct
     type t = var
     let equal x y = CilType.Varinfo.equal x y
-    let compare x y = compare x.vid y.vid
+    let compare x y = CilType.Varinfo.compare x y
   end
 
   module type Env =

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -17,7 +17,7 @@ struct
     | Statement stmt  -> string_of_int stmt.sid
     | Function f      -> "return of " ^ f.vname ^ "()"
     | FunctionEntry f -> f.vname ^ "()"
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (Goblintutil.escape (show x))
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let name () = "var"
   let invariant _ _ = Invariant.none
   let tag _ = failwith "PrintableVar: no tag"


### PR DESCRIPTION
This implements the thoughts I had in https://github.com/goblint/analyzer/pull/227#issuecomment-839698783 and furthers #31.

Instead of having equality, comparison and printing for CIL values duplicated all over the place whereever more sophisticated printables and lattices are defined, this moves those common implementations into `CilType`. For example, `CilType.Varinfo` has signature `Printable.S with type t = varinfo` and provides `equal`/`compare` based on just `vid`, which is how we compare them almost everywhere. For other types, e.g. `fieldinfo`, this provides proper implementations that don't forget to distinguish fields with the same name in different structs, etc. Whereever one really needs to override these sensible defaults, one can just define a new module to that use case specifically and include from `CilType`.

This also allows more ppx deriving to be used, which I tried to do as much as possible here. By defining new module types using `CilType.Varinfo.t` instead of `varinfo` directly, you can derive eq and ord, which will automatically use the sensible defaults for `varinfo` comparison from that module. This is cleaner than defining all these `equal_varinfo`, `compare_varinfo`, etc functions standalone in `Deriving.Cil` and having to remember to open that on top of `Cil`. The extra benefit is being able to use `CilType.Varinfo` directly as a `MapDomain` key module.