### PR TITLE
check indentation of changes on GitHub

### DIFF
--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -1,0 +1,30 @@
+name: indentation
+
+on: [ push, pull_request]
+
+jobs:
+  indentation:
+    strategy: # remove?
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 4.12.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # reuse tests.yml or depend on it? https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-an-action-in-the-same-repository-as-the-workflow
+      - name: Set up OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Install ocp-indent
+        run: opam install -y ocp-indent
+
+      - name: Run pre-commit hook
+        run: git reset --soft HEAD~ && ./scripts/hooks/pre-commit

--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -33,9 +33,9 @@ jobs:
           key: opam-ocp-indent-${{ runner.os }}-${{ matrix.ocaml-compiler }}
 
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v1
         with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          ocaml-version: ${{ matrix.ocaml-compiler }}
 
       - name: Install ocp-indent
         run: opam install -y ocp-indent

--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -4,14 +4,7 @@ on: [ push, pull_request]
 
 jobs:
   indentation:
-    strategy: # remove?
-      matrix:
-        os:
-          - ubuntu-latest
-        ocaml-compiler:
-          - 4.12.0 # setup-ocaml@v1 does not support 4.12.x for ocaml-version
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -19,26 +12,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # reuse tests.yml or depend on it to not have to setup OCaml? https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-an-action-in-the-same-repository-as-the-workflow
-
-      # rely on cache for now
-      - name: Cache opam switch # https://github.com/marketplace/actions/cache
-        uses: actions/cache@v2
-        with:
-          # A list of files, directories, and wildcard patterns to cache and restore
-          path: |
-            ~/.opam
-            _opam
-          # Key for restoring and saving the cache
-          key: opam-ocp-indent-${{ runner.os }}-${{ matrix.ocaml-compiler }}
-
-      - name: Set up OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v1
-        with:
-          ocaml-version: ${{ matrix.ocaml-compiler }}
-
       - name: Install ocp-indent
-        run: opam install -y ocp-indent
+        run: sudo apt install ocp-indent
 
       - name: Run pre-commit hook on changes since last push
         run: git reset --soft ${{ github.event.before }} && ./scripts/hooks/pre-commit

--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -19,7 +19,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      # reuse tests.yml or depend on it? https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-an-action-in-the-same-repository-as-the-workflow
+      # reuse tests.yml or depend on it to not have to setup OCaml? https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-an-action-in-the-same-repository-as-the-workflow
+
+      # rely on cache for now
+      - name: Cache opam switch # https://github.com/marketplace/actions/cache
+        uses: actions/cache@v2
+        with:
+          # A list of files, directories, and wildcard patterns to cache and restore
+          path: |
+            ~/.opam
+            _opam
+          # An explicit key for restoring and saving the cache
+          key: opam-ocp-indent-${{ runner.os }}-${{ runner.ocaml-compiler }}
+
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:

--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v1
         with:
-          ocaml-version: ${{ matrix.ocaml-compiler }}
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       - name: Install ocp-indent
         run: opam install -y ocp-indent

--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       # reuse tests.yml or depend on it? https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-an-action-in-the-same-repository-as-the-workflow
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}
@@ -29,4 +29,4 @@ jobs:
         run: opam install -y ocp-indent
 
       - name: Run pre-commit hook on changes since last push
-        run: git reset --soft ${{ github.event.push.before }} && ./scripts/hooks/pre-commit
+        run: git reset --soft ${{ github.event.before }} && ./scripts/hooks/pre-commit

--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -30,7 +30,7 @@ jobs:
             ~/.opam
             _opam
           # An explicit key for restoring and saving the cache
-          key: opam-ocp-indent-${{ runner.os }}-${{ runner.ocaml-compiler }}
+          key: opam-ocp-indent-${{ runner.os }}-${{ matrix.ocaml-compiler }}
 
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -29,7 +29,7 @@ jobs:
           path: |
             ~/.opam
             _opam
-          # An explicit key for restoring and saving the cache
+          # Key for restoring and saving the cache
           key: opam-ocp-indent-${{ runner.os }}-${{ matrix.ocaml-compiler }}
 
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}

--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       # reuse tests.yml or depend on it? https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-an-action-in-the-same-repository-as-the-workflow
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}

--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -9,7 +9,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 4.12.x
+          - 4.12.0 # setup-ocaml@v1 does not support 4.12.x for ocaml-version
 
     runs-on: ${{ matrix.os }}
 
@@ -35,7 +35,7 @@ jobs:
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v1
         with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          ocaml-version: ${{ matrix.ocaml-compiler }}
 
       - name: Install ocp-indent
         run: opam install -y ocp-indent

--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Install ocp-indent
         run: opam install -y ocp-indent
 
-      - name: Run pre-commit hook
-        run: git reset --soft HEAD~ && ./scripts/hooks/pre-commit
+      - name: Run pre-commit hook on changes since last push
+        run: git reset --soft ${{ github.event.push.before }} && ./scripts/hooks/pre-commit


### PR DESCRIPTION
Stumbled upon this: https://pre-commit.ci
Not sure if we want automatic commits that fix indentation in PRs.
Also, https://pre-commit.com does not list OCaml, so we might as well just add another GitHub workflow for it.

_Originally posted by @vogler in https://github.com/goblint/analyzer/issues/236#issuecomment-887556635_

Setting up OCaml just to install `ocp-indent` to check the code seems like a lot overhead, but maybe this can be cached.