### PR TITLE
fixes for Apple M1

### DIFF
--- a/includes/arm64.h
+++ b/includes/arm64.h
@@ -1,0 +1,9 @@
+// see https://github.com/goblint/cil/issues/41
+// If goblint pre-processes a file including stdlib.h on an Apple M1 machine,
+// it will include /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/mach/arm/_structs.h
+// which uses __uint128_t which is somehow not defined before.
+
+#if defined(__arm64__)
+  // typedef unsigned __int128 uint128_t; // https://stackoverflow.com/a/34588884 TODO __int128 exists in CIL but fails; see https://github.com/goblint/cil/issues/41
+  typedef unsigned long long __uint128_t; // TODO wrong! use the above once fixed. This the definition for __uint64_t
+#endif

--- a/scripts/set_version.sh
+++ b/scripts/set_version.sh
@@ -15,6 +15,7 @@ if [ ! -f src/config.ml ]; then
     echo "let tracking = false"
     echo "let experimental = false"
     echo "let cpp = \"cpp\""
+    echo "let mach = \"$(uname -m)\""
   } >> src/config.ml
 fi
 

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -175,6 +175,9 @@ let preprocess_files () =
   (* Preprocessor flags *)
   let cppflags = ref (get_string "cppflags") in
 
+  if Config.mach = "arm64" then
+    cppflags := !cppflags ^ "-include " ^ Filename.concat exe_dir "includes/arm64.h";
+
   (* the base include directory *)
   let include_dir =
     let incl1 = Filename.concat exe_dir "includes" in


### PR DESCRIPTION
Related issues:
- [ ] https://github.com/goblint/cil/issues/41
  - [ ] TODO fix `__int128` in CIL, then change the definition in `arm64.h` which currently uses `unsigned long long` instead
- [ ] add `linux-headers/arch/arm64` since we  only have `x86` which fails:
```
goblint/analyzer/linux-headers/arch/x86/include/asm/pvclock.h:56:2: error: #error implement me!
  -    56 | #error implement me!
  -       |  ^~~~~
  - Goblint: Preprocessing failed.
```