### PR TITLE
Undo update_suite ignoring precision difference for UNKNOWN

### DIFF
--- a/scripts/update_suite.rb
+++ b/scripts/update_suite.rb
@@ -166,8 +166,6 @@ regs.sort.each do |d|
         debug = true
         if obj =~ /FAIL/ then
           tests[i] = "fail"
-        elsif obj =~ /UNKNOWN!/ then
-          tests[i] = "unknown!"
         elsif obj =~ /UNKNOWN/ then
           tests[i] = "unknown"
         else
@@ -425,10 +423,8 @@ File.open(theresultfile, "w") do |f|
         end
       }
       case type
-      when "unknown"
-        check.call ["deadlock", "race", "fail", "unknown", "noterm", "term", "warn", "success"].include? warnings[idx]
-      when "deadlock", "race", "fail", "noterm", "unknown!", "term", "warn"
-        check.call warnings[idx] == type.tr('!', '')
+      when "deadlock", "race", "fail", "noterm", "unknown", "term", "warn"
+        check.call warnings[idx] == type
       when "nowarn"
         check.call warnings[idx].nil?
       when "assert"

--- a/tests/regression/00-sanity/19-update_suite.c
+++ b/tests/regression/00-sanity/19-update_suite.c
@@ -1,0 +1,10 @@
+// SKIP (just for manually testing that update_suite works)
+#include <assert.h>
+
+int main() {
+  int x = 42;
+  // Should fail with: Expected unknown, but registered success
+  assert(x == 42); // UNKNOWN
+
+  return 0;
+}

--- a/tests/regression/31-ikind-aware-ints/13-intervals-large.c
+++ b/tests/regression/31-ikind-aware-ints/13-intervals-large.c
@@ -9,8 +9,7 @@ int main(){
     if(x > 18446744073709551612ull){
         a = 1;
     }
-    // The following line should succeed, but is unknown for now
-    assert(a); // UNKNOWN
+    assert(a);
 
     unsigned long long y = x + 4;
     // Unsigned overflow -- The following assertion should succeed, but is unknown for now


### PR DESCRIPTION
In #196 among many other changes we merged this innocent-looking change: https://github.com/goblint/analyzer/commit/0cb2c9c42c660b2c0b6889581b659ef7d213d105. This PR reverts that.

During #278 I looked over all the UNKNOWN asserts to see if making `assert` refine the state would cause problems. I saw cases where problems should have appeared but didn't due to the reverted change, which completely silenced all the cases where we still have an `UNKNOWN` annotation but suddenly output success instead. I only realized this when I used regtest (which awfully does similar expected comparisons within Goblint...) and saw different output.

Because we haven't completely gone through the entire regression test suite to recategorize each `UNKNOWN` to either `UNKNOWN!` or `TODO`, then we still have cases where `UNKNOWN` is used with the meaning that it must be unknown. Therefore the script should report if we're suddenly unsoundly reporting success or fail. See #110.