### PR TITLE
Allow running without base analysis

### DIFF
--- a/src/domains/hoareDomain.ml
+++ b/src/domains/hoareDomain.ml
@@ -207,9 +207,12 @@ struct
         let evil = choose (filter p s1) in
         dprintf "%a:\n" B.pretty evil
         ++
-        fold (fun other acc ->
-            (dprintf "not leq %a because %a\n" B.pretty other B.pretty_diff (evil, other)) ++ acc
-          ) s2 nil
+        if is_empty s2 then
+          text "empty set s2"
+        else
+          fold (fun other acc ->
+              (dprintf "not leq %a because %a\n" B.pretty other B.pretty_diff (evil, other)) ++ acc
+            ) s2 nil
       with _ ->
         dprintf "choose failed b/c of empty set s1: %d s2: %d"
         (cardinal s1)
@@ -315,9 +318,12 @@ struct
         let evilr' = R.choose evilr in
         dprintf "%a -> %a:\n" SpecD.pretty evil R.pretty (R.singleton evilr')
         ++
-        fold' (fun other otherr acc ->
-            (dprintf "not leq %a because %a\nand not mem %a because %a\n" SpecD.pretty other SpecD.pretty_diff (evil, other) R.pretty otherr R.pretty_diff (R.singleton evilr', otherr)) ++ acc
-          ) s2 nil
+        if is_empty s2 then
+          text "empty set s2"
+        else
+          fold' (fun other otherr acc ->
+              (dprintf "not leq %a because %a\nand not mem %a because %a\n" SpecD.pretty other SpecD.pretty_diff (evil, other) R.pretty otherr R.pretty_diff (R.singleton evilr', otherr)) ++ acc
+            ) s2 nil
       with _ ->
         dprintf "choose failed b/c of empty set s1: %d s2: %d"
         (cardinal s1)

--- a/src/domains/hoareDomain.ml
+++ b/src/domains/hoareDomain.ml
@@ -159,8 +159,6 @@ end
 module type SetS =
 sig
   include SetDomain.S
-  val map_noreduce: (elt -> elt) -> t -> t (** HACK: for PathSensitive morphstate *)
-
   val apply_list: (elt list -> elt list) -> t -> t
 end
 
@@ -189,7 +187,6 @@ struct
   let inter _ _ = unsupported "Set.inter"
   let meet = product_bot B.meet
   let subset _ _ = unsupported "Set.subset"
-  let map_noreduce = map
   let map f a = map f a |> reduce
   let min_elt a = B.bot ()
   let split x a = unsupported "Set.split"
@@ -226,10 +223,6 @@ struct
   module S = Set (B)
   include SetDomain.LiftTop (S) (N)
 
-  let map_noreduce f x =
-    match x with
-    | `Top -> `Top
-    | `Lifted t -> `Lifted (S.map_noreduce f t)
   let min_elt a = B.bot ()
   let apply_list f = function
     | `Top -> `Top
@@ -262,7 +255,6 @@ struct
   let fold (f: key -> 'a -> 'a) (s: t) (acc: 'a): 'a = fold (fun x _ acc -> f x acc) s acc
   let add (x: key) (r: R.t) (s: t): t = add x (R.join r (find x s)) s
   let map (f: key -> key) (s: t): t = fold' (fun x v acc -> add (f x) v acc) s (empty ())
-  let map_noreduce = map (* HACK: for PathSensitive morphstate *)
   (* TODO: reducing map, like HoareSet *)
 
   let elements (s: t): (key * R.t) list = bindings s

--- a/src/domains/hoareDomain.ml
+++ b/src/domains/hoareDomain.ml
@@ -172,7 +172,7 @@ struct
   let mem x s = exists (B.leq x) s
   let leq a b = for_all (fun x -> mem x b) a (* mem uses B.leq! *)
   let le x y = B.leq x y && not (B.equal x y) && not (B.leq y x)
-  let reduce s = filter (fun x -> not (exists (le x) s) && not (B.is_bot x)) s
+  let reduce s = filter (fun x -> not (exists (le x) s)) s
   let product_bot op a b =
     let a,b = elements a, elements b in
     List.map (fun x -> List.map (fun y -> op x y) b) a |> List.flatten |> fun x -> reduce (of_list x)
@@ -277,7 +277,7 @@ struct
   let le x y = SpecD.leq x y && not (SpecD.equal x y) && not (SpecD.leq y x)
   let reduce (s: t): t =
     (* get map with just maximal keys and their ranges *)
-    let maximals = filter (fun x -> not (exists (le x) s) && not (SpecD.is_bot x)) s in
+    let maximals = filter (fun x -> not (exists (le x) s)) s in
     (* join le ranges also *)
     let maximals =
       mapi (fun x xr ->

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -986,7 +986,7 @@ struct
 
   let exitstate  v = D.singleton (Spec.exitstate  v)
   let startstate v = D.singleton (Spec.startstate v)
-  let morphstate v d = D.map_noreduce (Spec.morphstate v) d
+  let morphstate v d = D.map (Spec.morphstate v) d
 
   let call_descr = Spec.call_descr
 

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -676,8 +676,15 @@ struct
   let tf_proc var edge prev_node lv e args getl sidel getg sideg d =
     let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
     let functions =
-      let ls = ctx.ask (Queries.EvalFunvar e) in
-      Queries.LS.fold (fun ((x,_)) xs -> x::xs) ls []
+      match e with
+      | Lval (Var v, NoOffset) ->
+        (* Handle statically known function call directly.
+           Allows deactivating base. *)
+        [v]
+      | _ ->
+        (* Depends on base for query. *)
+        let ls = ctx.ask (Queries.EvalFunvar e) in
+        Queries.LS.fold (fun ((x,_)) xs -> x::xs) ls []
     in
     let one_function f =
       let has_dec = try ignore (Cilfacade.getdec f); true with Not_found -> false in

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -166,7 +166,7 @@ struct
 
   let exitstate  v = (Dom.singleton (Spec.exitstate  v) (R.bot ()), Sync.bot ())
   let startstate v = (Dom.singleton (Spec.startstate v) (R.bot ()), Sync.bot ())
-  let morphstate v (d, _) = (Dom.map_noreduce (Spec.morphstate v) d, Sync.bot ())
+  let morphstate v (d, _) = (Dom.map (Spec.morphstate v) d, Sync.bot ())
 
   let call_descr = Spec.call_descr
 

--- a/tests/regression/02-base/51-empty-not-dead.c
+++ b/tests/regression/02-base/51-empty-not-dead.c
@@ -1,0 +1,10 @@
+//PARAM: --set ana.activated '["base", "mallocWrapper"]'
+// Copied & modified from 33/04.
+#include <assert.h>
+
+int main() {
+    // state: {bot}, because no locals/globals
+    assert(1); // state: {bot}, because Hoare set add (in PathSensitive2 map) keeps bot, while reduce would remove
+    assert(1); // state: {bot}, because Hoare set add (in PathSensitive2 map) keeps bot, while reduce would remove
+    return 0;
+}

--- a/tests/regression/33-constants/01-const.c
+++ b/tests/regression/33-constants/01-const.c
@@ -1,4 +1,4 @@
-//PARAM: --sets ana.activated[+] constants
+//PARAM: --set ana.activated '["constants"]'
 int f(int a, int b){
     int d = 3;
     int z = a + d;

--- a/tests/regression/33-constants/02-simple.c
+++ b/tests/regression/33-constants/02-simple.c
@@ -1,4 +1,4 @@
-//PARAM: --sets ana.activated[+] constants
+//PARAM: --set ana.activated '["constants"]'
 
 int main(){
     int x = 3;

--- a/tests/regression/33-constants/03-empty-not-dead-branch.c
+++ b/tests/regression/33-constants/03-empty-not-dead-branch.c
@@ -1,0 +1,16 @@
+//PARAM: --set ana.activated '["constants"]'
+
+int g;
+
+int main() {
+    // state: {bot}, because no locals
+    if (g) {
+        g = 1; // state: {bot}, because Hoare set add (in PathSensitive2 map) keeps bot, while reduce would remove
+    }
+    else {
+        g = 2; // state: {bot}, because Hoare set add (in PathSensitive2 map) keeps bot, while reduce would remove
+    }
+    // state: {}, because reduce is applied after join and that removes bot
+    g = 3; // state: {} and PathSensitive2 map raises Deadcode
+    return 0;
+}

--- a/tests/regression/33-constants/04-empty-not-dead.c
+++ b/tests/regression/33-constants/04-empty-not-dead.c
@@ -1,0 +1,9 @@
+//PARAM: --set ana.activated '["constants"]'
+
+int g;
+
+int main() {
+    // state: {bot}, because no locals
+    g = 1; // state: {bot}, because Hoare set add (in PathSensitive2 map) keeps bot, while reduce would remove
+    return 0;
+}


### PR DESCRIPTION
Closes #245.

The explanation for path-sensitivity and Hoare set changes is here: https://github.com/goblint/analyzer/issues/245#issuecomment-873976513. Is it really the case that the Hoare set incorrectly filtered out `bot` values? I'm especially surprised since at some point for the traces paper we discussed these bottom and top things w.r.t Hoare domains and never questioned this.