### PR TITLE
Fix base `invariant` worsening precision via ambiguous pointer

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1087,7 +1087,15 @@ struct
       end else begin
         if M.tracing then M.tracel "setosek" ~var:x.vname "update_one_addr: update a local var '%s' ...\n" x.vname;
         (* Normal update of the local state *)
-        let new_value = VD.update_offset a (CPA.find x st.cpa) offs value lval_raw ((Var x), cil_offset) t in
+        let old_value = CPA.find x st.cpa in
+        let new_value = VD.update_offset a old_value offs value lval_raw ((Var x), cil_offset) t in
+        let new_value =
+          if not effect then
+            (* without this, invariant for ambiguous pointer might worsen precision for each individual address to their join *)
+            VD.meet old_value new_value
+          else
+            new_value
+        in
         (* what effect does changing this local variable have on arrays -
            we only need to do this here since globals are not allowed in the
            expressions for partitioning *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1037,7 +1037,7 @@ struct
   (** [set st addr val] returns a state where [addr] is set to [val]
   * it is always ok to put None for lval_raw and rval_raw, this amounts to not using/maintaining
   * precise information about arrays. *)
-  let set (a: Q.ask) ?(ctx=None) ?(effect=true) ?(change_array=true) ?lval_raw ?rval_raw ?t_override (gs:glob_fun) (st: store) (lval: AD.t) (lval_type: Cil.typ) (value: value) : store =
+  let set (a: Q.ask) ?(ctx=None) ?(invariant=false) ?(change_array=true) ?lval_raw ?rval_raw ?t_override (gs:glob_fun) (st: store) (lval: AD.t) (lval_type: Cil.typ) (value: value) : store =
     let update_variable x t y z =
       if M.tracing then M.tracel "setosek" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a\n\n" x.vname VD.pretty y CPA.pretty z;
       let r = update_variable x t y z in (* refers to defintion that is outside of set *)
@@ -1069,7 +1069,7 @@ struct
       in
       let update_offset old_value =
         let new_value = VD.update_offset a old_value offs value lval_raw ((Var x), cil_offset) t in
-        if not effect then
+        if invariant then
           (* without this, invariant for ambiguous pointer might worsen precision for each individual address to their join *)
           VD.meet old_value new_value
         else
@@ -1089,7 +1089,7 @@ struct
       if (!GU.earlyglobs || ThreadFlag.is_multi a) && is_global a x then begin
         if M.tracing then M.tracel "setosek" ~var:x.vname "update_one_addr: update a global var '%s' ...\n" x.vname;
         let new_value = update_offset (Priv.read_global a gs st x) in
-        let r = Priv.write_global ~invariant:(not effect) a gs (Option.get ctx).sideg st x new_value in
+        let r = Priv.write_global ~invariant a gs (Option.get ctx).sideg st x new_value in
         if M.tracing then M.tracel "setosek" ~var:x.vname "update_one_addr: updated a global var '%s' \nstate:%a\n\n" x.vname D.pretty r;
         r
       end else begin
@@ -1364,7 +1364,7 @@ struct
         let oldval = get a gs st addr None in (* None is ok here, we could try to get more precise, but this is ok (reading at unknown position in array) *)
         let oldval = if is_some_bot oldval then (M.tracec "invariant" "%a is bot! This should not happen. Will continue with top!" d_lval lval; VD.top ()) else oldval in
         let t_lval = Cilfacade.typeOfLval lval in
-        let state_with_excluded = set a gs st addr t_lval value ~effect:false ~change_array:false ~ctx:(Some ctx) in
+        let state_with_excluded = set a gs st addr t_lval value ~invariant:true ~change_array:false ~ctx:(Some ctx) in
         let value =  get a gs state_with_excluded addr None in
         let new_val = apply_invariant oldval value in
         if M.tracing then M.traceu "invariant" "New value is %a\n" VD.pretty new_val;
@@ -1374,8 +1374,8 @@ struct
           raise Analyses.Deadcode
         )
         else if VD.is_bot new_val
-        then set a gs st addr t_lval value ~effect:false ~change_array:false ~ctx:(Some ctx) (* no *_raw because this is not a real assignment *)
-        else set a gs st addr t_lval new_val ~effect:false ~change_array:false ~ctx:(Some ctx) (* no *_raw because this is not a real assignment *)
+        then set a gs st addr t_lval value ~invariant:true ~change_array:false ~ctx:(Some ctx) (* no *_raw because this is not a real assignment *)
+        else set a gs st addr t_lval new_val ~invariant:true ~change_array:false ~ctx:(Some ctx) (* no *_raw because this is not a real assignment *)
     | None ->
       if M.tracing then M.traceu "invariant" "Doing nothing.\n";
       M.warn_each ("Invariant failed: expression \"" ^ sprint d_plainexp exp ^ "\" not understood.");
