### PR TITLE
Change `enter`, `combine`, `FunctionEntry`, `Function` argument `varinfo` -> `fundec`

### DIFF
--- a/src/analyses/apron/octApron.apron.ml
+++ b/src/analyses/apron/octApron.apron.ml
@@ -51,8 +51,7 @@ struct
   let startstate _ =  D.top () (* TODO: correct env? *)
 
   let enter ctx r f args =
-    if D.is_bot ctx.local then [ctx.local, D.bot ()] else
-      let f = Cilfacade.getdec f in
+    if D.is_bot ctx.local then [ctx.local, D.bot ()] else (
       if Messages.tracing then Messages.tracel "combine" "apron enter f: %a\n" d_varinfo f.svar;
       if Messages.tracing then Messages.tracel "combine" "apron enter formals: %a\n" (d_list "," d_varinfo) f.sformals;
       if Messages.tracing then Messages.tracel "combine" "apron enter local: %a\n" D.pretty ctx.local;
@@ -67,11 +66,11 @@ struct
       D.remove_all_but_with newd (is);
       if Messages.tracing then Messages.tracel "combine" "apron enter newd: %a\n" D.pretty newd;
       [ctx.local, newd]
+    )
 
 
   let combine ctx r fe f args fc d =
-    if D.is_bot ctx.local || D.is_bot d then D.bot () else
-      let f = Cilfacade.getdec f in
+    if D.is_bot ctx.local || D.is_bot d then D.bot () else (
       if Messages.tracing then Messages.tracel "combine" "apron f: %a\n" d_varinfo f.svar;
       if Messages.tracing then Messages.tracel "combine" "apron formals: %a\n" (d_list "," d_varinfo) f.sformals;
       match r with
@@ -96,6 +95,7 @@ struct
       | _ ->
         (* TODO: don't go to top, but just forget r *)
         D.top_env (A.env ctx.local)
+    )
 
   let special ctx r f args =
     if D.is_bot ctx.local then D.bot () else

--- a/src/analyses/apron/poly.apron.ml
+++ b/src/analyses/apron/poly.apron.ml
@@ -26,7 +26,6 @@ struct
 
   let enter ctx r f args =
     if D.is_bot ctx.local then [ctx.local, D.bot ()] else
-      let f = Cilfacade.getdec f in
       let is, fs = D.typesort f.sformals in
       let is = is @ List.map (fun x -> x^"'") is in
       let fs = fs @ List.map (fun x -> x^"'") fs in
@@ -42,7 +41,6 @@ struct
 
   let combine ctx r fe f args fc d =
     if D.is_bot ctx.local || D.is_bot d then D.bot () else
-      let f = Cilfacade.getdec f in
       match r with
       | Some (Var v, NoOffset) when isArithmeticType v.vtype && (not v.vglob) ->
         let nd = D.forget_all ctx.local [v.vname] in

--- a/src/analyses/arinc.ml
+++ b/src/analyses/arinc.ml
@@ -503,7 +503,7 @@ struct
             let funs_ls = Queries.LS.filter (fun (v,o) -> let lval = Var v, Lval.CilLval.to_ciloffs o in isFunctionType (typeOfLval lval)) ls in (* do we need this? what happens if we spawn a variable that's not a function? shouldn't this check be in spawn? *)
             if M.tracing then M.tracel "arinc" "starting a thread %a with priority '%Ld' \n" Queries.LS.pretty funs_ls pri;
             let funs = funs_ls |> Queries.LS.elements |> List.map fst |> List.unique in
-            let f_d = { pid = Pid.of_int (get_pid name); pri = Pri.of_int pri; per = Per.of_int per; cap = Cap.of_int cap; pmo = Pmo.of_int 3L; pre = PrE.top (); pred = Pred.of_node (MyCFG.Function f); ctx = Ctx.top () } in
+            let f_d = { pid = Pid.of_int (get_pid name); pri = Pri.of_int pri; per = Per.of_int per; cap = Cap.of_int cap; pmo = Pmo.of_int 3L; pre = PrE.top (); pred = Pred.of_loc f.vdecl; ctx = Ctx.top () } in
             let tasks = Tasks.add (funs_ls, f_d) (ctx.global tasks_var) in
             ctx.sideg tasks_var tasks;
             let pid' = Process, name in
@@ -614,7 +614,7 @@ struct
             let pid = get_pid pname_ErrorHandler in
             let funs_ls = Queries.LS.filter (fun (v,o) -> let lval = Var v, Lval.CilLval.to_ciloffs o in isFunctionType (typeOfLval lval)) ls in
             let funs = funs_ls |> Queries.LS.elements |> List.map fst |> List.unique in
-            let f_d = { pid = Pid.of_int pid; pri = Pri.of_int infinity; per = Per.of_int infinity; cap = Cap.of_int infinity; pmo = Pmo.of_int 3L; pre = PrE.top (); pred = Pred.of_node (MyCFG.Function f); ctx = Ctx.top () } in
+            let f_d = { pid = Pid.of_int pid; pri = Pri.of_int infinity; per = Per.of_int infinity; cap = Cap.of_int infinity; pmo = Pmo.of_int 3L; pre = PrE.top (); pred = Pred.of_loc f.vdecl; ctx = Ctx.top () } in
             let tasks = Tasks.add (funs_ls, f_d) (ctx.global tasks_var) in
             ctx.sideg tasks_var tasks;
             add_actions (List.map (fun f -> CreateErrorHandler ((Process, pname_ErrorHandler), f)) funs)

--- a/src/analyses/arinc.ml
+++ b/src/analyses/arinc.ml
@@ -270,18 +270,18 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list = (* on function calls (also for main); not called for spawned processes *)
     (* print_endline @@ "ENTER " ^ f.vname ^" @ "^ string_of_int (!Tracing.current_loc).line; (* somehow M.debug_each doesn't print anything here *) *)
     let d_caller = ctx.local in
-    let d_callee = if D.is_bot ctx.local then ctx.local else { ctx.local with pred = Pred.of_node (MyCFG.Function f.svar); ctx = Ctx.top () } in (* set predecessor set to start node of function *)
+    let d_callee = if D.is_bot ctx.local then ctx.local else { ctx.local with pred = Pred.of_node (MyCFG.Function f); ctx = Ctx.top () } in (* set predecessor set to start node of function *)
     [d_caller, d_callee]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
-    let f = f.svar in
+  let combine ctx (lval:lval option) fexp (fd:fundec) (args:exp list) fc (au:D.t) : D.t =
+    let f = fd.svar in
     if D.is_bot1 ctx.local || D.is_bot1 au then ctx.local else
       let env = get_env ctx in
       let d_caller = ctx.local in
       let d_callee = au in
       (* check if the callee has some relevant edges, i.e. advanced from the entry point. if not, we generate no edge for the call and keep the predecessors from the caller *)
       if Pred.is_bot d_callee.pred then failwith "d_callee.pred is bot!"; (* set should never be empty *)
-      if Pred.equal d_callee.pred (Pred.of_node (MyCFG.Function f)) then
+      if Pred.equal d_callee.pred (Pred.of_node (MyCFG.Function fd)) then
         { d_callee with pred = d_caller.pred; ctx = d_caller.ctx }
       else (
         (* write out edges with call to f coming from all predecessor nodes of the caller *)
@@ -650,7 +650,7 @@ struct
     );
     if GobConfig.get_bool "ana.arinc.validate" then ArincUtil.validate ()
 
-  let startstate v = { pid = Pid.of_int 0L; pri = Pri.top (); per = Per.top (); cap = Cap.top (); pmo = Pmo.of_int 1L; pre = PrE.of_int 0L; pred = Pred.of_node (MyCFG.Function (emptyFunction "main").svar); ctx = Ctx.top () }
+  let startstate v = { pid = Pid.of_int 0L; pri = Pri.top (); per = Per.top (); cap = Cap.top (); pmo = Pmo.of_int 1L; pre = PrE.of_int 0L; pred = Pred.of_node (MyCFG.Function (emptyFunction "main")); ctx = Ctx.top () }
   let exitstate  v = D.bot ()
 
   let threadenter ctx lval f args =

--- a/src/analyses/arinc.ml
+++ b/src/analyses/arinc.ml
@@ -267,13 +267,14 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list = (* on function calls (also for main); not called for spawned processes *)
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list = (* on function calls (also for main); not called for spawned processes *)
     (* print_endline @@ "ENTER " ^ f.vname ^" @ "^ string_of_int (!Tracing.current_loc).line; (* somehow M.debug_each doesn't print anything here *) *)
     let d_caller = ctx.local in
-    let d_callee = if D.is_bot ctx.local then ctx.local else { ctx.local with pred = Pred.of_node (MyCFG.Function f); ctx = Ctx.top () } in (* set predecessor set to start node of function *)
+    let d_callee = if D.is_bot ctx.local then ctx.local else { ctx.local with pred = Pred.of_node (MyCFG.Function f.svar); ctx = Ctx.top () } in (* set predecessor set to start node of function *)
     [d_caller, d_callee]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
+    let f = f.svar in
     if D.is_bot1 ctx.local || D.is_bot1 au then ctx.local else
       let env = get_env ctx in
       let d_caller = ctx.local in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1832,7 +1832,14 @@ struct
         publish_all ctx `Thread;
         (* Collect the threads. *)
         let start_addr = eval_tv (Analyses.ask_of_ctx ctx) ctx.global ctx.local start in
-        List.filter_map (create_thread (Some (Mem id, NoOffset)) (Some ptc_arg)) (AD.to_var_may start_addr)
+        let start_funvars = AD.to_var_may start_addr in
+        let start_funvars_with_unknown =
+          if AD.mem Addr.UnknownPtr start_addr then
+            dummyFunDec.svar :: start_funvars
+          else
+            start_funvars
+        in
+        List.filter_map (create_thread (Some (Mem id, NoOffset)) (Some ptc_arg)) start_funvars_with_unknown
       end
     | `Unknown "free" -> []
     | `Unknown _ when get_bool "sem.unknown_function.spawn" -> begin

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1798,7 +1798,7 @@ struct
     {st' with cpa = new_cpa}
 
   let enter ctx lval fn args : (D.t * D.t) list =
-    [ctx.local, make_entry ctx fn args]
+    [ctx.local, make_entry ctx fn.svar args]
 
 
 
@@ -2124,7 +2124,7 @@ struct
         (* List.map (fun f -> f (fun lv -> (fun x -> set ~ctx:(Some ctx) ctx.ask ctx.global st (eval_lv ctx.ask ctx.global st lv) (Cil.typeOfLval lv) x))) (LF.effects_for f.vname args) |> BatList.fold_left D.meet st *)
       end
 
-  let combine ctx (lval: lval option) fexp (f: varinfo) (args: exp list) fc (after: D.t) : D.t =
+  let combine ctx (lval: lval option) fexp (f: fundec) (args: exp list) fc (after: D.t) : D.t =
     let combine_one (st: D.t) (fun_st: D.t) =
       if M.tracing then M.tracel "combine" "%a\n%a\n" CPA.pretty st.cpa CPA.pretty fun_st.cpa;
       (* This function does miscellaneous things, but the main task was to give the

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1816,7 +1816,11 @@ struct
         if LF.use_special f.vname then None (* we handle this function *)
         else if isFunctionType v.vtype then (
           M.warn_each ("Creating a thread from unknown function " ^ v.vname);
-          Some (lval, v, args)
+          let args = match arg with
+            | Some x -> [x]
+            | None -> []
+          in
+          Some (lval, v,  args)
         ) else (
           M.warn_each ("Not creating a thread from " ^ v.vname ^ " because its type is " ^ sprint d_type v.vtype);
           None
@@ -2183,10 +2187,10 @@ struct
                 mkAddrOf (Var vi, NoOffset) :: acc
               (* TODO: what about GVarDecl? *)
               | _ -> acc
-            ) []
+            ) args
         )
         else
-          []
+          args
       in
       (* TODO: what about escaped local variables? *)
       (* invalidate non-static globals for unknown functions *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1815,6 +1815,7 @@ struct
       with Not_found ->
         if LF.use_special f.vname then None (* we handle this function *)
         else if isFunctionType v.vtype then
+          (* FromSpec warns about unknown thread creation, so we don't do it here any more *)
           let args = match arg with
             | Some x -> [x]
             | None -> []

--- a/src/analyses/condVars.ml
+++ b/src/analyses/condVars.ml
@@ -133,10 +133,10 @@ struct
     (* D.only_globals ctx.local *)
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, D.bot ()]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     (* combine caller's state with globals from callee *)
     (* TODO (precision): globals with only global vars are kept, the rest is lost -> collect which globals are assigned to *)
     (* D.merge (fun k s1 s2 -> match s2 with Some ss2 when (fst k).vglob && D.only_global_exprs ss2 -> s2 | _ when (fst k).vglob -> None | _ -> s1) ctx.local au *)

--- a/src/analyses/constants.ml
+++ b/src/analyses/constants.ml
@@ -70,8 +70,7 @@ struct
     (* Do nothing, as we are not interested in return values for now. *)
     ctx.local
 
-  let enter ctx (lval: lval option) (fv:varinfo) (args:exp list) : (D.t * D.t) list =
-    let f = Cilfacade.getdec fv in
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     (* Set the formal int arguments to top *)
     let callee_state = List.fold (fun m l -> D.add l (I.top ()) m) (D.bot ()) f.sformals in
     [(ctx.local, callee_state)]
@@ -85,7 +84,7 @@ struct
         )
       |_ -> state
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     (* If we have a function call with assignment
         x = f (e1, ... , ek)
       with a local int variable x on the left, we set it to top *)

--- a/src/analyses/contain.ml
+++ b/src/analyses/contain.ml
@@ -684,7 +684,8 @@ struct
     time_transfer "special" time_wrapper
 
   (*let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : (D.t * exp * bool) list*)
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (fd:fundec) (args:exp list) : (D.t * D.t) list =
+    let f = fd.svar in
     (*D.report("ENTER ZERO : "^f.vname);*)
     (*D.report("ENTER_FN : "^f.vname);*)
     (*if D.is_top ctx.local then failwith "ARGH!";*)
@@ -741,7 +742,8 @@ struct
       end else [ctx.local, ctx.local]
 
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (fd:fundec) (args:exp list) fc (au:D.t) : D.t =
+    let f = fd.svar in
     (*eval_funvar ctx fexp;*)
     if danger_bot ctx then ctx.local else
       let a, b, c = ctx.local in

--- a/src/analyses/contain.ml
+++ b/src/analyses/contain.ml
@@ -709,7 +709,6 @@ struct
         (*       printf ":: no_mainclass:%b public:%b \n" no_mainclass (D.is_public_method_name f.vname); *)
         (*D.report("ENTER_FUN : "^f.vname);*)
         let fs = D.get_tainted_fields ctx.global in
-        let fd = Cilfacade.getdec f in
         let t (v, e) = true
    (*
         let _, ds, _ = ctx.local in
@@ -782,7 +781,6 @@ struct
                   in
                   let (a,b,c)=ContainDomain.ArgSet.fold (fun x y ->apply_var x y v rvs) rvs (a,b,c) in
 
-                  let fd = Cilfacade.getdec f in
                   let ll = match (zip fd.sformals args) with (*remove this*)
                     | [] -> []
                     | [x] -> []

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -76,11 +76,11 @@ struct
     ctx.local
 
   (* Calls/Enters a function *)
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [D.bot (),ctx.local]
 
   (* Leaves a function *)
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     au
 
   (* Helper function to convert query-offsets to valuedomain-offsets *)

--- a/src/analyses/deadlocksByRaces.ml
+++ b/src/analyses/deadlocksByRaces.ml
@@ -28,8 +28,8 @@ struct
   let branch ctx (exp:exp) (tv:bool) : D.t = MSpec.branch ctx exp tv
   let body ctx (f:fundec) : D.t = MSpec.body ctx f
   let return ctx (exp:exp option) (f:fundec) : D.t =  MSpec.return ctx exp f
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list = MSpec.enter ctx lval f args
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t = MSpec.combine ctx lval fexp f args fc au
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list = MSpec.enter ctx lval f args
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t = MSpec.combine ctx lval fexp f args fc au
 
   let fake_unlock = Goblintutil.create_var (makeGlobalVar "pthread_mutex_unlock" intType)
 

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -97,10 +97,10 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     au
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/extract_arinc.ml
+++ b/src/analyses/extract_arinc.ml
@@ -223,13 +223,14 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     let d_caller = ctx.local in
     let pid, ctxh, pred = ctx.local in
-    let d_callee = if D.is_bot ctx.local then ctx.local else pid, Ctx.top (), Pred.of_node (MyCFG.Function f) in (* set predecessor set to start node of function *)
+    let d_callee = if D.is_bot ctx.local then ctx.local else pid, Ctx.top (), Pred.of_node (MyCFG.Function f.svar) in (* set predecessor set to start node of function *)
     [d_caller, d_callee]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
+    let f = f.svar in
     if D.is_bot ctx.local || D.is_bot au then ctx.local else
       let pid, ctxh, pred = ctx.local in (* caller *)
       let _ , _, pred' = au in (* callee *)

--- a/src/analyses/extract_arinc.ml
+++ b/src/analyses/extract_arinc.ml
@@ -227,17 +227,16 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     let d_caller = ctx.local in
     let pid, ctxh, pred = ctx.local in
-    let d_callee = if D.is_bot ctx.local then ctx.local else pid, Ctx.top (), Pred.of_node (MyCFG.Function f.svar) in (* set predecessor set to start node of function *)
+    let d_callee = if D.is_bot ctx.local then ctx.local else pid, Ctx.top (), Pred.of_node (MyCFG.Function f) in (* set predecessor set to start node of function *)
     [d_caller, d_callee]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
-    let f = f.svar in
+  let combine ctx (lval:lval option) fexp (fd:fundec) (args:exp list) fc (au:D.t) : D.t =
     if D.is_bot ctx.local || D.is_bot au then ctx.local else
       let pid, ctxh, pred = ctx.local in (* caller *)
       let _ , _, pred' = au in (* callee *)
       (* check if the callee has some relevant edges, i.e. advanced from the entry point. if not, we generate no edge for the call and keep the predecessors from the caller *)
       if Pred.is_bot pred' then failwith "d_callee.pred is bot!"; (* set should never be empty *)
-      if Pred.equal pred' (Pred.of_node (MyCFG.Function f)) then
+      if Pred.equal pred' (Pred.of_node (MyCFG.Function fd)) then
         ctx.local
       else (
         (* set current node as new predecessor, since something interesting happend during the call *)
@@ -372,7 +371,7 @@ struct
                 extract_fun ~info_args:str_args args
               ) ctx.local args_product
 
-  let startstate v = Pid.of_int 0L, Ctx.top (), Pred.of_node (MyCFG.Function (emptyFunction "main").svar)
+  let startstate v = Pid.of_int 0L, Ctx.top (), Pred.of_node (MyCFG.Function (emptyFunction "main"))
   let exitstate  v = D.bot ()
 
   let init () = (* registers which functions to extract and writes out their definitions *)

--- a/src/analyses/extract_arinc.ml
+++ b/src/analyses/extract_arinc.ml
@@ -24,7 +24,8 @@ struct
   (* set of predecessor nodes *)
   module Pred = struct
     include SetDomain.Make (Basetype.ProgLocation)
-    let of_node = singleton % MyCFG.getLoc
+    let of_loc = singleton
+    let of_node = of_loc % MyCFG.getLoc
     let of_current_node () = of_node @@ Option.get !MyCFG.current_node
     let string_of_elt = Basetype.ProgLocation.show
   end
@@ -329,7 +330,7 @@ struct
               let funs_ls = Queries.LS.filter (fun (v,o) -> let lval = Var v, Lval.CilLval.to_ciloffs o in isFunctionType (typeOfLval lval)) ls in (* do we need this? what happens if we spawn a variable that's not a function? shouldn't this check be in spawn? *)
               if M.tracing then M.tracel "extract_arinc" "starting a thread %a with priority '%Ld' \n" Queries.LS.pretty funs_ls pri;
               let funs = funs_ls |> Queries.LS.elements |> List.map fst |> List.unique in
-              let f_d = Pid.of_int (Int64.of_int (Pids.get name)), Ctx.top (), Pred.of_node (MyCFG.Function f) in
+              let f_d = Pid.of_int (Int64.of_int (Pids.get name)), Ctx.top (), Pred.of_loc f.vdecl in
               List.iter (fun f -> Pfuns.add name f.vname) funs;
               Prios.add name pri;
               let tasks = Tasks.add (funs_ls, f_d) (ctx.global tasks_var) in

--- a/src/analyses/extract_osek.ml
+++ b/src/analyses/extract_osek.ml
@@ -217,13 +217,14 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     let d_caller = ctx.local in
     let pid, ctxh, pred = ctx.local in
-    let d_callee = if D.is_bot ctx.local then ctx.local else pid, Ctx.top (), Pred.of_node (MyCFG.Function f) in (* set predecessor set to start node of function *)
+    let d_callee = if D.is_bot ctx.local then ctx.local else pid, Ctx.top (), Pred.of_node (MyCFG.Function f.svar) in (* set predecessor set to start node of function *)
     [d_caller, d_callee]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
+    let f = f.svar in
     if D.is_bot ctx.local || D.is_bot au then ctx.local else
       let pid, ctxh, pred = ctx.local in (* caller *)
       let _ , _, pred' = au in (* callee *)

--- a/src/analyses/extract_osek.ml
+++ b/src/analyses/extract_osek.ml
@@ -220,11 +220,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     let d_caller = ctx.local in
     let pid, ctxh, pred = ctx.local in
-    let d_callee = if D.is_bot ctx.local then ctx.local else pid, Ctx.top (), Pred.of_node (MyCFG.Function f.svar) in (* set predecessor set to start node of function *)
+    let d_callee = if D.is_bot ctx.local then ctx.local else pid, Ctx.top (), Pred.of_node (MyCFG.Function f) in (* set predecessor set to start node of function *)
     [d_caller, d_callee]
 
   let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
-    let f = f.svar in
     if D.is_bot ctx.local || D.is_bot au then ctx.local else
       let pid, ctxh, pred = ctx.local in (* caller *)
       let _ , _, pred' = au in (* callee *)
@@ -317,7 +316,7 @@ struct
               extract_fun ~info_args:str_args args
             ) ctx.local args_product
 
-  let startstate v = Pid.of_int 0L, Ctx.top (), Pred.of_node (MyCFG.Function (emptyFunction "main").svar)
+  let startstate v = Pid.of_int 0L, Ctx.top (), Pred.of_node (MyCFG.Function (emptyFunction "main"))
   let threadenter ctx lval f args = [D.bot ()]
   let threadspawn ctx lval f args fctx = ctx.local
   let exitstate  v = D.bot ()

--- a/src/analyses/fileUse.ml
+++ b/src/analyses/fileUse.ml
@@ -153,9 +153,9 @@ struct
     List.fold_left (fun m var -> D.remove' (var, `NoOffset) m) au (f.sformals @ f.slocals)
   (* D.only_globals au *)
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     (* M.debug_each @@ "entering function "^f.vname^string_of_callstack ctx.local; *)
-    let m = if f.vname <> "main" then
+    let m = if f.svar.vname <> "main" then
         (* push current location onto stack *)
         D.edit_callstack (BatList.cons !Tracing.current_loc) ctx.local
       else ctx.local in
@@ -176,7 +176,7 @@ struct
       D.extend_value unclosed_var (mustOpen, mayOpen) m
     ) else m
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     (* M.debug_each @@ "leaving function "^f.vname^string_of_callstack au; *)
     let m = ctx.local in
     (* pop the last location off the stack *)

--- a/src/analyses/flag.ml
+++ b/src/analyses/flag.ml
@@ -112,11 +112,11 @@ struct
 
   (*   let eval_funvar ctx (fv:exp) =  [(ctx.local,ctx.local)] *)
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     let _ = List.iter no_addr_of_flag args in
     [(D.top (),D.top ())]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     let _ = List.iter no_addr_of_flag args in
     let _ = no_addr_of_flag fexp in
     D.top ()

--- a/src/analyses/flagModes.ml
+++ b/src/analyses/flagModes.ml
@@ -120,10 +120,10 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local,ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     au
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/mallocWrapperAnalysis.ml
+++ b/src/analyses/mallocWrapperAnalysis.ml
@@ -35,8 +35,8 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
-    let calleeofinterest = Hashtbl.mem wrappers f.vname in
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
+    let calleeofinterest = Hashtbl.mem wrappers f.svar.vname in
     let calleectx = if calleeofinterest then
        if ctx.local = `Top then
         `Lifted (MyCFG.getLoc ctx.node) (* if an interesting callee is called by an uninteresting caller, then we remember the callee context *)
@@ -44,7 +44,7 @@ struct
       else D.top () in  (* if an uninteresting callee is called, then we forget what was called before *)
     [(ctx.local, calleectx)]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -188,13 +188,13 @@ struct
     warn_deref_exp (Analyses.ask_of_ctx ctx) ctx.local fv;
     []
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     let nst = remove_unreachable (Analyses.ask_of_ctx ctx) args ctx.local in
     may (fun x -> warn_deref_exp (Analyses.ask_of_ctx ctx) ctx.local (Lval x)) lval;
     List.iter (warn_deref_exp (Analyses.ask_of_ctx ctx) ctx.local) args;
     [ctx.local,nst]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     let cal_st = remove_unreachable (Analyses.ask_of_ctx ctx) args ctx.local in
     let ret_st = D.union au (D.diff ctx.local cal_st) in
     let new_u =

--- a/src/analyses/mayLocks.ml
+++ b/src/analyses/mayLocks.ml
@@ -17,8 +17,8 @@ struct
   let branch ctx (exp:exp) (tv:bool) : D.t = ctx.local
   let body ctx (f:fundec) : D.t = ctx.local
   let return ctx (exp:exp option) (f:fundec) : D.t = ctx.local
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list = [ctx.local,ctx.local]
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t = au
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list = [ctx.local,ctx.local]
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t = au
 
   (* Helper function to convert query-offsets to valuedomain-offsets *)
   let rec conv_offset x =

--- a/src/analyses/octagon.ml
+++ b/src/analyses/octagon.ml
@@ -260,7 +260,7 @@ struct
       | Lval(Var v, NoOffset) -> v
       | _ -> raise (Invalid_argument "only call with Lval(Var v, NoOffset)")
     in
-    let formals = (Cilfacade.getdec fn).sformals in
+    let formals = fn.sformals in
     let formals_and_exps = zip formals args in
     let relevant_vars_in_args = List.filter is_relevant_var args |> List.map get_var in
     let relevant_octagon_part = D.keep_only relevant_vars_in_args ctx.local in
@@ -279,10 +279,10 @@ struct
     let closed = D.strong_closure (List.fold_left add_const relevant_octagon_part formals_and_exps) in (* compute closure so relationships between formals are inferred. TODO: Is it ok to do this here? *)
     D.keep_only formals closed (* Remove vars that were only needed because they were in exp *)
 
-  let enter ctx (lval: lval option) (fn:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (fn:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, make_entry ctx fn args]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (after:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (after:D.t) : D.t =
     match lval with
     | Some (Var v, NoOffset) ->
         let retval = evaluate_exp after (Lval ((Var (return_varinfo ())), NoOffset)) in

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -773,11 +773,11 @@ struct
     let read = access_one_top (Analyses.ask_of_ctx ctx) false exp in
     add_accesses ctx read ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
-    (M.enter ctx (lval: lval option) (f:varinfo) (args:exp list))
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
+    (M.enter ctx (lval: lval option) (f:fundec) (args:exp list))
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
-    M.combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc au
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
+    M.combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     let fvname = get_api_names f.vname in

--- a/src/analyses/osektransactionality.ml
+++ b/src/analyses/osektransactionality.ml
@@ -87,10 +87,10 @@ struct
   let eval_funvar ctx (fv:exp) : varinfo list =
     []
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local,ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     let (ctxs,ctxr) = ctx.local in
     let (aus,aur) = au in
     (ctxs, Osektupel.fcon ctxr aus)

--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -116,7 +116,7 @@ struct
     | x -> x
 
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (fundec:fundec) (args:exp list) : (D.t * D.t) list =
     let rec fold_right2 f xs ys r =
       match xs, ys with
       | x::xs, y::ys -> f x y (fold_right2 f xs ys r)
@@ -124,7 +124,6 @@ struct
     in
     match ctx.local with
     | `Lifted reg ->
-      let fundec = Cilfacade.getdec f in
       let f x r reg = Reg.assign (var x) r reg in
       let old_regpart = get_regpart ctx in
       let regpart, reg = fold_right2 f fundec.sformals args (old_regpart,reg) in
@@ -133,7 +132,7 @@ struct
       [ctx.local, `Lifted reg]
     | x -> [x,x]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     match au with
     | `Lifted reg -> begin
       let old_regpart = get_regpart ctx in

--- a/src/analyses/shapes.ml
+++ b/src/analyses/shapes.ml
@@ -206,13 +206,12 @@ struct
     tryReallyHard (Analyses.ask_of_ctx ctx) gl upd (fun st -> return_ld (Analyses.ask_of_ctx ctx) gl upd st exp f) st,
     Re.return (re_context ctx re) exp f
 
-  let enter_func_ld ask gl dup (lval: lval option) (f:varinfo) (args:exp list) st : LD.t =
+  let enter_func_ld ask gl dup (lval: lval option) (fd:fundec) (args:exp list) st : LD.t =
     let rec zip xs ys =
       match xs, ys with
       | x::xs, y::ys -> (x, y) :: zip xs ys
       | _ -> []
     in
-    let fd = Cilfacade.getdec f in
     let asg (v,e) d = assign_ld ask gl dup (Var v,NoOffset) e d in
     List.fold_right asg (zip fd.sformals args) st
 
@@ -224,7 +223,7 @@ struct
     let es' = Re.enter (re_context ctx re) lval f args in
     List.map (fun (x,y) -> (st,x),(es,y)) es'
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     au
 
   let special_fn_ld ask gl dup (lval: lval option) (f:varinfo) (arglist:exp list) st  =

--- a/src/analyses/spec.ml
+++ b/src/analyses/spec.ml
@@ -417,14 +417,14 @@ struct
     (* TODO only keep globals like in fileUse *)
     List.fold_left (fun m var -> D.remove' (var, `NoOffset) m) au (f.sformals @ f.slocals)
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     (* M.debug_each @@ "entering function "^f.vname^D.string_of_callstack ctx.local; *)
-    if f.vname = "main" then load_specfile ();
-    let m = if f.vname <> "main" then
+    if f.svar.vname = "main" then load_specfile ();
+    let m = if f.svar.vname <> "main" then
         D.edit_callstack (BatList.cons !Tracing.current_loc) ctx.local
       else ctx.local in [m, m]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     (* M.debug_each @@ "leaving function "^f.vname^D.string_of_callstack au; *)
     let au = D.edit_callstack List.tl au in
     let return_val = D.find_option return_var au in

--- a/src/analyses/stackTrace.ml
+++ b/src/analyses/stackTrace.ml
@@ -26,10 +26,10 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local,ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
@@ -63,10 +63,10 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, D.push !Tracing.current_loc ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/termination.ml
+++ b/src/analyses/termination.ml
@@ -219,10 +219,10 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local,ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     au
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -28,8 +28,8 @@ struct
       | _ -> ()
     end;
     ctx.local
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list = [ctx.local,ctx.local]
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t = au
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list = [ctx.local,ctx.local]
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t = au
 
   (* Helper function to convert query-offsets to valuedomain-offsets *)
   let rec conv_offset x =
@@ -121,8 +121,8 @@ struct
   let branch ctx (exp:exp) (tv:bool) : D.t =  ctx.local
   let body ctx (f:fundec) : D.t =  ctx.local
   let return ctx (exp:exp option) (f:fundec) : D.t = ctx.local
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list = [ctx.local,ctx.local]
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t = ctx.local
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list = [ctx.local,ctx.local]
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t = ctx.local
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t = ctx.local
 
   let main = D.singleton "main"

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -44,10 +44,10 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local,ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     au
 
   let rec cut_offset x =

--- a/src/analyses/threadReturn.ml
+++ b/src/analyses/threadReturn.ml
@@ -29,10 +29,10 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, false]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/uninit.ml
+++ b/src/analyses/uninit.ml
@@ -267,11 +267,11 @@ struct
     | _ -> nst
 
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     let nst = remove_unreachable (Analyses.ask_of_ctx ctx) args ctx.local in
     [ctx.local, nst]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : trans_out =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : trans_out =
     ignore (List.map (fun x -> is_expr_initd (Analyses.ask_of_ctx ctx) x ctx.local) args);
     let cal_st = remove_unreachable (Analyses.ask_of_ctx ctx) args ctx.local in
     let ret_st = D.union au (D.diff ctx.local cal_st) in

