### PR TITLE
Make use of congruences in invariant

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1453,7 +1453,15 @@ struct
             ID.meet a' (ID.sub (ID.mul (ID.div a b) b) c)
           else a'
         in
-        meet_bin a'' b'
+        let a''' =
+          (* if both b and c are definite, we can get a precise value in the congruence domain *)
+          if ID.is_int b && ID.is_int c then
+            (* a%b == c  -> a: c+bℤ *)
+            let t = ID.of_congruence ikind ((BatOption.get @@ ID.to_int c), (BatOption.get @@ ID.to_int b)) in
+            ID.meet a'' t
+          else a''
+        in
+        meet_bin a''' b'
       | Eq | Ne as op ->
         let both x = x, x in
         let m = ID.meet a b in

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2277,7 +2277,7 @@ struct
     match x, y with
     | None, None -> bot()
     | None, _ | _, None -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (show x) (show y)))
-    | Some (c1, m1), Some(c2, m2) -> (if m2 =: Ints_t.zero then (if (c2 |: m1) && (c2 |: c1) then zero else normalize(Some(c1, (gcd m1 c2))))
+    | Some (c1, m1), Some(c2, m2) -> (if m2 =: Ints_t.zero then (if (c2 |: m1) then Some(c1 %: c2,Ints_t.zero) else normalize(Some(c1, (gcd m1 c2))))
         else normalize (Some(c1, gcd m1 (gcd c2 m2))))
 
   let rem ik x y = let res = rem ik x y in

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -815,12 +815,6 @@ struct
     QCheck.(set_shrink shrink @@ set_print show @@ map (*~rev:BatOption.get*) (of_interval ik) pair_arb)
   let relift x = x
 
-  let abs x =
-    if Ints_t.compare x Ints_t.zero < 0 then
-      Ints_t.neg x
-    else
-      x
-
   let modulo n k =
     let result = Ints_t.rem n k in
     if Ints_t.compare result Ints_t.zero >= 0 then result
@@ -833,10 +827,12 @@ struct
       else if Ints_t.equal m Ints_t.zero then
         Some (c, c)
       else
-        let rcx = if Ints_t.equal x (min_int ik) then x else
-            Ints_t.add x (modulo (Ints_t.sub c x) (abs(m))) in
-        let lcy = if Ints_t.equal y (max_int ik) then y else
-            Ints_t.sub y (modulo (Ints_t.sub y c) (abs(m))) in
+        let rcx =
+          if Ints_t.equal x (min_int ik) then x else
+            Ints_t.add x (modulo (Ints_t.sub c x) (Ints_t.abs m)) in
+        let lcy =
+          if Ints_t.equal y (max_int ik) then y else
+            Ints_t.sub y (modulo (Ints_t.sub y c) (Ints_t.abs m)) in
         if Ints_t.compare rcx lcy > 0 then None
         else if Ints_t.equal rcx lcy then norm ik @@ Some (rcx, rcx)
         else norm ik @@ Some (rcx, lcy)
@@ -1978,11 +1974,6 @@ struct
 
   let rec gcd x y =
     if y =: Ints_t.zero then x else gcd y (x %: y)
-  let abs x =
-    if x <: Ints_t.zero then
-      Ints_t.neg x
-    else
-      x
 
   let normalize x =
     match x with
@@ -1991,7 +1982,7 @@ struct
       if m =: Ints_t.zero then
         Some (c, m)
       else
-        let m' = abs m in
+        let m' = Ints_t.abs m in
         let c' = c %: m' in
         if c' <: Ints_t.zero then
           Some (c' +: m', m')
@@ -2188,7 +2179,7 @@ struct
   let shift_left ik x y =
     (* Naive primality test *)
     let is_prime n =
-      let n = abs n in
+      let n = Ints_t.abs n in
       let rec is_prime' d =
         (d *: d >: n) || ((not ((n %: d) =: Ints_t.zero)) && (is_prime' [@tailcall]) (d +: Ints_t.one))
       in
@@ -2392,14 +2383,14 @@ struct
   let refine_with_interval ik (cong : t) (intv : (int_t * int_t ) option) : t =
     match intv, cong with
     | Some (x, y), Some (c, m) ->
-       if m =: Ints_t.zero then
-         if (c <: x || c >: y) then None else Some (c, Ints_t.zero)
-       else
-         let rcx = x +: ((c -: x) %: abs(m)) in
-         let lcy = y -: ((y -: c) %: abs(m)) in
-         if rcx >: lcy then None
-         else if rcx =: lcy then Some (rcx, Ints_t.zero)
-         else cong
+      if m =: Ints_t.zero then
+        if (c <: x || c >: y) then None else Some (c, Ints_t.zero)
+      else
+        let rcx = x +: ((c -: x) %: Ints_t.abs m) in
+        let lcy = y -: ((y -: c) %: Ints_t.abs m) in
+        if rcx >: lcy then None
+        else if rcx =: lcy then Some (rcx, Ints_t.zero)
+        else cong
     | _ -> None
 
   let refine_with_interval ik (cong : t) (intv : (int_t * int_t) option) : t =

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -226,6 +226,8 @@ sig
     * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
 
   val of_interval: Cil.ikind -> int_t * int_t -> t
+
+  val of_congruence: Cil.ikind -> int_t * int_t -> t
 end
 (** Interface of IntDomain implementations that do not take ikinds for arithmetic operations yet.
    TODO: Should be ported to S in the future. *)
@@ -257,6 +259,7 @@ sig
     * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
 
   val of_interval: Cil.ikind -> int_t * int_t -> t
+  val of_congruence: Cil.ikind -> int_t * int_t -> t
   val is_top_of: Cil.ikind -> t -> bool
   val invariant_ikind : Invariant.context -> Cil.ikind -> t -> Invariant.t
 
@@ -283,6 +286,8 @@ sig
     * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
 
   val of_interval: Cil.ikind -> int_t * int_t -> t
+
+  val of_congruence: Cil.ikind -> int_t * int_t -> t
 
   val starting   : Cil.ikind -> int_t -> t
   val ending     : Cil.ikind -> int_t -> t

--- a/src/util/intOps.ml
+++ b/src/util/intOps.ml
@@ -17,6 +17,7 @@ sig
 
   (* Arithmetic *)
   val neg : t -> t
+  val abs : t -> t
   val add : t -> t -> t
   val sub : t -> t -> t
   val mul : t -> t -> t
@@ -72,6 +73,7 @@ struct
   let upper_bound = Some max_int
 
   let neg x = (- x)
+  let abs = abs
   let add = (+)
   let sub = (-)
   let mul a b = a * b
@@ -109,6 +111,7 @@ struct
   let upper_bound = Some Int32.max_int
 
   let neg = Int32.neg
+  let abs = Int32.abs
   let add = Int32.add
   let sub = Int32.sub
   let mul = Int32.mul
@@ -148,6 +151,7 @@ struct
   let upper_bound = Some Int64.max_int
 
   let neg = Int64.neg
+  let abs = Int64.abs
   let add = Int64.add
   let sub = Int64.sub
   let mul = Int64.mul
@@ -187,6 +191,7 @@ struct
   let lower_bound = None
 
   let neg = Big_int_Z.minus_big_int
+  let abs = Big_int_Z.abs_big_int
   let add = Big_int_Z.add_big_int
   let sub = Big_int_Z.sub_big_int
   let mul = Big_int_Z.mult_big_int

--- a/src/util/intOps.ml
+++ b/src/util/intOps.ml
@@ -23,6 +23,7 @@ sig
   val mul : t -> t -> t
   val div : t -> t -> t
   val rem : t -> t -> t
+  val gcd : t-> t -> t
 
   (* Bitwise *)
   val shift_left : t -> int -> t
@@ -79,6 +80,9 @@ struct
   let mul a b = a * b
   let div = (/)
   let rem = (mod)
+  let gcd x y =
+    let rec gcd' x y = if y = 0 then x else gcd' y (rem x y) in
+    abs @@ gcd' x y
 
   let shift_left = (lsl)
   let shift_right = (lsr)
@@ -117,6 +121,9 @@ struct
   let mul = Int32.mul
   let div = Int32.div
   let rem = Int32.rem
+  let gcd x y =
+    let rec gcd' x y = if y = zero then x else gcd' y (rem x y) in
+    abs @@ gcd' x y
 
   let shift_left = Int32.shift_left
   let shift_right = Int32.shift_right_logical
@@ -157,6 +164,9 @@ struct
   let mul = Int64.mul
   let div = Int64.div
   let rem = Int64.rem
+  let gcd x y =
+    let rec gcd' x y = if y = zero then x else gcd' y (rem x y) in
+    abs @@ gcd' x y
 
   let shift_left = Int64.shift_left
   let shift_right = Int64.shift_right_logical
@@ -206,6 +216,7 @@ struct
   *)
   let rem a b = Big_int_Z.sub_big_int a (mul b (div a b))
 
+  let gcd x y = abs @@ Big_int_Z.gcd_big_int x y
   let compare = Big_int_Z.compare_big_int
   let equal = Big_int_Z.eq_big_int
 

--- a/tests/regression/37-congruence/06-refinements.c
+++ b/tests/regression/37-congruence/06-refinements.c
@@ -1,0 +1,22 @@
+// PARAM: --enable ana.int.congruence --enable ana.int.congruence_no_overflow
+int main() {
+    int top;
+    int i = 0;
+    if(top % 17 == 3) {
+        assert(top%17 ==3);
+        if(top %17 != 3) {
+            i = 12;
+        } else {
+
+        }
+    }
+    assert(i ==0);
+
+    if(top % 17 == 0) {
+        assert(top%17 == 0);
+        if(top %17 != 0) {
+            i = 12;
+        }
+    }
+    assert(i == 0);
+}

--- a/tests/regression/37-congruence/07-refinements-o.c
+++ b/tests/regression/37-congruence/07-refinements-o.c
@@ -1,4 +1,30 @@
 // PARAM: --enable ana.int.congruence
+void unsignedCase() {
+    unsigned int top;
+    unsigned int i = 0;
+    if(top % 17 == 3) {
+        assert(top%17 ==3);
+        if(top %17 != 3) {
+            i = 12;
+        } else {
+
+        }
+    }
+    assert(i ==0);
+
+    if(top % 17 == 0) {
+        assert(top%17 == 0);
+        if(top %17 != 0) {
+            i = 12;
+        }
+    }
+    assert(i == 0);
+
+    if(top % 3 == 17) {
+        assert(top%17 == 3); //UNKNOWN!
+    }
+}
+
 int main() {
     int top;
     int i = 0;
@@ -24,4 +50,5 @@ int main() {
         assert(top%17 == 3); //UNKNOWN!
     }
 
+    unsignedCase();
 }

--- a/tests/regression/37-congruence/07-refinements-o.c
+++ b/tests/regression/37-congruence/07-refinements-o.c
@@ -1,0 +1,27 @@
+// PARAM: --enable ana.int.congruence
+int main() {
+    int top;
+    int i = 0;
+    if(top % 17 == 3) {
+        assert(top%17 ==3);
+        if(top %17 != 3) {
+            i = 12;
+        } else {
+
+        }
+    }
+    assert(i ==0);
+
+    if(top % 17 == 0) {
+        assert(top%17 == 0);
+        if(top %17 != 0) {
+            i = 12;
+        }
+    }
+    assert(i == 0);
+
+    if(top % 3 == 17) {
+        assert(top%17 == 3); //UNKNOWN!
+    }
+
+}


### PR DESCRIPTION
This adds some refinement to the `invariant` function for expressions of the form `a % b == c`.

https://github.com/goblint/analyzer/blob/8b1e63d9eb92c7d8c4de601a7e12cb44f434ec74/src/analyses/base.ml#L1458-L1462

**If both `b` and `c` are definite values, then `a` is in `c+bℤ`.**


This is added on top of the other refinements already present in the `mod` case, so they keep working when congruences are disabled. As explained in #268, the refinement works even without this change when signed types are used and `ana.int.congruence_no_overflow` is enabled. After this change, it works also if the flag is off and for unsigned types.

To achieve this, the IntDomains now provide an `of_congruence` function similar to `of_interval` or `of_excl_list`.


This closes #268.