### PR TITLE
Preparations for removing the Assert  query

### DIFF
--- a/src/analyses/apron/poly.apron.ml
+++ b/src/analyses/apron/poly.apron.ml
@@ -110,7 +110,7 @@ struct
     | EvalInt e ->
       begin
         match D.get_int_val_for_cil_exp d e with
-        | Some i -> ID.of_int i
+        | Some i -> Queries.ID.of_int i
         | _ -> `Top
       end
     | MustBeEqual (e1, e2) ->

--- a/src/analyses/arinc.ml
+++ b/src/analyses/arinc.ml
@@ -398,15 +398,15 @@ struct
       | "LAP_Se_SetPartitionMode", [mode; r] -> begin
           match ctx.ask (Queries.EvalInt mode) with
           | `Lifted i ->
-            let pm = partition_mode_of_enum @@ Int64.to_int i in
-            if M.tracing then M.tracel "arinc" "setting partition mode to %Ld (%s)\n" i (show_partition_mode_opt pm);
-            if mode_is_multi (Pmo.of_int i) then (
+            let pm = partition_mode_of_enum @@ IntOps.BigIntOps.to_int i in
+            if M.tracing then M.tracel "arinc" "setting partition mode to %Ld (%s)\n" (IntOps.BigIntOps.to_int64 i) (show_partition_mode_opt pm);
+            if mode_is_multi (Pmo.of_int (IntOps.BigIntOps.to_int64 i)) then (
               let tasks = ctx.global tasks_var in
               ignore @@ printf "arinc: SetPartitionMode NORMAL: spawning %i processes!\n" (Tasks.cardinal tasks);
               Tasks.iter (fun (fs,f_d) -> Queries.LS.iter (fun f -> ctx.spawn None (fst f) []) fs) tasks;
             );
             add_action (SetPartitionMode pm)
-            |> D.pmo (const @@ Pmo.of_int i)
+            |> D.pmo (const @@ Pmo.of_int (IntOps.BigIntOps.to_int64 i))
           | _ -> D.top ()
         end
       | "LAP_Se_GetPartitionStatus", [status; r] -> todo () (* != mode *)
@@ -499,6 +499,9 @@ struct
         begin match name, entry_point, pri, per, cap with
           | `Lifted name, ls, `Lifted pri, `Lifted per, `Lifted cap when not (Queries.LS.is_top ls)
                                                                    && not (Queries.LS.mem (dummyFunDec.svar,`NoOffset) ls) ->
+            let pri = (IntOps.BigIntOps.to_int64 pri) in
+            let per = (IntOps.BigIntOps.to_int64 per) in
+            let cap = (IntOps.BigIntOps.to_int64 cap) in
             let funs_ls = Queries.LS.filter (fun (v,o) -> let lval = Var v, Lval.CilLval.to_ciloffs o in isFunctionType (typeOfLval lval)) ls in (* do we need this? what happens if we spawn a variable that's not a function? shouldn't this check be in spawn? *)
             if M.tracing then M.tracel "arinc" "starting a thread %a with priority '%Ld' \n" Queries.LS.pretty funs_ls pri;
             let funs = funs_ls |> Queries.LS.elements |> List.map fst |> List.unique in
@@ -527,7 +530,7 @@ struct
       | "LAP_Se_Suspend", [pid; r] ->
         add_actions @@ List.map (fun pid -> Suspend pid) (eval_id pid)
       | "LAP_Se_SuspendSelf", [timeout; r] ->
-        let t = eval_int timeout in
+        let t = IntOps.BigIntOps.to_int64 (eval_int timeout) in
         add_action (SuspendSelf (env.procid, t))
       | "LAP_Se_Resume", [pid; r] ->
         add_actions @@ List.map (fun pid -> Resume pid) (eval_id pid)
@@ -564,7 +567,7 @@ struct
       | "LAP_Se_DisplayBlackboard", [bbid; msg_addr; len; r] ->
         add_actions @@ List.map (fun id -> DisplayBlackboard id) (eval_id bbid)
       | "LAP_Se_ReadBlackboard", [bbid; timeout; msg_addr; len; r] ->
-        let t = eval_int timeout in
+        let t = IntOps.BigIntOps.to_int64 (eval_int timeout) in
         add_actions @@ List.map (fun id -> ReadBlackboard (id, t)) (eval_id bbid)
       | "LAP_Se_ClearBlackboard", [bbid; r] ->
         add_actions @@ List.map (fun id -> ClearBlackboard id) (eval_id bbid)
@@ -576,9 +579,9 @@ struct
         (* create resource for name *)
         let sid' = Semaphore, eval_str name in
         assign_id sid (get_id sid');
-        add_action (CreateSemaphore Action.({ sid = sid'; cur = eval_int cur; max = eval_int max; queuing = eval_int queuing }))
+        add_action (CreateSemaphore Action.({ sid = sid'; cur = (IntOps.BigIntOps.to_int64 (eval_int cur)); max = (IntOps.BigIntOps.to_int64 (eval_int max)); queuing = (IntOps.BigIntOps.to_int64 (eval_int queuing)) }))
       | "LAP_Se_WaitSemaphore", [sid; timeout; r] -> (* TODO timeout *)
-        let t = eval_int timeout in
+        let t = IntOps.BigIntOps.to_int64 (eval_int timeout) in
         add_actions @@ List.map (fun id -> WaitSemaphore (id, t)) (eval_id sid)
       | "LAP_Se_SignalSemaphore", [sid; r] ->
         add_actions @@ List.map (fun id -> SignalSemaphore id) (eval_id sid)
@@ -595,7 +598,7 @@ struct
       | "LAP_Se_ResetEvent", [eid; r] ->
         add_actions @@ List.map (fun id -> ResetEvent id) (eval_id eid)
       | "LAP_Se_WaitEvent", [eid; timeout; r] -> (* TODO timeout *)
-        let t = eval_int timeout in
+        let t = IntOps.BigIntOps.to_int64 (eval_int timeout) in
         add_actions @@ List.map (fun id -> WaitEvent (id, t)) (eval_id eid)
       | "LAP_Se_GetEventId", [name; eid; r] ->
         assign_id_by_name Event name eid; d
@@ -603,7 +606,7 @@ struct
       (* Time *)
       | "LAP_Se_GetTime", [time; r] -> todo ()
       | "LAP_Se_TimedWait", [delay; r] ->
-        add_action (TimedWait (eval_int delay))
+        add_action (TimedWait (IntOps.BigIntOps.to_int64 (eval_int delay)))
       | "LAP_Se_PeriodicWait", [r] ->
         add_action PeriodicWait
       (* Errors *)
@@ -632,8 +635,11 @@ struct
     let d = ctx.local in
     match q with
     | Queries.Priority _ ->
-      if Pri.is_int d.pri then
-        Queries.ID.of_int @@ Option.get @@ Pri.to_int d.pri
+      if Pri.is_int d.pri then Queries.ID.of_int @@ IntOps.BigIntOps.of_int64 @@ Option.get @@ Pri.to_int d.pri
+        (*match Option.get @@ Pri.to_int d.pri with
+          | `Lifted i -> Queries.ID.of_int @@ IntOps.BigIntOps.of_int64 i
+          | `Top -> Queries.Result.top q
+          | `Bot -> Queries.Result.bot q *)
       else if Pri.is_top d.pri then Queries.Result.top q else Queries.Result.bot q (* TODO: remove bot *)
     (* | Queries.MayBePublic _ -> *)
     (*   `Bool ((PrE.to_int d.pre = Some 0L || PrE.to_int d.pre = None) && (not (mode_is_init d.pmo))) *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -274,6 +274,7 @@ struct
 
   (* evaluate value using our "query functions" *)
   let eval_rv_pre (ask: Q.ask) exp pr =
+    let _other_analsyis_result = ask.f (Q.EvalInt exp) in
     let binop op e1 e2 =
       let equality () =
         (* TODO: just return bool? *)

--- a/src/analyses/extract_arinc.ml
+++ b/src/analyses/extract_arinc.ml
@@ -250,7 +250,7 @@ struct
         let fname = str_remove "LAP_Se_" f.vname in
         let eval_int exp =
           match ctx.ask (Queries.EvalInt exp) with
-          | `Lifted x -> [Int64.to_string x]
+          | `Lifted x -> [IntOps.BigIntOps.to_string x]
           | _ -> failwith @@ "Could not evaluate int-argument "^sprint d_plainexp exp
         in
         let eval_str exp =
@@ -325,6 +325,7 @@ struct
           begin match name, entry_point, pri, per, cap with
             | `Lifted name, ls, `Lifted pri, `Lifted per, `Lifted cap when not (Queries.LS.is_top ls)
                                                                      && not (Queries.LS.mem (dummyFunDec.svar,`NoOffset) ls) ->
+              let pri = (IntOps.BigIntOps.to_int64 pri) in
               let funs_ls = Queries.LS.filter (fun (v,o) -> let lval = Var v, Lval.CilLval.to_ciloffs o in isFunctionType (typeOfLval lval)) ls in (* do we need this? what happens if we spawn a variable that's not a function? shouldn't this check be in spawn? *)
               if M.tracing then M.tracel "extract_arinc" "starting a thread %a with priority '%Ld' \n" Queries.LS.pretty funs_ls pri;
               let funs = funs_ls |> Queries.LS.elements |> List.map fst |> List.unique in

--- a/src/analyses/extract_osek.ml
+++ b/src/analyses/extract_osek.ml
@@ -244,7 +244,7 @@ struct
         let fname = str_remove "LAP_Se_" f.vname in
         let eval_int exp =
           match ctx.ask (Queries.EvalInt exp) with
-          | `Lifted x -> [Int64.to_string x]
+          | `Lifted x -> [IntOps.BigIntOps.to_string x]
           | _ -> failwith @@ "Could not evaluate int-argument "^sprint d_plainexp exp
         in
         let eval_str exp =

--- a/src/analyses/flagModes.ml
+++ b/src/analyses/flagModes.ml
@@ -32,12 +32,12 @@ struct
               ctx.local
             end else begin
               match eval_int (Analyses.ask_of_ctx ctx) rval with
-              | Some ex -> D.add f (`Lifted (false,true,ex)) ctx.local
+              | Some ex -> D.add f (`Lifted (false,true, Option.get(IntDomain.FlatPureIntegers.to_int (IntOps.BigIntOps.to_int64 ex)))) ctx.local
               | _ -> D.remove f ctx.local
             end
           end else begin
             match eval_int (Analyses.ask_of_ctx ctx) rval with
-            | Some ex -> D.add f (`Lifted (false,true,ex)) ctx.local
+            | Some ex -> D.add f (`Lifted (false,true, IntOps.BigIntOps.to_int64 ex)) ctx.local
             | _ -> D.remove f ctx.local
           end
         end
@@ -60,6 +60,7 @@ struct
           let temp = eval_int (Analyses.ask_of_ctx ctx) ex in
           match temp with
           | Some value -> begin (*guard == value = (true true value*)
+              let value = IntOps.BigIntOps.to_int64 value in
               try
                 match (D.find f ctx.local) with
                 | `Lifted (false,_,old_val) -> if value <> old_val then D.add f `Bot ctx.local else ctx.local
@@ -100,6 +101,7 @@ struct
           let temp = eval_int (Analyses.ask_of_ctx ctx) ex in
           match temp with
           | Some value -> begin
+              let value = IntOps.BigIntOps.to_int64 value in
               try
                 match (D.find f ctx.local) with
                 | `Lifted (false,_,old_val) -> if value <> old_val then ctx.local else D.add f `Bot ctx.local

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -527,6 +527,7 @@ struct
     (Queries.Result.top q) 
   else
     (* let () = Printf.printf "Size 1: %d\n" (QuerySet.cardinal asked) in *)
+    let asked = QuerySet.add (Any(q)) asked in
     let module Result = (val Queries.Result.lattice q) in
     let f a (n,(module S:MCPSpec),d) =
       let ctx' : (S.D.t, S.G.t, S.C.t) ctx =
@@ -536,7 +537,7 @@ struct
         ; control_context = ctx.control_context
         ; context = (fun () -> ctx.context () |> assoc n |> obj)
         ; edge   = ctx.edge
-        ; ask    = (fun (type b) (q: b Queries.t) -> query' (QuerySet.add (Any(q)) asked) ctx q)
+        ; ask    = (fun (type b) (q: b Queries.t) -> query' asked ctx q)
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in query context.")
         ; presub = filter_presubs n ctx.local
         ; postsub= []

--- a/src/analyses/octagon.ml
+++ b/src/analyses/octagon.ml
@@ -362,7 +362,7 @@ struct
     | Queries.EvalInt exp ->
       let inv = evaluate_exp ctx.local exp in
       if INV.is_int inv
-      then INV.to_int inv |> Option.get |> BI.to_int64 |> Queries.ID.of_int
+      then INV.to_int inv |> Option.get |> Queries.ID.of_int
       else Queries.Result.top q
     | _ -> Queries.Result.top q
 

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -569,8 +569,8 @@ struct
     match q with
     | Queries.Priority "" ->
       let pry = resourceset_to_priority (List.map names (Mutex.Lockset.ReverseAddrSet.elements ctx.local)) in
-      Queries.ID.of_int @@ Int64.of_int pry
-    | Queries.Priority vname -> begin try Queries.ID.of_int @@ Int64.of_int (Hashtbl.find offensivepriorities vname) with _ -> Queries.Result.top q end
+      Queries.ID.of_int @@ IntOps.BigIntOps.of_int pry
+    | Queries.Priority vname -> begin try Queries.ID.of_int @@ IntOps.BigIntOps.of_int (Hashtbl.find offensivepriorities vname) with _ -> Queries.Result.top q end
     | Queries.MayBePublic {global=v; _} ->
       let pry = resourceset_to_priority (List.map names (Mutex.Lockset.ReverseAddrSet.elements ctx.local)) in
       if pry = min_int then

--- a/src/analyses/spec.ml
+++ b/src/analyses/spec.ml
@@ -79,7 +79,7 @@ struct
           | b -> (match Queries.ID.to_bool b with Some b -> a=b | None -> false)
         )
       | `Int a, e  -> (match ctx.ask (Queries.EvalInt e) with
-          | b -> (match Queries.ID.to_int b with Some b -> (Int64.of_int a)=b | None -> false)
+          | b -> (match Queries.ID.to_int b with Some b -> (Int64.of_int a)=(IntOps.BigIntOps.to_int64 b) | None -> false)
         )
       | `Float a, Const(CReal (b, fkind, str_opt)) -> a=b
       | `Float a, _ -> M.warn_each "EQUAL Float: unsupported!"; false

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -397,7 +397,7 @@ struct
     | Some infimum, Some supremum ->
       begin
         if (supremum = infimum) then
-          (Some infimum)
+          (Some (IntOps.BigIntOps.of_int64 infimum))
         else None
       end
     | _ -> None

--- a/src/cdomains/apron/octApronDomain.apron.ml
+++ b/src/cdomains/apron/octApronDomain.apron.ml
@@ -228,7 +228,7 @@ struct
     | CastE (TInt(new_ikind, _), e) ->
       let new_exp = (match e with
       (* Do a cast of int constants *)
-      | Const (CInt64 (value, old_ikind, _)) -> Cil.kinteger64 new_ikind (IntDomain.Integers.cast_to new_ikind value)
+      | Const (CInt64 (value, old_ikind, _)) -> let module I = IntDomain.Integers(IntOps.Int64Ops) in Cil.kinteger64 new_ikind (I.cast_to new_ikind value)
       (* Ignore other casts *)
       | Lval (Var varinfo, _) -> e (* TODO: handle variable casts *)
       |_ -> e)
@@ -547,7 +547,7 @@ struct
     | Some infimum, Some supremum ->
       begin
         if (supremum = infimum) then
-          (Some infimum)
+          (Some (IntOps.BigIntOps.of_int64 infimum))
         else None
       end
     | _ -> None

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -236,7 +236,7 @@ struct
                 let n = ask.f (Q.EvalInt e') in
                 match Q.ID.to_int n with
                 | Some i ->
-                  (`Lifted (Cil.kinteger64 IInt i), (xl, xm, xr))
+                  (`Lifted (Cil.kinteger64 IInt (IntOps.BigIntOps.to_int64 i)), (xl, xm, xr))
                 | _ -> default
               end
             | _ -> default
@@ -294,7 +294,7 @@ struct
         match e with
         | `Lifted e' ->
           let n = ask.f (Q.EvalInt e') in
-          Option.map BI.of_int64 (Q.ID.to_int n)
+          Option.map BI.of_bigint (Q.ID.to_int n)
         |_ -> None
       in
       let equals_zero e = BatOption.map_default (BI.equal BI.zero) false (exp_value e) in

--- a/src/cdomains/shapeDomain.ml
+++ b/src/cdomains/shapeDomain.ml
@@ -2,7 +2,7 @@ module Q     = Queries
 module GU    = Goblintutil
 module Var   = Basetype.Variables
 module Bool  = IntDomain.Booleans
-module Offs  = Lval.Offset (IntDomain.IntDomWithDefaultIkind (IntDomain.IntDomLifter (IntDomain.OldDomainFacade (IntDomain.Integers))) (IntDomain.PtrDiffIkind))
+module Offs  = Lval.Offset (IntDomain.IntDomWithDefaultIkind (IntDomain.IntDomLifter (IntDomain.OldDomainFacade (IntDomain.Integers (IntOps.Int64Ops)))) (IntDomain.PtrDiffIkind))
 module CLval = Lval.CilLval
 
 open Cil

--- a/src/domains/intDomainProperties.ml
+++ b/src/domains/intDomainProperties.ml
@@ -54,7 +54,7 @@ end
 module IntegerSet =
 struct
   (* TODO: base this on BI instead *)
-  module Base = IntDomain.Integers
+  module Base = IntDomain.Integers(IntOps.Int64Ops)
 
   include SetDomain.Make(Base)
 

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -234,18 +234,11 @@ module Query = struct
               r3
             else
               Bool.compare x1.write x2.write
-        | Any(CurrentLockset), Any(CurrentLockset) -> 0
-        | Any(MustBeAtomic), Any(MustBeAtomic) -> 0
-        | Any(MustBeSingleThreaded), Any(MustBeSingleThreaded) -> 0
-        | Any(MustBeUniqueThread), Any(MustBeUniqueThread) -> 0
-        | Any(CurrentThreadId), Any(CurrentThreadId) -> 0
-        | Any(MayBeThreadReturn), Any(MayBeThreadReturn) -> 0
         | Any(EvalFunvar e1), Any(EvalFunvar e2) -> CilType.Exp.compare e1 e2
         | Any(EvalInt e1), Any(EvalInt e2) -> CilType.Exp.compare e1 e2
         | Any(EvalStr e1), Any(EvalStr e2) -> CilType.Exp.compare e1 e2
         | Any(EvalLength e1), Any(EvalLength e2) -> CilType.Exp.compare e1 e2
         | Any(BlobSize e1), Any(BlobSize e2) -> CilType.Exp.compare e1 e2
-        | Any(PrintFullState), Any(PrintFullState) -> 0
         | Any(CondVars e1), Any(CondVars e2) -> CilType.Exp.compare e1 e2
         | Any(PartAccess p1), Any(PartAccess p2) ->
           let r2 = CilType.Exp.compare p1.exp p2.exp in
@@ -282,7 +275,6 @@ module Query = struct
             r2
           else
             CilType.Exp.compare e2 e4 
-        | Any(HeapVar), Any(HeapVar) -> 0
         | Any(IsHeapVar v1), Any(IsHeapVar v2) -> CilType.Varinfo.compare v1 v2
         | Any(Assert a1), Any(Assert a2) -> CilType.Exp.compare a1 a2 
         | _, _ -> Stdlib.compare (order a) (order b)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -1,7 +1,7 @@
 (** Structures for the querying subsystem. *)
 
 module GU = Goblintutil
-module ID = IntDomain.Flattened
+module ID = IntDomain.FlattenedBI
 module LS = SetDomain.ToppedSet (Lval.CilLval) (struct let topname = "All" end)
 module TS = SetDomain.ToppedSet (Basetype.CilType) (struct let topname = "All" end)
 module ES = SetDomain.Reverse (SetDomain.ToppedSet (Exp.Exp) (struct let topname = "All" end))

--- a/src/transform/expressionEvaluation.ml
+++ b/src/transform/expressionEvaluation.ml
@@ -129,7 +129,7 @@ module ExpEval : Transform.S =
         method private try_ask location expression =
           match ~? (fun () -> (ask location).Queries.f (Queries.EvalInt expression)) with
             (* Evaluable: Definite *)
-          | Some (`Lifted value) -> Some (Some (value <> Int64.zero))
+          | Some (`Lifted value) -> Some (Some (value <> IntOps.BigIntOps.zero))
             (* Evaluable: Inconclusive *)
           | Some `Top -> Some None
             (* Inapplicable: Unreachable *)

--- a/src/transform/transform.ml
+++ b/src/transform/transform.ml
@@ -23,7 +23,7 @@ module PartialEval = struct
     method! vexpr e =
       let eval e = match (ask !loc).Queries.f (Queries.EvalInt e) with
         | `Lifted i ->
-          let e' = integer @@ i64_to_int i in
+          let e' = integer @@ IntOps.BigIntOps.to_int i in
           ignore @@ Pretty.printf "Replacing non-constant expression %a with %a at %a\n" d_exp e d_exp e' d_loc !loc;
           e'
         | _ ->


### PR DESCRIPTION
- Asked queries are tracked to prevent cycles, this seems to not fully work yet.
- `Queries.ml` now has `BigInt` in the integer domain.
- `IntDomain.Integers` are now a functor which takes `IntOps`. This way we can choose if we want them with `int64` or `BigInt`.