--- a/src/analyses/unit.ml
+++ b/src/analyses/unit.ml
@@ -25,10 +25,10 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
     au
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -470,7 +470,6 @@ struct
       let rm = remove (Analyses.ask_of_ctx ctx) (Var lv, NoOffset) st in
       add_eq (Analyses.ask_of_ctx ctx) (Var lv, NoOffset) exp rm
     in
-    let f = Cilfacade.getdec f in
     let nst =
       try fold_left2 assign_one_param ctx.local f.sformals args
       with SetDomain.Unsupported _ -> (* ignore varargs fr now *) D.top ()

--- a/src/cdomains/arincDomain.ml
+++ b/src/cdomains/arincDomain.ml
@@ -21,7 +21,8 @@ module Ctx = IntDomain.Flattened
 module Pred = struct
   module Base = Basetype.ProgLocation
   include SetDomain.Make (Base)
-  let of_node = singleton % MyCFG.getLoc
+  let of_loc = singleton
+  let of_node = of_loc % MyCFG.getLoc
   let of_current_node () = of_node @@ Option.get !MyCFG.current_node
   let string_of_elt = Basetype.ProgLocation.show
 end

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -50,8 +50,8 @@ struct
   let pretty_node () (l,x) =
     match x with
     | MyCFG.Statement     s -> dprintf "statement \"%a\" at %a" dn_stmt s ProgLines.pretty l
