### PR TITLE
Replace `Cil.typeOf` with `Cilfacade.typeOf` which uses sensible exceptions

### DIFF
--- a/src/analyses/apron/octApron.apron.ml
+++ b/src/analyses/apron/octApron.apron.ml
@@ -142,7 +142,7 @@ struct
     if D.is_bot ctx.local then D.bot () else
 
       let nd = match e with
-        | Some e when isIntegralType (typeOf e) ->
+        | Some e when isIntegralType (Cilfacade.typeOf e) ->
           let nd = D.add_vars ctx.local ["#ret"] in
           let () = D.assign_var_with nd "#ret" e in
           nd
@@ -173,7 +173,7 @@ struct
     let d = ctx.local in
     match q with
     | EvalInt e ->
-      let ik = Cilfacade.get_ikind (Cil.typeOf e) in
+      let ik = Cilfacade.get_ikind (Cilfacade.typeOf e) in
       begin match e with
         (* constraint *)
         | BinOp ((Lt | Gt | Le | Ge | Eq | Ne), _, _, _) ->

--- a/src/analyses/apron/octApron.apron.ml
+++ b/src/analyses/apron/octApron.apron.ml
@@ -173,7 +173,7 @@ struct
     let d = ctx.local in
     match q with
     | EvalInt e ->
-      let ik = Cilfacade.get_ikind (Cilfacade.typeOf e) in
+      let ik = Cilfacade.get_ikind_exp e in
       begin match e with
         (* constraint *)
         | BinOp ((Lt | Gt | Le | Ge | Eq | Ne), _, _, _) ->

--- a/src/analyses/apron/poly.apron.ml
+++ b/src/analyses/apron/poly.apron.ml
@@ -108,7 +108,7 @@ struct
     let d = ctx.local in
     match q with
     | EvalInt e ->
-      let ik = Cilfacade.get_ikind (Cilfacade.typeOf e) in
+      let ik = Cilfacade.get_ikind_exp e in
       begin
         match D.get_int_val_for_cil_exp d e with
         | Some i -> ID.of_int ik i

--- a/src/analyses/apron/poly.apron.ml
+++ b/src/analyses/apron/poly.apron.ml
@@ -77,9 +77,9 @@ struct
   let return ctx e f =
     if D.is_bot ctx.local then D.bot () else
       match e with
-      | Some e when isArithmeticType (typeOf e) ->
+      | Some e when isArithmeticType (Cilfacade.typeOf e) ->
         let nd =
-          if isIntegralType (typeOf e) then
+          if isIntegralType (Cilfacade.typeOf e) then
             D.add_vars ctx.local (["#ret"],[])
           else
             D.add_vars ctx.local (["#ret"],[])
@@ -108,7 +108,7 @@ struct
     let d = ctx.local in
     match q with
     | EvalInt e ->
-      let ik = Cilfacade.get_ikind (Cil.typeOf e) in
+      let ik = Cilfacade.get_ikind (Cilfacade.typeOf e) in
       begin
         match D.get_int_val_for_cil_exp d e with
         | Some i -> ID.of_int ik i

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1335,7 +1335,7 @@ struct
           (* This is tricky: It it is not sufficient to check that ID.cast_to_ik v = v
            * If there is one domain that knows this to be true and the other does not, we
            * should still impose the invariant. E.g. i -> ([1,5]; Not {0}[byte]) *)
-          if VD.is_safe_cast t1 (Cilfacade.typeOf (Lval x)) then
+          if VD.is_safe_cast t1 (Cilfacade.typeOfLval x) then
             derived_invariant (BinOp (op, Lval x, rval, typ)) tv
           else
             None

