### PR TITLE
Serialize additional data for Gobview

### DIFF
--- a/goblint.opam
+++ b/goblint.opam
@@ -49,5 +49,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/analyzer.git"
 pin-depends: [
-  [ "goblint-cil.1.7.8" "git+https://github.com/goblint/cil.git#5fdf44c42b194130fefabbbe8a7a29818ad3f539" ]
+  [ "goblint-cil.1.8.1" "git+https://github.com/goblint/cil.git#d61cfa6a403f4d278c86344091bc07dccd8b549b" ]
 ]

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -26,7 +26,7 @@ depends: [
   "cppo" {= "1.6.6"}
   "dune" {= "2.7.1"}
   "easy-format" {= "1.3.2"}
-  "goblint-cil" {= "1.7.8"}
+  "goblint-cil" {= "1.8.1"}
   "mlgmpidl" {= "1.2.13"}
   "num" {= "1.3"}
   "ocaml" {= "4.11.1"}
@@ -68,7 +68,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/analyzer.git"
 pin-depends: [
-  [ "goblint-cil.1.7.8" "git+https://github.com/goblint/cil.git#5fdf44c42b194130fefabbbe8a7a29818ad3f539" ]
+  [ "goblint-cil.1.8.1" "git+https://github.com/goblint/cil.git#d61cfa6a403f4d278c86344091bc07dccd8b549b" ]
 ]
 name: "goblint"
 version: "dev"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  [ "goblint-cil.1.7.8" "git+https://github.com/goblint/cil.git#5fdf44c42b194130fefabbbe8a7a29818ad3f539" ]
+  [ "goblint-cil.1.8.1" "git+https://github.com/goblint/cil.git#d61cfa6a403f4d278c86344091bc07dccd8b549b" ]
 ]

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -383,23 +383,24 @@ struct
 
     let solve_and_postprocess () =
       (* handle save_run/load_run *)
-      let append_opt opt file = let o = get_string opt in if o = "" then "" else o ^ Filename.dir_sep ^ file in
       let solver_file = "solver.marshalled" in
-      let save_run = append_opt "save_run" solver_file in
-      let load_run = append_opt "load_run" solver_file in
+      let load_run = get_string "load_run" in
       let compare_runs = get_string_list "compare_runs" in
