### PR TITLE
Clean up variable grouping using magic lines -3 and -4

### DIFF
--- a/src/analyses/octagon.ml
+++ b/src/analyses/octagon.ml
@@ -29,8 +29,7 @@ struct
   let is_local_and_not_pointed_to v =
     (not (v.vglob ||
          v.vdecl.line = -1 || (* TODO: Why?  CIL says:The line number. -1 means "do not know"	*)
-         v.vdecl.line = -3 ||
-         v.vdecl.line = -4))
+         v.vdecl.line = -3))
     && (not v.vaddrof)  (* to avoid handling pointers, only vars whose address is never taken (i.e. can not be pointed to) *)
     && (Cil.isIntegralType v.vtype)
 

--- a/src/analyses/octagon.ml
+++ b/src/analyses/octagon.ml
@@ -29,7 +29,7 @@ struct
   let is_local_and_not_pointed_to v =
     (not (v.vglob ||
          v.vdecl.line = -1 || (* TODO: Why?  CIL says:The line number. -1 means "do not know"	*)
-         v.vdecl.line = -3))
+         Cilfacade.is_varinfo_formal v))
     && (not v.vaddrof)  (* to avoid handling pointers, only vars whose address is never taken (i.e. can not be pointed to) *)
     && (Cil.isIntegralType v.vtype)
 

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -27,13 +27,12 @@ struct
   let pretty () x = Pretty.text (show x)
   let pretty_trace () x = Pretty.dprintf "%s on %a" x.vname CilType.Location.pretty x.vdecl
   let get_location x = x.vdecl
-  type group = Global | Local | Context | Parameter | Temp [@@deriving show { with_path = false }]
+  type group = Global | Local | Parameter | Temp [@@deriving show { with_path = false }]
   let (%) = Batteries.(%)
   let to_group = Option.some % function
     | x when x.vglob -> Global
     | x when x.vdecl.line = -1 -> Temp
     | x when x.vdecl.line = -3 -> Parameter
-    | x when x.vdecl.line = -4 -> Context
     | _ -> Local
   let name () = "variables"
   let loopSep _ = true

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -32,7 +32,7 @@ struct
   let to_group = Option.some % function
     | x when x.vglob -> Global
     | x when x.vdecl.line = -1 -> Temp
-    | x when x.vdecl.line = -3 -> Parameter
+    | x when Cilfacade.is_varinfo_formal x -> Parameter
     | _ -> Local
   let name () = "variables"
   let loopSep _ = true

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -493,7 +493,6 @@ struct
     | _ when v.vglob -> `Global
     | _ when v.vdecl.line = -1 -> `Temp
     | _ when v.vdecl.line = -3 -> `Parameter
-    | _ when v.vdecl.line = -4 -> `Context
     | _ -> `Local
 
   let rec short_offs (o: (fieldinfo, exp) offs) a =

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -492,7 +492,7 @@ struct
     match v with
     | _ when v.vglob -> `Global
     | _ when v.vdecl.line = -1 -> `Temp
-    | _ when v.vdecl.line = -3 -> `Parameter
+    | _ when Cilfacade.is_varinfo_formal v -> `Parameter
     | _ -> `Local
 
   let rec short_offs (o: (fieldinfo, exp) offs) a =

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -7,16 +7,6 @@ module H = NodeH
 module NH = NodeH
 
 
-(* TODO: remove variable grouping via magic location changes *)
-let do_the_params (fd: fundec) =
-  (* This function used to create extra variables, but now it just sets the
-   * vdecl to -3, lovely... *)
-  let create_extra_var (p: varinfo): unit =
-    p.vdecl <- {p.vdecl with line = -3 }
-  in
-  List.iter create_extra_var fd.sformals
-
-
 (* TODO: refactor duplication with find_loop_heads *)
 module NS = Set.Make (Node)
 let find_loop_heads_fun (module Cfg:CfgForward) (fd:Cil.fundec): unit NH.t =
