### PR TITLE
Fix unsoundness of Modulo Operations involving negative numbers #301

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1976,7 +1976,16 @@ struct
   let normalize x =
     match x with
     | None -> None
-    | Some (c, m) -> if m =: Ints_t.zero then Some (c, m) else Some (c %: (abs m), (abs m))
+    | Some (c, m) ->
+      if m =: Ints_t.zero then
+        Some (c, m)
+      else
+        let m' = abs m in
+        let c' = c %: m' in
+        if c' <: Ints_t.zero then
+          Some (c' +: m', m')
+        else
+          Some (c' %: m', m')
 
   let min_int ik = Ints_t.of_bigint @@ fst @@ Size.range_big_int ik
 

--- a/src/util/intOps.ml
+++ b/src/util/intOps.ml
@@ -21,6 +21,9 @@ sig
   val sub : t -> t -> t
   val mul : t -> t -> t
   val div : t -> t -> t
+
+  (* This should be the remainder, not the Euclidian Modulus *)
+  (* -1 rem 5 == -1, whereas -1 Euclid-Mod 5 == 4 *)
   val rem : t -> t -> t
 
   (* Bitwise *)

--- a/src/util/intOps.ml
+++ b/src/util/intOps.ml
@@ -192,10 +192,14 @@ struct
   let mul = Big_int_Z.mult_big_int
 
   (* If the first operand of a div is negative, Zarith rounds the result away from zero.
-    We thus always transform this into a divison with a non-negative first operand.
+     We thus always transform this into a division with a non-negative first operand.
   *)
   let div a b = if Big_int_Z.lt_big_int a zero then Big_int_Z.minus_big_int (Big_int_Z.div_big_int (Big_int_Z.minus_big_int a) b) else Big_int_Z.div_big_int a b
-  let rem = Big_int_Z.mod_big_int
+
+  (* Big_int_Z.mod_big_int computes the Euclidian Modulus, but what we want here is the remainder, as returned by mod on ints
+     -1 rem 5 == -1, whereas -1 Euclid-Mod 5 == 4
+  *)
+  let rem a b = Big_int_Z.sub_big_int a (mul b (div a b))
 
   let compare = Big_int_Z.compare_big_int
   let equal = Big_int_Z.eq_big_int

--- a/tests/regression/00-sanity/22-modulo.c
+++ b/tests/regression/00-sanity/22-modulo.c
@@ -1,0 +1,20 @@
+#include "assert.h"
+int main() {
+    int x = -1;
+    int m = x % 5;
+    int r = x /5;
+    assert(m == -1);
+    assert(r == 0);
+
+    x = 1;
+    m = x%-5;
+    r = x/-5;
+    assert(m == 1);
+    assert(r == 0);
+
+    x = -1;
+    m = x%-5;
+    r = x/-5;
+    assert(m == -1);
+    assert(r == 0);
+}

--- a/tests/regression/00-sanity/23-modulo-interval.c
+++ b/tests/regression/00-sanity/23-modulo-interval.c
@@ -1,0 +1,21 @@
+// PARAMS: --disable ana.int.def_exc --enable ana.int.intervals
+#include "assert.h"
+int main() {
+    int x = -1;
+    int m = x % 5;
+    int r = x /5;
+    assert(m == -1);
+    assert(r == 0);
+
+    x = 1;
+    m = x%-5;
+    r = x/-5;
+    assert(m == 1);
+    assert(r ==0);
+
+    x = -1;
+    m = x%-5;
+    r = x/-5;
+    assert(m == -1);
+    assert(r == 0);
+}

--- a/tests/regression/00-sanity/23-modulo-interval.c
+++ b/tests/regression/00-sanity/23-modulo-interval.c
@@ -1,4 +1,4 @@
-// PARAMS: --disable ana.int.def_exc --enable ana.int.intervals
+// PARAM: --disable ana.int.def_exc --enable ana.int.interval
 #include "assert.h"
 int main() {
     int x = -1;


### PR DESCRIPTION
Replaces incorrect usage of `Big_int_Z.mod_big_int` which computes the Euclidian Modulus with `Big_int_Z.sub_big_int a (mul b (div a b))` which computes the remainder (as does C and the `mod` operation on normal ints).

This necessitated a fix to the `normalize` function in the congruence domain, as the `c` in `c+mℤ` is no longer guaranteed to be non-negative leading to two different representations of the same congruence class (one with `c` and one with an equivalent `c'` of different sign).

Closes #301 