### PR TITLE
HoarePO.merge_join: Merge smaller map into larger one to improve performance

### DIFF
--- a/src/domains/hoareDomain.ml
+++ b/src/domains/hoareDomain.ml
@@ -68,7 +68,7 @@ struct
   (* join all elements from the smaller map into their bucket in the other one.
    * this doesn't need to go over all elements of both maps as the general merge above. *)
   let merge_join f x y =
-    (* let x, y = if Map.cardinal x < Map.cardinal y then x, y else y, x in *)
+    let x, y = if Map.cardinal x < Map.cardinal y then x, y else y, x in
     List.fold_left (flip (B.merge_element (B.join f))) y (elements x)
 
   let join   x y = merge_join E.join x y


### PR DESCRIPTION
This was already an commented out performance tweak. In the library analysis uncommenting this code improves performance quite significantly, but this heavily relies on joining addresses. I assume this tweak should still have a positive impact on performance with the regular base analysis, although probably not as significant in most cases.

