### PR TITLE
module Integers: Fix usage of logical operations in place of bit ops

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -832,10 +832,10 @@ struct
   let ge n1 n2 = of_bool (n1 >= n2)
   let eq n1 n2 = of_bool (n1 =  n2)
   let ne n1 n2 = of_bool (n1 <> n2)
-  let bitnot = Ints_t.lognot
-  let bitand = Ints_t.logand
-  let bitor  = Ints_t.logor
-  let bitxor = Ints_t.logxor
+  let bitnot = Ints_t.bitnot
+  let bitand = Ints_t.bitand
+  let bitor  = Ints_t.bitor
+  let bitxor = Ints_t.bitxor
   let shift_left  n1 n2 = Ints_t.shift_left n1 (Ints_t.to_int n2)
   let shift_right n1 n2 = Ints_t.shift_right n1 (Ints_t.to_int n2)
   let lognot n1    = of_bool (not (to_bool' n1))


### PR DESCRIPTION
In the course of #251, we generalized `Integers` to take an `Ints_t : IntOps.IntOps` to allow for different underlying integers other than `int64`.

However, there was an oversight when doing that:

https://github.com/goblint/analyzer/pull/251/files#diff-7c2aff56950cfd3ab8421eed789e8ee63632f69397ffbe53db74ae4729641fa3L835-R838

**The equivalent to `Int64.logor` (`Bitwise logical or`) is not `Ints_t.logor` but `Ints_t.bitor`.**

This is the cause why #260 now fails the domain tests after merging #251, as we use Integers to compute the expected exact result for the `valid_*` tests:

```
Concrete Computation: {0} bitor {3} -> {1} (* sic! should be {3} *)

Abstract:
abstracting {0} by 0
abstracting {3} by 3
(af (abstract2 a) is: 3

Abstracting {1} yields 1 which is not leq 3 => Test fails
```