### PR TITLE
Documentation: Add basic description on how to run Goblint and on need for context widening 

### DIFF
--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -51,7 +51,9 @@ Other tracing functions are available:
 
 To build a Goblint executable with debug information, run the following command within the `analyzer` directory.
 
-`make debug`
+```console
+make debug
+```
 
 This will create a file called `goblint.byte`.
 
@@ -68,12 +70,16 @@ Install the [`hackwaly.ocamlearlybird` extension](https://marketplace.visualstud
 To be able to use this extension, you additionally need to install `ocamlearlybird` on the opam switch you use for Goblint.
 Running:
 
-`make dev`
+```console
+make dev
+```
 
 will install `ocamlearlybird` along with some other useful development tools.
 In case you do not want to install all of these and only want to install `ocamlearlybird` by itself, run the following command in the `analyzer` directory:
 
-`opam install earlybird`
+```console
+opam install earlybird
+```
 
 ### Providing a Launch Configuration
 
@@ -104,7 +110,7 @@ Note that the individual arguments to Goblint should be passed here as separate 
 
 To make sure that VS Code can find `ocamlearlybird`, run the following commands in the `analyzer` directory:
 
-```
+```console
 eval $(opam env) // Sets up envrionment variables
 code .           // Starts VS Code in the current directory
 ```

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -3,6 +3,7 @@
 ## Regression tests
 Regression tests are small programs that can be used to quickly verify that existing functionality hasn't been broken.
 They can be found in `./tests/regression/`.
+Options that should be passed to Goblint when executing a regression test are specified in the test file using a single line comment starting with `//PARAM:`.
 
 ### Running
 Regression tests can be run with various granularity:

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -25,21 +25,6 @@ For a list of all options and their possible configurations, run:
 ./goblint --print_all_options
 ```
 
-## Executing Regression Tests
-The regression tests contained in `./tests/regression` usually come with some specific options that should be passed be Goblint when executing them. The script `regtest.sh` can be used to execute Goblint on an individual regression test.
-It passes the options that are specified in a test file to Goblint.
-The options for a regression test are specified in a single line comment starting with `//PARAM:`.
-
-#### Example:
-The following command executes Goblint on a regression test. The test is identified using the digit-prefix of the folder and the source file.
-```
-./regtest.sh 01 02
-```
-To execute all regression tests, run:
-```
-make test
-```
-
 ## Analyzing Recursive Programs
 In some cases, when using the default configuration, Goblint might not terminate in reasonable time on recursive programs, or
 crash in a stack overflow (indicated by the error message `exception Stack overflow`). If the stack overflow occurs within a C function called by Goblint, it will result in the following error message: `Command terminated by signal 11`.

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -7,7 +7,7 @@ To generate an HTML-output that can be [inspected using the browser](inspecting.
 
 #### Example:
 
-```
+```console
 ./goblint tests/regression/01-cpa/02-branch.c --html
 ```
 ## Passing Options
@@ -15,13 +15,13 @@ To generate an HTML-output that can be [inspected using the browser](inspecting.
 Goblint offers many options to tweak how the analysis is performed.
 For more information on how to set options, run:
 
-```
+```console
 ./goblint --help
 ```
 
 For a list of all options and their possible configurations, run:
 
-```
+```console
 ./goblint --print_all_options
 ```
 

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -1,0 +1,47 @@
+# Running Goblint
+
+## Basic Execution
+
+To analyze a C-source file with Goblint, you may simply pass the path to the file as a command line argument to it.
+To generate an HTML-output that can be [inspected using the browser](inspecting.md), additionally pass the `--html` flag.
+
+#### Example:
+
+```
+./goblint tests/regression/01-cpa/02-branch.c --html
+```
+## Passing Options
+
+Goblint offers many options to tweak how the analysis is performed.
+For more information on how to set options, run:
+
+```
+./goblint --help
+```
+
+For a list of all options and their possible configurations, run:
+
+```
+./goblint --print_all_options
+```
+
+## Executing Regression Tests
+The regression tests contained in `./tests/regression` usually come with some specific options that should be passed be Goblint when executing them. The script `regtest.sh` can be used to execute Goblint on an individual regression test.
+It passes the options that are specified in a test file to Goblint.
+The options for a regression test are specified in a single line comment starting with `//PARAM:`.
+
+#### Example:
+The following command executes Goblint on a regression test. The test is identified using the digit-prefix of the folder and the source file.
+```
+./regtest.sh 01 02
+```
+To execute all regression tests, run:
+```
+make test
+```
+
+## Analyzing Recursive Programs
+In some cases, when using the default configuration, Goblint might not terminate in reasonable time on recursive programs, or
+crash in a stack overflow (indicated by the error message `exception Stack overflow`). If the stack overflow occurs within a C function called by Goblint, it will result in the following error message: `Command terminated by signal 11`.
+
+Adding the option `--enable exp.widen-context` will enable widening on the contexts in which functions are analyzed. This avoids stack overflows possibly caused by the analysis of recursive functions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ dev_addr: '127.0.0.1:8010' # different port from default python http.server for 
 nav:
   - Home: index.md
   - 'User guide':
+    - user-guide/running.md
     - user-guide/inspecting.md
   - 'Developer guide':
     - developer-guide/testing.md


### PR DESCRIPTION
In https://github.com/goblint/analyzer/issues/206#issuecomment-842326410, @vogler  noted that stack overflows that occur in calls for C-functions result in Goblint being killed with `signal 11`. 

This PR adds a very basic documentation on how to run Goblint, with a remark to enable `exp.widen-context` when the analysis of recursive function leads to a stack overflow / `signal 11`.

Related to #208. 