### PR TITLE
Update scripts to use more portable shebang

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -e # exit immediately if a command fails
 set -o pipefail # or all $? in pipe instead of returning exit code of the last command only
 

--- a/regtest.sh
+++ b/regtest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ $# -lt 2 ]; then
     echo "Usage: $0 group-nr test-nr [extra options]"
     exit 1

--- a/scripts/bisect.sh
+++ b/scripts/bisect.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #git bisect start HEAD {last known good revision}
 #git bisect run ./scripts/bisect.sh
 ./make.sh opt || exit 125

--- a/scripts/incremental.sh
+++ b/scripts/incremental.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -e # exit immediately if a command fails
 set -o pipefail # or all $? in pipe instead of returning exit code of the last command only
 

--- a/scripts/privPrecCompare-creduce.sh
+++ b/scripts/privPrecCompare-creduce.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # creduce ./scripts/privPrecCompare-creduce.sh ./pfscan_comb.c
 

--- a/scripts/privPrecCompare.sh
+++ b/scripts/privPrecCompare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ./scripts/privPrecCompare.sh ../goblint-bench/pthread/pfscan_comb.c --enable custom_libc
 

--- a/scripts/set_version.sh
+++ b/scripts/set_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 VERSION=$(git describe --all --long --dirty 2> /dev/null)
 CILVERSION=$(git --git-dir=../cil/.git describe --tags 2> /dev/null | sed s@^cil-@@)
 

--- a/scripts/trace_off.sh
+++ b/scripts/trace_off.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#/usr/bin/env bash
 make gen
 scripts/set_version.sh
 grep -q 'tracing = true' src/config.ml && \

--- a/scripts/trace_on.sh
+++ b/scripts/trace_on.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#/usr/bin/env bash
 make gen
 scripts/set_version.sh
 grep -q 'tracing = false' src/config.ml && \

--- a/scripts/track_off.sh
+++ b/scripts/track_off.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#/usr/bin/env bash
 make gen
 scripts/set_version.sh
 grep -q 'tracking = true' src/config.ml && \

--- a/scripts/track_on.sh
+++ b/scripts/track_on.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#/usr/bin/env bash
 make gen
 scripts/set_version.sh
 grep -q 'tracking = false' src/config.ml && \

--- a/sv-comp/archive.sh
+++ b/sv-comp/archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd ..
 

--- a/sv-comp/benchexec/my-bench-sv-comp/goblint-all-fast.sh
+++ b/sv-comp/benchexec/my-bench-sv-comp/goblint-all-fast.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 shopt -s extglob
 

--- a/sv-comp/benchexec/my-bench-sv-comp/goblint-data-race.sh
+++ b/sv-comp/benchexec/my-bench-sv-comp/goblint-data-race.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 shopt -s extglob
 

--- a/sv-comp/benchexec/my-bench-sv-comp/goblint.sh
+++ b/sv-comp/benchexec/my-bench-sv-comp/goblint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 shopt -s extglob
 

--- a/sv-comp/benchexec/my-bench/goblint.sh
+++ b/sv-comp/benchexec/my-bench/goblint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 shopt -s extglob
 


### PR DESCRIPTION
> Using `#!/usr/bin/env bash` instead of `#!/bin/bash` as shebang makes the scripts usable on systems where bash is not available under `/bin`, e.g., NixOS.

This PR is by the team that added congruences in the practical. I pulled it out of #260 so the diff there becomes more focused.

Any opinions @sim642 @vogler?