### PR TITLE
Fix unsoundness due to `pthread_cond_wait`

### DIFF
--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -364,6 +364,18 @@ struct
     | _, "__VERIFIER_atomic_end" when get_bool "ana.sv-comp.functions" ->
       ctx.emit (Events.Unlock verifier_atomic);
       Lockset.remove (verifier_atomic, true) ctx.local
+    | _, "pthread_cond_wait"
+    | _, "pthread_cond_timedwait" ->
+      (* mutex is unlocked while waiting but relocked when returns *)
+      (* emit unlock-lock events for privatization *)
+      let m_arg = List.nth arglist 1 in
+      let ms = eval_exp_addr (Analyses.ask_of_ctx ctx) m_arg in
+      List.iter (fun m ->
+          (* unlock-lock each possible mutex as a split to be dependent *)
+          (* otherwise may-point-to {a, b} might unlock a, but relock b *)
+          ctx.split ctx.local [Events.Unlock m; Events.Lock m];
+        ) ms;
+      raise Deadcode (* splits cover all cases *)
     | _, x ->
       let arg_acc act =
         match LF.get_threadsafe_inv_ac x with

--- a/tests/regression/13-privatized/67-pthread_cond_wait.c
+++ b/tests/regression/13-privatized/67-pthread_cond_wait.c
@@ -10,7 +10,7 @@ void* f1(void* ptr) {
     pthread_mutex_lock(&mut);
     g = 1;
     pthread_cond_wait(&cond,&mut);
-    assert(g == 1); //FAIL
+    assert(g == 0); // TODO (no cond-flow support)
     printf("g is %i", g);
     g = 0;
     pthread_mutex_unlock(&mut);

--- a/tests/regression/13-privatized/67-pthread_cond_wait.c
+++ b/tests/regression/13-privatized/67-pthread_cond_wait.c
@@ -1,0 +1,40 @@
+#include<pthread.h>
+#include<stdio.h>
+#include <unistd.h>
+int g;
+
+pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+void* f1(void* ptr) {
+    pthread_mutex_lock(&mut);
+    g = 1;
+    pthread_cond_wait(&cond,&mut);
+    assert(g == 1); //FAIL
+    printf("g is %i", g);
+    g = 0;
+    pthread_mutex_unlock(&mut);
+}
+
+void* f2(void* ptr) {
+    pthread_mutex_lock(&mut);
+    assert(g == 0); //UNKNOWN!
+    g = 0;
+    pthread_cond_signal(&cond);
+    pthread_mutex_unlock(&mut);
+}
+
+int main(int argc, char const *argv[])
+{
+    pthread_t t1;
+    pthread_t t2;
+
+    pthread_create(&t1,NULL,f1,NULL);
+    sleep(1);
+    pthread_create(&t2,NULL,f2,NULL);
+
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+
+    return 0;
+}


### PR DESCRIPTION
Closes #267.

Emitting the unlock-lock events informs privatization (in base or octApron) about it and should make it sound.

I flipped and weakened the assert
```c
assert(g == 1); //FAIL
```
to
```c
assert(g == 0); // TODO (no cond-flow support)
```