### PR TITLE
Remove floats from octApron

### DIFF
--- a/src/analyses/apron/octApron.apron.ml
+++ b/src/analyses/apron/octApron.apron.ml
@@ -54,7 +54,7 @@ struct
       let f = Cilfacade.getdec f in
       let is = D.typesort f.sformals in
       let is = is @ List.map (fun x -> x^"'") is in
-      let newd = D.add_vars ctx.local (is,[]) in
+      let newd = D.add_vars ctx.local is in
       let formargs = Goblintutil.zip f.sformals args in
       let arith_formals = List.filter (fun (x,_) -> isIntegralType x.vtype) formargs in
       List.iter (fun (v, e) -> D.assign_var_with newd (v.vname^"'") e) arith_formals;
@@ -72,8 +72,7 @@ struct
         let nd = D.forget_all ctx.local [v.vname] in
         let fis,ffs = D.get_vars ctx.local in
         let fis = List.map Var.to_string fis in
-        let ffs = List.map Var.to_string ffs in
-        let nd' = D.add_vars d (fis,ffs) in
+        let nd' = D.add_vars d fis in
         let formargs = Goblintutil.zip f.sformals args in
         let arith_formals = List.filter (fun (x,_) -> isIntegralType x.vtype) formargs in
         List.iter (fun (v, e) -> D.substitute_var_with nd' (v.vname^"'") e) arith_formals;
@@ -133,11 +132,11 @@ struct
 
       let nd = match e with
         | Some e when isIntegralType (typeOf e) ->
-          let nd = D.add_vars ctx.local (["#ret"],[]) in
+          let nd = D.add_vars ctx.local ["#ret"] in
           let () = D.assign_var_with nd "#ret" e in
           nd
         | None -> D.topE (A.env ctx.local)
-        | _ -> D.add_vars ctx.local (["#ret"],[])
+        | _ -> D.add_vars ctx.local ["#ret"]
       in
       let vars = List.filter (fun x -> isIntegralType x.vtype) (f.slocals @ f.sformals) in
       let vars = List.map (fun x -> x.vname) vars in
@@ -147,7 +146,7 @@ struct
   let body ctx f =
     if D.is_bot ctx.local then D.bot () else
       let vars = D.typesort f.slocals in
-      D.add_vars ctx.local (vars, [])
+      D.add_vars ctx.local vars
 
   let assign ctx (lv:lval) e =
     if D.is_bot ctx.local then D.bot () else

--- a/src/analyses/apron/octApron.apron.ml
+++ b/src/analyses/apron/octApron.apron.ml
@@ -52,16 +52,15 @@ struct
   let enter ctx r f args =
     if D.is_bot ctx.local then [ctx.local, D.bot ()] else
       let f = Cilfacade.getdec f in
-      let is, fs = D.typesort f.sformals in
+      let is = D.typesort f.sformals in
       let is = is @ List.map (fun x -> x^"'") is in
-      let fs = fs @ List.map (fun x -> x^"'") fs in
-      let newd = D.add_vars ctx.local (is,fs) in
+      let newd = D.add_vars ctx.local (is,[]) in
       let formargs = Goblintutil.zip f.sformals args in
       let arith_formals = List.filter (fun (x,_) -> isIntegralType x.vtype) formargs in
       List.iter (fun (v, e) -> D.assign_var_with newd (v.vname^"'") e) arith_formals;
       D.forget_all_with newd (List.map (fun (x,_) -> x.vname) arith_formals);
       List.iter  (fun (v,_)   -> D.assign_var_eq_with newd v.vname (v.vname^"'")) arith_formals;
-      D.remove_all_but_with newd (is@fs);
+      D.remove_all_but_with newd (is);
       [ctx.local, newd]
 
 
@@ -148,7 +147,7 @@ struct
   let body ctx f =
     if D.is_bot ctx.local then D.bot () else
       let vars = D.typesort f.slocals in
-      D.add_vars ctx.local vars
+      D.add_vars ctx.local (vars, [])
 
   let assign ctx (lv:lval) e =
     if D.is_bot ctx.local then D.bot () else

--- a/src/analyses/apron/octApron.apron.ml
+++ b/src/analyses/apron/octApron.apron.ml
@@ -70,7 +70,7 @@ struct
       match r with
       | Some (Var v, NoOffset) when isIntegralType v.vtype && (not v.vglob) ->
         let nd = D.forget_all ctx.local [v.vname] in
-        let fis,ffs = D.get_vars ctx.local in
+        let fis = D.get_vars ctx.local in
         let fis = List.map Var.to_string fis in
         let nd' = D.add_vars d fis in
         let formargs = Goblintutil.zip f.sformals args in

--- a/src/analyses/apron/octApron.apron.ml
+++ b/src/analyses/apron/octApron.apron.ml
@@ -57,7 +57,7 @@ struct
       let fs = fs @ List.map (fun x -> x^"'") fs in
       let newd = D.add_vars ctx.local (is,fs) in
       let formargs = Goblintutil.zip f.sformals args in
-      let arith_formals = List.filter (fun (x,_) -> isArithmeticType x.vtype) formargs in
+      let arith_formals = List.filter (fun (x,_) -> isIntegralType x.vtype) formargs in
       List.iter (fun (v, e) -> D.assign_var_with newd (v.vname^"'") e) arith_formals;
       D.forget_all_with newd (List.map (fun (x,_) -> x.vname) arith_formals);
       List.iter  (fun (v,_)   -> D.assign_var_eq_with newd v.vname (v.vname^"'")) arith_formals;
@@ -69,14 +69,14 @@ struct
     if D.is_bot ctx.local || D.is_bot d then D.bot () else
       let f = Cilfacade.getdec f in
       match r with
-      | Some (Var v, NoOffset) when isArithmeticType v.vtype && (not v.vglob) ->
+      | Some (Var v, NoOffset) when isIntegralType v.vtype && (not v.vglob) ->
         let nd = D.forget_all ctx.local [v.vname] in
         let fis,ffs = D.get_vars ctx.local in
         let fis = List.map Var.to_string fis in
         let ffs = List.map Var.to_string ffs in
         let nd' = D.add_vars d (fis,ffs) in
         let formargs = Goblintutil.zip f.sformals args in
-        let arith_formals = List.filter (fun (x,_) -> isArithmeticType x.vtype) formargs in
+        let arith_formals = List.filter (fun (x,_) -> isIntegralType x.vtype) formargs in
         List.iter (fun (v, e) -> D.substitute_var_with nd' (v.vname^"'") e) arith_formals;
         let vars = List.map (fun (x,_) -> x.vname^"'") arith_formals in
         D.remove_all_with nd' vars;
@@ -133,14 +133,14 @@ struct
     if D.is_bot ctx.local then D.bot () else
 
       let nd = match e with
-        | Some e when isArithmeticType (typeOf e) ->
+        | Some e when isIntegralType (typeOf e) ->
           let nd = D.add_vars ctx.local (["#ret"],[]) in
           let () = D.assign_var_with nd "#ret" e in
           nd
         | None -> D.topE (A.env ctx.local)
         | _ -> D.add_vars ctx.local (["#ret"],[])
       in
-      let vars = List.filter (fun x -> isArithmeticType x.vtype) (f.slocals @ f.sformals) in
+      let vars = List.filter (fun x -> isIntegralType x.vtype) (f.slocals @ f.sformals) in
       let vars = List.map (fun x -> x.vname) vars in
       D.remove_all_with nd vars;
       nd
@@ -154,7 +154,7 @@ struct
     if D.is_bot ctx.local then D.bot () else
       match lv with
       (* Locals which are numbers, have no offset and their address wasn't taken *)
-      | Var v, NoOffset when isArithmeticType v.vtype && (not v.vglob) && (not v.vaddrof)->
+      | Var v, NoOffset when isIntegralType v.vtype && (not v.vglob) && (not v.vaddrof)->
           D.assign_var_handling_underflow_overflow ctx.local v e
       (* Ignoring all other assigns *)
       | _ -> ctx.local
@@ -185,8 +185,8 @@ let _ =
 let () =
   Printexc.register_printer
     (function
-      | Apron.Manager.Error e -> 
+      | Apron.Manager.Error e ->
         let () = Apron.Manager.print_exclog Format.str_formatter e in
-        Some(Printf.sprintf "Apron.Manager.Error\n %s" (Format.flush_str_formatter ())) 
+        Some(Printf.sprintf "Apron.Manager.Error\n %s" (Format.flush_str_formatter ()))
       | _ -> None (* for other exceptions *)
     )

--- a/src/cdomains/apron/octApronDomain.apron.ml
+++ b/src/cdomains/apron/octApronDomain.apron.ml
@@ -129,8 +129,6 @@ struct
       Var (Var.of_string v.vname)
     | Const (CInt64 (i,_,_)) ->
       Cst (Coeff.s_of_int (Int64.to_int i))
-    | Const (CReal (f,_,_)) ->
-      Cst (Coeff.s_of_float f)
     | UnOp  (Neg ,e,_) ->
       Unop (Neg,cil_exp_to_cil_lhost e,Int,Near)
     | BinOp (PlusA,e1,e2,_) ->
@@ -143,9 +141,6 @@ struct
       Binop (Div,cil_exp_to_cil_lhost e1,cil_exp_to_cil_lhost e2,Int,Zero)
     | BinOp (Mod,e1,e2,_) ->
       Binop (Mod,cil_exp_to_cil_lhost e1,cil_exp_to_cil_lhost e2,Int,Near)
-    | CastE (TFloat (FFloat,_),e) -> Unop(Cast,cil_exp_to_cil_lhost e,Texpr0.Single,Zero)
-    | CastE (TFloat (FDouble,_),e) -> Unop(Cast,cil_exp_to_cil_lhost e,Texpr0.Double,Zero)
-    | CastE (TFloat (FLongDouble,_),e) -> Unop(Cast,cil_exp_to_cil_lhost e,Texpr0.Extended,Zero)
     | CastE (TInt _,e) -> Unop(Cast,cil_exp_to_cil_lhost e,Int,Zero)
     | _ -> raise Invalid_CilExpToLhost
 

--- a/src/cdomains/apron/octApronDomain.apron.ml
+++ b/src/cdomains/apron/octApronDomain.apron.ml
@@ -125,7 +125,7 @@ struct
 
   let rec cil_exp_to_cil_lhost =
     function
-    | Lval (Var v,NoOffset) when isArithmeticType v.vtype && (not v.vglob) ->
+    | Lval (Var v,NoOffset) when isIntegralType v.vtype && (not v.vglob) ->
       Var (Var.of_string v.vname)
     | Const (CInt64 (i,_,_)) ->
       Cst (Coeff.s_of_int (Int64.to_int i))
@@ -187,7 +187,7 @@ struct
       | _ -> raise Invalid_CilExpToLexp
     in
     function
-    | Lval (Var v,NoOffset) when isArithmeticType v.vtype && (not v.vglob) ->
+    | Lval (Var v,NoOffset) when isIntegralType v.vtype && (not v.vglob) ->
       [v.vname,`int 1], `none, EQ
     | Const (CInt64 (i,_,_)) ->
       [], `int (Int64.to_int i), EQ
@@ -307,7 +307,7 @@ struct
   let assert_op_inv d x b =
     (* if assert(x) then convert it to assert(x != 0) *)
     let x = match x with
-    | Lval (Var v,NoOffset) when isArithmeticType v.vtype ->
+    | Lval (Var v,NoOffset) when isIntegralType v.vtype ->
       BinOp (Ne, x, (Const (CInt64(Int64.of_int 0, IInt, None))), intType)
     | _ -> x in
     try
@@ -499,7 +499,7 @@ struct
 
   let remove_all_with d xs =
     if list_length xs > 0 then
-      (* let vars = List.filter (fun v -> isArithmeticType v.vtype) xs in *)
+      (* let vars = List.filter (fun v -> isIntegralType v.vtype) xs in *)
       let vars = Array.of_enum (List.enum (List.map (fun v -> Var.of_string v) xs)) in
       let (existing_vars_int, existing_vars_real) = Environment.vars (A.env d) in
       let vars_filtered = List.filter (fun elem -> (List.mem elem (Array.to_list existing_vars_int)) || (List.mem elem (Array.to_list existing_vars_int))) (Array.to_list vars) in

--- a/src/cdomains/apron/octApronDomain.apron.ml
+++ b/src/cdomains/apron/octApronDomain.apron.ml
@@ -109,19 +109,19 @@ struct
   open Lincons1
 
   let typesort =
-    let f (is,fs) v =
+    let f is v =
       if isIntegralType v.vtype then
         if GobConfig.get_bool "ana.octapron.no_uints" then
           if Cil.isSigned (Cilfacade.get_ikind v.vtype) then
-            (v.vname::is,fs)
+            v.vname::is
           else
-            (is,fs)
+            is
         else
-          (v.vname::is,fs)
+          v.vname::is
       else
-        (is,fs)
+        is
     in
-    List.fold_left f ([],[])
+    List.fold_left f []
 
   let rec cil_exp_to_cil_lhost =
     function

--- a/src/cdomains/apron/octApronDomain.apron.ml
+++ b/src/cdomains/apron/octApronDomain.apron.ml
@@ -380,12 +380,16 @@ struct
       (* let () = print_endline (String.concat ", " oct_vars) in *)
       List.mem ("\""^v^"\"") oct_vars
 
+  let get_vars d =
+    let xs, ys = Environment.vars (A.env d) in
+    assert (Array.length ys = 0); (* shouldn't ever contain floats *)
+    List.of_enum (Array.enum xs)
+
   let var_in_env (v:string) d =
     if (is_chosen v) then
-      let (existing_vars_int, existing_vars_real) = Environment.vars (A.env d) in
-      let existing_var_names_int = List.map (fun v -> Var.to_string v) (Array.to_list existing_vars_int) in
-      let existing_var_names_real = List.map (fun v -> Var.to_string v) (Array.to_list existing_vars_real) in
-      (List.mem v existing_var_names_int) || (List.mem v existing_var_names_real)
+      let existing_vars_int = get_vars d in
+      let existing_var_names_int = List.map (fun v -> Var.to_string v) existing_vars_int in
+      List.mem v existing_var_names_int
     else
       false
 
@@ -452,11 +456,6 @@ struct
            ignore (Pretty.printf "Manager.Error: assign_var_with _ %s %a\n" v d_plainexp e);
            raise (Manager.Error q) *)
     end
-
-  let get_vars d =
-    let xs, ys = Environment.vars (A.env d) in
-    assert (Array.length ys = 0); (* shouldn't ever contain floats *)
-    List.of_enum (Array.enum xs)
 
   let add_vars_with newd newis =
     (* TODO: why is this necessary? *)

--- a/src/cdomains/apron/octApronDomain.apron.ml
+++ b/src/cdomains/apron/octApronDomain.apron.ml
@@ -455,7 +455,8 @@ struct
 
   let get_vars d =
     let xs, ys = Environment.vars (A.env d) in
-    List.of_enum (Array.enum xs), List.of_enum (Array.enum ys)
+    assert (Array.length ys = 0); (* shouldn't ever contain floats *)
+    List.of_enum (Array.enum xs)
 
   let add_vars_with newd newis =
     (* TODO: why is this necessary? *)
@@ -463,12 +464,11 @@ struct
       match list with
       | [] -> []
       | head::tail -> head::(remove_duplicates (List.filter (fun x -> x <> head) tail)) in
-    let oldis, oldfs = get_vars newd in
-    let oldvs = oldis@oldfs in
+    let oldis = get_vars newd in
     let environment = (A.env newd) in
     let newis = remove_duplicates newis in
     (* why is this not done by remove_duplicates already? *)
-    let cis = List.filter (fun x -> not (List.mem x oldvs) && (not (Environment.mem_var environment x))) (List.map Var.of_string newis) in (* TODO: why is the mem_var check necessary? *)
+    let cis = List.filter (fun x -> not (List.mem x oldis) && (not (Environment.mem_var environment x))) (List.map Var.of_string newis) in (* TODO: why is the mem_var check necessary? *)
     let cis = Array.of_enum (List.enum cis) in
     let newenv = Environment.add environment cis [||] in
     A.change_environment_with Man.mgr newd newenv false
@@ -491,9 +491,8 @@ struct
     | head::body -> (list_length body) + 1
 
   let remove_all_but_with d xs =
-      let is', fs' = get_vars d in
-      let vs = List.append (List.filter (fun x -> not (List.mem (Var.to_string x) xs)) is')
-          (List.filter (fun x -> not (List.mem (Var.to_string x) xs)) fs') in
+      let is' = get_vars d in
+      let vs = List.filter (fun x -> not (List.mem (Var.to_string x) xs)) is' in
       let env = Environment.remove (A.env d) (Array.of_enum (List.enum vs)) in
       A.change_environment_with Man.mgr d env false
 

--- a/src/cdomains/apron/octApronDomain.apron.ml
+++ b/src/cdomains/apron/octApronDomain.apron.ml
@@ -457,7 +457,8 @@ struct
     let xs, ys = Environment.vars (A.env d) in
     List.of_enum (Array.enum xs), List.of_enum (Array.enum ys)
 
-  let add_vars_with newd (newis, newfs) =
+  let add_vars_with newd newis =
+    (* TODO: why is this necessary? *)
     let rec remove_duplicates list =
       match list with
       | [] -> []
@@ -466,11 +467,10 @@ struct
     let oldvs = oldis@oldfs in
     let environment = (A.env newd) in
     let newis = remove_duplicates newis in
-    let newfs = remove_duplicates newfs in
-    let cis = List.filter (fun x -> not (List.mem x oldvs) && (not (Environment.mem_var environment x))) (List.map Var.of_string newis) in
-    let cfs = List.filter (fun x -> not (List.mem x oldvs) && (not (Environment.mem_var environment x))) (List.map Var.of_string newfs) in
-    let cis, cfs = Array.of_enum (List.enum cis), Array.of_enum (List.enum cfs) in
-    let newenv = Environment.add environment cis cfs in
+    (* why is this not done by remove_duplicates already? *)
+    let cis = List.filter (fun x -> not (List.mem x oldvs) && (not (Environment.mem_var environment x))) (List.map Var.of_string newis) in (* TODO: why is the mem_var check necessary? *)
+    let cis = Array.of_enum (List.enum cis) in
+    let newenv = Environment.add environment cis [||] in
     A.change_environment_with Man.mgr newd newenv false
 
   let add_vars d vars =

--- a/src/cdomains/apron/octApronDomain.apron.ml
+++ b/src/cdomains/apron/octApronDomain.apron.ml
@@ -499,8 +499,8 @@ struct
     if list_length xs > 0 then
       (* let vars = List.filter (fun v -> isIntegralType v.vtype) xs in *)
       let vars = Array.of_enum (List.enum (List.map (fun v -> Var.of_string v) xs)) in
-      let (existing_vars_int, existing_vars_real) = Environment.vars (A.env d) in
-      let vars_filtered = List.filter (fun elem -> (List.mem elem (Array.to_list existing_vars_int)) || (List.mem elem (Array.to_list existing_vars_int))) (Array.to_list vars) in
+      let existing_vars_int = get_vars d in
+      let vars_filtered = List.filter (fun elem -> List.mem elem existing_vars_int) (Array.to_list vars) in
       let env = Environment.remove (A.env d) (Array.of_list vars_filtered) in
       A.change_environment_with Man.mgr d env false
 

--- a/src/cdomains/apron/octApronDomain.apron.ml
+++ b/src/cdomains/apron/octApronDomain.apron.ml
@@ -118,8 +118,6 @@ struct
             (is,fs)
         else
           (v.vname::is,fs)
-      else if (isArithmeticType v.vtype) && (not (GobConfig.get_bool "ana.octapron.no_floats")) then
-        (is,v.vname::fs)
       else
         (is,fs)
     in

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -135,7 +135,6 @@ let _ = ()
       ; reg Analyses "ana.specification"   "" "SV-COMP specification (path or string)"
       ; reg Analyses "ana.wp"              "false" "Weakest precondition feasibility analysis for SV-COMP violations"
       ; reg Analyses "ana.octapron.no_uints"    "false"  "Use OctApron without tracking unsigned integers."
-      ; reg Analyses "ana.octapron.no_floats"   "true"  "Use OctApron without tracking floats."
       ; reg Analyses "ana.octapron.no_signed_overflow" "true" "Assume there will be no signed overflow for OctApron."
       ; reg Analyses "ana.octapron.vars"    "[]"           "Variables tracked by OctApron. Empty list means all are included!"
 


### PR DESCRIPTION
Follow-up for https://github.com/goblint/analyzer/issues/248#issuecomment-860471640.

Since Goblint doesn't even analyze floats non-relationally in base, we shouldn't try to make octApron do it either. The old implementation from poly tried to support them to some extent because Apron supposedly does, but it doesn't know about NaN, which causes problems. Therefore it's the easiest to remove their support in octApron for now.

It also simplifies a bunch of logic in octApron because one doesn't have to constantly manage the integer and floating-point variables in the Apron environment separately (and have to think about weird situations where they might be named the same etc).