@@ -1500,7 +1500,7 @@ struct
     in
     let eval e st = eval_rv a gs st e in
     let eval_bool e st = match eval e st with `Int i -> ID.to_bool i | _ -> None in
-    let set' lval v st = set a gs st (eval_lv a gs st lval) (Cilfacade.typeOfLval lval) v ~effect:false ~change_array:false ~ctx:(Some ctx) in
+    let set' lval v st = set a gs st (eval_lv a gs st lval) (Cilfacade.typeOfLval lval) v ~invariant:true ~change_array:false ~ctx:(Some ctx) in
     let rec inv_exp c exp (st:store): store =
       (* trying to improve variables in an expression so it is bottom means dead code *)
       if ID.is_bot c then raise Deadcode;

--- a/tests/regression/27-inv_invariants/09-invariant-worsen.c
+++ b/tests/regression/27-inv_invariants/09-invariant-worsen.c
@@ -16,8 +16,8 @@ int main() {
   b = 2;
 
   assert(a == 1);
-  if (*x != 0) { // TODO: invariant makes less precise!
-    assert(a == 1); // TODO
+  if (*x != 0) { // invariant shouldn't make less precise!
+    assert(a == 1);
   }
   return 0;
 }

--- a/tests/regression/27-inv_invariants/10-invariant-worsen-global.c
+++ b/tests/regression/27-inv_invariants/10-invariant-worsen-global.c
@@ -29,8 +29,8 @@ int main() {
   b = 2;
 
   assert(a == 1);
-  if (*x != 0) { // TODO: invariant makes less precise!
-    assert(a == 1); // TODO
+  if (*x != 0) { // invariant shouldn't make less precise!
+    assert(a == 1);
   }
   return 0;
 }

--- a/tests/regression/27-inv_invariants/10-invariant-worsen-global.c
+++ b/tests/regression/27-inv_invariants/10-invariant-worsen-global.c
@@ -1,0 +1,36 @@
+// modified from 27/09
+#include <assert.h>
+#include <pthread.h>
+
+int a = 1;
+int b = 1;
+
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void* t_fun(void *arg) {
+  return NULL;
+}
+
+int main() {
+  int *x;
+  int rnd;
+
+  if (rnd)
+    x = &a;
+  else
+    x = &b;
+
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL); // go multithreaded
+
+  pthread_mutex_lock(&A); // continue with protected (privatized) values
+
+  assert(*x == 1);
+  b = 2;
+
+  assert(a == 1);
+  if (*x != 0) { // TODO: invariant makes less precise!
+    assert(a == 1); // TODO
+  }
+  return 0;
+}

--- a/tests/regression/27-inv_invariants/11-indirect-addresses.c
+++ b/tests/regression/27-inv_invariants/11-indirect-addresses.c
@@ -1,0 +1,24 @@
+// modified from 27/09
+#include <assert.h>
+
+int main() {
+  int a = 1;
+  int b = 1;
+  int *x;
+  int rnd;
+
+  if (rnd)
+    x = &a;
+  else
+    x = &b;
+
+  assert(*x == 1);
+  b = 2;
+
+  assert(a == 1);
+  if (*x > 1) { // invariant rules out x == &a
+    assert(x == &b); // TODO
+    assert(*x == 2); // TODO
+  }
+  return 0;
+}


### PR DESCRIPTION
Closes #285.

Base `invariant` handles the refinement of lvalues monolithically:
https://github.com/goblint/analyzer/blob/dd4dee67a81961aff191f9d70a1c00b8fecd0fcd/src/analyses/base.ml#L1543-L1549

In the problematic example, it first evaluates `*x` to `Not {0}` (join of 1 and 2). The invariant expression `*x != 0` gives for `*x` the restriction to also `Not {0}`. These are met without change. Finally `*x` is `set` to the value `Not {0}`, which is written through the pointer to `a` and `b`, making them less precise. No meet happens on a per target address basis.

Fixing this in `invariant` directly would require duplicating `set`, which first evaluates `*x` to the address set `{&a, &b}` and then updates each one individually with the given value `Not {0}`. Since `set` has an `effect` argument (which is false for `invariant`), I changed this per-address met to happen inside `set` conditioned on that. This happens on just `ValueDomain` elements, so no possibly problematic meeting of `Priv` components is happening. Hopefully this is right!

This can easily be done in `set` because it reads variables before using `VD.update_offset` on them and writing. Following this change fixing #254 gets another condition when it still needs to read before writing globals: when coming from `invariant`.