### PR TITLE
Add output of location columns

### DIFF
--- a/scripts/update_suite.rb
+++ b/scripts/update_suite.rb
@@ -378,7 +378,7 @@ File.open(theresultfile, "w") do |f|
     lines = IO.readlines(File.join(testresults, warnfile))
     lines.each do |l|
       if l =~ /does not reach the end/ then warnings[-1] = "noterm" end
-      next unless l =~ /(.*)\(.*\:(.*)\)/
+      next unless l =~ /(.*)\(.*?\:(\d+)(?:\:\d+)?\)/
       obj,i = $1,$2.to_i
 
       ranking = ["other", "warn", "race", "norace", "deadlock", "nodeadlock", "success", "fail", "unknown", "term", "noterm"]

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -306,7 +306,7 @@ struct
       CPA.find x st.cpa
   (* let read_global ask getg cpa x =
     let (cpa', v) as r = read_global ask getg cpa x in
-    ignore (Pretty.printf "READ GLOBAL %a (%a, %B) = %a\n" d_varinfo x d_loc !Tracing.current_loc (is_unprotected ask x) VD.pretty v);
+    ignore (Pretty.printf "READ GLOBAL %a (%a, %B) = %a\n" d_varinfo x CilType.Location.pretty !Tracing.current_loc (is_unprotected ask x) VD.pretty v);
     r *)
   let write_global ?(invariant=false) ask getg sideg (st: BaseComponents (D).t) x v =
     let cpa' = CPA.add x v st.cpa in
@@ -1526,7 +1526,7 @@ struct
   let dump () =
     let f = open_out_bin (get_string "exp.priv-prec-dump") in
     (* LVH.iter (fun (l, x) v ->
-        ignore (Pretty.printf "%a %a = %a\n" d_loc l d_varinfo x VD.pretty v)
+        ignore (Pretty.printf "%a %a = %a\n" CilType.Location.pretty l d_varinfo x VD.pretty v)
       ) lvh; *)
     Marshal.output f {name = get_string "exp.privatization"; lvh};
     close_out_noerr f

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -28,9 +28,9 @@ struct
     if !Goblintutil.in_verifying_stage then begin
       D.iter (fun e -> List.iter (fun (a,b) ->
           if ((MyLock.equal a e) && (MyLock.equal b newLock)) then (
-            let msg = (sprintf "Deadlock warning: Locking order %s, %s at lines %i, %i violates order at %i, %i." (ValueDomain.Addr.show e.addr) (ValueDomain.Addr.show newLock.addr) e.loc.line newLock.loc.line b.loc.line a.loc.line) in
+            let msg = (sprintf "Deadlock warning: Locking order %s, %s at %s, %s violates order at %s, %s." (ValueDomain.Addr.show e.addr) (ValueDomain.Addr.show newLock.addr) (CilType.Location.show e.loc) (CilType.Location.show newLock.loc) (CilType.Location.show b.loc) (CilType.Location.show a.loc)) in
             Messages.report msg;
-            let msg = (sprintf "Deadlock warning: Locking order %s, %s at lines %i, %i violates order at %i, %i." (ValueDomain.Addr.show newLock.addr) (ValueDomain.Addr.show e.addr) b.loc.line a.loc.line e.loc.line newLock.loc.line) in
+            let msg = (sprintf "Deadlock warning: Locking order %s, %s at %s, %s violates order at %s, %s." (ValueDomain.Addr.show newLock.addr) (ValueDomain.Addr.show e.addr) (CilType.Location.show b.loc) (CilType.Location.show a.loc) (CilType.Location.show e.loc) (CilType.Location.show newLock.loc)) in
             Messages.report ~loc:a.loc msg;
           )
           else () ) !forbiddenList ) lockList;

--- a/src/analyses/extract_arinc.ml
+++ b/src/analyses/extract_arinc.ml
@@ -23,11 +23,11 @@ struct
   module Ctx = IntDomain.Flattened
   (* set of predecessor nodes *)
   module Pred = struct
-    include SetDomain.Make (Basetype.ProgLocation)
+    include SetDomain.Make (Basetype.ExtractLocation)
     let of_loc = singleton
     let of_node = of_loc % MyCFG.getLoc
     let of_current_node () = of_node @@ Option.get !MyCFG.current_node
-    let string_of_elt = Basetype.ProgLocation.show
+    let string_of_elt = Basetype.ExtractLocation.show
   end
   module D = Lattice.Prod3 (Pid) (Ctx) (Pred)
   module C = D

--- a/src/analyses/extract_osek.ml
+++ b/src/analyses/extract_osek.ml
@@ -23,10 +23,10 @@ struct
   module Ctx = IntDomain.Flattened
   (* set of predecessor nodes *)
   module Pred = struct
-    include SetDomain.Make (Basetype.ProgLocation)
+    include SetDomain.Make (Basetype.ExtractLocation)
     let of_node = singleton % MyCFG.getLoc
     let of_current_node () = of_node @@ Option.get !MyCFG.current_node
-    let string_of_elt = Basetype.ProgLocation.show
+    let string_of_elt = Basetype.ExtractLocation.show
   end
   module D = Lattice.Prod3 (Pid) (Ctx) (Pred)
   module C = D
@@ -106,7 +106,7 @@ struct
         "Fun_"^fname^":"
     in
     (* build adjacency matrix for all nodes of this process *)
-    let module HashtblN = Hashtbl.Make (Basetype.ProgLocation) in
+    let module HashtblN = Hashtbl.Make (Basetype.ExtractLocation) in
     let a2bs = HashtblN.create 97 in
     Set.iter (fun (a, _, b as edge) -> HashtblN.modify_def Set.empty a (Set.add edge) a2bs) (get_edges id);
     let nodes = HashtblN.keys a2bs |> List.of_enum in

--- a/src/analyses/mallocWrapperAnalysis.ml
+++ b/src/analyses/mallocWrapperAnalysis.ml
@@ -8,7 +8,7 @@ module Spec : Analyses.MCPSpec =
 struct
   include Analyses.DefaultSpec
 
-  module PL = Lattice.Flat (Basetype.ProgLines) (struct
+  module PL = Lattice.Flat (CilType.Location) (struct
     let top_name = "Unknown line"
     let bot_name = "Unreachable line"
   end)

--- a/src/analyses/mallocWrapperAnalysis.ml
+++ b/src/analyses/mallocWrapperAnalysis.ml
@@ -61,7 +61,7 @@ struct
   let get_heap_var loc =
     try Hashtbl.find heap_hash loc
     with Not_found ->
-      let name = "(alloc@" ^ loc.file ^ ":" ^ string_of_int loc.line ^ ")" in
+      let name = "(alloc@" ^ CilType.Location.show loc ^ ")" in
       let newvar = Goblintutil.create_var (makeGlobalVar name voidType) in
       Hashtbl.add heap_hash loc newvar;
       Hashtbl.add heap_vars newvar.vid ();

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -242,7 +242,7 @@ struct
   module Flags = FlagModes.Spec.D
   module Acc = Hashtbl.Make (Basetype.Variables)
   module AccKeySet = Set.Make (Basetype.Variables)
-  module AccLoc = Printable.Prod3 (Printable.Prod3 (Basetype.ProgLines) (Flag) (IntDomain.Booleans)) (Lockset) (Offs)
+  module AccLoc = Printable.Prod3 (Printable.Prod3 (CilType.Location) (Flag) (IntDomain.Booleans)) (Lockset) (Offs)
   module AccValSet = Set.Make (Printable.Prod (AccLoc) (Flags))
   let acc     : AccValSet.t Acc.t = Acc.create 100
   let accKeys : AccKeySet.t ref   = ref AccKeySet.empty

--- a/src/analyses/termination.ml
+++ b/src/analyses/termination.ml
@@ -11,13 +11,17 @@ module TermDomain = struct
   include SetDomain.ToppedSet (Basetype.Variables) (struct let topname = "All Variables" end)
 end
 
+(* some kind of location string suitable for variable names? *)
+let show_location_id l =
+  string_of_int l.line ^ "_" ^ string_of_int l.column
+
 class loopCounterVisitor (fd : fundec) = object(self)
   inherit nopCilVisitor
   method! vstmt s =
     let action s = match s.skind with
       | Loop (b, loc, _, _) ->
         (* insert loop counter variable *)
-        let name = "term"^string_of_int loc.line in
+        let name = "term"^show_location_id loc in
         let typ = intType in (* TODO the type should be the same as the one of the original loop counter *)
         let v = Goblintutil.create_var (makeLocalVar fd name ~init:(SingleInit zero) typ) in
         (* make an init stmt since the init above is apparently ignored *)
@@ -83,7 +87,7 @@ let stripCastsDeep e =
 let cur_loop = ref None (* current loop *)
 let cur_loop' = ref None (* for nested loops *)
 let makeVar fd loc name =
-  let id = name ^ "__" ^ string_of_int loc.line in
+  let id = name ^ "__" ^ show_location_id loc in
   try List.find (fun v -> v.vname = id) fd.slocals
   with Not_found ->
     let typ = intType in (* TODO the type should be the same as the one of the original loop counter *)
@@ -135,7 +139,7 @@ class loopInstrVisitor (fd : fundec) = object(self)
          | _ -> ());
         s
       | Loop (b, loc, Some continue, Some break) ->
-        print_endline @@ "WARN: Could not determine loop variable for loop on line " ^ string_of_int loc.line;
+        print_endline @@ "WARN: Could not determine loop variable for loop at " ^ CilType.Location.show loc;
         s
       | _ when Hashtbl.mem loopBreaks s.sid -> (* after a loop, we check that t is bounded/positive (no overflow happened) *)
         let loc = Hashtbl.find loopBreaks s.sid in

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -130,7 +130,7 @@ struct
   let exitstate  v = D.top ()
 
   let threadenter ctx lval f args =
-    let location x = let l = !Tracing.current_loc in l.file ^ ":" ^ string_of_int l.line ^ ":" ^ x.vname in
+    let location x = let l = !Tracing.current_loc in CilType.Location.show l ^ ":" ^ x.vname in
     [D.singleton (location f)]
 
   let threadspawn ctx lval f args fctx = ctx.local

--- a/src/cdomains/arincDomain.ml
+++ b/src/cdomains/arincDomain.ml
@@ -19,12 +19,12 @@ module PrE = IntDomain.Flattened
 module Ctx = IntDomain.Flattened
 (* predecessor nodes *)
 module Pred = struct
-  module Base = Basetype.ProgLocation
+  module Base = Basetype.ExtractLocation
   include SetDomain.Make (Base)
   let of_loc = singleton
   let of_node = of_loc % MyCFG.getLoc
   let of_current_node () = of_node @@ Option.get !MyCFG.current_node
-  let string_of_elt = Basetype.ProgLocation.show
+  let string_of_elt = Basetype.ExtractLocation.show
 end
 
 (* define record type here so that fields are accessable outside of D *)

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -70,7 +70,7 @@ struct
   let copy x = x
   let show x = GU.demangle x.vname
   let pretty () x = Pretty.text (show x)
-  let pretty_trace () x = Pretty.dprintf "%s on %a" x.vname ProgLines.pretty x.vdecl
+  let pretty_trace () x = Pretty.dprintf "%s on %a" x.vname CilType.Location.pretty x.vdecl
   let get_location x = x.vdecl
   type group = Global | Local | Context | Parameter | Temp [@@deriving show { with_path = false }]
   let (%) = Batteries.(%)
@@ -286,7 +286,7 @@ struct
 
   let pretty () x = Pretty.text (show x)
   let pretty_trace () x = let name = show x in
-    Pretty.dprintf "%s on %a" name ProgLines.pretty (get_var x).vdecl
+    Pretty.dprintf "%s on %a" name CilType.Location.pretty (get_var x).vdecl
 
   let get_location x = (get_var x).vdecl
   let to_group x = Variables.to_group (get_var x)

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -41,25 +41,6 @@ struct
   let to_yojson x = `String (show x)
 end
 
-module ProgLinesFun: Printable.S with type t = MyCFG.node =
-struct
-  include Printable.Std
-  type t = MyCFG.node
-  let copy x = x
-  let equal a b = MyCFG.Node.equal a b
-  let compare a b = MyCFG.node_compare a b
-  let hash a = MyCFG.Node.hash a
-
-  let show a =
-    let x = Tracing.getLoc a in
-    let f = MyCFG.getFun a in
-    ProgLines.show x ^ "(" ^ f.svar.vname ^ ")"
-  let pretty () x = text (show x)
-  let name () = "proglinesfun"
-  let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
-  let to_yojson x = `String (show x)
-end
 
 module Variables =
 struct

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -41,21 +41,19 @@ struct
   let to_yojson x = `String (show x)
 end
 
-module ProgLinesFun: Printable.S with type t = location * MyCFG.node * fundec =
+module ProgLinesFun: Printable.S with type t = MyCFG.node =
 struct
   include Printable.Std
-  type t = location * MyCFG.node * fundec
+  type t = MyCFG.node
   let copy x = x
-  let equal (x,a,_) (y,b,_) = ProgLines.equal x y && MyCFG.Node.equal a b (* ignores fundec component *)
-  let compare (x,a,_) (y,b,_) = match ProgLines.compare x y with 0 -> MyCFG.node_compare a b | x -> x (* ignores fundec component *)
-  let hash (x,a,f) = ProgLines.hash x * MyCFG.Node.hash a (* ignores fundec component *)
-  let pretty_node () (l,x) =
-    match x with
-    | MyCFG.Statement     s -> dprintf "statement \"%a\" at %a" dn_stmt s ProgLines.pretty l
-    | MyCFG.Function      f -> dprintf "result of %s at %a" f.svar.vname ProgLines.pretty l
-    | MyCFG.FunctionEntry f -> dprintf "entry state of %s at %a" f.svar.vname ProgLines.pretty l
+  let equal a b = MyCFG.Node.equal a b
+  let compare a b = MyCFG.node_compare a b
+  let hash a = MyCFG.Node.hash a
 
-  let show (x,a,f) = ProgLines.show x ^ "(" ^ f.svar.vname ^ ")"
+  let show a =
+    let x = Tracing.getLoc a in
+    let f = MyCFG.getFun a in
+    ProgLines.show x ^ "(" ^ f.svar.vname ^ ")"
   let pretty () x = text (show x)
   let name () = "proglinesfun"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -2,6 +2,7 @@ module GU = Goblintutil
 open Cil
 open Pretty
 
+(* TODO: remove *)
 module ProgLines : Printable.S with type t = location =
 struct
   include Printable.Std

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -3,22 +3,15 @@ open Cil
 open Pretty
 
 
-module ProgLocation : Printable.S with type t = location =
+(** Location with special alphanumeric output for extraction. *)
+module ExtractLocation : Printable.S with type t = location =
 struct
-  include Printable.Std (* for default invariant, tag, ... *)
+  include CilType.Location
 
-  open Pretty
-  type t = location
-  let equal = (=)
-  let compare = compare
-  let hash = Hashtbl.hash
-  (* let short _ x = if x <> locUnknown then Filename.basename x.file ^ ":" ^ string_of_int x.line else "S" *)
   let show loc =
     let f i = (if i < 0 then "n" else "") ^ string_of_int (abs i) in
     f loc.line ^ "b" ^ f loc.byte
-  let show x = show x
   let pretty () x = text (show x)
-  let name () = "proglines_byte"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String (show x)

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -2,23 +2,6 @@ module GU = Goblintutil
 open Cil
 open Pretty
 
-(* TODO: remove *)
-module ProgLines : Printable.S with type t = location =
-struct
-  include Printable.Std
-  type t = location
-  let copy x = x
-  let equal x y =
-    x.line = y.line && x.file = y.file (* ignores byte field *)
-  let compare x y = compare (x.file, x.line) (y.file, y.line) (* ignores byte field *)
-  let hash x = Hashtbl.hash (x.line, x.file)
-  let show x = if x <> locUnknown then Filename.basename x.file ^ ":" ^ string_of_int x.line else "??"
-  let pretty () x = text (show x)
-  let name () = "proglines"
-  let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
-  let to_yojson x = `String (show x)
-end
 
 module ProgLocation : Printable.S with type t = location =
 struct

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -39,7 +39,6 @@ struct
   let name () = "variables"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let category _ = -1
-  let file_name a = a.vdecl.file
   let description n = sprint 80 (pretty_trace () n)
   let context () _ = Pretty.nil
   let loopSep _ = true

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -39,7 +39,6 @@ struct
   let name () = "variables"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let category _ = -1
-  let line_nr a = a.vdecl.line
   let file_name a = a.vdecl.file
   let description n = sprint 80 (pretty_trace () n)
   let context () _ = Pretty.nil

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -38,7 +38,6 @@ struct
     | _ -> Local
   let name () = "variables"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let description n = sprint 80 (pretty_trace () n)
   let context () _ = Pretty.nil
   let loopSep _ = true
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -38,7 +38,6 @@ struct
     | _ -> Local
   let name () = "variables"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let category _ = -1
   let description n = sprint 80 (pretty_trace () n)
   let context () _ = Pretty.nil
   let loopSep _ = true

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -38,7 +38,6 @@ struct
     | _ -> Local
   let name () = "variables"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let context () _ = Pretty.nil
   let loopSep _ = true
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let var_id _ = "globals"

--- a/src/cdomains/concDomain.ml
+++ b/src/cdomains/concDomain.ml
@@ -61,7 +61,7 @@ module Thread = struct
       let name =
         match loc with
         | None -> f.vname
-        | Some l -> f.vname ^ "@" ^ Basetype.ProgLines.show l
+        | Some l -> f.vname ^ "@" ^ CilType.Location.show l
       in
       let newvar = Goblintutil.create_var (makeGlobalVar name voidType) in
       Hashtbl.add thread_hash (f,loc) newvar;

--- a/src/cdomains/deadlockDomain.ml
+++ b/src/cdomains/deadlockDomain.ml
@@ -14,8 +14,9 @@ struct
   let equal x y = Ad.equal x.addr y.addr (* ignores loc field *)
   let hash x = Ad.hash x.addr
   let compare x y = Ad.compare x.addr y.addr (* ignores loc field *)
-  let show x = (Ad.show x.addr) ^ "@" ^ (Basetype.ProgLines.show x.loc)
-  let pretty () x = Ad.pretty () x.addr ++ text "@" ++ Basetype.ProgLines.pretty () x.loc
+  (* TODO: deadlock analysis output doesn't even use these, but manually outputs locations *)
+  let show x = (Ad.show x.addr) ^ "@" ^ (CilType.Location.show x.loc)
+  let pretty () x = Ad.pretty () x.addr ++ text "@" ++ CilType.Location.pretty () x.loc
   let printXml c x = Ad.printXml c x.addr
   let pretty_diff () (x,y) = Ad.pretty_diff () (x.addr,y.addr)
   let to_yojson x = `String (show x)

--- a/src/cdomains/lvalMapDomain.ml
+++ b/src/cdomains/lvalMapDomain.ml
@@ -104,7 +104,7 @@ struct
 
   (* Printing *)
   let string_of_key k = Lval.CilLval.show k
-  let string_of_loc xs = String.concat ", " (List.map (fun x -> string_of_int x.line) xs)
+  let string_of_loc xs = String.concat ", " (List.map CilType.Location.show xs)
   let string_of_record r = Impl.string_of_state r.state^" ("^string_of_loc r.loc^")"
   let string_of (x,y) =
     if is_alias (x,y) then
@@ -223,7 +223,7 @@ struct
   (* callstack for locations *)
   let callstack_var = Goblintutil.create_var @@ Cil.makeVarinfo false "@callstack" Cil.voidType, `NoOffset
   let callstack m = get_record callstack_var m |> Option.map_default V.loc []
-  let string_of_callstack m = " [call stack: "^String.concat ", " (List.map (fun x -> string_of_int x.line) (callstack m))^"]"
+  let string_of_callstack m = " [call stack: "^String.concat ", " (List.map CilType.Location.show (callstack m))^"]"
   let edit_callstack f m = edit_record callstack_var (V.edit_loc f) m
 
 

--- a/src/cdomains/stackDomain.ml
+++ b/src/cdomains/stackDomain.ml
@@ -56,7 +56,7 @@ struct
 end
 
 module Loc = struct
-  include Printable.Liszt (Basetype.ProgLines)
+  include Printable.Liszt (CilType.Location)
   let dummy = []
 end
 module Dom3 = struct

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -416,7 +416,7 @@ struct
 
   let warn_type op x y =
     if GobConfig.get_bool "dbg.verbose" then
-      ignore @@ printf "warn_type %s: incomparable abstr. values %s and %s at line %i: %a and %a\n" op (tag_name x) (tag_name y) !Tracing.current_loc.line pretty x pretty y
+      ignore @@ printf "warn_type %s: incomparable abstr. values %s and %s at %a: %a and %a\n" op (tag_name x) (tag_name y) CilType.Location.pretty !Tracing.current_loc pretty x pretty y
 
   let leq x y =
     match (x,y) with

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -570,13 +570,14 @@ let print_accesses () =
   in
   TypeHash.iter f accs
 
+(* TODO: this races xml output is unused, remove? *)
 let print_accesses_xml () =
   let allglobs = get_bool "allglobs" in
   let g ls (acs,_) =
     let h (conf,w,loc,e,lp) =
       let atyp = if w then "write" else "read" in
       BatPrintf.printf "  <access type=\"%s\" loc=\"%s\" conf=\"%d\">\n"
-        atyp (Basetype.ProgLines.show loc) conf; (* TODO: can loc attribute contain column now? what is this output used for? *)
+        atyp (CilType.Location.show loc) conf;
 
       let d_lp f (t,id) = BatPrintf.fprintf f "type=\"%s\" id=\"%s\"" t id in
 

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -576,7 +576,7 @@ let print_accesses_xml () =
     let h (conf,w,loc,e,lp) =
       let atyp = if w then "write" else "read" in
       BatPrintf.printf "  <access type=\"%s\" loc=\"%s\" conf=\"%d\">\n"
-        atyp (Basetype.ProgLines.show loc) conf;
+        atyp (Basetype.ProgLines.show loc) conf; (* TODO: can loc attribute contain column now? what is this output used for? *)
 
       let d_lp f (t,id) = BatPrintf.fprintf f "type=\"%s\" id=\"%s\"" t id in
 

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -118,10 +118,13 @@ let d_acct () = function
 
 let file_re = Str.regexp "\\(.*/\\|\\)\\([^/]*\\)"
 let d_loc () loc =
-  if Str.string_match file_re loc.file 0 then
-    dprintf "%s:%d" (Str.matched_group 2 loc.file) loc.line
-  else
-    dprintf "%s:%d" loc.file loc.line
+  let loc =
+    if Str.string_match file_re loc.file 0 then
+      {loc with file = Str.matched_group 2 loc.file}
+    else
+      loc
+  in
+  CilType.Location.pretty () loc
 
 let d_memo () (t, lv) =
   match lv with

--- a/src/domains/octagonMapDomain.ml
+++ b/src/domains/octagonMapDomain.ml
@@ -598,7 +598,7 @@ module MapOctagon : S
       let add_constraints (sign, var2, const) =
         let index2 = try (Hashtbl.find vars var2) * 2
           with Not_found ->
-          raise (Invalid_argument ("Not found var:" ^ var2.vname ^ "@" ^ var2.vdecl.file ^ ":" ^ (string_of_int var2.vdecl.line)))
+          raise (Invalid_argument ("Not found var:" ^ var2.vname ^ "@" ^ CilType.Location.show var2.vdecl))
         in
         let upper = OPT.default max_int (INV.maximal const) in
         let lower = OPT.default min_int (INV.minimal const) in

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -50,7 +50,7 @@ struct
     | MyCFG.Function      f -> dprintf "call of %s" f.svar.vname
     | MyCFG.FunctionEntry f -> dprintf "entry state of %s" f.svar.vname
 
-  let pretty_trace () x =  dprintf "%a on %a" pretty x Basetype.ProgLines.pretty (getLocation x)
+  let pretty_trace () x =  dprintf "%a on %a" pretty x CilType.Location.pretty (getLocation x)
 
   let kind = function
     | MyCFG.Function f                         -> `ExitOfProc f
@@ -107,8 +107,8 @@ struct
     | (MyCFG.FunctionEntry f,d) -> dprintf "entry state of %s" f.svar.vname
 
   let pretty_trace () (n,c as x) =
-    if get_bool "dbg.trace.context" then dprintf "(%a, %a) on %a \n" pretty x LD.pretty c Basetype.ProgLines.pretty (getLocation x)
-    else dprintf "%a on %a" pretty x Basetype.ProgLines.pretty (getLocation x)
+    if get_bool "dbg.trace.context" then dprintf "(%a, %a) on %a \n" pretty x LD.pretty c CilType.Location.pretty (getLocation x)
+    else dprintf "%a on %a" pretty x CilType.Location.pretty (getLocation x)
 
   let printXml f (n,c) =
     Var.printXml f n;
@@ -321,6 +321,7 @@ struct
     | s -> failwith @@ "Unsupported value for option `result`: "^s
 end
 
+(* TODO: unused *)
 module ComposeResults (R1: Printable.S) (R2: Printable.S) (C: ResultConf) =
 struct
   module R = Printable.Either (R1) (R2)

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -165,7 +165,7 @@ struct
   let show a =
     let x = Tracing.getLoc a in
     let f = MyCFG.getFun a in
-    Basetype.ProgLines.show x ^ "(" ^ f.svar.vname ^ ")"
+    (if x <> locUnknown then Filename.basename x.file ^ ":" ^ string_of_int x.line else "??") ^ "(" ^ f.svar.vname ^ ")"
   let pretty () x = text (show x)
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -342,24 +342,6 @@ struct
     | s -> failwith @@ "Unsupported value for option `result`: "^s
 end
 
-(* TODO: unused *)
-module ComposeResults (R1: Printable.S) (R2: Printable.S) (C: ResultConf) =
-struct
-  module R = Printable.Either (R1) (R2)
-  module H1 = Hash.Printable (ProgLinesFun) (R1)
-  module H2 = Hash.Printable (ProgLinesFun) (R2)
-
-  include Result (R) (C)
-
-  let merge h1 h2 =
-    let hash = create 113 in
-    let f k v = add hash k (`Left v) in
-    let g k v = add hash k (`Right v) in
-    H1.iter f h1;
-    H2.iter g h2;
-    hash
-end
-
 
 (* Experiment to reduce the number of arguments on transfer functions and allow
    sub-analyses. The list sub contains the current local states of analyses in

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -154,6 +154,25 @@ struct
 end
 
 
+module ProgLinesFun: Printable.S with type t = MyCFG.node =
+struct
+  include Printable.Std
+  type t = MyCFG.node
+  let copy x = x
+  let equal a b = MyCFG.Node.equal a b
+  let compare a b = MyCFG.node_compare a b
+  let hash a = MyCFG.Node.hash a
+
+  let show a =
+    let x = Tracing.getLoc a in
+    let f = MyCFG.getFun a in
+    Basetype.ProgLines.show x ^ "(" ^ f.svar.vname ^ ")"
+  let pretty () x = text (show x)
+  let name () = "proglinesfun"
+  let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
+  let to_yojson x = `String (show x)
+end
 
 module type ResultConf =
 sig
@@ -162,7 +181,7 @@ end
 
 module Result (Range: Printable.S) (C: ResultConf) =
 struct
-  include Hash.Printable (Basetype.ProgLinesFun) (Range)
+  include Hash.Printable (ProgLinesFun) (Range)
   include C
 
   let printXml f xs =
@@ -327,8 +346,8 @@ end
 module ComposeResults (R1: Printable.S) (R2: Printable.S) (C: ResultConf) =
 struct
   module R = Printable.Either (R1) (R2)
-  module H1 = Hash.Printable (Basetype.ProgLinesFun) (R1)
-  module H2 = Hash.Printable (Basetype.ProgLinesFun) (R2)
+  module H1 = Hash.Printable (ProgLinesFun) (R1)
+  module H2 = Hash.Printable (ProgLinesFun) (R2)
 
   include Result (R) (C)
 

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -154,7 +154,7 @@ struct
 end
 
 
-module ProgLinesFun: Printable.S with type t = MyCFG.node =
+module ResultNode: Printable.S with type t = MyCFG.node =
 struct
   include Printable.Std
   type t = MyCFG.node
@@ -168,7 +168,7 @@ struct
     let f = MyCFG.getFun a in
     Basetype.ProgLines.show x ^ "(" ^ f.svar.vname ^ ")"
   let pretty () x = text (show x)
-  let name () = "proglinesfun"
+  let name () = "resultnode"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String (show x)
@@ -181,7 +181,7 @@ end
 
 module Result (Range: Printable.S) (C: ResultConf) =
 struct
-  include Hash.Printable (ProgLinesFun) (Range)
+  include Hash.Printable (ResultNode) (Range)
   include C
 
   let printXml f xs =

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -157,18 +157,16 @@ end
 module ResultNode: Printable.S with type t = MyCFG.node =
 struct
   include Printable.Std
-  type t = MyCFG.node
-  let copy x = x
-  let equal a b = MyCFG.Node.equal a b
-  let compare a b = MyCFG.node_compare a b
-  let hash a = MyCFG.Node.hash a
+
+  include Node.Node
+
+  let name () = "resultnode"
 
   let show a =
     let x = Tracing.getLoc a in
     let f = MyCFG.getFun a in
     Basetype.ProgLines.show x ^ "(" ^ f.svar.vname ^ ")"
   let pretty () x = text (show x)
-  let name () = "resultnode"
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String (show x)

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -171,7 +171,8 @@ struct
       | MyCFG.Function g      -> BatPrintf.fprintf f "ret%d" g.svar.vid
       | MyCFG.FunctionEntry g -> BatPrintf.fprintf f "fun%d" g.svar.vid
     in
-    let print_one (loc,n,fd) v =
+    let print_one n v =
+      let loc = Tracing.getLoc n in
       BatPrintf.fprintf f "<call id=\"%a\" file=\"%s\" line=\"%d\" order=\"%d\">\n" print_id n loc.file loc.line loc.byte;
       BatPrintf.fprintf f "%a</call>\n" Range.printXml v
     in
@@ -183,7 +184,8 @@ struct
       | MyCFG.Function g      -> BatPrintf.fprintf f "ret%d" g.svar.vid
       | MyCFG.FunctionEntry g -> BatPrintf.fprintf f "fun%d" g.svar.vid
     in
-    let print_one (loc,n,fd) v =
+    let print_one n v =
+      let loc = Tracing.getLoc n in
       BatPrintf.fprintf f "{\n\"id\": \"%a\", \"file\": \"%s\", \"line\": \"%d\", \"byte\": \"%d\", \"states\": %s\n},\n" print_id n loc.file loc.line loc.byte (Yojson.Safe.to_string (Range.to_yojson v))
     in
     iter print_one xs
@@ -222,7 +224,7 @@ struct
       let module SH = BatHashtbl.Make (Basetype.RawStrings) in
       let file2funs = SH.create 100 in
       let funs2node = SH.create 100 in
-      iter (fun (_,n,_) _ -> SH.add funs2node (MyCFG.getFun n).svar.vname n) (Lazy.force table);
+      iter (fun n _ -> SH.add funs2node (MyCFG.getFun n).svar.vname n) (Lazy.force table);
       iterGlobals file (function
           | GFun (fd,loc) -> SH.add file2funs loc.file fd.svar.vname
           | _ -> ()
@@ -274,7 +276,7 @@ struct
       let module SH = BatHashtbl.Make (Basetype.RawStrings) in
       let file2funs = SH.create 100 in
       let funs2node = SH.create 100 in
-      iter (fun (_,n,_) _ -> SH.add funs2node (MyCFG.getFun n).svar.vname n) (Lazy.force table);
+      iter (fun n _ -> SH.add funs2node (MyCFG.getFun n).svar.vname n) (Lazy.force table);
       iterGlobals file (function
           | GFun (fd,loc) -> SH.add file2funs loc.file fd.svar.vname
           | _ -> ()

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -20,7 +20,6 @@ sig
 
   val printXml : 'a BatInnerIO.output -> t -> unit
   val var_id   : t -> string
-  val file_name : t -> string
   val node      : t -> MyCFG.node
   val relift    : t -> t (* needed only for incremental+hashcons to re-hashcons contexts after loading *)
 end
@@ -72,7 +71,6 @@ struct
     | MyCFG.Function f      -> "ret" ^ string_of_int f.svar.vid
     | MyCFG.FunctionEntry f -> "fun" ^ string_of_int f.svar.vid
 
-  let file_name n = (MyCFG.getLoc n).file
   let description n = sprint 80 (pretty () n)
   let context () _ = Pretty.nil
   let node n = n
@@ -116,7 +114,6 @@ struct
 
   let var_id (n,_) = Var.var_id n
 
-  let file_name (n,_) = (MyCFG.getLoc n).file
   let description (n,_) = sprint 80 (Var.pretty () n)
   let context () (_,c) = LD.pretty () c
   let node (n,_) = n

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -16,7 +16,6 @@ sig
   include Hashtbl.HashedType
   val pretty_trace: unit -> t -> doc
   val compare : t -> t -> int
-  val category : t -> int
 
   val printXml : 'a BatInnerIO.output -> t -> unit
   val var_id   : t -> string
@@ -28,11 +27,6 @@ module Var =
 struct
   type t = MyCFG.node [@@deriving eq, ord]
   let relift x = x
-
-  let category = function
-    | MyCFG.Statement     s -> 1
-    | MyCFG.Function      f -> 2
-    | MyCFG.FunctionEntry f -> 3
 
   let hash x =
     match x with
@@ -81,11 +75,6 @@ module VarF (LD: Printable.S) =
 struct
   type t = MyCFG.node * LD.t [@@deriving eq, ord]
   let relift (n,x) = n, LD.relift x
-
-  let category = function
-    | (MyCFG.Statement     s,_) -> 1
-    | (MyCFG.Function      f,_) -> 2
-    | (MyCFG.FunctionEntry f,_) -> 3
 
   let hashmul x y = if x=0 then y else if y=0 then x else x*y
   let hash x =

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -64,8 +64,6 @@ struct
     | MyCFG.Statement s     -> string_of_int s.sid
     | MyCFG.Function f      -> "ret" ^ string_of_int f.svar.vid
     | MyCFG.FunctionEntry f -> "fun" ^ string_of_int f.svar.vid
-
-  let context () _ = Pretty.nil
   let node n = n
 end
 
@@ -101,8 +99,6 @@ struct
     BatPrintf.fprintf f "</context>\n"
 
   let var_id (n,_) = Var.var_id n
-
-  let context () (_,c) = LD.pretty () c
   let node (n,_) = n
 end
 exception Deadcode

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -44,11 +44,6 @@ struct
 
   let pretty_trace () x =  dprintf "%a on %a" pretty x CilType.Location.pretty (getLocation x)
 
-  let kind = function
-    | MyCFG.Function f                         -> `ExitOfProc f
-    | MyCFG.Statement {skind = Instr [Call _]; _} -> `ProcCall
-    | _ -> `Other
-
   let printXml f n =
     let id ch n =
       match n with

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -65,7 +65,7 @@ struct
       | MyCFG.FunctionEntry f -> BatPrintf.fprintf ch "fun%d" f.svar.vid
     in
     let l = MyCFG.getLoc n in
-    BatPrintf.fprintf f "<call id=\"%a\" file=\"%s\" fun=\"%s\" line=\"%d\" order=\"%d\">\n" id n l.file (MyCFG.getFun n).svar.vname l.line l.byte
+    BatPrintf.fprintf f "<call id=\"%a\" file=\"%s\" fun=\"%s\" line=\"%d\" order=\"%d\" column=\"%d\">\n" id n l.file (MyCFG.getFun n).svar.vname l.line l.byte l.column
 
   let var_id n =
     match n with
@@ -165,7 +165,7 @@ struct
   let show a =
     let x = Tracing.getLoc a in
     let f = MyCFG.getFun a in
-    (if x <> locUnknown then Filename.basename x.file ^ ":" ^ string_of_int x.line else "??") ^ "(" ^ f.svar.vname ^ ")"
+    CilType.Location.show x ^ "(" ^ f.svar.vname ^ ")"
   let pretty () x = text (show x)
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
@@ -190,7 +190,7 @@ struct
     in
     let print_one n v =
       let loc = Tracing.getLoc n in
-      BatPrintf.fprintf f "<call id=\"%a\" file=\"%s\" line=\"%d\" order=\"%d\">\n" print_id n loc.file loc.line loc.byte;
+      BatPrintf.fprintf f "<call id=\"%a\" file=\"%s\" line=\"%d\" order=\"%d\" column=\"%d\">\n" print_id n loc.file loc.line loc.byte loc.column;
       BatPrintf.fprintf f "%a</call>\n" Range.printXml v
     in
     iter print_one xs
@@ -203,13 +203,13 @@ struct
     in
     let print_one n v =
       let loc = Tracing.getLoc n in
-      BatPrintf.fprintf f "{\n\"id\": \"%a\", \"file\": \"%s\", \"line\": \"%d\", \"byte\": \"%d\", \"states\": %s\n},\n" print_id n loc.file loc.line loc.byte (Yojson.Safe.to_string (Range.to_yojson v))
+      BatPrintf.fprintf f "{\n\"id\": \"%a\", \"file\": \"%s\", \"line\": \"%d\", \"byte\": \"%d\", \"column\": \"%d\", \"states\": %s\n},\n" print_id n loc.file loc.line loc.byte loc.column (Yojson.Safe.to_string (Range.to_yojson v))
     in
     iter print_one xs
 
   let printXmlWarning f () =
     let one_text f (m,l) =
-      BatPrintf.fprintf f "\n<text file=\"%s\" line=\"%d\">%s</text>" l.file l.line (GU.escape m)
+      BatPrintf.fprintf f "\n<text file=\"%s\" line=\"%d\" column=\"%d\">%s</text>" l.file l.line l.column (GU.escape m)
     in
     let one_w f = function
       | `text (m,l)  -> one_text f (m,l)
@@ -221,7 +221,7 @@ struct
 
   let printXmlGlobals f () =
     let one_text f (m,l) =
-      BatPrintf.fprintf f "\n<text file=\"%s\" line=\"%d\">%s</text>" l.file l.line m
+      BatPrintf.fprintf f "\n<text file=\"%s\" line=\"%d\" column=\"%d\">%s</text>" l.file l.line l.column m
     in
     let one_w f = function
       | `text (m,l)  -> one_text f (m,l)

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -21,7 +21,6 @@ sig
   val printXml : 'a BatInnerIO.output -> t -> unit
   val var_id   : t -> string
   val file_name : t -> string
-  val line_nr   : t -> int
   val node      : t -> MyCFG.node
   val relift    : t -> t (* needed only for incremental+hashcons to re-hashcons contexts after loading *)
 end
@@ -73,7 +72,6 @@ struct
     | MyCFG.Function f      -> "ret" ^ string_of_int f.svar.vid
     | MyCFG.FunctionEntry f -> "fun" ^ string_of_int f.svar.vid
 
-  let line_nr n = (MyCFG.getLoc n).line
   let file_name n = (MyCFG.getLoc n).file
   let description n = sprint 80 (pretty () n)
   let context () _ = Pretty.nil
@@ -118,7 +116,6 @@ struct
 
   let var_id (n,_) = Var.var_id n
 
-  let line_nr (n,_) = (MyCFG.getLoc n).line
   let file_name (n,_) = (MyCFG.getLoc n).file
   let description (n,_) = sprint 80 (Var.pretty () n)
   let context () (_,c) = LD.pretty () c

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -65,7 +65,6 @@ struct
     | MyCFG.Function f      -> "ret" ^ string_of_int f.svar.vid
     | MyCFG.FunctionEntry f -> "fun" ^ string_of_int f.svar.vid
 
-  let description n = sprint 80 (pretty () n)
   let context () _ = Pretty.nil
   let node n = n
 end
@@ -103,7 +102,6 @@ struct
 
   let var_id (n,_) = Var.var_id n
 
-  let description (n,_) = sprint 80 (Var.pretty () n)
   let context () (_,c) = LD.pretty () c
   let node (n,_) = n
 end

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1206,20 +1206,20 @@ struct
     (if should_verify then Goblintutil.verified := Some true);
     let complain_l (v:LVar.t) lhs rhs =
       Goblintutil.verified := Some false;
-      ignore (Pretty.printf "Fixpoint not reached at %a (%s:%d)\n @[Solver computed:\n%a\nRight-Hand-Side:\n%a\nDifference: %a\n@]"
-                LVar.pretty_trace v (LVar.file_name v) (LVar.line_nr v) D.pretty lhs D.pretty rhs D.pretty_diff (rhs,lhs))
+      ignore (Pretty.printf "Fixpoint not reached at %a\n @[Solver computed:\n%a\nRight-Hand-Side:\n%a\nDifference: %a\n@]"
+                LVar.pretty_trace v D.pretty lhs D.pretty rhs D.pretty_diff (rhs,lhs))
     in
     let complain_sidel v1 (v2:LVar.t) lhs rhs =
       Goblintutil.verified := Some false;
-      ignore (Pretty.printf "Fixpoint not reached at %a (%s:%d)\nOrigin: %a (%s:%d)\n @[Solver computed:\n%a\nSide-effect:\n%a\nDifference: %a\n@]"
-      LVar.pretty_trace v2 (LVar.file_name v2) (LVar.line_nr v2)
-      LVar.pretty_trace v1 (LVar.file_name v1) (LVar.line_nr v1)
+      ignore (Pretty.printf "Fixpoint not reached at %a\nOrigin: %a\n @[Solver computed:\n%a\nSide-effect:\n%a\nDifference: %a\n@]"
+      LVar.pretty_trace v2
+      LVar.pretty_trace v1
       D.pretty lhs D.pretty rhs D.pretty_diff (rhs,lhs))
     in
     let complain_sideg v (g:GVar.t) lhs rhs =
       Goblintutil.verified := Some false;
-      ignore (Pretty.printf "Fixpoint not reached. Unsatisfied constraint for global %a at variable %a (%s:%d)\n  @[Variable:\n%a\nRight-Hand-Side:\n%a\nDifference: %a\n@]"
-                GVar.pretty_trace g LVar.pretty_trace v (LVar.file_name v) (LVar.line_nr v)
+      ignore (Pretty.printf "Fixpoint not reached. Unsatisfied constraint for global %a at variable %a\n  @[Variable:\n%a\nRight-Hand-Side:\n%a\nDifference: %a\n@]"
+                GVar.pretty_trace g LVar.pretty_trace v
                 G.pretty lhs G.pretty rhs
                 G.pretty_diff (rhs,lhs))
     in

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1126,11 +1126,11 @@ struct
           incr eq
         else if b1 then begin
           if get_bool "solverdiffs" then
-            ignore (Pretty.printf "%a @@ %a is more precise using left:\n%a\n" pretty_node k d_loc (getLoc k) D.pretty_diff (v1,v2));
+            ignore (Pretty.printf "%a @@ %a is more precise using left:\n%a\n" pretty_node k CilType.Location.pretty (getLoc k) D.pretty_diff (v1,v2));
           incr le
         end else if b2 then begin
           if get_bool "solverdiffs" then
-            ignore (Pretty.printf "%a @@ %a is more precise using right:\n%a\n" pretty_node k d_loc (getLoc k) D.pretty_diff (v1,v2));
+            ignore (Pretty.printf "%a @@ %a is more precise using right:\n%a\n" pretty_node k CilType.Location.pretty (getLoc k) D.pretty_diff (v1,v2));
           incr gr
         end else
           incr uk
@@ -1158,11 +1158,11 @@ struct
           f_eq ()
         else if b1 then begin
           (* if get_bool "solverdiffs" then *)
-          (*   ignore (Pretty.printf "%a @@ %a is more precise using left:\n%a\n" pretty_node k d_loc (getLoc k) D.pretty_diff (v1,v2)); *)
+          (*   ignore (Pretty.printf "%a @@ %a is more precise using left:\n%a\n" pretty_node k CilType.Location.pretty (getLoc k) D.pretty_diff (v1,v2)); *)
           f_le ()
         end else if b2 then begin
           (* if get_bool "solverdiffs" then *)
-          (*   ignore (Pretty.printf "%a @@ %a is more precise using right:\n%a\n" pretty_node k d_loc (getLoc k) D.pretty_diff (v1,v2)); *)
+          (*   ignore (Pretty.printf "%a @@ %a is more precise using right:\n%a\n" pretty_node k CilType.Location.pretty (getLoc k) D.pretty_diff (v1,v2)); *)
           f_gr ()
         end else
           f_uk ()

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -775,10 +775,6 @@ struct
     | `L a -> LV.hash a
     | `G a -> 113 * GV.hash a
 
-  let category = function
-    | `L a -> LV.category a
-    | `G _ -> -1
-
   let pretty_trace () = function
     | `L a -> LV.pretty_trace () a
     | `G a -> GV.pretty_trace () a

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -791,10 +791,6 @@ struct
     | `L a -> LV.var_id a
     | `G a -> GV.var_id a
 
-  let file_name = function
-    | `L a -> LV.file_name a
-    | `G a -> GV.file_name a
-
   let node = function
     | `L a -> LV.node a
     | `G a -> GV.node a

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -791,10 +791,6 @@ struct
     | `L a -> LV.var_id a
     | `G a -> GV.var_id a
 
-  let line_nr = function
-    | `L a -> LV.line_nr a
-    | `G a -> GV.line_nr a
-
   let file_name = function
     | `L a -> LV.file_name a
     | `G a -> GV.file_name a

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -491,7 +491,7 @@ struct
             uncalled_dead := !uncalled_dead + cnt;
             if get_bool "dbg.uncalled" then (
               let msg = "Function \"" ^ fn.svar.vname ^ "\" will never be called: " ^ string_of_int cnt  ^ "LoC" in
-              ignore (Pretty.fprintf out "%s (%a)\n" msg Basetype.ProgLines.pretty loc)
+              ignore (Pretty.fprintf out "%s (%a)\n" msg CilType.Location.pretty loc)
             )
         | _ -> ()
       in

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -74,7 +74,9 @@ struct
       let open BatPrintf in
       let live_lines = ref StringMap.empty in
       let dead_lines = ref StringMap.empty in
-      let add_one (l,n,f) v =
+      let add_one n v =
+        let l = Tracing.getLoc n in
+        let f = MyCFG.getFun n in
         let add_fun  = BatISet.add l.line in
         let add_file = StringMap.modify_def BatISet.empty f.svar.vname add_fun in
         let is_dead = LT.for_all (fun (_,x,f) -> Spec.D.is_bot x) v in
@@ -156,14 +158,14 @@ struct
       let add_local_var (n,es) state =
         let loc = Tracing.getLoc n in
         if loc <> locUnknown then try
-            let (_,_, fundec) as p = loc, n, MyCFG.getFun n in
-            if Result.mem res p then
+            let fundec = MyCFG.getFun n in
+            if Result.mem res n then
               (* If this source location has been added before, we look it up
                * and add another node to it information to it. *)
-              let prev = Result.find res p in
-              Result.replace res p (LT.add (es,state,fundec) prev)
+              let prev = Result.find res n in
+              Result.replace res n (LT.add (es,state,fundec) prev)
             else
-              Result.add res p (LT.singleton (es,state,fundec))
+              Result.add res n (LT.singleton (es,state,fundec))
           (* If the function is not defined, and yet has been included to the
            * analysis result, we generate a warning. *)
           with Not_found ->

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -135,8 +135,8 @@ struct
       let report tv (loc, dead) =
         if Deadcode.Locmap.mem dead_locations loc then
           match dead, Deadcode.Locmap.find_option Deadcode.dead_branches_cond loc with
-          | true, Some exp -> ignore (Pretty.printf "Dead code: the %s branch over expression '%a' is dead! (%a)\n" (str tv) d_exp exp d_loc loc)
-          | true, None     -> ignore (Pretty.printf "Dead code: an %s branch is dead! (%a)\n" (str tv) d_loc loc)
+          | true, Some exp -> ignore (Pretty.printf "Dead code: the %s branch over expression '%a' is dead! (%a)\n" (str tv) d_exp exp CilType.Location.pretty loc)
+          | true, None     -> ignore (Pretty.printf "Dead code: an %s branch is dead! (%a)\n" (str tv) CilType.Location.pretty loc)
           | _ -> ()
       in
       if get_bool "dbg.print_dead_code" then (
@@ -239,7 +239,7 @@ struct
       let funs = ref [] in
       (*let count = ref 0 in*)
       let transfer_func (st : Spec.D.t) (edge, loc) : Spec.D.t =
-        if M.tracing then M.trace "con" "Initializer %a\n" d_loc loc;
+        if M.tracing then M.trace "con" "Initializer %a\n" CilType.Location.pretty loc;
         (*incr count;
           if (get_bool "dbg.verbose")&& (!count mod 1000 = 0)  then Printf.printf "%d %!" !count;    *)
         Tracing.current_loc := loc;

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -271,7 +271,7 @@ let createCFG (file: file) =
            * so the Eclipse plug-in can know what function a given result
            * belongs to. *)
           Hashtbl.add stmt_fundec_map stmt.sid fd;
-          if Messages.tracing then Messages.trace "cfg" "Statement %d at %a.\n" stmt.sid d_loc (get_stmtLoc stmt.skind);
+          if Messages.tracing then Messages.trace "cfg" "Statement %d at %a.\n" stmt.sid CilType.Location.pretty (get_stmtLoc stmt.skind);
 
           let real_succs () = List.map (find_real_stmt ~parent:stmt) stmt.succs in
 

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -22,7 +22,7 @@ let pretty_node () = function
 
 
 let pretty_short_node () = function
-  | Statement s -> text "Statement @ " ++ d_loc () (get_stmtLoc s.skind)
+  | Statement s -> text "Statement @ " ++ CilType.Location.pretty () (get_stmtLoc s.skind)
   | Function f -> text "Function " ++ text f.svar.vname
   | FunctionEntry f -> text "FunctionEntry " ++ text f.svar.vname
 

--- a/src/privPrecCompare.ml
+++ b/src/privPrecCompare.ml
@@ -86,7 +86,7 @@ let compare_dumps {name = name1; lvh = lvh1} {name = name2; lvh = lvh2} =
   (c, msg)
 
 let count_locations dumps =
-  let module LH = Hashtbl.Make (Basetype.ProgLines) in
+  let module LH = Hashtbl.Make (CilType.Location) in
   let locations = LH.create 113 in
   let location_vars = LVH.create 113 in
   List.iter (fun {lvh; _} ->

--- a/src/privPrecCompare.ml
+++ b/src/privPrecCompare.ml
@@ -78,7 +78,7 @@ let compare_dumps {name = name1; lvh = lvh1} {name = name2; lvh = lvh2} =
       match c with
       | Comparison.Equal -> ()
       | _ ->
-        ignore (Pretty.printf "%a %a: %t\n" d_loc l d_varinfo x (fun () -> msg))
+        ignore (Pretty.printf "%a %a: %t\n" CilType.Location.pretty l d_varinfo x (fun () -> msg))
     ) compared;
   let c = LVH.fold (fun _ (c, _) acc -> Comparison.aggregate_same c acc) compared Comparison.Equal in
   let (m, l) = Comparison.counts c in

--- a/src/solvers/generic.ml
+++ b/src/solvers/generic.ml
@@ -47,7 +47,6 @@ struct
   let var_id (c,_) = B.var_id c
   let printXml f (c,_) = B.printXml f c
   let file_name (c,_) = B.file_name c
-  let line_nr (c,_) = B.line_nr c
   let node (c,_) = B.node c
 end
 

--- a/src/solvers/generic.ml
+++ b/src/solvers/generic.ml
@@ -141,7 +141,7 @@ struct
   let warning_id = ref 1
   let writeXmlWarnings () =
     let one_text f (m,l) =
-      fprintf f "\n<text file=\"%s\" line=\"%d\">%s</text>" l.file l.line m
+      fprintf f "\n<text file=\"%s\" line=\"%d\" column=\"%d\">%s</text>" l.file l.line l.column m
     in
     let one_w f = function
       | `text (m,l)  -> one_text f (m,l)

--- a/src/solvers/generic.ml
+++ b/src/solvers/generic.ml
@@ -341,7 +341,7 @@ struct
     (* print_endline "# Generic solver stats"; *)
     Printf.printf "runtime: %s\n" (string_of_time ());
     Printf.printf "vars: %d, evals: %d\n" !Goblintutil.vars !Goblintutil.evals;
-    Option.may (fun v -> ignore @@ Pretty.printf "max updates: %d for var %a on line %d\n" !max_c Var.pretty_trace v (Var.line_nr v)) !max_var;
+    Option.may (fun v -> ignore @@ Pretty.printf "max updates: %d for var %a\n" !max_c Var.pretty_trace v) !max_var;
     print_newline ();
     (* print_endline "# Solver specific stats"; *)
     !print_solver_stats ();

--- a/src/solvers/generic.ml
+++ b/src/solvers/generic.ml
@@ -46,7 +46,6 @@ struct
 
   let var_id (c,_) = B.var_id c
   let printXml f (c,_) = B.printXml f c
-  let file_name (c,_) = B.file_name c
   let node (c,_) = B.node c
 end
 

--- a/src/solvers/generic.ml
+++ b/src/solvers/generic.ml
@@ -39,7 +39,6 @@ struct
     | 0 -> B.compare u1 v1
     | n -> n
   let equal ((u1,u2):t) (v1,v2) = u2=v2 && B.equal u1 v1 (* cannot derive, compares snd first for efficiency *)
-  let category (u,_) = B.category u
   let hash (u,v) = B.hash u + 131233 * v
   let pretty_trace () (u,v:t) =
     Pretty.dprintf "(%a,%d)" B.pretty_trace u v

--- a/src/solvers/sLRphased.ml
+++ b/src/solvers/sLRphased.ml
@@ -136,10 +136,10 @@ module Make =
           HM.replace rho0 x d;
           HM.replace infl x VS.empty;
           if side then (
-            print_endline @@ "Variable by side-effect " ^ S.Var.var_id x ^ " ("^ string_of_int (S.Var.line_nr x) ^") to " ^ string_of_int !count_side;
+            print_endline @@ "Variable by side-effect " ^ S.Var.var_id x ^ " to " ^ string_of_int !count_side;
             HM.replace key  x !count_side; decr count_side
           ) else (
-            print_endline @@ "Variable " ^ S.Var.var_id x ^ " ("^ string_of_int (S.Var.line_nr x) ^") to " ^ string_of_int !count;
+            print_endline @@ "Variable " ^ S.Var.var_id x ^ " to " ^ string_of_int !count;
             HM.replace key  x !count; decr count
           );
           do_var false x;

--- a/src/solvers/sLRterm.ml
+++ b/src/solvers/sLRterm.ml
@@ -51,9 +51,9 @@ module SLR3term =
       let () = print_solver_stats := fun () ->
         Printf.printf "wpoint: %d, rho: %d, rho': %d, q: %d, count: %d, count_side: %d\n" (HM.length wpoint) (HM.length rho) (HPM.length rho') (H.size !q) (Int.neg !count) (max_int - !count_side);
         let histo = Hashtbl.create 13 in (* histogram: node id -> number of contexts *)
-        HM.iter (fun k _ -> Hashtbl.modify_def 1 (S.Var.var_id k, S.Var.line_nr k) ((+)1) histo) rho;
-        let (vid,vln),n = Hashtbl.fold (fun k v (k',v') -> if v > v' then k,v else k',v') histo (Obj.magic (), 0) in
-        ignore @@ Pretty.printf "max #contexts: %d for var_id %s on line %d\n" n vid vln
+        HM.iter (fun k _ -> Hashtbl.modify_def 1 (S.Var.var_id k) ((+)1) histo) rho;
+        let vid,n = Hashtbl.fold (fun k v (k',v') -> if v > v' then k,v else k',v') histo (Obj.magic (), 0) in
+        ignore @@ Pretty.printf "max #contexts: %d for var_id %s\n" n vid
       in
 
       let init ?(side=false) x =

--- a/src/solvers/topDown.ml
+++ b/src/solvers/topDown.ml
@@ -42,15 +42,15 @@ module WP =
       in
       let is_side x = HM.mem set x in
       let rec destabilize x =
-        (* if tracing then trace "sol2" "destabilize %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x); *)
+        (* if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace x; *)
         let w = HM.find_default infl x VS.empty in
         HM.replace infl x VS.empty;
         VS.iter (fun y ->
           HM.remove stable y;
-          if tracing then trace "sol2" "destabilize %a on %i\n" S.Var.pretty_trace y (S.Var.line_nr y);
+          if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace y;
           if not (HM.mem called y) then destabilize y) w
       and solve x =
-        if tracing then trace "sol2" "solve %a on %i, called: %b, stable: %b\n" S.Var.pretty_trace x (S.Var.line_nr x) (HM.mem called x) (HM.mem stable x);
+        if tracing then trace "sol2" "solve %a, called: %b, stable: %b\n" S.Var.pretty_trace x (HM.mem called x) (HM.mem stable x);
         if not (HM.mem called x || HM.mem stable x) then (
           HM.replace stable x ();
           HM.replace called x ();
@@ -67,14 +67,14 @@ module WP =
             if tracing then if is_side x then trace "sol2" "solve side: old = %a, tmp = %a, widen = %a\n" S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty (S.Dom.widen old (S.Dom.join old tmp));
             update_var_event x old tmp;
             if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty tmp;
-            if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) on %i is %a. Old value was %a\n" S.Var.pretty_trace x (HM.mem rho x) (is_side x) (S.Var.line_nr x) S.Dom.pretty tmp S.Dom.pretty old;
+            if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) is %a. Old value was %a\n" S.Var.pretty_trace x (HM.mem rho x) (is_side x) S.Dom.pretty tmp S.Dom.pretty old;
             HM.replace rho x tmp;
             destabilize x;
           );
           (solve[@tailcall]) x
         )
       and eq x get set =
-        if tracing then trace "sol2" "eq %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "eq %a\n" S.Var.pretty_trace x;
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
@@ -89,7 +89,7 @@ module WP =
           in
           f get sidef
       and eval x y =
-        if tracing then trace "sol2" "eval %a on %i ## %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x) S.Var.pretty_trace y (S.Var.line_nr y);
+        if tracing then trace "sol2" "eval %a ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y;
         get_var_event y;
         if HM.mem called y || S.system y = None then HM.replace wpoint y ();
         solve y;
@@ -98,10 +98,10 @@ module WP =
       and sides x =
         let w = try HM.find set x with Not_found -> VS.empty in
         let d = Enum.fold (fun d y -> let r = try S.Dom.join d (HPM.find rho' (y,x)) with Not_found -> d in if tracing then trace "sol2" "sides: side %a from %a: %a\n" S.Var.pretty_trace x S.Var.pretty_trace y S.Dom.pretty r; r) (S.Dom.bot ()) (VS.enum w) in
-        if tracing then trace "sol2" "sides %a on %i ## %a\n" S.Var.pretty_trace x (S.Var.line_nr x) S.Dom.pretty d;
+        if tracing then trace "sol2" "sides %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
         d
       and side x y d =
-        if tracing then trace "sol2" "side %a on %i ## %a on %i (wpx: %b) ## %a\n" S.Var.pretty_trace x  (S.Var.line_nr x) S.Var.pretty_trace y (S.Var.line_nr y) (HM.mem rho y) S.Dom.pretty d;
+        if tracing then trace "sol2" "side %a ## %a (wpx: %b) ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y (HM.mem rho y) S.Dom.pretty d;
         let old = try HPM.find rho' (x,y) with Not_found -> S.Dom.bot () in
         if not (S.Dom.equal old d) then (
           add_set x y (S.Dom.join old d);
@@ -109,7 +109,7 @@ module WP =
           solve y;
         )
       and init x =
-        if tracing then trace "sol2" "init %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "init %a\n" S.Var.pretty_trace x;
         if not (HM.mem rho x) then (
           new_var_event x;
           HM.replace rho  x (S.Dom.bot ())
@@ -117,7 +117,7 @@ module WP =
       in
 
       let set_start (x,d) =
-        if tracing then trace "sol2" "set_start %a on %i ## %a\n" S.Var.pretty_trace x  (S.Var.line_nr x) S.Dom.pretty d;
+        if tracing then trace "sol2" "set_start %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
         init x;
         add_set x x d;
         solve x

--- a/src/solvers/topDown_deprecated.ml
+++ b/src/solvers/topDown_deprecated.ml
@@ -240,16 +240,16 @@ module TD3 =
       let add_set x y d = HM.replace set y (VS.add x (try HM.find set y with Not_found -> VS.empty)); HPM.add rho' (x,y) d; HM.add sidevs y () in
       let is_side x = HM.mem set x in
       let make_wpoint x =
-        if tracing then trace "sol2" "make_wpoint %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "make_wpoint %a\n" S.Var.pretty_trace x;
         HM.replace wpoint x ()
       in
       let rec destabilize x =
-        if tracing then trace "sol2" "destabilize %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace x;
         let t = HM.find_default infl x VS.empty in
         HM.replace infl x VS.empty;
         VS.iter (fun y -> HM.remove stable y; if not (HM.mem called y) then destabilize y) t
       and solve x =
-        if tracing then trace "sol2" "solve %a on %i, called: %b, stable: %b\n" S.Var.pretty_trace x (S.Var.line_nr x) (HM.mem called x) (HM.mem stable x);
+        if tracing then trace "sol2" "solve %a, called: %b, stable: %b\n" S.Var.pretty_trace x (HM.mem called x) (HM.mem stable x);
         if not (HM.mem called x || HM.mem stable x) then begin
           HM.replace called x ();
           let wpx = HM.mem wpoint x in
@@ -265,14 +265,14 @@ module TD3 =
           if not (S.Dom.equal old tmp) then begin
             update_var_event x old tmp;
             if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty tmp;
-            if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) on %i is %a. Old value was %a\n" S.Var.pretty_trace x wpx (is_side x) (S.Var.line_nr x) S.Dom.pretty tmp S.Dom.pretty old;
+            if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) is %a. Old value was %a\n" S.Var.pretty_trace x wpx (is_side x) S.Dom.pretty tmp S.Dom.pretty old;
             HM.replace rho x tmp;
             destabilize x;
             (solve[@tailcall]) x;
           end;
         end;
       and eq x get set =
-        if tracing then trace "sol2" "eq %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "eq %a\n" S.Var.pretty_trace x;
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
@@ -287,7 +287,7 @@ module TD3 =
           in
           f get sidef
       and eval x y =
-        if tracing then trace "sol2" "eval %a on %i ## %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x) S.Var.pretty_trace y (S.Var.line_nr y);
+        if tracing then trace "sol2" "eval %a ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y;
         get_var_event y;
         if not (HM.mem rho y) then init y;
         if HM.mem called y then make_wpoint y else if neg is_side y then solve y;
@@ -296,11 +296,11 @@ module TD3 =
       and sides x =
         let w = try HM.find set x with Not_found -> VS.empty in
         let d = Enum.fold (fun d z -> try S.Dom.join d (HPM.find rho' (z,x)) with Not_found -> d) (S.Dom.bot ()) (VS.enum w) in
-        if tracing then trace "sol2" "sides %a on %i ## %a\n" S.Var.pretty_trace x (S.Var.line_nr x) S.Dom.pretty d;
+        if tracing then trace "sol2" "sides %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
         d
       and side x y d =
         if S.Dom.is_bot d then () else
-        if tracing then trace "sol2" "side %a on %i ## %a on %i (wpx: %b) ## %a\n" S.Var.pretty_trace x  (S.Var.line_nr x) S.Var.pretty_trace y (S.Var.line_nr y) (HM.mem wpoint y) S.Dom.pretty d;
+        if tracing then trace "sol2" "side %a ## %a (wpx: %b) ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y (HM.mem wpoint y) S.Dom.pretty d;
         if not (HM.mem rho y) then begin
           init y;
           add_set x y d;
@@ -317,7 +317,7 @@ module TD3 =
           end
         end
       and init x =
-        if tracing then trace "sol2" "init %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "init %a\n" S.Var.pretty_trace x;
         if not (HM.mem rho x) then begin
           new_var_event x;
           HM.replace rho  x (S.Dom.bot ());
@@ -326,7 +326,7 @@ module TD3 =
       in
 
       let set_start (x,d) =
-        if tracing then trace "sol2" "set_start %a on %i ## %a\n" S.Var.pretty_trace x  (S.Var.line_nr x) S.Dom.pretty d;
+        if tracing then trace "sol2" "set_start %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
         init x;
         add_set x x d;
         solve x

--- a/src/solvers/topDown_space_cache_term.ml
+++ b/src/solvers/topDown_space_cache_term.ml
@@ -162,7 +162,7 @@ module WP =
             let d1 = HM.find rho x in
             let d2 = eq x in
             if not (S.Dom.leq d2 d1) then
-              ignore @@ Pretty.printf "Fixpoint not reached in restore step at %a (%s:%d)\n  @[Variable:\n%a\nRight-Hand-Side:\n%a\nCalculating one more step changes: %a\n@]" S.Var.pretty_trace x (S.Var.file_name x) (S.Var.line_nr x) S.Dom.pretty d1 S.Dom.pretty d2 S.Dom.pretty_diff (d1,d2);
+              ignore @@ Pretty.printf "Fixpoint not reached in restore step at %a\n  @[Variable:\n%a\nRight-Hand-Side:\n%a\nCalculating one more step changes: %a\n@]" S.Var.pretty_trace x S.Dom.pretty d1 S.Dom.pretty d2 S.Dom.pretty_diff (d1,d2);
             d1
           ) else (
             let d = eq x in

--- a/src/solvers/topDown_space_cache_term.ml
+++ b/src/solvers/topDown_space_cache_term.ml
@@ -35,12 +35,12 @@ module WP =
         HM.replace infl y (VS.add x (try HM.find infl y with Not_found -> VS.empty))
       in
       let rec destabilize x =
-        if tracing then trace "sol2" "destabilize %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace x;
         let w = HM.find_default infl x VS.empty in
         HM.replace infl x VS.empty;
         VS.iter (fun y -> HM.remove stable y; if not (HM.mem called y) then destabilize y) w
       and solve x phase =
-        if tracing then trace "sol2" "solve %a on %i, called: %b, stable: %b\n" S.Var.pretty_trace x (S.Var.line_nr x) (HM.mem called x) (HM.mem stable x);
+        if tracing then trace "sol2" "solve %a, called: %b, stable: %b\n" S.Var.pretty_trace x (HM.mem called x) (HM.mem stable x);
         if not (HM.mem called x || HM.mem stable x) then (
           HM.replace stable x ();
           HM.replace called x ();
@@ -52,13 +52,13 @@ module WP =
           if tracing then trace "sol" "Contrib:%a\n" S.Dom.pretty tmp;
           HM.remove called x;
           let tmp = match phase with Widen -> S.Dom.widen old (S.Dom.join old tmp) | Narrow -> S.Dom.narrow old tmp in
-          if tracing then trace "cache" "cache size %d for %a on %i\n" (HM.length l) S.Var.pretty_trace x (S.Var.line_nr x);
+          if tracing then trace "cache" "cache size %d for %a\n" (HM.length l) S.Var.pretty_trace x;
           cache_sizes := HM.length l :: !cache_sizes;
           if not (S.Dom.equal old tmp) then (
             (* if tracing then if is_side x then trace "sol2" "solve side: old = %a, tmp = %a, widen = %a\n" S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty (S.Dom.widen old (S.Dom.join old tmp)); *)
             update_var_event x old tmp;
             if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty tmp;
-            (* if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) on %i is %a. Old value was %a\n" S.Var.pretty_trace x (HM.mem rho x) (is_side x) (S.Var.line_nr x) S.Dom.pretty tmp S.Dom.pretty old; *)
+            (* if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) is %a. Old value was %a\n" S.Var.pretty_trace x (HM.mem rho x) (is_side x) S.Dom.pretty tmp S.Dom.pretty old; *)
             HM.replace rho x tmp;
             destabilize x;
             (solve[@tailcall]) x phase;
@@ -70,13 +70,13 @@ module WP =
           );
         )
       and eq x get set =
-        if tracing then trace "sol2" "eq %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "eq %a \n" S.Var.pretty_trace x;
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
         | Some f -> f get set
       and simple_solve l x y =
-        if tracing then trace "sol2" "simple_solve %a on %i (rhs: %b)\n" S.Var.pretty_trace y (S.Var.line_nr y) (S.system y <> None);
+        if tracing then trace "sol2" "simple_solve %a (rhs: %b)\n" S.Var.pretty_trace y (S.system y <> None);
         if S.system y = None then init y;
         if HM.mem rho y then (solve y Widen; HM.find rho y) else
         if HM.mem called y then (init y; HM.remove l y; HM.find rho y) else
@@ -89,13 +89,13 @@ module WP =
           else (HM.replace l y tmp; tmp)
         )
       and eval l x y =
-        if tracing then trace "sol2" "eval %a on %i ## %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x) S.Var.pretty_trace y (S.Var.line_nr y);
+        if tracing then trace "sol2" "eval %a ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y;
         get_var_event y;
         let tmp = simple_solve l x y in
         if HM.mem rho y then add_infl y x;
         tmp
       and side l y d =
-        if tracing then trace "sol2" "side to %a on %i (wpx: %b) ## value: %a\n" S.Var.pretty_trace y (S.Var.line_nr y) (HM.mem rho y) S.Dom.pretty d;
+        if tracing then trace "sol2" "side to %a (wpx: %b) ## value: %a\n" S.Var.pretty_trace y (HM.mem rho y) S.Dom.pretty d;
         let old = try HM.find rho' y with Not_found -> S.Dom.bot () in
         if not (S.Dom.leq d old) then (
           HM.replace rho' y (S.Dom.join old d);
@@ -105,7 +105,7 @@ module WP =
           solve y Widen;
         )
       and init x =
-        if tracing then trace "sol2" "init %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "init %a\n" S.Var.pretty_trace x;
         if not (HM.mem rho x) then (
           new_var_event x;
           HM.replace rho  x (S.Dom.bot ())
@@ -113,7 +113,7 @@ module WP =
       in
 
       let set_start (x,d) =
-        if tracing then trace "sol2" "set_start %a on %i ## %a\n" S.Var.pretty_trace x  (S.Var.line_nr x) S.Dom.pretty d;
+        if tracing then trace "sol2" "set_start %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
         init x;
         HM.replace rho x d;
         HM.replace rho' x d;
@@ -178,7 +178,7 @@ module WP =
         let restore () =
           let get x =
             let d = get x in
-            if tracing then trace "sol2" "restored var %a on %i ## %a\n" S.Var.pretty_trace x  (S.Var.line_nr x) S.Dom.pretty d
+            if tracing then trace "sol2" "restored var %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d
           in
           List.iter get vs
         in

--- a/src/solvers/topDown_term.ml
+++ b/src/solvers/topDown_term.ml
@@ -34,15 +34,15 @@ module WP =
         HM.replace infl y (VS.add x (try HM.find infl y with Not_found -> VS.empty))
       in
       let rec destabilize x =
-        if tracing then trace "sol2" "destabilize %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace x;
         let w = HM.find_default infl x VS.empty in
         HM.replace infl x VS.empty;
         VS.iter (fun y ->
           HM.remove stable y;
-          (* if tracing then trace "sol2" "destabilize %a on %i\n" S.Var.pretty_trace y (S.Var.line_nr y); *)
+          (* if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace y; *)
           if not (HM.mem called y) then destabilize y) w
       and solve x phase =
-        if tracing then trace "sol2" "solve %a on %i, called: %b, stable: %b\n" S.Var.pretty_trace x (S.Var.line_nr x) (HM.mem called x) (HM.mem stable x);
+        if tracing then trace "sol2" "solve %a, called: %b, stable: %b\n" S.Var.pretty_trace x (HM.mem called x) (HM.mem stable x);
         if not (HM.mem called x || HM.mem stable x) then (
           HM.replace stable x ();
           HM.replace called x ();
@@ -59,7 +59,7 @@ module WP =
             (* if tracing then if is_side x then trace "sol2" "solve side: old = %a, tmp = %a, widen = %a\n" S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty (S.Dom.widen old (S.Dom.join old tmp)); *)
             update_var_event x old tmp;
             if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty tmp;
-            (* if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) on %i is %a. Old value was %a\n" S.Var.pretty_trace x (HM.mem rho x) (is_side x) (S.Var.line_nr x) S.Dom.pretty tmp S.Dom.pretty old; *)
+            (* if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) is %a. Old value was %a\n" S.Var.pretty_trace x (HM.mem rho x) (is_side x) S.Dom.pretty tmp S.Dom.pretty old; *)
             HM.replace rho x tmp;
             destabilize x;
             (solve[@tailcall]) x phase;
@@ -71,13 +71,13 @@ module WP =
           );
         )
       and eq x get set =
-        if tracing then trace "sol2" "eq %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "eq %a\n" S.Var.pretty_trace x;
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
         | Some f -> f get set
       and eval x y =
-        if tracing then trace "sol2" "eval %a on %i ## %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x) S.Var.pretty_trace y (S.Var.line_nr y);
+        if tracing then trace "sol2" "eval %a ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y;
         get_var_event y;
         if HM.mem called y then HM.replace wpoint y ();
         solve y Widen;
@@ -92,7 +92,7 @@ module WP =
           solve y Widen;
         )
       and init x =
-        if tracing then trace "sol2" "init %a on %i\n" S.Var.pretty_trace x (S.Var.line_nr x);
+        if tracing then trace "sol2" "init %a\n" S.Var.pretty_trace x;
         if not (HM.mem rho x) then (
           new_var_event x;
           HM.replace rho  x (S.Dom.bot ())
@@ -100,7 +100,7 @@ module WP =
       in
 
       let set_start (x,d) =
-        if tracing then trace "sol2" "set_start %a on %i ## %a\n" S.Var.pretty_trace x  (S.Var.line_nr x) S.Dom.pretty d;
+        if tracing then trace "sol2" "set_start %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
         init x;
         HM.replace rho x d;
         solve x Widen

--- a/src/transform/expressionEvaluation.ml
+++ b/src/transform/expressionEvaluation.ml
@@ -153,7 +153,7 @@ module ExpEval : Transform.S =
               Ok query
 
     let string_of_location (location : Cil.location) =
-      location.file ^ ":" ^ (location.line |> string_of_int) ^ " [" ^ (location.byte |> string_of_int) ^ "]"
+      CilType.Location.show location ^ " [" ^ (location.byte |> string_of_int) ^ "]"
 
     let file_compare (_, l, _, _) (_, l', _, _) = let open Cil in compare l.file l'.file
     let byte_compare (_, l, _, _) (_, l', _, _) = let open Cil in compare l.byte l'.byte

--- a/src/transform/transform.ml
+++ b/src/transform/transform.ml
@@ -18,17 +18,17 @@ module PartialEval = struct
     inherit nopCilVisitor
     method! vstmt s =
       loc := get_stmtLoc s.skind;
-      (* ignore @@ Pretty.printf "Set loc at stmt %a to %a\n" d_stmt s d_loc !loc; *)
+      (* ignore @@ Pretty.printf "Set loc at stmt %a to %a\n" d_stmt s CilType.Location.pretty !loc; *)
       DoChildren
     method! vexpr e =
       let eval e = match (ask !loc).Queries.f (Queries.EvalInt e) with
         | x when Queries.ID.is_int x ->
           let i = Option.get @@ Queries.ID.to_int x in
           let e' = integer @@ IntOps.BigIntOps.to_int i in
-          ignore @@ Pretty.printf "Replacing non-constant expression %a with %a at %a\n" d_exp e d_exp e' d_loc !loc;
+          ignore @@ Pretty.printf "Replacing non-constant expression %a with %a at %a\n" d_exp e d_exp e' CilType.Location.pretty !loc;
           e'
         | _ ->
-          ignore @@ Pretty.printf "Can't replace expression %a at %a\n" d_exp e d_loc !loc; e
+          ignore @@ Pretty.printf "Can't replace expression %a at %a\n" d_exp e CilType.Location.pretty !loc; e
       in
       match e with
       | Const _ -> SkipChildren

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -14,6 +14,26 @@ struct
   let pretty_diff () (_, _) = nil
 end
 
+module Location: S with type t = location =
+struct
+  include Std
+
+  type t = location
+
+  let name () = "location"
+
+  (* Identity *)
+  let compare x y = Cil.compareLoc x y
+  let equal x y = compare x y = 0
+  let hash x = Hashtbl.hash x (* struct of primitives, so this is fine *)
+
+  (* Output *)
+  let show x = x.file ^ ":" ^ string_of_int x.line ^ ":" ^ string_of_int x.column (* TODO: add special output for locUnknown *)
+  let pretty () x = Pretty.text (show x)
+  let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
+  let to_yojson x = `String (show x)
+end
+
 module Varinfo:
 sig
   include S with type t = varinfo

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -28,7 +28,11 @@ struct
   let hash x = Hashtbl.hash x (* struct of primitives, so this is fine *)
 
   (* Output *)
-  let show x = x.file ^ ":" ^ string_of_int x.line ^ ":" ^ string_of_int x.column (* TODO: add special output for locUnknown *)
+  let show x =
+    (* Also used for gccwarn, so should be the GCC format *)
+    (* TODO: add special output for locUnknown *)
+    x.file ^ ":" ^ string_of_int x.line ^ ":" ^ string_of_int x.column
+
   let pretty () x = Pretty.text (show x)
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
   let to_yojson x = `String (show x)

--- a/src/util/deadcode.ml
+++ b/src/util/deadcode.ml
@@ -1,4 +1,4 @@
-module Locmap = BatHashtbl.Make (Basetype.ProgLines)
+module Locmap = BatHashtbl.Make (CilType.Location)
 
 let dead_branches_then : bool Locmap.t = Locmap.create 10
 let dead_branches_else : bool Locmap.t = Locmap.create 10

--- a/src/util/messages.ml
+++ b/src/util/messages.ml
@@ -60,10 +60,10 @@ let print_msg msg loc =
   let msg  = colorize ~on:false msg in
   push_warning (`text (msg, loc));
   if get_bool "gccwarn" then
-    Printf.printf "%s:%d:0: warning: %s\n" loc.file loc.line msg
+    Printf.printf "%s: warning: %s\n" (CilType.Location.show loc) msg
   else
     let color = if colors_on () then "{violet}" else "" in
-    let s = Printf.sprintf "%s %s(%s:%d)" msgc color loc.file loc.line in
+    let s = Printf.sprintf "%s %s(%s)" msgc color (CilType.Location.show loc) in
     Printf.fprintf !warn_out "%s\n%!" (colorize s)
 
 let print_err msg loc =

--- a/src/util/messages.ml
+++ b/src/util/messages.ml
@@ -19,7 +19,7 @@ let push_warning w =
 
 let track m =
   let loc = !Tracing.current_loc in
-  Printf.fprintf !warn_out "Track (%s:%d); %s\n" loc.file loc.line m
+  Printf.fprintf !warn_out "Track (%s); %s\n" (CilType.Location.show loc) m
 
 (*Warning files*)
 let warn_race = ref stdout
@@ -69,15 +69,15 @@ let print_msg msg loc =
 let print_err msg loc =
   push_warning (`text (msg, loc));
   if get_bool "gccwarn" then
-    Printf.printf "%s:%d:0: error: %s\n" loc.file loc.line msg
+    Printf.printf "%s: error: %s\n" (CilType.Location.show loc) msg
   else
-    Printf.fprintf !warn_out "%s (%s:%d)\n%!" msg loc.file loc.line
+    Printf.fprintf !warn_out "%s (%s)\n%!" msg (CilType.Location.show loc)
 
 
 let print_group group_name errors =
   (* Add warnings to global warning list *)
   push_warning (`group (group_name, errors));
-  let f (msg,loc): doc = Pretty.dprintf "%s (%s:%d)" msg loc.file loc.line in
+  let f (msg,loc): doc = Pretty.dprintf "%s (%a)" msg CilType.Location.pretty loc in
   if (get_bool "ana.osek.warnfiles") then begin
     match (String.sub group_name 0 6) with
     | "Safely" -> ignore (Pretty.fprintf !warn_safe "%s:\n  @[%a@]\n" group_name (docList ~sep:line f) errors)

--- a/src/util/privPrecCompareUtil.ml
+++ b/src/util/privPrecCompareUtil.ml
@@ -1,6 +1,6 @@
 open Prelude
 
-module LVH = Hashtbl.Make (Printable.Prod (Basetype.ProgLines) (Basetype.Variables))
+module LVH = Hashtbl.Make (Printable.Prod (CilType.Location) (Basetype.Variables))
 module VD = BaseDomain.VD
 
 type dump = {

--- a/src/util/tracing.ml
+++ b/src/util/tracing.ml
@@ -127,7 +127,7 @@ let trace sys ?var fmt = gtrace true printtrace sys var ignore fmt
 let tracel sys ?var fmt =
   let loc = !current_loc in
   let docloc sys doc =
-    printtrace sys (dprintf "(%s:%d)@?" loc.file loc.line ++ indent 2 doc);
+    printtrace sys (dprintf "(%a)@?" CilType.Location.pretty loc ++ indent 2 doc);
   in
   gtrace true docloc sys var ~loc:loc.line ignore fmt
 
@@ -148,7 +148,7 @@ let traceli sys ?var ?(subsys=[]) fmt =
   let loc = !current_loc in
   let g () = activate sys subsys in
   let docloc sys doc: unit =
-    printtrace sys (dprintf "(%s:%d)" loc.file loc.line ++ indent 2 doc);
+    printtrace sys (dprintf "(%a)" CilType.Location.pretty loc ++ indent 2 doc);
     traceIndent ()
   in
   gtrace true docloc sys var ~loc:loc.line g fmt

--- a/src/util/tracing.ml
+++ b/src/util/tracing.ml
@@ -102,11 +102,12 @@ let printtrace sys d: unit =
 let gtrace always f sys var ?loc do_subsys fmt =
   let cond =
     (Strs.mem sys !activated || always && Strs.mem sys !trace_sys) &&
+    (* TODO: allow file, column in tracelocs? *)
     match var,loc with
     | Some s, Some l -> (!tracevars = [] || List.mem s !tracevars) &&
-                        (!tracelocs = [] || List.mem l !tracelocs)
+                        (!tracelocs = [] || List.mem l.line !tracelocs)
     | Some s, None   -> (!tracevars = [] || List.mem s !tracevars)
-    | None  , Some l -> (!tracelocs = [] || List.mem l !tracelocs)
+    | None  , Some l -> (!tracelocs = [] || List.mem l.line !tracelocs)
     | _ -> true
   in
   if cond then begin
@@ -129,7 +130,7 @@ let tracel sys ?var fmt =
   let docloc sys doc =
     printtrace sys (dprintf "(%a)@?" CilType.Location.pretty loc ++ indent 2 doc);
   in
-  gtrace true docloc sys var ~loc:loc.line ignore fmt
+  gtrace true docloc sys var ~loc ignore fmt
 
 let tracei (sys:string) ?var ?(subsys=[]) fmt =
   let f sys d = printtrace sys d; traceIndent () in
@@ -151,4 +152,4 @@ let traceli sys ?var ?(subsys=[]) fmt =
     printtrace sys (dprintf "(%a)" CilType.Location.pretty loc ++ indent 2 doc);
     traceIndent ()
   in
-  gtrace true docloc sys var ~loc:loc.line g fmt
+  gtrace true docloc sys var ~loc g fmt


### PR DESCRIPTION
Closes #297.

This is still in progress, but at least adds the column output to assertion results, so Magpie can immediately start using these on this `output-location-column` branch (@karoliineh). The format for such locations is `file:line:column`.

### Changes
1. Removes `ProgLines`, `ProgLinesFun`, `ProgLocation` in `Basetype` and replaces them with `CilType.Location`, which also shows the column.
2. Simplify `Analyses.Result` hashtable keys from `location * node * fundec` to just `node`. The other two components were populated using CIL helper mappings anyway. There's no point in having overly complicated keys since their comparison wanted to ignore them anyway, which clearly indicates that `node` represents the entire identity of the key.
3. Adds column output to warnings, e.g. assertion results.
4. Adds column output to everywhere else I found locations being used.
5. Cleans up the solver variables `Analyses.VarType`.
    1. Remove `file_name` and `line_nr`, which are already printed by `pretty_trace`, so solvers don't have to manually trace those in the output.
    2. Remove other unused functions in that interface.

### TODO
- [x] Fix regression testing script location parsing.
- [x] Change `d_loc` usages.
- [x] Change manual location string constructions.
- [x] Change manual location format string constructions.
- [x] Change `line_nr` used by solvers? Removed because unnecessary, already part of `pretty_trace`.