-    | MyCFG.Function      f -> dprintf "result of %s at %a" f.vname ProgLines.pretty l
-    | MyCFG.FunctionEntry f -> dprintf "entry state of %s at %a" f.vname ProgLines.pretty l
+    | MyCFG.Function      f -> dprintf "result of %s at %a" f.svar.vname ProgLines.pretty l
+    | MyCFG.FunctionEntry f -> dprintf "entry state of %s at %a" f.svar.vname ProgLines.pretty l
 
   let show (x,a,f) = ProgLines.show x ^ "(" ^ f.svar.vname ^ ")"
   let pretty () x = text (show x)
@@ -88,7 +88,7 @@ struct
   let loopSep _ = true
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let var_id _ = "globals"
-  let node _ = MyCFG.Function Cil.dummyFunDec.svar
+  let node _ = MyCFG.Function Cil.dummyFunDec
 
   let arbitrary () = MyCheck.Arbitrary.varinfo
 end

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -417,8 +417,8 @@ sig
 
 
   val special : (D.t, G.t, C.t) ctx -> lval option -> varinfo -> exp list -> D.t
-  val enter   : (D.t, G.t, C.t) ctx -> lval option -> varinfo -> exp list -> (D.t * D.t) list
-  val combine : (D.t, G.t, C.t) ctx -> lval option -> exp -> varinfo -> exp list -> C.t -> D.t -> D.t
+  val enter   : (D.t, G.t, C.t) ctx -> lval option -> fundec -> exp list -> (D.t * D.t) list
+  val combine : (D.t, G.t, C.t) ctx -> lval option -> exp -> fundec -> exp list -> C.t -> D.t -> D.t
 
   (** Returns initial state for created thread. *)
   val threadenter : (D.t, G.t, C.t) ctx -> lval option -> varinfo -> exp list -> D.t list

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -562,7 +562,8 @@ struct
             ignore (getl (Function fd, c))
           | exception Not_found ->
             (* unknown function *)