@@ -150,8 +140,6 @@ let createCFG (file: file) =
         if get_bool "dbg.cilcfgdot" then
           Cfg.printCfgFilename ("cilcfg." ^ fd.svar.vname ^ ".dot") fd;
 
-        (* Walk through the parameters and pre-process them a bit... *)
-        do_the_params fd;
         (* Find the first statement in the function *)
         let entrynode = find_real_stmt (Cilfacade.getFirstStmt fd) in
         (* Add the entry edge to that node *)

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -436,26 +436,43 @@ let name_fundecs: fundec StringH.t Lazy.t =
 let find_name_fundec name = StringH.find (Lazy.force name_fundecs) name (* name argument must be explicit, otherwise force happens immediately *)
 
 
-let scope_fundecs: fundec option VarinfoH.t Lazy.t =
+type varinfo_role =
+  | Formal of fundec
+  | Local of fundec
+  | Function
+  | Global
+
+let varinfo_roles: varinfo_role VarinfoH.t Lazy.t =
   lazy (
     let h = VarinfoH.create 113 in
     iterGlobals !current_file (function
         | GFun (fd, _) ->
-          VarinfoH.replace h fd.svar None; (* function itself can be used as a variable (function pointer) *)
-          List.iter (fun vi -> VarinfoH.replace h vi (Some fd)) fd.sformals;
-          List.iter (fun vi -> VarinfoH.replace h vi (Some fd)) fd.slocals
+          VarinfoH.replace h fd.svar Function; (* function itself can be used as a variable (function pointer) *)
+          List.iter (fun vi -> VarinfoH.replace h vi (Formal fd)) fd.sformals;
+          List.iter (fun vi -> VarinfoH.replace h vi (Local fd)) fd.slocals
         | GVar (vi, _, _)
         | GVarDecl (vi, _) ->
-          VarinfoH.replace h vi None
+          VarinfoH.replace h vi Global
         | _ -> ()
       );
     h
   )
 
+(** Find the role of the [varinfo]. *)
+let find_varinfo_role vi = VarinfoH.find (Lazy.force varinfo_roles) vi (* vi argument must be explicit, otherwise force happens immediately *)
+
+
 (** Find the scope of the [varinfo].
     If [varinfo] is a local or a formal argument of [fundec], then returns [Some fundec].
     If [varinfo] is a global or a function itself, then returns [None]. *)
-let find_scope_fundec vi = VarinfoH.find (Lazy.force scope_fundecs) vi (* vi argument must be explicit, otherwise force happens immediately *)
+let find_scope_fundec vi =
+  match find_varinfo_role vi with
+  | Formal fd
+  | Local fd ->
+    Some fd
+  | Function
+  | Global ->
+    None
 
 
 let original_names: string VarinfoH.t Lazy.t =

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -461,6 +461,11 @@ let varinfo_roles: varinfo_role VarinfoH.t Lazy.t =
 (** Find the role of the [varinfo]. *)
 let find_varinfo_role vi = VarinfoH.find (Lazy.force varinfo_roles) vi (* vi argument must be explicit, otherwise force happens immediately *)
 
+let is_varinfo_formal vi =
+  match find_varinfo_role vi with
+  | Formal _ -> true
+  | _ -> false
+
 
 (** Find the scope of the [varinfo].
     If [varinfo] is a local or a formal argument of [fundec], then returns [Some fundec].


### PR DESCRIPTION
### Changes
1. Removes unused magic line -4 for context variables.
2. Removes magic line -3 for formal argument variables, added by `do_the_params`. It is replaced by refining the `varinfo` scope mapping to also contain the exact role and looking that up instead, as I suggested in https://github.com/goblint/analyzer/pull/294#discussion_r674813992.

Besides cleaning up, this might also be a good thing for user-friendly output if we (or the interactive stuff) ever wants to refer to a variable's location, then parameters have valid locations.