### PR TITLE
Fix more CFG display issues

### DIFF
--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -172,7 +172,7 @@ let createCFG (file: file) =
         let loop_head_neg1 = NH.create 3 in
         (* So for each statement in the function body, we do the following: *)
         let handle stmt =
-          if Messages.tracing then Messages.trace "cfg" "Statement %d at %a.\n" stmt.sid d_loc (get_stmtLoc stmt.skind);
+          if Messages.tracing then Messages.trace "cfg" "Statement %d at %a.\n" stmt.sid d_loc (Cilfacade.get_stmtLoc stmt);
 
           let real_succs () = List.map (find_real_stmt ~parent:stmt) stmt.succs in
 

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -187,7 +187,8 @@ let createCFG (file: file) =
               | [] -> () (* if stmt.succs is empty (which in other cases requires pseudo return), then it isn't a self-loop to add anyway *)
               | [succ] ->
                 if CilType.Stmt.equal succ stmt then (* self-loop *)
-                  addEdge (Statement stmt) (Cil.locUnknown, Skip) (Statement succ) (* TODO: better loc from somewhere? *)
+                  let loc = Cilfacade.get_stmtLoc stmt in (* get location from label because Instr [] itself doesn't have one *)
+                  addEdge (Statement stmt) (loc, Skip) (Statement succ)
               | _ -> failwith "MyCFG.createCFG: >1 Instr [] succ"
             end
 
@@ -285,7 +286,7 @@ let createCFG (file: file) =
         let reachable_return = find_backwards_reachable (module TmpCfg) (Function fd) in
         NH.iter (fun node () ->
             if not (NH.mem reachable_return node) then (
-              if Messages.tracing then Messages.tracei "cfg" "unreachable loop head %a\n" pretty_short_node node;
+              if Messages.tracing then Messages.tracei "cfg" "unreachable loop head %a\n" Node.pretty_plain_short node;
               let targets = match NH.find_all loop_head_neg1 node with
                 | [] -> [Lazy.force pseudo_return]
                 | targets -> targets
@@ -294,7 +295,7 @@ let createCFG (file: file) =
               List.iter (fun target ->
                   addEdge_fromLoc node (Test (one, false)) target
                 ) targets;
-              if Messages.tracing then Messages.traceu "cfg" "unreachable loop head %a\n" pretty_short_node node
+              if Messages.tracing then Messages.traceu "cfg" "unreachable loop head %a\n" Node.pretty_plain_short node
             )
           ) loop_heads;
 

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -606,7 +606,7 @@ end
 let compute_cfg file =
   let cfgF, cfgB = CfgTools.getCFG file in
   let cfgB' = function
-    | MyCFG.Statement s as n -> ([get_stmtLoc s.skind,MyCFG.SelfLoop], n) :: cfgB n
+    | MyCFG.Statement s as n -> ([Cilfacade.get_stmtLoc s,MyCFG.SelfLoop], n) :: cfgB n
     | n -> cfgB n
   in
   let cfgB = if (get_bool "ana.osek.intrpts") then cfgB' else cfgB in

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -25,7 +25,7 @@ let pretty_plain () = function
 (* TODO: remove this? *)
 (** Pretty node plainly with stmt location. *)
 let pretty_plain_short () = function
-  | Statement s -> text "Statement @ " ++ CilType.Location.pretty () (get_stmtLoc s.skind)
+  | Statement s -> text "Statement @ " ++ CilType.Location.pretty () (Cilfacade.get_stmtLoc s)
   | Function f -> text "Function " ++ text f.svar.vname
   | FunctionEntry f -> text "FunctionEntry " ++ text f.svar.vname
 

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -55,7 +55,7 @@ let hash = function
 
 let location (node: t) =
   match node with
-  | Statement stmt -> get_stmtLoc stmt.skind
+  | Statement stmt -> Cilfacade.get_stmtLoc stmt
   | Function fd -> fd.svar.vdecl
   | FunctionEntry fd -> fd.svar.vdecl
 

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -52,7 +52,7 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_id
     List.iter (fun (l, o_l) -> l.vid <- o_l.vid) (List.combine f.slocals old_f.slocals);
     List.iter (fun (lo, o_f) -> lo.vid <- o_f.vid) (List.combine f.sformals old_f.sformals);
     List.iter (fun (s, o_s) -> s.sid <- o_s.sid) (List.combine f.sallstmts old_f.sallstmts);
-    List.iter (fun s -> store_node_location (Statement s) (get_stmtLoc s.skind)) f.sallstmts;
+    List.iter (fun s -> store_node_location (Statement s) (Cilfacade.get_stmtLoc s)) f.sallstmts;
 
     store_node_location (Function f) f.svar.vdecl;
     store_node_location (FunctionEntry f) f.svar.vdecl;

--- a/src/transform/expressionEvaluation.ml
+++ b/src/transform/expressionEvaluation.ml
@@ -66,7 +66,7 @@ module ExpEval : Transform.S =
             |> List.map (fun (f : Cil.fundec) -> f.sallstmts |> List.map (fun s -> f, s))
             |> List.flatten
             (* Add locations *)
-            |> List.map (fun (f, (s : Cil.stmt)) -> (Cil.get_stmtLoc s.skind, f, s))
+            |> List.map (fun (f, (s : Cil.stmt)) -> (Cilfacade.get_stmtLoc s, f, s))
             (* Filter artificial ones by impossible location *)
             |> List.filter (fun ((l : Cil.location), _, _) -> l.line >= 0)
             (* Create hash table *)
@@ -105,7 +105,7 @@ module ExpEval : Transform.S =
                         fun (s : Cil.stmt) ->
                           succeeding_statement := Some s;
                           (* Evaluate at (directly before) a succeeding location *)
-                          Some(self#try_ask (Cil.get_stmtLoc s.skind) expression)
+                          Some(self#try_ask (Cilfacade.get_stmtLoc s) expression)
                       end
                       statement.succs
                     with Not_found -> None

--- a/src/transform/transform.ml
+++ b/src/transform/transform.ml
@@ -17,7 +17,7 @@ module PartialEval = struct
   class visitor ask = object
     inherit nopCilVisitor
     method! vstmt s =
-      loc := get_stmtLoc s.skind;
+      loc := Cilfacade.get_stmtLoc s;
       (* ignore @@ Pretty.printf "Set loc at stmt %a to %a\n" d_stmt s CilType.Location.pretty !loc; *)
       DoChildren
     method! vexpr e =

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -483,3 +483,17 @@ let stmt_pretty_short () x =
   | Instr (y::ys) -> dn_instr () y
   | If (exp,_,_,_) -> dn_exp () exp
   | _ -> dn_stmt () x
+
+
+let get_labelLoc = function
+  | Label (_, loc, _) -> loc
+  (* TODO: other cases *)
+  | _ -> Cil.locUnknown
+
+let get_stmtkindLoc = Cil.get_stmtLoc (* CIL has a confusing name for this function *)
+
+let get_stmtLoc stmt =
+  match stmt.skind with
+  | Instr [] -> get_labelLoc (List.hd stmt.labels) (* TODO: multiple labels *)
+  (* TODO: empty block *)
+  | _ -> get_stmtkindLoc stmt.skind

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -487,8 +487,9 @@ let stmt_pretty_short () x =
 
 let get_labelLoc = function
   | Label (_, loc, _) -> loc
-  (* TODO: other cases *)
-  | _ -> Cil.locUnknown
+  | Case (_, loc) -> loc
+  | CaseRange (_, _, loc) -> loc
+  | Default loc -> loc
 
 let get_stmtkindLoc = Cil.get_stmtLoc (* CIL has a confusing name for this function *)
 

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -504,6 +504,8 @@ let get_stmtkindLoc = Cil.get_stmtLoc (* CIL has a confusing name for this funct
 
 let get_stmtLoc stmt =
   match stmt.skind with
-  | Instr [] -> get_labelsLoc stmt.labels
-  (* TODO: empty block *)
+  (* Cil.get_stmtLoc returns Cil.locUnknown in these cases, so try labels instead *)
+  | Instr []
+  | Block {bstmts = []; _} ->
+    get_labelsLoc stmt.labels
   | _ -> get_stmtkindLoc stmt.skind

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -491,10 +491,19 @@ let get_labelLoc = function
   | CaseRange (_, _, loc) -> loc
   | Default loc -> loc
 
+let rec get_labelsLoc = function
+  | [] -> Cil.locUnknown
+  | label :: labels ->
+    let loc = get_labelLoc label in
+    if CilType.Location.equal loc Cil.locUnknown then
+      get_labelsLoc labels (* maybe another label has known location *)
+    else
+      loc
+
 let get_stmtkindLoc = Cil.get_stmtLoc (* CIL has a confusing name for this function *)
 
 let get_stmtLoc stmt =
   match stmt.skind with
-  | Instr [] -> get_labelLoc (List.hd stmt.labels) (* TODO: multiple labels *)
+  | Instr [] -> get_labelsLoc stmt.labels
   (* TODO: empty block *)
   | _ -> get_stmtkindLoc stmt.skind

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -129,7 +129,10 @@ class addConstructors cons = object
   method! vfunc fd =
     if List.mem fd.svar.vname (List.map string (get_list "mainfun")) then begin
       if get_bool "dbg.verbose" then ignore (Pretty.printf "Adding constructors to: %s\n" fd.svar.vname);
-      let loc = try get_stmtLoc (List.hd fd.sbody.bstmts) with Failure _ -> locUnknown in (* TODO: what fails? *)
+      let loc = match fd.sbody.bstmts with
+        | s :: _ -> get_stmtLoc s
+        | [] -> locUnknown
+      in
       let f fd = mkStmt (Instr [Call (None,Lval (Var fd.svar, NoOffset),[],loc)]) in
       let call_cons = List.map f cons1 in
       let body = mkBlock (call_cons @ fd.sbody.bstmts) in

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -7,6 +7,31 @@ module E = Errormsg
 module GU = Goblintutil
 
 
+let get_labelLoc = function
+  | Label (_, loc, _) -> loc
+  | Case (_, loc) -> loc
+  | CaseRange (_, _, loc) -> loc
+  | Default loc -> loc
+
+let rec get_labelsLoc = function
+  | [] -> Cil.locUnknown
+  | label :: labels ->
+    let loc = get_labelLoc label in
+    if CilType.Location.equal loc Cil.locUnknown then
+      get_labelsLoc labels (* maybe another label has known location *)
+    else
+      loc
+
+let get_stmtkindLoc = Cil.get_stmtLoc (* CIL has a confusing name for this function *)
+
+let get_stmtLoc stmt =
+  match stmt.skind with
+  (* Cil.get_stmtLoc returns Cil.locUnknown in these cases, so try labels instead *)
+  | Instr []
+  | Block {bstmts = []; _} ->
+    get_labelsLoc stmt.labels
+  | _ -> get_stmtkindLoc stmt.skind
+
 
 let init () =
   initCIL ();
@@ -104,7 +129,7 @@ class addConstructors cons = object
   method! vfunc fd =
     if List.mem fd.svar.vname (List.map string (get_list "mainfun")) then begin
       if get_bool "dbg.verbose" then ignore (Pretty.printf "Adding constructors to: %s\n" fd.svar.vname);
-      let loc = try get_stmtLoc (List.hd fd.sbody.bstmts).skind with Failure _ -> locUnknown in
+      let loc = try get_stmtLoc (List.hd fd.sbody.bstmts) with Failure _ -> locUnknown in (* TODO: what fails? *)
       let f fd = mkStmt (Instr [Call (None,Lval (Var fd.svar, NoOffset),[],loc)]) in
       let call_cons = List.map f cons1 in
       let body = mkBlock (call_cons @ fd.sbody.bstmts) in
@@ -483,29 +508,3 @@ let stmt_pretty_short () x =
   | Instr (y::ys) -> dn_instr () y
   | If (exp,_,_,_) -> dn_exp () exp
   | _ -> dn_stmt () x
-
-
-let get_labelLoc = function
-  | Label (_, loc, _) -> loc
-  | Case (_, loc) -> loc
-  | CaseRange (_, _, loc) -> loc
-  | Default loc -> loc
-
-let rec get_labelsLoc = function
-  | [] -> Cil.locUnknown
-  | label :: labels ->
-    let loc = get_labelLoc label in
-    if CilType.Location.equal loc Cil.locUnknown then
-      get_labelsLoc labels (* maybe another label has known location *)
-    else
-      loc
-
-let get_stmtkindLoc = Cil.get_stmtLoc (* CIL has a confusing name for this function *)
-
-let get_stmtLoc stmt =
-  match stmt.skind with
-  (* Cil.get_stmtLoc returns Cil.locUnknown in these cases, so try labels instead *)
-  | Instr []
-  | Block {bstmts = []; _} ->
-    get_labelsLoc stmt.labels
-  | _ -> get_stmtkindLoc stmt.skind

--- a/src/witness/witnessUtil.ml
+++ b/src/witness/witnessUtil.ml
@@ -25,9 +25,9 @@ let find_loop_heads (module Cfg:CfgForward) (file:Cil.file): unit NH.t =
   (* DFS *)
   let rec iter_node path_visited_nodes node =
     if NS.mem node path_visited_nodes then
-      NH.add loop_heads node ()
+      NH.replace loop_heads node ()
     else if not (NH.mem global_visited_nodes node) then begin
-      NH.add global_visited_nodes node ();
+      NH.replace global_visited_nodes node ();
       let new_path_visited_nodes = NS.add node path_visited_nodes in
       List.iter (fun (_, to_node) ->
           iter_node new_path_visited_nodes to_node


### PR DESCRIPTION
## Empty while loops appear dead
Closes #292.

As described in the issue, such loop bodies contain `Instr []` that has no locations to use, thus they're not properly reported in the results. Turns out that the instruction statement still has a label inserted by CIL (loop continue) and that has a location. So I implemented `Cilfacade.get_stmtLoc` (which actually works on `stmt`, not `stmtkind`) that takes the location from labels in such corner case.

A question is whether to keep it in Goblint's `Cilfacade` or move this fix up into goblint-cil. That means changing the type of a CIL function.


## Duplicate Neg(1) edges
https://github.com/goblint/analyzer/blob/0e6698e178e9b33ace993e2cb8ed4b93c160bdb1/tests/regression/34-localization/02-hybrid.c#L8-L17

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/378740/126952755-1e69ffb7-1136-41c0-ac11-3e0685af8a20.png) | ![image](https://user-images.githubusercontent.com/378740/126952878-a5489f3d-72f5-48f5-8202-f2422f4e56fb.png) |

**Change:** A duplicate Neg(1) edge 6 → 22 is removed.

This was due to using `add` instead of `replace` on a `Hashtbl` to record loop heads. Loop heads reachable via multiple back edges were added multiple times and a Neg(1) edge was added for each one.