+      let gobview = get_bool "gobview" in
+      let save_run = let o = get_string "save_run" in if o = "" then (if gobview then "run" else "") else o in
 
       let lh, gh = if load_run <> "" then (
+          let solver = Filename.concat load_run solver_file in
           if get_bool "dbg.verbose" then
-            print_endline ("Loading the solver result of a saved run from " ^ load_run);
-            let lh,gh = Serialize.unmarshal load_run in
-            if get_bool "ana.opt.hashcons" then (
-              let lh' = LHT.create (LHT.length lh) in
-              let gh' = GHT.create (GHT.length gh) in
-              LHT.iter (fun k v -> let k' = EQSys.LVar.relift k in let v' = EQSys.D.join (EQSys.D.bot ()) v in LHT.replace lh' k' v') lh;
-              GHT.iter (fun k v -> let k' = EQSys.GVar.relift k in let v' = EQSys.G.join (EQSys.G.bot ()) v in GHT.replace gh' k' v') gh;
-              lh', gh'
-            ) else lh,gh
+            print_endline ("Loading the solver result of a saved run from " ^ solver);
+          let lh,gh = Serialize.unmarshal solver in
+          if get_bool "ana.opt.hashcons" then (
+            let lh' = LHT.create (LHT.length lh) in
+            let gh' = GHT.create (GHT.length gh) in
+            LHT.iter (fun k v -> let k' = EQSys.LVar.relift k in let v' = EQSys.D.join (EQSys.D.bot ()) v in LHT.replace lh' k' v') lh;
+            GHT.iter (fun k v -> let k' = EQSys.GVar.relift k in let v' = EQSys.G.join (EQSys.G.bot ()) v in GHT.replace gh' k' v') gh;
+            lh', gh'
+          ) else lh,gh
         ) else if compare_runs <> [] then (
           match compare_runs with
           | d1::d2::[] -> (* the directories of the runs *)
@@ -411,19 +412,22 @@ struct
         ) else (
           if get_bool "dbg.verbose" then
             print_endline ("Solving the constraint system with " ^ get_string "solver" ^ ". Solver statistics are shown every " ^ string_of_int (get_int "dbg.solver-stats-interval") ^ "s or by signal " ^ get_string "dbg.solver-signal" ^ ".");
-          if get_string "warn" = "early" then Goblintutil.should_warn := true;
+          Goblintutil.should_warn := get_string "warn" = "early" || gobview;
           let lh, gh = Stats.time "solving" (Slvr.solve entrystates entrystates_global) startvars' in
           if save_run <> "" then (
-            let analyses = append_opt "save_run" "analyses.marshalled" in
-            let config = append_opt "save_run" "config.json" in
-            let meta = append_opt "save_run" "meta.json" in
-            let solver_stats = append_opt "save_run" "solver_stats.csv" in (* see Generic.SolverStats... *)
+            let solver = Filename.concat save_run solver_file in
+            let analyses = Filename.concat save_run "analyses.marshalled" in
+            let config = Filename.concat save_run "config.json" in
+            let meta = Filename.concat save_run "meta.json" in
+            let solver_stats = Filename.concat save_run "solver_stats.csv" in (* see Generic.SolverStats... *)
+            let cil = Filename.concat save_run "cil.marshalled" in
+            let warnings = Filename.concat save_run "warnings.marshalled" in
+            let stats = Filename.concat save_run "stats.marshalled" in
             if get_bool "dbg.verbose" then (
-              print_endline ("Saving the solver result to " ^ save_run ^ ", the analysis table to " ^ analyses ^ ", the current configuration to " ^ config ^ ", meta-data about this run to " ^ meta ^ ", and solver statistics to " ^ solver_stats);
+              print_endline ("Saving the solver result to " ^ solver ^ ", the current configuration to " ^ config ^ ", meta-data about this run to " ^ meta ^ ", and solver statistics to " ^ solver_stats);
             );
-            ignore @@ GU.create_dir (get_string "save_run"); (* ensure the directory exists *)
-            Serialize.marshal (lh, gh) save_run;
-            Serialize.marshal !MCP.analyses_table analyses;
+            ignore @@ GU.create_dir (save_run); (* ensure the directory exists *)
+            Serialize.marshal (lh, gh) solver;
             GobConfig.write_file config;
             let module Meta = struct
                 type t = { command : string; version: string; timestamp : float; localtime : string } [@@deriving to_yojson]
@@ -432,6 +436,15 @@ struct
             in
             (* Yojson.Safe.to_file meta Meta.json; *)
             Yojson.Safe.pretty_to_channel (Stdlib.open_out meta) Meta.json; (* the above is compact, this is pretty-printed *)
+            if gobview then (
+              if get_bool "dbg.verbose" then (
+                print_endline ("Saving the analysis table to " ^ analyses ^ ", the CIL state to " ^ cil ^ ", the warning table to " ^ warnings ^ ", and the runtime stats to " ^ stats);
+              );
+              Serialize.marshal !MCP.analyses_table analyses;
+              Serialize.marshal (file, Cabs2cil.environment) cil;
+              Serialize.marshal !Messages.warning_table warnings;
+              Serialize.marshal (Stats.top, Gc.quick_stat ()) stats
+            );
             Goblintutil.(self_signal (signal_of_string (get_string "dbg.solver-signal"))); (* write solver_stats after solving (otherwise no rows if faster than dbg.solver-stats-interval). TODO better way to write solver_stats without terminal output? *)
           );
           lh, gh

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -91,6 +91,7 @@ let _ = ()
       ; reg Std "load_run"        "''"           "Load a saved run. See save_run."
       ; reg Std "compare_runs"    "[]"           "Load these saved runs and compare the results. Note that currently only two runs can be compared!"
       ; reg Std "warn"            "'post'"       "When to output warnings. Values: 'post' (default): after solving; 'never': no warnings; 'early': for debugging - outputs warnings already while solving (may lead to spurious warnings/asserts that would disappear after narrowing)."
+      ; reg Std "gobview"         "false"        "Include additional information for Gobview (e.g., the Goblint warning messages) in the directory specified by 'save_run'."
 
 (* {4 category [Analyses]} *)
 let _ = ()
@@ -295,6 +296,7 @@ let default_schema = "\
   , 'save_run'        : {}
   , 'load_run'        : {}
   , 'compare_runs'    : {}
+  , 'gobview'         : {}
   , 'warn'            : {}
   }
 }"

--- a/src/util/messages.ml
+++ b/src/util/messages.ml
@@ -13,6 +13,10 @@ let warn_out = ref stdout
 let tracing = Config.tracing
 let xml_file_name = ref ""
 
+let push_warning w =
+  if get_string "result" = "fast_xml" || get_bool "gobview" then
+    warning_table := w :: !warning_table
+
 let track m =
   let loc = !Tracing.current_loc in
   Printf.fprintf !warn_out "Track (%s:%d); %s\n" loc.file loc.line m
@@ -54,7 +58,7 @@ let colorize ?on:(on=colors_on ()) msg =
 let print_msg msg loc =
   let msgc = colorize msg in
   let msg  = colorize ~on:false msg in
-  if (get_string "result") = "fast_xml" then warning_table := (`text (msg,loc))::!warning_table;
+  push_warning (`text (msg, loc));
   if get_bool "gccwarn" then
     Printf.printf "%s:%d:0: warning: %s\n" loc.file loc.line msg
   else
@@ -63,7 +67,7 @@ let print_msg msg loc =
     Printf.fprintf !warn_out "%s\n%!" (colorize s)
 
 let print_err msg loc =
-  if (get_string "result") = "fast_xml" then warning_table := (`text (msg,loc))::!warning_table;
+  push_warning (`text (msg, loc));
   if get_bool "gccwarn" then
     Printf.printf "%s:%d:0: error: %s\n" loc.file loc.line msg
   else
@@ -72,7 +76,7 @@ let print_err msg loc =
 
 let print_group group_name errors =
   (* Add warnings to global warning list *)
-  if (get_string "result") = "fast_xml" then warning_table := (`group (group_name,errors))::!warning_table;
+  push_warning (`group (group_name, errors));
   let f (msg,loc): doc = Pretty.dprintf "%s (%s:%d)" msg loc.file loc.line in
   if (get_bool "ana.osek.warnfiles") then begin
     match (String.sub group_name 0 6) with


### PR DESCRIPTION
* Update `goblint-cil` to commit `94ba9835b86977e73fb9b6ea0c09adc43f716a43` (to be able to use goblint/cil#38)
* Add a new boolean option "gobview".
* Serialize the MCP analysis table, the CIL file, the Cabs2cil environment, the Goblint warning table, and the GC/runtime stats if this flag is set.

Example usage:
```bash
$ ./goblint --enable gobview main.c # Implies --sets save_run run
$ ./goblint --sets save_run data --enable gobview main.c
```