-            ()
+            M.warn_each ("Created a thread from unknown function " ^ f.vname)
+            (* actual implementation (e.g. invalidation) is done by threadenter *)
         ) ds
     in
     (* ... nice, right! *)

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -554,10 +554,15 @@ struct
       (* TODO: don't repeat for all paths that spawn same *)
       let ds = S.threadenter ctx lval f args in
       List.iter (fun d ->
-          let c = S.context d in
           spawns := (lval, f, args, d) :: !spawns;
-          if not full_context then sidel (FunctionEntry f, c) d;
-          ignore (getl (Function f, c))
+          match Cilfacade.getdec f with
+          | fd ->
+            let c = S.context d in
+            if not full_context then sidel (FunctionEntry f, c) d;
+            ignore (getl (Function f, c))
+          | exception Not_found ->
+            (* unknown function *)
+            ()
         ) ds
     in
     (* ... nice, right! *)

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -368,11 +368,11 @@ struct
   let enter ctx r f args =
     let m = snd ctx.local in
     let d' v_cur =
-      let v_old = M.find f m in (* S.D.bot () if not found *)
+      let v_old = M.find f.svar m in (* S.D.bot () if not found *)
       let v_new = S.D.widen v_old (S.D.join v_old v_cur) in
-      Messages.(if tracing && not (S.D.equal v_old v_new) then tracel "widen-context" "enter results in new context for function %s\n" f.vname);
+      Messages.(if tracing && not (S.D.equal v_old v_new) then tracel "widen-context" "enter results in new context for function %s\n" f.svar.vname);
       let v_new = if GobConfig.get_bool "exp.widen-context-partial" then S.val_of (S.context v_new) else v_new in
-      v_new, M.add f v_new m
+      v_new, M.add f.svar v_new m
     in
     S.enter (conv ctx) r f args
     |> List.map (fun (c,v) -> (c,m), d' v) (* c: caller, v: callee *)
@@ -420,11 +420,11 @@ struct
   let enter ctx r f args =
     let m = snd ctx.local in
     let d' v_cur =
-      let v_old = M.find f m in (* S.D.bot () if not found *)
+      let v_old = M.find f.svar m in (* S.D.bot () if not found *)
       let v_new = S.D.widen v_old (S.D.join v_old v_cur) in
-      Messages.(if tracing && not (S.D.equal v_old v_new) then tracel "widen-context" "enter results in new context for function %s\n" f.vname);
+      Messages.(if tracing && not (S.D.equal v_old v_new) then tracel "widen-context" "enter results in new context for function %s\n" f.svar.vname);
       let v_new = if GobConfig.get_bool "exp.widen-context-partial" then S.val_of (S.context v_new) else v_new in
-      v_new, M.add f v_new m
+      v_new, M.add f.svar v_new m
     in
     S.enter (conv ctx) r f args
     |> List.map (fun (c,v) -> (c,m), d' v) (* c: caller, v: callee *)
@@ -638,7 +638,7 @@ struct
     let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
     common_join ctx (S.branch ctx e tv) !r !spawns
 
-  let tf_normal_call ctx lv e f args  getl sidel getg sideg =
+  let tf_normal_call ctx lv e (f:fundec) args  getl sidel getg sideg =
     let combine (cd, fc, fd) =
       if M.tracing then M.traceli "combine" "local: %a\n" S.D.pretty cd;
       (* Extra sync in case function has multiple returns.
@@ -650,7 +650,7 @@ struct
         let rec sync_ctx = { ctx with
             ask = (fun (type a) (q: a Queries.t) -> S.query sync_ctx q);
             local = fd;
-            prev_node = Function f
+            prev_node = Function f.svar
           }
         in
         sync sync_ctx
@@ -662,8 +662,8 @@ struct
     in
     let paths = S.enter ctx lv f args in
     let paths = List.map (fun (c,v) -> (c, S.context v, v)) paths in
-    let _     = if not full_context then List.iter (fun (c,fc,v) -> if not (S.D.is_bot v) then sidel (FunctionEntry f, fc) v) paths in
-    let paths = List.map (fun (c,fc,v) -> (c, fc, if S.D.is_bot v then v else getl (Function f, fc))) paths in
+    let _     = if not full_context then List.iter (fun (c,fc,v) -> if not (S.D.is_bot v) then sidel (FunctionEntry f.svar, fc) v) paths in
+    let paths = List.map (fun (c,fc,v) -> (c, fc, if S.D.is_bot v then v else getl (Function f.svar, fc))) paths in
     let paths = List.filter (fun (c,fc,v) -> not (D.is_bot v)) paths in
     if M.tracing then M.traceli "combine" "combining\n";
     let paths = List.map combine paths in
@@ -680,16 +680,13 @@ struct
       Queries.LS.fold (fun ((x,_)) xs -> x::xs) ls []
     in
     let one_function f =
-      let has_dec = try ignore (Cilfacade.getdec f); true with Not_found -> false in
-      if has_dec then (
-        if LibraryFunctions.use_special f.vname then (
-          M.warn_each ("Using special for defined function " ^ f.vname);
-          tf_special_call ctx lv f args
-        )
-        else
-          tf_normal_call ctx lv e f args getl sidel getg sideg
-      )
-      else
+      match Cilfacade.getdec f with
+      | fd when LibraryFunctions.use_special f.vname ->
+        M.warn_each ("Using special for defined function " ^ f.vname);
+        tf_special_call ctx lv f args
+      | fd ->
+        tf_normal_call ctx lv e fd args getl sidel getg sideg
+      | exception Not_found ->
         tf_special_call ctx lv f args
     in
     if [] = functions then

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -558,8 +558,8 @@ struct
           match Cilfacade.getdec f with
           | fd ->
             let c = S.context d in
-            if not full_context then sidel (FunctionEntry f, c) d;
-            ignore (getl (Function f, c))
+            if not full_context then sidel (FunctionEntry fd, c) d;
+            ignore (getl (Function fd, c))
           | exception Not_found ->
             (* unknown function *)
             ()
@@ -655,7 +655,7 @@ struct
         let rec sync_ctx = { ctx with
             ask = (fun (type a) (q: a Queries.t) -> S.query sync_ctx q);
             local = fd;
-            prev_node = Function f.svar
+            prev_node = Function f
           }
         in
         sync sync_ctx
@@ -667,8 +667,8 @@ struct
     in
     let paths = S.enter ctx lv f args in
     let paths = List.map (fun (c,v) -> (c, S.context v, v)) paths in
-    let _     = if not full_context then List.iter (fun (c,fc,v) -> if not (S.D.is_bot v) then sidel (FunctionEntry f.svar, fc) v) paths in
-    let paths = List.map (fun (c,fc,v) -> (c, fc, if S.D.is_bot v then v else getl (Function f.svar, fc))) paths in
+    let _     = if not full_context then List.iter (fun (c,fc,v) -> if not (S.D.is_bot v) then sidel (FunctionEntry f, fc) v) paths in
+    let paths = List.map (fun (c,fc,v) -> (c, fc, if S.D.is_bot v then v else getl (Function f, fc))) paths in
     let paths = List.filter (fun (c,fc,v) -> not (D.is_bot v)) paths in
     if M.tracing then M.traceli "combine" "combining\n";
     let paths = List.map combine paths in

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -324,14 +324,14 @@ struct
       in
       let args = List.map (fun x -> MyCFG.unknown_exp) fd.sformals in
       let ents = Spec.enter ctx None fd args in
-      List.map (fun (_,s) -> fd.svar, s) ents
+      List.map (fun (_,s) -> fd, s) ents
     in
 
     (try MyCFG.dummy_func.svar.vdecl <- (List.hd otherfuns).svar.vdecl with Failure _ -> ());
 
     let startvars =
       if startfuns = []
-      then [[MyCFG.dummy_func.svar, startstate]]
+      then [[MyCFG.dummy_func, startstate]]
       else
         let morph f = Spec.morphstate f startstate in
         List.map (enter_with morph) startfuns
@@ -461,8 +461,8 @@ struct
 
       let out = M.get_out "uncalled" Legacy.stdout in
       let insrt k _ s = match k with
-        | (MyCFG.Function fn,_) -> if not (get_bool "exp.forward") then Set.Int.add fn.vid s else s
-        | (MyCFG.FunctionEntry fn,_) -> if (get_bool "exp.forward") then Set.Int.add fn.vid s else s
+        | (MyCFG.Function fn,_) -> if not (get_bool "exp.forward") then Set.Int.add fn.svar.vid s else s
+        | (MyCFG.FunctionEntry fn,_) -> if (get_bool "exp.forward") then Set.Int.add fn.svar.vid s else s
         | _ -> s
       in
       (* set of ids of called functions *)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -323,7 +323,7 @@ struct
         }
       in
       let args = List.map (fun x -> MyCFG.unknown_exp) fd.sformals in
-      let ents = Spec.enter ctx None fd.svar args in
+      let ents = Spec.enter ctx None fd args in
       List.map (fun (_,s) -> fd.svar, s) ents
     in
 

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -109,15 +109,15 @@ let do_the_params (fd: fundec) =
 
 let unknown_exp : exp = mkString "__unknown_value__"
 let dummy_func = emptyFunction "__goblint_dummy_init" (* TODO get rid of this? *)
-let dummy_node = FunctionEntry Cil.dummyFunDec.svar
+let dummy_node = FunctionEntry Cil.dummyFunDec
 
 let all_array_index_exp : exp = CastE(TInt(Cilfacade.ptrdiff_ikind (),[]), unknown_exp)
 
 let getLoc (node: node) =
   match node with
   | Statement stmt -> get_stmtLoc stmt.skind
-  | Function fv -> fv.vdecl
-  | FunctionEntry fv -> fv.vdecl
+  | Function fv -> fv.svar.vdecl
+  | FunctionEntry fv -> fv.svar.vdecl
 
 (* TODO: refactor duplication with find_loop_heads *)
 module NH = Hashtbl.Make (Node)
@@ -139,7 +139,7 @@ let find_loop_heads_fun (module Cfg:CfgForward) (fd:Cil.fundec): unit NH.t =
     end
   in
 
-  let entry_node = FunctionEntry fd.svar in
+  let entry_node = FunctionEntry fd in
   iter_node NS.empty entry_node;
 
   loop_heads
@@ -202,7 +202,7 @@ let createCFG (file: file) =
           end
     in realnode is_entry [] stmt
   in
-  addCfg (Function dummy_func.svar) (Ret (None, dummy_func), FunctionEntry dummy_func.svar);
+  addCfg (Function dummy_func) (Ret (None, dummy_func), FunctionEntry dummy_func);
   (* We iterate over all globals looking for functions: *)
   iterGlobals file (fun glob ->
       match glob with
@@ -213,7 +213,7 @@ let createCFG (file: file) =
         (* Find the first statement in the function *)
         let entrynode = realnode true (CF.getFirstStmt fd) in
         (* Add the entry edge to that node *)
-        let _ = addCfg (Statement entrynode) ((Entry fd), (FunctionEntry fd.svar)) in
+        let _ = addCfg (Statement entrynode) ((Entry fd), (FunctionEntry fd)) in
         (* Return node to be used for infinite loop connection to end of function
          * lazy, so it's only added when actually needed *)
         let pseudo_return = lazy (
@@ -223,7 +223,7 @@ let createCFG (file: file) =
           newst.sid <- if sid < start_id then sid + start_id else sid;
           Hashtbl.add stmt_fundec_map newst.sid fd;
           let newst_node = Statement newst in
-          addCfg (Function fd.svar) (Ret (None,fd), newst_node);
+          addCfg (Function fd) (Ret (None,fd), newst_node);
           newst_node
         )
         in
@@ -287,7 +287,7 @@ let createCFG (file: file) =
                 addCfg (Lazy.force pseudo_return) (Test (one, false), Statement (realnode true stmt)) (* TODO: is this necessary anymore? maybe could just leave it out and let the general case below handle it *)
             end
           (* The return edges are connected to the function *)
-          | Return (exp,loc) -> addCfg (Function fd.svar) (Ret (exp,fd), Statement stmt)
+          | Return (exp,loc) -> addCfg (Function fd) (Ret (exp,fd), Statement stmt)
           (* Gotos are skipped over by realnode and usually not needed.
            * Except goto loops with empty bodies need the Skip edge to be identified as loop heads and connected to return.
            * This also creates some unconnected but unnecessary edges which are covered by realnode. *)
@@ -306,7 +306,7 @@ let createCFG (file: file) =
         end
         in
         let loop_heads = find_loop_heads_fun (module TmpCfg) fd in
-        let reachable_return = find_backwards_reachable (module TmpCfg) (Function fd.svar) in
+        let reachable_return = find_backwards_reachable (module TmpCfg) (Function fd) in
         NH.iter (fun node () ->
             if not (NH.mem reachable_return node) then
               addCfg (Lazy.force pseudo_return) (Test (one, false), node)
@@ -323,8 +323,8 @@ let print cfg  =
   let _ = Printf.fprintf out "digraph cfg {\n" in
   let p_node () = function
     | Statement stmt  -> Pretty.dprintf "%d" stmt.sid
-    | Function f      -> Pretty.dprintf "ret%d" f.vid
-    | FunctionEntry f -> Pretty.dprintf "fun%d" f.vid
+    | Function f      -> Pretty.dprintf "ret%d" f.svar.vid
+    | FunctionEntry f -> Pretty.dprintf "fun%d" f.svar.vid
   in
   let dn_exp () e =
     text (XmlUtil.escape (sprint 800 (dn_exp () e)))
@@ -356,8 +356,8 @@ let print cfg  =
     match n with
     | Statement {skind=If (_,_,_,_); _} as s  -> ignore (Pretty.fprintf out "\t%a [shape=diamond]\n" p_node s)
     | Statement stmt  -> ()
-    | Function f      -> ignore (Pretty.fprintf out "\t%a [label =\"return of %s()\",shape=box];\n" p_node (Function f) f.vname)
-    | FunctionEntry f -> ignore (Pretty.fprintf out "\t%a [label =\"%s()\",shape=box];\n" p_node (FunctionEntry f) f.vname)
+    | Function f      -> ignore (Pretty.fprintf out "\t%a [label =\"return of %s()\",shape=box];\n" p_node (Function f) f.svar.vname)
+    | FunctionEntry f -> ignore (Pretty.fprintf out "\t%a [label =\"%s()\",shape=box];\n" p_node (FunctionEntry f) f.svar.vname)
   in
   let printEdge (toNode: node) ((edges:(location * edge) list), (fromNode: node)) =
     ignore (Pretty.fprintf out "\t%a -> %a [label = \"%a\"] ;\n" p_node fromNode p_node toNode p_edges edges);
@@ -479,8 +479,8 @@ let get_containing_function (stmt: stmt): fundec = Hashtbl.find stmt_fundec_map 
 let getFun (node: node) =
   match node with
   | Statement stmt -> get_containing_function stmt
-  | Function fv -> CF.getdec fv
-  | FunctionEntry fv -> CF.getdec fv
+  | Function fv -> fv
+  | FunctionEntry fv -> fv
 
 let printFun (module Cfg : CfgBidir) live fd out =
   (* let out = open_out "cfg.dot" in *)
@@ -490,8 +490,8 @@ let printFun (module Cfg : CfgBidir) live fd out =
   let _ = Printf.fprintf out "digraph cfg {\n" in
   let p_node () = function
     | Statement stmt  -> Pretty.dprintf "%d" stmt.sid
-    | Function f      -> Pretty.dprintf "ret%d" f.vid
-    | FunctionEntry f -> Pretty.dprintf "fun%d" f.vid
+    | Function f      -> Pretty.dprintf "ret%d" f.svar.vid
+    | FunctionEntry f -> Pretty.dprintf "fun%d" f.svar.vid
   in
   let dn_exp () e =
     text (XmlUtil.escape (sprint 800 (dn_exp () e)))
@@ -522,8 +522,8 @@ let printFun (module Cfg : CfgBidir) live fd out =
       match n with
       | Statement {skind=If (_,_,_,_); _}  -> "shape=diamond"
       | Statement stmt  -> ""
-      | Function f      -> "label =\"return of "^f.vname^"()\",shape=box"
-      | FunctionEntry f -> "label =\""^f.vname^"()\",shape=box"
+      | Function f      -> "label =\"return of "^f.svar.vname^"()\",shape=box"
+      | FunctionEntry f -> "label =\""^f.svar.vname^"()\",shape=box"
     in
     ignore (Pretty.fprintf out ("\t%a [id=\"%a\",URL=\"javascript:show_info('\\N');\",%s,%s];\n") p_node n p_node n liveness kind_style)
   in
@@ -540,7 +540,7 @@ let printFun (module Cfg : CfgBidir) live fd out =
       List.iter (fun (_,x) -> printNode x) prevs
     end
   in
-  printNode (Function fd.svar);
+  printNode (Function fd);
   NH.iter printNodeStyle node_table;
   Printf.fprintf out "}\n";
   flush out;

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -8,9 +8,9 @@ open Pretty
 type node =
   | Statement of stmt
   (** The statements as identified by CIL *)
-  | FunctionEntry of varinfo
+  | FunctionEntry of fundec
   (** *)
-  | Function of varinfo
+  | Function of fundec
   (** The variable information associated with the function declaration. *)
 [@@deriving to_yojson]
 
@@ -18,32 +18,32 @@ let write_cfgs : ((node -> bool) -> unit) ref = ref (fun _ -> ())
 
 let pretty_node () = function
   | Statement s -> text "Statement " ++ dn_stmt () s
-  | Function f -> text "Function " ++ text f.vname
-  | FunctionEntry f -> text "FunctionEntry " ++ text f.vname
+  | Function f -> text "Function " ++ text f.svar.vname
+  | FunctionEntry f -> text "FunctionEntry " ++ text f.svar.vname
 
 
 let pretty_short_node () = function
   | Statement s -> text "Statement @ " ++ d_loc () (get_stmtLoc s.skind)
-  | Function f -> text "Function " ++ text f.vname
-  | FunctionEntry f -> text "FunctionEntry " ++ text f.vname
+  | Function f -> text "Function " ++ text f.svar.vname
+  | FunctionEntry f -> text "FunctionEntry " ++ text f.svar.vname
 
 let node_compare n1 n2 =
   match n1, n2 with
-  | FunctionEntry f, FunctionEntry g -> compare f.vid g.vid
+  | FunctionEntry f, FunctionEntry g -> compare f.svar.vid g.svar.vid
   | _                    , FunctionEntry g -> -1
   | FunctionEntry g, _                     -> 1
   | Statement _, Function _  -> -1
   | Function  _, Statement _ -> 1
   | Statement s, Statement l -> compare s.sid l.sid
-  | Function  f, Function g  -> compare f.vid g.vid
+  | Function  f, Function g  -> compare f.svar.vid g.svar.vid
 
 let compare_node = node_compare
 
 let equal_node x y =
   match x,y with
   | Statement s1, Statement s2 -> CilType.Stmt.equal s1 s2
-  | Function f1, Function f2 -> CilType.Varinfo.equal f1 f2
-  | FunctionEntry f1, FunctionEntry f2 -> CilType.Varinfo.equal f1 f2
+  | Function f1, Function f2 -> CilType.Fundec.equal f1 f2
+  | FunctionEntry f1, FunctionEntry f2 -> CilType.Fundec.equal f1 f2
   | _ -> false
 
 let print doc =
@@ -64,6 +64,6 @@ struct
   let hash x =
     match x with
     | Statement s     -> s.sid * 17
-    | Function f      -> f.vid
-    | FunctionEntry f -> -f.vid
+    | Function f      -> f.svar.vid
+    | FunctionEntry f -> -f.svar.vid
 end

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -45,8 +45,8 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_id
     List.iter (fun (s, o_s) -> s.sid <- o_s.sid) (List.combine f.sallstmts old_f.sallstmts);
     List.iter (fun s -> store_node_location (Statement s) (get_stmtLoc s.skind)) f.sallstmts;
 
-    store_node_location (Function f.svar) f.svar.vdecl;
-    store_node_location (FunctionEntry f.svar) f.svar.vdecl;
+    store_node_location (Function f) f.svar.vdecl;
+    store_node_location (FunctionEntry f) f.svar.vdecl;
     override_fundec f old_f;
     List.iter (fun l -> update_vid_max l.vid) f.slocals;
     List.iter (fun f -> update_vid_max f.vid) f.sformals;

--- a/src/util/tracing.ml
+++ b/src/util/tracing.ml
@@ -26,8 +26,8 @@ let getLoc (node: node) =
   with e ->
     match node with
     | Statement stmt -> get_stmtLoc stmt.skind
-    | Function fv -> fv.vdecl
-    | FunctionEntry fv -> fv.vdecl
+    | Function fv -> fv.svar.vdecl
+    | FunctionEntry fv -> fv.svar.vdecl
 
 let addsystem sys = trace_sys := Strs.add sys !trace_sys
 let activate (sys:string) (subsys: string list): unit =

--- a/src/witness/observerAnalysis.ml
+++ b/src/witness/observerAnalysis.ml
@@ -62,12 +62,12 @@ struct
   let return ctx (exp:exp option) (f:fundec) : D.t =
     step_ctx ctx
 
-  let enter ctx (lval: lval option) (f:varinfo) (args:exp list) : (D.t * D.t) list =
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     (* ctx.local doesn't matter here? *)
-    [ctx.local, step ctx.local ctx.prev_node (FunctionEntry f)]
+    [ctx.local, step ctx.local ctx.prev_node (FunctionEntry f.svar)]
 
-  let combine ctx (lval:lval option) fexp (f:varinfo) (args:exp list) fc (au:D.t) : D.t =
-    step au (Function f) ctx.node
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
+    step au (Function f.svar) ctx.node
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     step_ctx ctx

--- a/src/witness/observerAnalysis.ml
+++ b/src/witness/observerAnalysis.ml
@@ -64,10 +64,10 @@ struct
 
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     (* ctx.local doesn't matter here? *)
-    [ctx.local, step ctx.local ctx.prev_node (FunctionEntry f.svar)]
+    [ctx.local, step ctx.local ctx.prev_node (FunctionEntry f)]
 
   let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t =
-    step au (Function f.svar) ctx.node
+    step au (Function f) ctx.node
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     step_ctx ctx

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -214,9 +214,9 @@ let write_file filename (module Task:Task) (module TaskResult:WitnessTaskResult)
         end;
         begin match from_cfgnode, to_cfgnode with
           | _, FunctionEntry f ->
-            [("enterFunction", f.vname)]
+            [("enterFunction", f.svar.vname)]
           | Function f, _ ->
-            [("returnFromFunction", f.vname)]
+            [("returnFromFunction", f.svar.vname)]
           | _, _ -> []
         end;
         begin match edge with
@@ -353,8 +353,8 @@ struct
         let i_str = string_of_int i in
         match n with
         | Statement stmt  -> Printf.sprintf "s%d(%d)[%s]" stmt.sid c_tag i_str
-        | Function f      -> Printf.sprintf "ret%d%s(%d)[%s]" f.vid f.vname c_tag i_str
-        | FunctionEntry f -> Printf.sprintf "fun%d%s(%d)[%s]" f.vid f.vname c_tag i_str
+        | Function f      -> Printf.sprintf "ret%d%s(%d)[%s]" f.svar.vid f.svar.vname c_tag i_str
+        | FunctionEntry f -> Printf.sprintf "fun%d%s(%d)[%s]" f.svar.vid f.svar.vname c_tag i_str
 
       (* TODO: less hacky way (without ask_indices) to move node *)
       let is_live (n, c, i) = not (Spec.D.is_bot (get (n, c)))
@@ -435,7 +435,7 @@ struct
         LHT.fold (fun (n, c) v acc ->
             match n with
             (* FunctionEntry isn't used for extern __VERIFIER_error... *)
-            | FunctionEntry f when Svcomp.is_error_function f ->
+            | FunctionEntry f when Svcomp.is_error_function f.svar ->
               let is_dead = Spec.D.is_bot v in
               acc && is_dead
             | _ -> acc
@@ -455,7 +455,7 @@ struct
         (module TaskResult:WitnessTaskResult)
       ) else (
         let is_violation = function
-          | FunctionEntry f, _, _ when Svcomp.is_error_function f -> true
+          | FunctionEntry f, _, _ when Svcomp.is_error_function f.svar -> true
           | _, _, _ -> false
         in
         (* redefine is_violation to shift violations back by one, so enterFunction __VERIFIER_error is never used *)

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -318,7 +318,7 @@ struct
         if should_inline f then
           let nosync = (Sync.singleton x (SyncSet.singleton x)) in
           (* returns already post-sync in FromSpec *)
-          step (Function f) fc x (InlineReturn l) nosync
+          step (Function f.svar) fc x (InlineReturn l) nosync
         else
           step_ctx_edge ctx cd
       in

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -15,8 +15,8 @@ struct
     let open MyCFG in
     match x with
     | Statement stmt  -> string_of_int stmt.sid
-    | Function f      -> "return of " ^ f.vname ^ "()"
-    | FunctionEntry f -> f.vname ^ "()"
+    | Function f      -> "return of " ^ f.svar.vname ^ "()"
+    | FunctionEntry f -> f.svar.vname ^ "()"
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let name () = "var"
   let invariant _ _ = Invariant.none
@@ -318,7 +318,7 @@ struct
         if should_inline f then
           let nosync = (Sync.singleton x (SyncSet.singleton x)) in
           (* returns already post-sync in FromSpec *)
-          step (Function f.svar) fc x (InlineReturn l) nosync
+          step (Function f) fc x (InlineReturn l) nosync
         else
           step_ctx_edge ctx cd
       in

--- a/src/witness/witnessUtil.ml
+++ b/src/witness/witnessUtil.ml
@@ -8,7 +8,7 @@ let find_main_entry entrystates =
     entrystates
     |> List.map fst
     |> List.partition (function
-        | FunctionEntry f, _ -> f.vname = "main"
+        | FunctionEntry f, _ -> f.svar.vname = "main"
         | _, _ -> false
       )
   in
@@ -37,7 +37,7 @@ let find_loop_heads (module Cfg:CfgForward) (file:Cil.file): unit NH.t =
 
   Cil.iterGlobals file (function
       | GFun (fd, _) ->
-        let entry_node = FunctionEntry fd.svar in
+        let entry_node = FunctionEntry fd in
         iter_node NS.empty entry_node
       | _ -> ()
     );

--- a/tests/regression/02-base/51-spawn-special.c
+++ b/tests/regression/02-base/51-spawn-special.c
@@ -1,0 +1,13 @@
+#include <pthread.h>
+#include <assert.h>
+
+extern void* magic(void* arg);
+int g;
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, magic, NULL);
+
+  assert(g == 0); // UNKNOWN! (magic may invalidate)
+  return 0;
+}

--- a/tests/regression/02-base/52-otherfun-special.c
+++ b/tests/regression/02-base/52-otherfun-special.c
@@ -1,0 +1,14 @@
+// PARAM: --set otherfun '["magic"]'
+#include <pthread.h>
+#include <assert.h>
+
+extern void* magic(void* arg);
+int g;
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, magic, NULL);
+
+  assert(g == 0); // UNKNOWN! (magic may invalidate)
+  return 0;
+}

--- a/tests/regression/02-base/52-otherfun-special.c
+++ b/tests/regression/02-base/52-otherfun-special.c
@@ -6,9 +6,6 @@ extern void* magic(void* arg);
 int g;
 
 int main() {
-  pthread_t id;
-  pthread_create(&id, NULL, magic, NULL);
-
   assert(g == 0); // UNKNOWN! (magic may invalidate)
   return 0;
 }

--- a/tests/regression/02-base/52-otherfun-special.c
+++ b/tests/regression/02-base/52-otherfun-special.c
@@ -1,4 +1,4 @@
-// PARAM: --set otherfun '["magic"]'
+// SKIP PARAM: --set otherfun '["magic"]'
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/02-base/53-spawn-special-arg.c
+++ b/tests/regression/02-base/53-spawn-special-arg.c
@@ -1,0 +1,13 @@
+#include <pthread.h>
+#include <assert.h>
+
+extern void* magic(void* arg);
+
+int main() {
+  int x = 0;
+  pthread_t id;
+  pthread_create(&id, NULL, magic, &x);
+
+  assert(x == 0); // UNKNOWN! (magic may invalidate)
+  return 0;
+}

--- a/tests/regression/02-base/54-spawn-special-unknown.c
+++ b/tests/regression/02-base/54-spawn-special-unknown.c
@@ -1,0 +1,14 @@
+#include <pthread.h>
+#include <assert.h>
+
+int g;
+
+int main() {
+  void (*unknown)(void*);
+
+  pthread_t id;
+  pthread_create(&id, NULL, unknown, NULL);
+
+  assert(g == 0); // UNKNOWN! (unknown thread may invalidate)
+  return 0;
+}


### PR DESCRIPTION
Many of them use `Cilfacade.getdec` to look up the `fundec` anyway, e.g. to check `sformals`. `FromSpec` already looked up the existence of `fundec` as well to determine whether normal or special function call should be performed, but it ignored the `fundec` instead of passing it into `enter` and `combine` for normal calls. This makes normal calls more consistent because their `body` and `return` already have `fundec` arguments.

`special` will still have to have a `varinfo` argument because those functions have no `fundec`, but they don't do `enter` and `combine` either.

## TODO
There's a few related changes I'd do:
- [x] Change `FunctionEntry` and `Function` nodes to contain `fundec` instead of `varinfo`?
- [x] ~~Change `threadenter` and `threadspawn` similarly?~~ (see comment)

### Questions
Both are complicated by one factor: it's possible to spawn threads with `extern` (i.e. unknown) functions as the thread body. As I started looking into this, I realized that our current support for such thing is broken and accidental: base analysis properly calls `ctx.spawn` for them (with a `varinfo`) and `FromSpec` calls `threadenter` and `threadspawn` correspondingly. The code surrounding `threadenter` treats it always as if it's a normal function: side effects to `FunctionEntry` and demands (and ignores) `Function` to force the function to be analyzed. This causes warnings like:
```
Creating a thread from unknown function magic (tests/regression/02-base/52-otherfun-special.c:9)
Calculated state for undefined function: unexpected node FunctionEntry magic (initfun:0)
Calculated state for undefined function: unexpected node Function magic (initfun:0)
```
These nodes and their values are complete nonsense: because there's no definition, there's no CFG and thus there's no edges even between them. We thereby assume that an unknown thread doesn't do anything (which isn't exactly sound).

So the big question is, what should we do when unknown threads get spawned. What may it do? This is slightly similar to calling an unknown function in a defined thread: currently we assume it invalidates globals but doesn't lock, unlock, spawn, etc.

This determines what part of that can be changed. I think `threadspawn` will have to take `varinfo` because the spawner should be aware of a thread having been spawned regardless (to go multithreaded, etc). But what should `threadenter` be for, only entering defined threads (like `enter`) or also for entering unknown threads (if so, then what would be done with that state)? Maybe there also needs to be `threadspecial` (like `special`) that does the invalidation?

(There's a related even more obscure case: `otherfun`s are also "spawned" using `threadenter`. So what if you add an extern function to `otherfun`? Apparently values in `otherfun` etc without corresponding definitions are silently ignored...)