### PR TITLE
Remove ppx_import

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 <src> or <src/**>: include
-true: package(findlib), package(ppx_import), package(goblint-cil.all-features), package(batteries.unthreaded), package(ppx_deriving.std), package(ppx_deriving_yojson), package(ppx_distr_guards), package(qcheck-core.runner)
+true: package(findlib), package(goblint-cil.all-features), package(batteries.unthreaded), package(ppx_deriving.std), package(ppx_deriving_yojson), package(ppx_distr_guards), package(qcheck-core.runner)
 <unittest/**>: include, package(oUnit)
 <src/extract/*.*>: package(ocaml-monadic)
 true: bin_annot, debug, optimize(3), thread

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,6 @@
     qcheck-core
     ; z3
     (ppx_distr_guards (>= 0.2))
-    ppx_import
     ppx_deriving
     ppx_deriving_yojson
     ocaml-monadic

--- a/goblint.opam
+++ b/goblint.opam
@@ -21,7 +21,6 @@ depends: [
   "qcheck-core"
   # "z3"
   "ppx_distr_guards" {>= "0.2"}
-  "ppx_import"
   "ppx_deriving"
   "ppx_deriving_yojson"
   "ocaml-monadic"

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -39,7 +39,6 @@ depends: [
   "ppx_deriving" {= "4.5"}
   "ppx_deriving_yojson" {= "3.5.3"}
   "ppx_distr_guards" {= "0.2"}
-  "ppx_import" {= "1.7.1"}
   "ppx_tools" {= "6.2"}
   "ppx_tools_versioned" {= "5.4.0"}
   "ppxfind" {= "1.4"}

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1372,7 +1372,6 @@ struct
       st
 
   let invariant ctx a gs st exp tv: store =
-    let open Deriving.Cil in
     let fallback reason st =
       if M.tracing then M.tracel "inv" "Can't handle %a.\n%s\n" d_plainexp exp reason;
       invariant ctx a gs st exp tv

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1482,11 +1482,11 @@ struct
           | _, _ -> a, b)
         | _ -> a, b)
       | BOr | BXor as op->
-        if M.tracing then M.tracel "inv" "Unhandled operator %s\n" (show_binop op);
+        if M.tracing then M.tracel "inv" "Unhandled operator %a\n" d_binop op;
         (* Be careful: inv_exp performs a meet on both arguments of the BOr / BXor. *)
         a, b
       | op ->
-        if M.tracing then M.tracel "inv" "Unhandled operator %s\n" (show_binop op);
+        if M.tracing then M.tracel "inv" "Unhandled operator %a\n" d_binop op;
         a, b
     in
     let eval e st = eval_rv a gs st e in
@@ -1512,7 +1512,7 @@ struct
       | BinOp(op, CastE (t1, c1), CastE (t2, c2), t) when (op = Eq || op = Ne) && typeSig (typeOf c1) = typeSig (typeOf c2) && VD.is_safe_cast t1 (typeOf c1) && VD.is_safe_cast t2 (typeOf c2) ->
         inv_exp c (BinOp (op, c1, c2, t)) st
       | BinOp (op, e1, e2, _) as e ->
-        if M.tracing then M.tracel "inv" "binop %a with %a %s %a == %a\n" d_exp e VD.pretty (eval e1 st) (show_binop op) VD.pretty (eval e2 st) ID.pretty c;
+        if M.tracing then M.tracel "inv" "binop %a with %a %a %a == %a\n" d_exp e VD.pretty (eval e1 st) d_binop op VD.pretty (eval e2 st) ID.pretty c;
         (match eval e1 st, eval e2 st with
         | `Int a, `Int b ->
           let ikind = Cilfacade.get_ikind @@ typeOf e1 in (* both operands have the same type (except for Shiftlt, Shiftrt)! *)

--- a/src/analyses/basePriv.mli
+++ b/src/analyses/basePriv.mli
@@ -1,5 +1,6 @@
 open Cil
 (* Cannot use local module substitutions because ppx_import is still stuck at 4.07 AST: https://github.com/ocaml-ppx/ppx_import/issues/50#issuecomment-775817579. *)
+(* TODO: try again, because ppx_import is now removed *)
 
 module type S =
 sig

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -6,7 +6,7 @@ open Pretty
 module ProgLines : Printable.S with type t = location =
 struct
   include Printable.Std
-  type t = location [@@deriving to_yojson]
+  type t = location
   let copy x = x
   let equal x y =
     x.line = y.line && x.file = y.file (* ignores byte field *)
@@ -17,6 +17,7 @@ struct
   let name () = "proglines"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
+  let to_yojson x = `String (show x)
 end
 
 module ProgLocation : Printable.S with type t = location =
@@ -24,7 +25,7 @@ struct
   include Printable.Std (* for default invariant, tag, ... *)
 
   open Pretty
-  type t = location [@@deriving to_yojson]
+  type t = location
   let equal = (=)
   let compare = compare
   let hash = Hashtbl.hash
@@ -37,12 +38,13 @@ struct
   let name () = "proglines_byte"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
+  let to_yojson x = `String (show x)
 end
 
 module ProgLinesFun: Printable.S with type t = location * MyCFG.node * fundec =
 struct
   include Printable.Std
-  type t = location * MyCFG.node * fundec [@@deriving to_yojson]
+  type t = location * MyCFG.node * fundec
   let copy x = x
   let equal (x,a,_) (y,b,_) = ProgLines.equal x y && MyCFG.Node.equal a b (* ignores fundec component *)
   let compare (x,a,_) (y,b,_) = match ProgLines.compare x y with 0 -> MyCFG.node_compare a b | x -> x (* ignores fundec component *)
@@ -58,6 +60,7 @@ struct
   let name () = "proglinesfun"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
+  let to_yojson x = `String (show x)
 end
 
 module Variables =

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -253,7 +253,7 @@ module FieldVariables =
 struct
   include Printable.Std
 
-  type t = varinfo*fieldinfo option [@@deriving to_yojson]
+  type t = varinfo*CilType.Fieldinfo.t option [@@deriving to_yojson]
 
   let gen v = (v,None)
   let gen_f v f = (v,Some f)

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -1,6 +1,5 @@
 module GU = Goblintutil
 open Cil
-open Deriving.Cil
 open Pretty
 
 module ProgLines : Printable.S with type t = location =
@@ -253,7 +252,7 @@ module FieldVariables =
 struct
   include Printable.Std
 
-  type t = varinfo*CilType.Fieldinfo.t option [@@deriving to_yojson]
+  type t = CilType.Varinfo.t*CilType.Fieldinfo.t option [@@deriving to_yojson]
 
   let gen v = (v,None)
   let gen_f v f = (v,Some f)

--- a/src/cdomains/deadlockDomain.ml
+++ b/src/cdomains/deadlockDomain.ml
@@ -1,14 +1,14 @@
 open Deriving.Cil
 open Pretty
 
-type myowntypeEntry = {addr : ValueDomain.Addr.t ; loc : location} [@@deriving to_yojson]
+type myowntypeEntry = {addr : ValueDomain.Addr.t ; loc : location}
 
 
 module MyLock : Printable.S with type t = myowntypeEntry =
 struct
   include Printable.Std (* for default invariant, tag, ... *)
 
-  type t = myowntypeEntry [@@deriving to_yojson]
+  type t = myowntypeEntry
   module Ad = ValueDomain.Addr
   let name () = "address with location"
   let equal x y = Ad.equal x.addr y.addr (* ignores loc field *)
@@ -18,6 +18,7 @@ struct
   let pretty () x = Ad.pretty () x.addr ++ text "@" ++ Basetype.ProgLines.pretty () x.loc
   let printXml c x = Ad.printXml c x.addr
   let pretty_diff () (x,y) = Ad.pretty_diff () (x.addr,y.addr)
+  let to_yojson x = `String (show x)
 end
 
 module Lockset = SetDomain.ToppedSet (MyLock) (struct let topname = "all locks" end)

--- a/src/cdomains/deadlockDomain.ml
+++ b/src/cdomains/deadlockDomain.ml
@@ -1,4 +1,4 @@
-open Deriving.Cil
+open Cil
 open Pretty
 
 type myowntypeEntry = {addr : ValueDomain.Addr.t ; loc : location}

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -1,6 +1,5 @@
 open Pretty
 open Cil
-open Deriving.Cil
 
 module Exp =
 struct

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -1,5 +1,4 @@
 open Cil
-open Deriving.Cil
 open Pretty
 
 module GU = Goblintutil

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -68,7 +68,7 @@ module PMap (Domain: Groupable) (Range: Lattice.S) : PS with
   type key = Domain.t and
   type value = Range.t =
 struct
-  module M = Deriving.Map.Make (Domain)
+  module M = Map.Make (Domain)
 
   include Printable.Std
   type key = Domain.t

--- a/src/domains/octagonMapDomain.ml
+++ b/src/domains/octagonMapDomain.ml
@@ -131,8 +131,8 @@ sig
   val strong_closure  : t -> t
   val map_to_matrix   : t -> elt array array * (BV.t, int) Hashtbl.t
   val matrix_to_map   : elt array array -> (BV.t, int) Hashtbl.t -> t
-  val get_relation    : Deriving.Cil.varinfo -> Deriving.Cil.varinfo -> t -> OctagonDomain.INV.t option * OctagonDomain.INV.t option * bool
-  val keep_only       : Deriving.Cil.varinfo list -> t -> t
+  val get_relation    : Cil.varinfo -> Cil.varinfo -> t -> OctagonDomain.INV.t option * OctagonDomain.INV.t option * bool
+  val keep_only       : Cil.varinfo list -> t -> t
   (* TODO: Currently last bool indicates if it was necessary to switch the order of vars and therefore multiplying diff by -1 in consumers may be necessary. *)
   (* This is ugly and needs to be fixed *)
 end

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -1,6 +1,6 @@
 (** Structures for the querying subsystem. *)
 
-open Deriving.Cil
+open Cil
 
 module GU = Goblintutil
 module ID =

--- a/src/dune
+++ b/src/dune
@@ -32,7 +32,7 @@
     )
   )
   (preprocess
-    (staged_pps ppx_import ppx_deriving.std ppx_deriving_yojson
+    (staged_pps ppx_deriving.std ppx_deriving_yojson
       ppx_distr_guards ocaml-monadic))
 )
 
@@ -48,7 +48,7 @@
   (modes native js) ; https://dune.readthedocs.io/en/stable/dune-files.html#linking-modes
   (modules goblint mainarinc maindomaintest mainspec)
   (libraries goblint.lib)
-  (preprocess (staged_pps ppx_import ppx_deriving.std ppx_deriving_yojson ppx_distr_guards ocaml-monadic))
+  (preprocess (staged_pps ppx_deriving.std ppx_deriving_yojson ppx_distr_guards ocaml-monadic))
   (flags :standard -linkall)
 )
 
@@ -56,7 +56,7 @@
   (name privPrecCompare)
   (modules privPrecCompare)
   (libraries goblint.lib)
-  (preprocess (staged_pps ppx_import ppx_deriving.std ppx_deriving_yojson ppx_distr_guards ocaml-monadic))
+  (preprocess (staged_pps ppx_deriving.std ppx_deriving_yojson ppx_distr_guards ocaml-monadic))
   (flags :standard -linkall)
 )
 

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -16,10 +16,10 @@ type edge =
   (** Assignments lval = exp *)
   | Proc of CilType.Lval.t option * exp * exp list
   (** Function calls of the form lva = fexp (e1, e2, ...) *)
-  | Entry of fundec
+  | Entry of CilType.Fundec.t
   (** Entry edge that relates function declaration to function body. You can use
     * this to initialize the local variables. *)
-  | Ret of exp option * fundec
+  | Ret of exp option * CilType.Fundec.t
   (** Return edge is between the return statement, which may optionally contain
     * a return value, and the function. The result of the call is then
     * transferred to the function node! *)

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -3,27 +3,26 @@
 module GU = Goblintutil
 module CF = Cilfacade
 open Cil
-open Deriving.Cil
 open Pretty
 open GobConfig
 include Node
 
 type asm_out = (string option * string * CilType.Lval.t) list [@@deriving to_yojson]
-type asm_in  = (string option * string * exp ) list [@@deriving to_yojson]
+type asm_in  = (string option * string * CilType.Exp.t ) list [@@deriving to_yojson]
 
 type edge =
-  | Assign of CilType.Lval.t * exp
+  | Assign of CilType.Lval.t * CilType.Exp.t
   (** Assignments lval = exp *)
-  | Proc of CilType.Lval.t option * exp * exp list
+  | Proc of CilType.Lval.t option * CilType.Exp.t * CilType.Exp.t list
   (** Function calls of the form lva = fexp (e1, e2, ...) *)
   | Entry of CilType.Fundec.t
   (** Entry edge that relates function declaration to function body. You can use
     * this to initialize the local variables. *)
-  | Ret of exp option * CilType.Fundec.t
+  | Ret of CilType.Exp.t option * CilType.Fundec.t
   (** Return edge is between the return statement, which may optionally contain
     * a return value, and the function. The result of the call is then
     * transferred to the function node! *)
-  | Test of exp * bool
+  | Test of CilType.Exp.t * bool
   (** The true-branch or false-branch of a conditional exp *)
   | ASM of string list * asm_out * asm_in
   (** Inline assembly statements, and the annotations for output and input

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -8,13 +8,13 @@ open Pretty
 open GobConfig
 include Node
 
-type asm_out = (string option * string * lval) list [@@deriving to_yojson]
+type asm_out = (string option * string * CilType.Lval.t) list [@@deriving to_yojson]
 type asm_in  = (string option * string * exp ) list [@@deriving to_yojson]
 
 type edge =
-  | Assign of lval * exp
+  | Assign of CilType.Lval.t * exp
   (** Assignments lval = exp *)
-  | Proc of lval option * exp * exp list
+  | Proc of CilType.Lval.t option * exp * exp list
   (** Function calls of the form lva = fexp (e1, e2, ...) *)
   | Entry of fundec
   (** Entry edge that relates function declaration to function body. You can use

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -28,7 +28,7 @@ type edge =
   | ASM of string list * asm_out * asm_in
   (** Inline assembly statements, and the annotations for output and input
     * variables. *)
-  | VDecl of varinfo
+  | VDecl of CilType.Varinfo.t
   (** VDecl edge for the variable in varinfo. Whether such an edge is there for all
     * local variables or only when it is not possible to pull the declaration up, is
     * determined by alwaysGenerateVarDecl in cabs2cil.ml in CIL. One case in which a VDecl

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -1,5 +1,4 @@
 open Cil
-open Deriving.Cil
 open Pretty
 
 (** A node in the Control Flow Graph is either a statement or function. Think of
@@ -8,9 +7,9 @@ open Pretty
 type node =
   | Statement of CilType.Stmt.t
   (** The statements as identified by CIL *)
-  | FunctionEntry of fundec
+  | FunctionEntry of CilType.Fundec.t
   (** *)
-  | Function of fundec
+  | Function of CilType.Fundec.t
   (** The variable information associated with the function declaration. *)
 [@@deriving to_yojson]
 

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -6,7 +6,7 @@ open Pretty
  * the function node as last node that all the returning nodes point to.  So
  * the result of the function call is contained in the function node. *)
 type node =
-  | Statement of stmt
+  | Statement of CilType.Stmt.t
   (** The statements as identified by CIL *)
   | FunctionEntry of fundec
   (** *)

--- a/src/util/arincUtil.ml
+++ b/src/util/arincUtil.ml
@@ -34,7 +34,7 @@ let pname_ErrorHandler = "ErrorHandler"
 
 module Action = (* encapsulate types because some process field names are also used for D.t -> use local opening of modules (since OCaml 4.00) for output *)
 struct
-  type process = { pid: id; f: varinfo; pri: int64; per: time; cap: time } [@@deriving show]
+  type process = { pid: id; f: CilType.Varinfo.t; pri: int64; per: time; cap: time } [@@deriving show]
   type semaphore = { sid: id; cur: int64; max: int64; queuing: int64 } [@@deriving show]
 end
 type action =
@@ -43,7 +43,7 @@ type action =
   | Assign of string * string (* var_callee = var_caller *)
   | Call of string
   | LockPreemption | UnlockPreemption | SetPartitionMode of partition_mode option
-  | CreateProcess of Action.process | CreateErrorHandler of id * varinfo | Start of id | Stop of id | Suspend of id | SuspendSelf of id * time | Resume of id
+  | CreateProcess of Action.process | CreateErrorHandler of id * CilType.Varinfo.t | Start of id | Stop of id | Suspend of id | SuspendSelf of id * time | Resume of id
   | CreateBlackboard of id | DisplayBlackboard of id | ReadBlackboard of id * time | ClearBlackboard of id
   | CreateSemaphore of Action.semaphore | WaitSemaphore of id * time | SignalSemaphore of id
   | CreateEvent of id | WaitEvent of id * time | SetEvent of id | ResetEvent of id

--- a/src/util/arincUtil.ml
+++ b/src/util/arincUtil.ml
@@ -1,6 +1,5 @@
 open Prelude
 open Cil
-open Deriving.Cil
 (* we don't want to use M.debug_each because everything here should be done after the analysis, so the location would be some old value for all invocations *)
 let debug_each msg = print_endline @@ Messages.colorize @@ "{blue}"^msg
 
@@ -112,7 +111,7 @@ let get_globals () = Hashtbl.values return_vars |> Set.of_enum |> flatten_set |>
 (* ARINC output *)
 (* console and dot *)
 let str_resource id =
-  let str_funs fs = "["^(List.map show_varinfo fs |> String.concat ", ")^"]" in
+  let str_funs fs = "["^(List.map CilType.Varinfo.show fs |> String.concat ", ")^"]" in
   match id with
   | Process, "mainfun" ->
     "mainfun/["^String.concat ", " (List.map Json.string (GobConfig.get_list "mainfun"))^"]"
@@ -125,7 +124,7 @@ let str_action pid = function
   | Cond (r, cond) -> "If "^cond
   | SetPartitionMode m -> "SetPartitionMode "^show_partition_mode_opt m
   | CreateProcess x ->
-    Action.("CreateProcess "^str_resource x.pid^" (fun "^show_varinfo x.f^", prio "^Int64.to_string x.pri^", period "^show_time x.per^", capacity "^show_time x.cap^")")
+    Action.("CreateProcess "^str_resource x.pid^" (fun "^CilType.Varinfo.show x.f^", prio "^Int64.to_string x.pri^", period "^show_time x.per^", capacity "^show_time x.cap^")")
   | CreateErrorHandler (id, funs) -> "CreateErrorHandler "^str_resource id
   | CreateSemaphore x ->
     Action.("CreateSemaphore "^str_resource x.sid^" ("^Int64.to_string x.cur^"/"^Int64.to_string x.max^", "^string_of_queuing_discipline x.queuing^")")

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -1,5 +1,4 @@
 open Cil
-open Deriving.Cil
 open Pretty
 
 module type S =

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -14,7 +14,11 @@ struct
   let pretty_diff () (_, _) = nil
 end
 
-module Varinfo: S with type t = varinfo =
+module Varinfo:
+sig
+  include S with type t = varinfo
+  val pp: Format.formatter -> t -> unit (* for deriving show *)
+end =
 struct
   include Std
 
@@ -33,6 +37,7 @@ struct
   let pretty () x = Pretty.text (show x)
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String x.vname
+  let pp fmt x = Format.fprintf fmt "%s" x.vname (* for deriving show *)
 end
 
 module Stmt: S with type t = stmt =

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -17,8 +17,7 @@ module Cil = struct
   (* To fix this properly, the types above should be annotated with sth like @to_yojson to give a custom function to  *)
   (* create json from them. This is however currently not supported by ppx_derving. This should work in the meanwhile *)
   (* see also https://github.com/ocaml-ppx/ppx_deriving/issues/184 *)
-  let rec varinfo_to_yojson (v:varinfo) = `String(v.vname)
-  and exp_to_yojson (l:exp) = `String(Pretty.sprint ~width:80 (Cil.d_exp () l))
+  let exp_to_yojson (l:exp) = `String(Pretty.sprint ~width:80 (Cil.d_exp () l))
 
   let pp_varinfo fmt v = Format.fprintf fmt "%s" v.vname
   let show_varinfo v = v.vname

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -46,7 +46,7 @@ module Cil = struct
   and init = [%import: Cil.init]
   and typsig = [%import: Cil.typsig]
   and fundec = [%import: Cil.fundec]
-  [@@deriving to_yojson, show]
+  [@@deriving to_yojson]
 
   (* To fix this properly, the types above should be annotated with sth like @to_yojson to give a custom function to  *)
   (* create json from them. This is however currently not supported by ppx_derving. This should work in the meanwhile *)

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -17,8 +17,7 @@ module Cil = struct
   (* To fix this properly, the types above should be annotated with sth like @to_yojson to give a custom function to  *)
   (* create json from them. This is however currently not supported by ppx_derving. This should work in the meanwhile *)
   (* see also https://github.com/ocaml-ppx/ppx_deriving/issues/184 *)
-  let rec fundec_to_yojson (x:fundec) = varinfo_to_yojson x.svar
-  and fieldinfo_to_yojson (f:fieldinfo) = `String (f.fname)
+  let rec fieldinfo_to_yojson (f:fieldinfo) = `String (f.fname)
   and varinfo_to_yojson (v:varinfo) = `String(v.vname)
   and exp_to_yojson (l:exp) = `String(Pretty.sprint ~width:80 (Cil.d_exp () l))
 

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -11,11 +11,6 @@ module Map = struct
     let to_yojson poly_v x = [%to_yojson: (K.t * 'v) list] poly_v (bindings x)
   end
 end
-module Pretty = struct
-  include Pretty
-  let doc_to_yojson x = assert false
-  let pp_doc x = assert false
-end
 module Cil = struct
   open Cil
 

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -46,7 +46,6 @@ module Cil = struct
   and init = [%import: Cil.init]
   and typsig = [%import: Cil.typsig]
   and fundec = [%import: Cil.fundec]
-  [@@deriving to_yojson]
 
   (* To fix this properly, the types above should be annotated with sth like @to_yojson to give a custom function to  *)
   (* create json from them. This is however currently not supported by ppx_derving. This should work in the meanwhile *)

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -18,6 +18,5 @@ module Cil = struct
   (* create json from them. This is however currently not supported by ppx_derving. This should work in the meanwhile *)
   (* see also https://github.com/ocaml-ppx/ppx_deriving/issues/184 *)
 
-  let pp_varinfo fmt v = Format.fprintf fmt "%s" v.vname
   let show_varinfo v = v.vname
 end

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -1,7 +1,5 @@
 type json = Yojson.Safe.t
-module Stdlib = struct (* since ocaml 4.07, Stdlib (which includes Pervasives) is opened by default, since 4.08 Pervasives is deprectated in favor of just Stdlib *)
-  type 'a ref = [%import: 'a Stdlib.ref] [@@deriving yojson, show]
-end
+
 module Map = struct
   (* include all of Map but Make *)
   include (Map : module type of Map with module Make := Map.Make)

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -11,12 +11,3 @@ module Map = struct
     let to_yojson poly_v x = [%to_yojson: (K.t * 'v) list] poly_v (bindings x)
   end
 end
-module Cil = struct
-  open Cil
-
-  (* To fix this properly, the types above should be annotated with sth like @to_yojson to give a custom function to  *)
-  (* create json from them. This is however currently not supported by ppx_derving. This should work in the meanwhile *)
-  (* see also https://github.com/ocaml-ppx/ppx_deriving/issues/184 *)
-
-  let show_varinfo v = v.vname
-end

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -1,11 +1,1 @@
 type json = Yojson.Safe.t
-
-module Map = struct
-  (* include all of Map but Make *)
-  include (Map : module type of Map with module Make := Map.Make)
-  (* define Map.Make with to_yojson *)
-  module Make (K : sig include OrderedType val to_yojson : t -> json end) = struct
-    include Map.Make (K)
-    let to_yojson poly_v x = [%to_yojson: (K.t * 'v) list] poly_v (bindings x)
-  end
-end

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -17,35 +17,7 @@ module Pretty = struct
   let pp_doc x = assert false
 end
 module Cil = struct
-  type location = [%import: Cil.location]
-  and stmt = [%import: Cil.stmt]
-  and stmtkind = [%import: Cil.stmtkind]
-  and label = [%import: Cil.label]
-  and instr = [%import: Cil.instr]
-  and exp = [%import: Cil.exp]
-  and block = [%import: Cil.block]
-  and lval = [%import: Cil.lval]
-  and lhost = [%import: Cil.lhost]
-  and varinfo = [%import: Cil.varinfo]
-  and offset = [%import: Cil.offset]
-  and attributes = [%import: Cil.attributes]
-  and attribute = [%import: Cil.attribute]
-  and constant = [%import: Cil.constant]
-  and typ = [%import: Cil.typ]
-  and unop = [%import: Cil.unop]
-  and binop = [%import: Cil.binop]
-  and initinfo = [%import: Cil.initinfo]
-  and storage = [%import: Cil.storage]
-  and fieldinfo = [%import: Cil.fieldinfo]
-  and attrparam = [%import: Cil.attrparam]
-  and ikind = [%import: Cil.ikind]
-  and fkind = [%import: Cil.fkind]
-  and enuminfo = [%import: Cil.enuminfo]
-  and typeinfo = [%import: Cil.typeinfo]
-  and compinfo = [%import: Cil.compinfo]
-  and init = [%import: Cil.init]
-  and typsig = [%import: Cil.typsig]
-  and fundec = [%import: Cil.fundec]
+  open Cil
 
   (* To fix this properly, the types above should be annotated with sth like @to_yojson to give a custom function to  *)
   (* create json from them. This is however currently not supported by ppx_derving. This should work in the meanwhile *)

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -17,8 +17,7 @@ module Cil = struct
   (* To fix this properly, the types above should be annotated with sth like @to_yojson to give a custom function to  *)
   (* create json from them. This is however currently not supported by ppx_derving. This should work in the meanwhile *)
   (* see also https://github.com/ocaml-ppx/ppx_deriving/issues/184 *)
-  let rec fieldinfo_to_yojson (f:fieldinfo) = `String (f.fname)
-  and varinfo_to_yojson (v:varinfo) = `String(v.vname)
+  let rec varinfo_to_yojson (v:varinfo) = `String(v.vname)
   and exp_to_yojson (l:exp) = `String(Pretty.sprint ~width:80 (Cil.d_exp () l))
 
   let pp_varinfo fmt v = Format.fprintf fmt "%s" v.vname

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -17,7 +17,6 @@ module Cil = struct
   (* To fix this properly, the types above should be annotated with sth like @to_yojson to give a custom function to  *)
   (* create json from them. This is however currently not supported by ppx_derving. This should work in the meanwhile *)
   (* see also https://github.com/ocaml-ppx/ppx_deriving/issues/184 *)
-  let exp_to_yojson (l:exp) = `String(Pretty.sprint ~width:80 (Cil.d_exp () l))
 
   let pp_varinfo fmt v = Format.fprintf fmt "%s" v.vname
   let show_varinfo v = v.vname

--- a/src/util/deriving.ml
+++ b/src/util/deriving.ml
@@ -1,1 +1,0 @@
-type json = Yojson.Safe.t

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -32,7 +32,7 @@ end
 
 type inline_edge =
   | CFGEdge of edge
-  | InlineEntry of Deriving.Cil.exp list
+  | InlineEntry of CilType.Exp.t list
   | InlineReturn of CilType.Lval.t option
   [@@deriving to_yojson]
 

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -33,7 +33,7 @@ end
 type inline_edge =
   | CFGEdge of edge
   | InlineEntry of Deriving.Cil.exp list
-  | InlineReturn of Deriving.Cil.lval option
+  | InlineReturn of CilType.Lval.t option
   [@@deriving to_yojson]
 
 let pretty_inline_edge () = function


### PR DESCRIPTION
ppx_import causes issues here: https://github.com/goblint/analyzer/issues/279#issuecomment-878866381. And we don't really depend on ppx_import (and the derived `to_yojson` implementations): https://github.com/goblint/analyzer/pull/277#issuecomment-877218709.

So this PR does the following:
1. Removes imported CIL types and `to_yojson` derivation. We only cared about the manual implementations there, which are now in `CilType` for more convenient use anyway.
2. Removes imported `ref` type and its derivations. Nothing seems to depend on that?
3. Removes ppx_import dependency.
4. Removes `Deriving.Map.Make`, which additionally provides manually implemented `to_yojson`. This is useless because the only place `Deriving.Map.Make` is used is in `MapDomain` and there we have a different manual implementation of `to_yojson` now anyway.
5. Removes `Deriving` altogether because nothing is left of it.

In a handful of places I replaced a derived CIL `to_yojson` with one based on an already existing manual `show` implementation, particularly for `Cil.location`. This changes the `to_yojson` output of some locations from a JSON object of the location components (file, line) to some kind of string that's in the XML output anyway like that. @keremc, GobView doesn't depend on that, does it? If so, I'll just add a manual implementation of that to match the old behavior.