--- a/src/analyses/contain.ml
+++ b/src/analyses/contain.ml
@@ -396,7 +396,7 @@ struct
       (*D.report ("before assign: " ^(sprint 160 (d_lval () lval))^ " = "^(sprint 160 (d_exp () rval))^"\n");*)
       let nctx = D.assign_to_local (Analyses.ask_of_ctx ctx) lval (Some rval) ctx.local fs ctx.global in
       let nctx,uses_fp = handle_func_ptr rval nctx fs ctx.global in (*warn/error on ret of fptr to priv fun, fptrs don't have ptr type :(; *)
-      if uses_fp||isPointerType (typeOf (stripCasts rval)) then
+      if uses_fp||isPointerType (Cilfacade.typeOf (stripCasts rval)) then
         begin
           (*D.report ("assign: " ^(sprint 160 (d_lval () lval))^ " = "^(sprint 160 (d_exp () rval))^"\n");*)
           (*let a,b,c=nctx in D.dangerDump "BF ASS:" b;*)
@@ -639,7 +639,7 @@ struct
               let (fn,st,gd),uses_fp = List.fold_left (fun (lctx,y) globa -> let (mlctx,my)=handle_func_ptr globa lctx fs ctx.global in (mlctx,y||my) ) ((fn,st,gd),false) arglist  in
               let (fn,st,gd),_ =  List.fold_left
                   (fun (lctx,arg_num) globa -> (*D.report ("check arg: "^(sprint 160 (d_exp () globa))) ;*)
-                     if uses_fp||isPointerType (typeOf (stripCasts globa))  then
+                     if uses_fp||isPointerType (Cilfacade.typeOf (stripCasts globa))  then
                        begin
                          (assign_lvals globa lctx arg_num,arg_num+1)
                        end
@@ -648,7 +648,7 @@ struct
               in
               let (fn,st,gd),_ =
                 List.fold_right
-                  (fun globa (lctx,arg_num) -> if (*uses_fp||isPointerType (typeOf (stripCasts globa))*) true  then
+                  (fun globa (lctx,arg_num) -> if (*uses_fp||isPointerType (Cilfacade.typeOf (stripCasts globa))*) true  then
                       begin (assign_lvals globa lctx arg_num,arg_num+1) end
                     else (lctx,arg_num+1)
                   )
@@ -658,12 +658,12 @@ struct
             end
           else ctx.local
         in
-        (*List.iter (fun x->if isPointerType (typeOf (stripCasts rval))&&(D.is_tainted fs )then ) arglist*)
+        (*List.iter (fun x->if isPointerType (Cilfacade.typeOf (stripCasts rval))&&(D.is_tainted fs )then ) arglist*)
         (*let fn,st,gd = nctx in*)
         begin match lval with (*handle retval*)
           | Some v ->
             let fn,st,gd =
-              if isPointerType (typeOfLval v)
+              if isPointerType (Cilfacade.typeOfLval v)
               then begin
                 if not (D.is_safe_name f.vname) then
                   let fn,st,gd = D.assign_to_local (Analyses.ask_of_ctx ctx) v from nctx fs ctx.global in
@@ -756,7 +756,7 @@ struct
         | Some v ->
           D.warn_glob (Lval v) ("return val of "^GU.demangle f.vname);
           D.warn_tainted fs (*ctx.local*) au (Lval v) ("return val of "^(GU.demangle f.vname));
-          if isPointerType (typeOfLval v)
+          if isPointerType (Cilfacade.typeOfLval v)
           then
             if is_ext f.vname ctx.global then
               begin

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -47,7 +47,7 @@ struct
       | x -> x
 
   let isFloat e =
-    match Cil.unrollTypeDeep (Cil.typeOf e) with
+    match Cil.unrollTypeDeep (Cilfacade.typeOf e) with
     | TFloat _ -> true
     | _ -> false
 

--- a/src/analyses/extract_arinc.ml
+++ b/src/analyses/extract_arinc.ml
@@ -301,7 +301,7 @@ struct
         in
         match fname, arglist with (* first some special cases *)
         | "CreateProcess", [AddrOf attr; pid'; r] ->
-          let cm = match unrollType (typeOfLval attr) with
+          let cm = match unrollType (Cilfacade.typeOfLval attr) with
             | TComp (c,_) -> c
             | _ -> failwith "type-error: first argument of LAP_Se_CreateProcess not a struct."
           in
@@ -326,7 +326,7 @@ struct
             | `Lifted name, ls, pri, per, cap when not (Queries.LS.is_top ls)
                                                                      && not (Queries.LS.mem (dummyFunDec.svar,`NoOffset) ls) && Queries.ID.is_int pri && Queries.ID.is_int per && Queries.ID.is_int cap ->
               let pri = (IntOps.BigIntOps.to_int64 (Option.get @@ Queries.ID.to_int pri)) in
-              let funs_ls = Queries.LS.filter (fun (v,o) -> let lval = Var v, Lval.CilLval.to_ciloffs o in isFunctionType (typeOfLval lval)) ls in (* do we need this? what happens if we spawn a variable that's not a function? shouldn't this check be in spawn? *)
+              let funs_ls = Queries.LS.filter (fun (v,o) -> let lval = Var v, Lval.CilLval.to_ciloffs o in isFunctionType (Cilfacade.typeOfLval lval)) ls in (* do we need this? what happens if we spawn a variable that's not a function? shouldn't this check be in spawn? *)
               if M.tracing then M.tracel "extract_arinc" "starting a thread %a with priority '%Ld' \n" Queries.LS.pretty funs_ls pri;
               let funs = funs_ls |> Queries.LS.elements |> List.map fst |> List.unique in
               let f_d = Pid.of_int (Int64.of_int (Pids.get name)), Ctx.top (), Pred.of_node (MyCFG.Function f) in

--- a/src/analyses/octagon.ml
+++ b/src/analyses/octagon.ml
@@ -362,7 +362,7 @@ struct
     | Queries.EvalInt exp ->
       let inv = evaluate_exp ctx.local exp in
       if INV.is_int inv
-      then INV.to_int inv |> Option.get |> Queries.ID.of_int (Cilfacade.get_ikind (Cil.typeOf exp))
+      then INV.to_int inv |> Option.get |> Queries.ID.of_int (Cilfacade.get_ikind (Cilfacade.typeOf exp))
       else Queries.Result.top q
     | _ -> Queries.Result.top q
 

--- a/src/analyses/octagon.ml
+++ b/src/analyses/octagon.ml
@@ -362,7 +362,7 @@ struct
     | Queries.EvalInt exp ->
       let inv = evaluate_exp ctx.local exp in
       if INV.is_int inv
-      then INV.to_int inv |> Option.get |> Queries.ID.of_int (Cilfacade.get_ikind (Cilfacade.typeOf exp))
+      then INV.to_int inv |> Option.get |> Queries.ID.of_int (Cilfacade.get_ikind_exp exp)
       else Queries.Result.top q
     | _ -> Queries.Result.top q
 

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -35,7 +35,7 @@ let is_atomic lval =
 let is_ignorable lval =
   (*  ignore (printf "Var %a\n" d_lval lval);*)
   try ValueDomain.Compound.is_immediate_type (Cilfacade.typeOfLval lval) || is_atomic lval
-  with Not_found -> false
+  with Cilfacade.TypeOfError _ -> false
 
 
 module Flag =

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -29,7 +29,7 @@ let is_atomic_type (t: typ): bool =
 
 let is_atomic lval =
   let (lval, _) = removeOffsetLval lval in
-  let typ = typeOfLval lval in
+  let typ = Cilfacade.typeOfLval lval in
   is_atomic_type typ
 
 let is_ignorable lval =
@@ -471,7 +471,7 @@ struct
       match fs with
       | LockingPattern.EField f :: _ -> (e,f.fcomp,fs) :: xs
       | _ -> xs
-      (*      match unrollType (typeOf (LockingPattern.fromEl e dummy)) with
+      (*      match unrollType (Cilfacade.typeOf (LockingPattern.fromEl e dummy)) with
               | TComp (c,_) -> (e,c,fs) :: xs
               | _ -> xs*)
     in

--- a/src/analyses/termination.ml
+++ b/src/analyses/termination.ml
@@ -63,7 +63,7 @@ class loopVarsVisitor (fd : fundec) = object
   method! vstmt s =
     let add_exit_cond e loc =
       match lvals_of_expr e with
-      | [lval] when typeOf e |> isArithmeticType -> Hashtbl.add loopVars loc lval
+      | [lval] when Cilfacade.typeOf e |> isArithmeticType -> Hashtbl.add loopVars loc lval
       | _ -> ()
     in
     (match s.skind with
@@ -165,8 +165,8 @@ class loopInstrVisitor (fd : fundec) = object(self)
            | _ ->
              (* otherwise diff is e - counter *)
              let t = makeVar fd cur_loop "t" in
-             let dt1 = mkStmtOneInstr @@ Set (var d1, BinOp (MinusA, Lval x, Lval (var t), typeOf e), loc) in
-             let dt2 = mkStmtOneInstr @@ Set (var d2, BinOp (MinusA, Lval x, Lval (var t), typeOf e), loc) in
+             let dt1 = mkStmtOneInstr @@ Set (var d1, BinOp (MinusA, Lval x, Lval (var t), Cilfacade.typeOf e), loc) in
+             let dt2 = mkStmtOneInstr @@ Set (var d2, BinOp (MinusA, Lval x, Lval (var t), Cilfacade.typeOf e), loc) in
              let nb = mkBlock [mkStmt s.skind; dt1; dt2] in
              s.skind <- Block nb;
              s

--- a/src/analyses/termination.ml
+++ b/src/analyses/termination.ml
@@ -165,8 +165,9 @@ class loopInstrVisitor (fd : fundec) = object(self)
            | _ ->
              (* otherwise diff is e - counter *)
              let t = makeVar fd cur_loop "t" in
-             let dt1 = mkStmtOneInstr @@ Set (var d1, BinOp (MinusA, Lval x, Lval (var t), Cilfacade.typeOf e), loc) in
-             let dt2 = mkStmtOneInstr @@ Set (var d2, BinOp (MinusA, Lval x, Lval (var t), Cilfacade.typeOf e), loc) in
+             let te = Cilfacade.typeOf e in
+             let dt1 = mkStmtOneInstr @@ Set (var d1, BinOp (MinusA, Lval x, Lval (var t), te), loc) in
+             let dt2 = mkStmtOneInstr @@ Set (var d2, BinOp (MinusA, Lval x, Lval (var t), te), loc) in
              let nb = mkBlock [mkStmt s.skind; dt1; dt2] in
              s.skind <- Block nb;
              s

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -210,7 +210,7 @@ struct
       | Lval (Var _,NoOffset), AddrOf (Mem(Lval _),Field(_, _)) ->
         (* lval *.field changes -> local var stays the same *)
         false
-      (*         | dr, Lval (Var lv,NoOffset) when (isIntegralType (Cilfacade.typeOf dr)) && (isPointerType (lv.vtype)) && not (isIntegralType (Cilfacade.typeOf (Lval (Mem (Lval (Var lv,NoOffset)),NoOffset)))) ->
+      (*         | dr, Lval (Var lv,NoOffset) when (isIntegralType (Cilfacade.typeOf dr)) && (isPointerType (lv.vtype)) && not (isIntegralType (Cilfacade.typeOfLval (Mem (Lval (Var lv,NoOffset)),NoOffset))) ->
                   (* lval *x changes -> local var stays the same *)
                   false*)
       | _ ->
@@ -375,7 +375,7 @@ struct
           match x with (Var v,_) -> not v.vglob | _ -> false
           in
           let st =
-    *)  let lvt = unrollType @@ Cilfacade.typeOf (Lval lv) in
+    *)  let lvt = unrollType @@ Cilfacade.typeOfLval lv in
     (*     Messages.report (sprint 80 (d_type () lvt)); *)
     if is_global_var ask (Lval lv) = Some false
     && Exp.interesting rv

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -132,7 +132,7 @@ struct
         | Index (e,o) -> type_may_change_t e bt || may_change_t_offset o
         | Field (_,o) -> may_change_t_offset o
       in
-      let at = typeOf a in
+      let at = Cilfacade.typeOf a in
       (isIntegralType at && isIntegralType bt) || (typ_equal at bt) ||
       match a with
       | Const _
@@ -153,7 +153,7 @@ struct
       | Question _ -> failwith "Logical operations should be compiled away by CIL."
       | _ -> failwith "Unmatched pattern."
     in
-    let bt =  unrollTypeDeep (typeOf b) in
+    let bt =  unrollTypeDeep (Cilfacade.typeOf b) in
     type_may_change_t a bt
 
   let may_change_pt ask (b:exp) (a:exp) : bool =
@@ -196,7 +196,7 @@ struct
     let pt e = ask.f (Queries.MayPointTo e) in
     let bls = pt b in
     let bt =
-      match unrollTypeDeep (typeOf b) with
+      match unrollTypeDeep (Cilfacade.typeOf b) with
       | TPtr (t,_) -> t
       | _ -> voidType
     in (* type of thing that changed: typeof( *b ) *)
@@ -210,7 +210,7 @@ struct
       | Lval (Var _,NoOffset), AddrOf (Mem(Lval _),Field(_, _)) ->
         (* lval *.field changes -> local var stays the same *)
         false
-      (*         | dr, Lval (Var lv,NoOffset) when (isIntegralType (typeOf dr)) && (isPointerType (lv.vtype)) && not (isIntegralType (typeOf (Lval (Mem (Lval (Var lv,NoOffset)),NoOffset)))) ->
+      (*         | dr, Lval (Var lv,NoOffset) when (isIntegralType (Cilfacade.typeOf dr)) && (isPointerType (lv.vtype)) && not (isIntegralType (Cilfacade.typeOf (Lval (Mem (Lval (Var lv,NoOffset)),NoOffset)))) ->
                   (* lval *x changes -> local var stays the same *)
                   false*)
       | _ ->
@@ -223,7 +223,7 @@ struct
         | Field (_,o) -> may_change_t_offset o
       in
       let at =
-        match unrollTypeDeep (typeOf a) with
+        match unrollTypeDeep (Cilfacade.typeOf a) with
         | TPtr (t,a) -> t
         | at -> at
       in
@@ -375,7 +375,7 @@ struct
           match x with (Var v,_) -> not v.vglob | _ -> false
           in
           let st =
-    *)  let lvt = unrollType @@ typeOf (Lval lv) in
+    *)  let lvt = unrollType @@ Cilfacade.typeOf (Lval lv) in
     (*     Messages.report (sprint 80 (d_type () lvt)); *)
     if is_global_var ask (Lval lv) = Some false
     && Exp.interesting rv
@@ -541,7 +541,7 @@ struct
     | None -> Queries.ES.empty ()
     | Some es when D.B.is_bot es -> Queries.ES.bot ()
     | Some es ->
-      let et = typeOf e in
+      let et = Cilfacade.typeOf e in
       let add x xs =
         Queries.ES.add (CastE (et,x)) xs
       in

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -377,8 +377,9 @@ struct
               | false -> Val.bot()
               | _ -> xm) (* if e' may be equal to i', but e' may not be smaller than i' then we only need xm *)
               (
-                let ik = Cilfacade.get_ikind (Cilfacade.typeOf e') in
-                match ask.f (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik 1, Cilfacade.typeOf e'),i')) with
+                let t = Cilfacade.typeOf e' in
+                let ik = Cilfacade.get_ikind t in
+                match ask.f (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik 1, t),i')) with
                 | true -> xm
                 | _ ->
                   begin
@@ -394,8 +395,9 @@ struct
               | _ -> xm)
 
               (
-                let ik = Cilfacade.get_ikind (Cilfacade.typeOf e') in
-                match ask.f (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik (-1), Cilfacade.typeOf e'),i')) with
+                let t = Cilfacade.typeOf e' in
+                let ik = Cilfacade.get_ikind t in
+                match ask.f (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik (-1), t),i')) with
                 | true -> xm
                 | _ ->
                   begin

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -377,8 +377,8 @@ struct
               | false -> Val.bot()
               | _ -> xm) (* if e' may be equal to i', but e' may not be smaller than i' then we only need xm *)
               (
-                let ik = Cilfacade.get_ikind (Cil.typeOf e') in
-                match ask.f (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik 1, Cil.typeOf e'),i')) with
+                let ik = Cilfacade.get_ikind (Cilfacade.typeOf e') in
+                match ask.f (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik 1, Cilfacade.typeOf e'),i')) with
                 | true -> xm
                 | _ ->
                   begin
@@ -394,8 +394,8 @@ struct
               | _ -> xm)
 
               (
-                let ik = Cilfacade.get_ikind (Cil.typeOf e') in
-                match ask.f (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik (-1), Cil.typeOf e'),i')) with
+                let ik = Cilfacade.get_ikind (Cilfacade.typeOf e') in
+                match ask.f (Q.MustBeEqual(BinOp(PlusA, e', Cil.kinteger ik (-1), Cilfacade.typeOf e'),i')) with
                 | true -> xm
                 | _ ->
                   begin

--- a/src/cdomains/containDomain.ml
+++ b/src/cdomains/containDomain.ml
@@ -758,7 +758,7 @@ struct
           not (ArgSet.is_bot (Danger.find v st))
         end
     in
-    if isPointerType (typeOf (stripCasts e)) then
+    if isPointerType (Cilfacade.typeOf (stripCasts e)) then
       begin
         (*dbg_report ("mbg_start: " ^(sprint 160 (d_exp () e)));*)
         (*let is_local = (constructed_from_this st e)
@@ -981,7 +981,7 @@ struct
                 false
               end
         in
-        if (*isPointerType (typeOf (stripCasts e))*)true then
+        if (*isPointerType (Cilfacade.typeOf (stripCasts e))*)true then
           begin
             let res =
               (ArgSet.fold (fun x a -> warn_one_lv (FieldVars.get_var x) ||a) (used_ptrs st e) false)  (*avoid multiple warnings*)
@@ -1028,7 +1028,7 @@ struct
               false
             end
       in
-      if isPointerType (typeOf (stripCasts e)) then
+      if isPointerType (Cilfacade.typeOf (stripCasts e)) then
         begin
           (ArgSet.fold (fun x a -> warn_one_lv (FieldVars.get_var x) ||a) (used_args st e) false)
           ||(ArgSet.fold (fun x a -> warn_one_lv (FieldVars.get_var x) ||a) (used_ptrs st e) false)  (*avoid multiple warnings*)
@@ -1093,7 +1093,7 @@ struct
               false
             end
       in
-      if isPointerType (typeOf (stripCasts e)) then begin
+      if isPointerType (Cilfacade.typeOf (stripCasts e)) then begin
         if not (ArgSet.fold (fun x a -> warn_one_lv (FieldVars.get_var x) ||a) (used_args st e) false) then (*avoid multiple warnings*)
           begin
             if not (ArgSet.fold (fun x a -> warn_one_lv (FieldVars.get_var x) ||a) (used_ptrs st e) false) then (*avoid multiple warnings*)
@@ -1434,7 +1434,7 @@ struct
 
     let p = function
       | Some e ->
-        isPointerType (typeOf (stripCasts e)) &&
+        isPointerType (Cilfacade.typeOf (stripCasts e)) &&
         (may_be_a_perfectly_normal_global e false (fd,st,df) fs)
       (*&& not (is_method e)*)
       | None -> true
@@ -1473,7 +1473,7 @@ struct
             )
           in
           report ("INFO : Write to local state : this->"^sprint 160 (FieldSet.pretty () flds)^" via "^str^ (sprint 160 (ArgSet.pretty () ars)));
-          (*report ("isPtr "^string_of_bool (isPointerType (typeOf (Lval lval)))^" mayderef "^string_of_bool (maybe_deref (Lval lval))^" direct_this "^ string_of_bool (may_be_constructed_from_this_direct st (Lval lval)));*)
+          (*report ("isPtr "^string_of_bool (isPointerType (Cilfacade.typeOf (Lval lval)))^" mayderef "^string_of_bool (maybe_deref (Lval lval))^" direct_this "^ string_of_bool (may_be_constructed_from_this_direct st (Lval lval)));*)
           (fd,st, Diff.add (taintedFunDec, (flds,VarNameSet.bot (),ClassNameSet.bot ()))  df)
         end
       else

--- a/src/cdomains/containDomain.ml
+++ b/src/cdomains/containDomain.ml
@@ -1473,7 +1473,7 @@ struct
             )
           in
           report ("INFO : Write to local state : this->"^sprint 160 (FieldSet.pretty () flds)^" via "^str^ (sprint 160 (ArgSet.pretty () ars)));
-          (*report ("isPtr "^string_of_bool (isPointerType (Cilfacade.typeOf (Lval lval)))^" mayderef "^string_of_bool (maybe_deref (Lval lval))^" direct_this "^ string_of_bool (may_be_constructed_from_this_direct st (Lval lval)));*)
+          (*report ("isPtr "^string_of_bool (isPointerType (Cilfacade.typeOfLval lval))^" mayderef "^string_of_bool (maybe_deref (Lval lval))^" direct_this "^ string_of_bool (may_be_constructed_from_this_direct st (Lval lval)));*)
           (fd,st, Diff.add (taintedFunDec, (flds,VarNameSet.bot (),ClassNameSet.bot ()))  df)
         end
       else

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -758,7 +758,7 @@ struct
       let open Invariant in
       let (x1', x2') = BatTuple.Tuple2.mapn (fun a -> Cilint.Big (Ints_t.to_bigint a)) (x1, x2) in
       (try
-        (* typeOf will fail if c is heap allocated *)
+        (* Cilfacade.typeOf will fail if c is heap allocated *)
         let i1 = if Ints_t.compare (min_int ik) x1 <> 0 then of_exp Cil.(BinOp (Le, kintegerCilint ik x1', c, intType)) else none in
         let i2 = if Ints_t.compare x2 (max_int ik) <> 0 then of_exp Cil.(BinOp (Le, c, kintegerCilint ik x2', intType)) else none in
         i1 && i2

--- a/src/cdomains/regionDomain.ml
+++ b/src/cdomains/regionDomain.ml
@@ -200,7 +200,7 @@ struct
 
   let assign (lval: lval) (rval: exp) (st: t): t =
     (*    let _ = printf "%a = %a\n" (printLval plainCilPrinter) lval (printExp plainCilPrinter) rval in *)
-    if isPointerType (typeOf rval) then begin
+    if isPointerType (Cilfacade.typeOf rval) then begin
       match eval_exp (Lval lval), eval_exp rval with
       (* TODO: should offs_x matter? *)
       | Some (deref_x, x,offs_x), Some (deref_y,y,offs_y) ->
@@ -227,7 +227,7 @@ struct
               add_set (RS.join (RS.single_vf x) (RegMap.find y m)) [y] st
           end
       | _ -> st
-    end else if isIntegralType (typeOf rval) then begin
+    end else if isIntegralType (Cilfacade.typeOf rval) then begin
       match lval with
       | Var x, NoOffset -> update x rval st
       | _ -> st

--- a/src/cdomains/regionDomain.ml
+++ b/src/cdomains/regionDomain.ml
@@ -200,7 +200,8 @@ struct
 
   let assign (lval: lval) (rval: exp) (st: t): t =
     (*    let _ = printf "%a = %a\n" (printLval plainCilPrinter) lval (printExp plainCilPrinter) rval in *)
-    if isPointerType (Cilfacade.typeOf rval) then begin
+    let t = Cilfacade.typeOf rval in
+    if isPointerType t then begin
       match eval_exp (Lval lval), eval_exp rval with
       (* TODO: should offs_x matter? *)
       | Some (deref_x, x,offs_x), Some (deref_y,y,offs_y) ->
@@ -227,7 +228,7 @@ struct
               add_set (RS.join (RS.single_vf x) (RegMap.find y m)) [y] st
           end
       | _ -> st
-    end else if isIntegralType (Cilfacade.typeOf rval) then begin
+    end else if isIntegralType t then begin
       match lval with
       | Var x, NoOffset -> update x rval st
       | _ -> st

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -699,7 +699,7 @@ struct
           | Some (v') ->
             begin
               (* This should mean the entire expression we have here is a pointer into the array *)
-              if Cil.isArrayType (Cilfacade.typeOf (Lval v')) then
+              if Cil.isArrayType (Cilfacade.typeOfLval v') then
                 let expr = ptr in
                 let start_of_array = StartOf v' in
                 let start_type = typeSigWithoutArraylen (Cilfacade.typeOf start_of_array) in

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -699,11 +699,11 @@ struct
           | Some (v') ->
             begin
               (* This should mean the entire expression we have here is a pointer into the array *)
-              if Cil.isArrayType (Cil.typeOf (Lval v')) then
+              if Cil.isArrayType (Cilfacade.typeOf (Lval v')) then
                 let expr = ptr in
                 let start_of_array = StartOf v' in
-                let start_type = typeSigWithoutArraylen (Cil.typeOf start_of_array) in
-                let expr_type = typeSigWithoutArraylen (Cil.typeOf ptr) in
+                let start_type = typeSigWithoutArraylen (Cilfacade.typeOf start_of_array) in
+                let expr_type = typeSigWithoutArraylen (Cilfacade.typeOf ptr) in
                 (* Comparing types for structural equality is incorrect here, use typeSig *)
                 (* as explained at https://people.eecs.berkeley.edu/~necula/cil/api/Cil.html#TYPEtyp *)
                 if start_type = expr_type then

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -252,10 +252,11 @@ type part  = LSSSet.t * LSSet.t
 
 let get_val_type e (vo: var_o) (oo: off_o) : acc_typ =
   try (* FIXME: Cilfacade.typeOf fails on our fake variables: (struct s).data *)
+    let t = Cilfacade.typeOf e in
     match vo, oo with
-    | Some v, Some o -> get_type (Cilfacade.typeOf e) (AddrOf (Var v, o))
-    | Some v, None -> get_type (Cilfacade.typeOf e) (AddrOf (Var v, NoOffset))
-    | _ -> get_type (Cilfacade.typeOf e) e
+    | Some v, Some o -> get_type t (AddrOf (Var v, o))
+    | Some v, None -> get_type t (AddrOf (Var v, NoOffset))
+    | _ -> get_type t e
   with _ -> get_type voidType e
 
 let some_accesses = ref false

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -251,11 +251,11 @@ type off_o = offset  option
 type part  = LSSSet.t * LSSet.t
 
 let get_val_type e (vo: var_o) (oo: off_o) : acc_typ =
-  try (* FIXME: Cil's typeOf fails on our fake variables: (struct s).data *)
+  try (* FIXME: Cilfacade.typeOf fails on our fake variables: (struct s).data *)
     match vo, oo with
-    | Some v, Some o -> get_type (typeOf e) (AddrOf (Var v, o))
-    | Some v, None -> get_type (typeOf e) (AddrOf (Var v, NoOffset))
-    | _ -> get_type (typeOf e) e
+    | Some v, Some o -> get_type (Cilfacade.typeOf e) (AddrOf (Var v, o))
+    | Some v, None -> get_type (Cilfacade.typeOf e) (AddrOf (Var v, NoOffset))
+    | _ -> get_type (Cilfacade.typeOf e) e
   with _ -> get_type voidType e
 
 let some_accesses = ref false

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -251,14 +251,26 @@ let ptrdiff_ikind () = get_ikind !ptrdiffType
     instead of printing all errors directly... *)
 
 type typeOfError =
-  | RealImag_NonNumerical (** unexpected non-numerical type for argument to __real__ *) (* TODO: or __imag__? *)
+  | RealImag_NonNumerical (** unexpected non-numerical type for argument to __real__/__imag__ *) (* TODO: CIL's own output forgets __imag__ *)
   | StartOf_NonArray (** typeOf: StartOf on a non-array *)
   | Mem_NonPointer of exp (** typeOfLval: Mem on a non-pointer (exp) *)
   | Index_NonArray (** typeOffset: Index on a non-array *)
   | Field_NonCompound (** typeOffset: Field on a non-compound *)
 
-(* TODO: add exception printer *)
 exception TypeOfError of typeOfError
+
+let () = Printexc.register_printer (function
+    | TypeOfError error ->
+      let msg = match error with
+        | RealImag_NonNumerical -> "unexpected non-numerical type for argument to __real__/__imag__"
+        | StartOf_NonArray -> "typeOf: StartOf on a non-array"
+        | Mem_NonPointer exp -> Printf.sprintf "typeOfLval: Mem on a non-pointer (%s)" (CilType.Exp.show exp)
+        | Index_NonArray -> "typeOffset: Index on a non-array"
+        | Field_NonCompound -> "typeOffset: Field on a non-compound"
+      in
+      Some (Printf.sprintf "Cilfacade.TypeOfError(%s)" msg)
+    | _ -> None (* for other exceptions *)
+  )
 
 (* Cil doesn't expose this *)
 let stringLiteralType = ref charPtrType

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -251,7 +251,7 @@ let ptrdiff_ikind () = get_ikind !ptrdiffType
     instead of printing all errors directly... *)
 
 type typeOfError =
-  | RealImag_NonNumerical (** unexpected non-numerical type for argument to __real__/__imag__ *) (* TODO: CIL's own output forgets __imag__ *)
+  | RealImag_NonNumerical (** unexpected non-numerical type for argument to __real__/__imag__ *)
   | StartOf_NonArray (** typeOf: StartOf on a non-array *)
   | Mem_NonPointer of exp (** typeOfLval: Mem on a non-pointer (exp) *)
   | Index_NonArray (** typeOffset: Index on a non-array *)

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -349,6 +349,10 @@ and typeOffset basetyp =
       blendAttributes baseAttrs fieldType
     | _ -> raise (TypeOfError Field_NonCompound)
 
+
+let get_ikind_exp e = get_ikind (typeOf e)
+
+
 (** HashSet of line numbers *)
 let locs = Hashtbl.create 200
 

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -317,7 +317,7 @@ struct
       (* avoid unnecessary ternary *)
       e_cond
     else
-      Question(e_cond, e_true, e_false, typeOf e_false)
+      Question(e_cond, e_true, e_false, Cilfacade.typeOf e_false)
 
   let next_opt' n = match n with
     | Statement {skind=If (_, _, _, loc); _} when GobConfig.get_bool "exp.witness.uncil" ->


### PR DESCRIPTION
The motivation for this is here: https://github.com/goblint/analyzer/pull/251#issuecomment-877068090.
It fixes the scrambled output of a couple of SV-COMP benchmarks from there.

Currently this PR is opened with #251 as base to avoid major conflicts, but we don't have to merge it there, just wait until #251 is in master and change the base for this.