### PR TITLE
Make Spec & Inc arguments of the functor AnalyzeCFG

### DIFF
--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -584,6 +584,11 @@ struct
     Result.output (lazy local_xml) gh make_global_fast_xml file
 end
 
+(* This function was originally a part of the [AnalyzeCFG] module, but
+   now that [AnalyzeCFG] takes [Spec] as a functor parameter,
+   [analyze_loop] cannot reside in it anymore since each invocation of
+   [get_spec] in the loop might/should return a different module, and we
+   cannot swap the functor parameter from inside [AnalyzeCFG]. *)
 let rec analyze_loop (module CFG : CfgBidir) file fs change_info =
   try
     let (module Spec) = get_spec () in

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -30,154 +30,150 @@ let get_spec () : (module Spec) =
           ) in
   (module S1)
 
-(** Given a [Cfg], computes the solution to [MCP.Path] *)
-module AnalyzeCFG (Cfg:CfgBidir) =
+(** Given a [Cfg], a [Spec], and an [Inc], computes the solution to [MCP.Path] *)
+module AnalyzeCFG (Cfg:CfgBidir) (Spec:Spec) (Inc:Increment) =
 struct
 
-  (** The main function to preform the selected analyses. *)
-  let analyze (file: file) (startfuns, exitfuns, otherfuns: Analyses.fundecs)  (module Spec : Spec) (increment: increment_data) =
+  (* The Equation system *)
+  module EQSys = FromSpec (Spec) (Cfg) (Inc)
 
-    let module Inc = struct let increment = increment end in
+  (* Hashtbl for locals *)
+  module LHT   = BatHashtbl.Make (EQSys.LVar)
+  (* Hashtbl for globals *)
+  module GHT   = BatHashtbl.Make (EQSys.GVar)
 
-    (* The Equation system *)
-    let module EQSys = FromSpec (Spec) (Cfg) (Inc) in
+  (* The solver *)
+  module Slvr  = Selector.Make (EQSys) (LHT) (GHT)
+  (* The verifyer *)
+  module Vrfyr = Verify2 (EQSys) (LHT) (GHT)
+  (* The comparator *)
+  module Comp = Compare (Spec) (EQSys) (LHT) (GHT)
 
-    (* Hashtbl for locals *)
-    let module LHT   = BatHashtbl.Make (EQSys.LVar) in
-    (* Hashtbl for globals *)
-    let module GHT   = BatHashtbl.Make (EQSys.GVar) in
+  (* Triple of the function, context, and the local value. *)
+  module RT = Analyses.ResultType2 (Spec)
+  (* Set of triples [RT] *)
+  module LT = SetDomain.HeadlessSet (RT)
+  (* Analysis result structure---a hashtable from program points to [LT] *)
+  module Result = Analyses.Result (LT) (struct let result_name = "analysis" end)
 
-    (* The solver *)
-    let module Slvr  = Selector.Make (EQSys) (LHT) (GHT) in
-    (* The verifyer *)
-    let module Vrfyr = Verify2 (EQSys) (LHT) (GHT) in
-    (* The comparator *)
-    let module Comp = Compare (Spec) (EQSys) (LHT) (GHT) in
+  (* SV-COMP and witness generation *)
+  module WResult = Witness.Result (Cfg) (Spec) (EQSys) (LHT) (GHT)
 
-    (* Triple of the function, context, and the local value. *)
-    let module RT = Analyses.ResultType2 (Spec) in
-    (* Set of triples [RT] *)
-    let module LT = SetDomain.HeadlessSet (RT) in
-    (* Analysis result structure---a hashtable from program points to [LT] *)
-    let module Result = Analyses.Result (LT) (struct let result_name = "analysis" end) in
-
-    (* SV-COMP and witness generation *)
-    let module WResult = Witness.Result (Cfg) (Spec) (EQSys) (LHT) (GHT) in
-
-    (* print out information about dead code *)
-    let print_dead_code (xs:Result.t) uncalled_fn_loc =
-      let dead_locations : unit Deadcode.Locmap.t = Deadcode.Locmap.create 10 in
-      let module NH = Hashtbl.Make (Node) in
-      let live_nodes : unit NH.t = NH.create 10 in
-      let count = ref 0 in (* Is only populated if "dbg.print_dead_code" is true *)
-      let module StringMap = BatMap.Make (String) in
-      let open BatPrintf in
-      let live_lines = ref StringMap.empty in
-      let dead_lines = ref StringMap.empty in
-      let add_one n v =
-        (* Not using Node.location here to have updated locations in incremental analysis.
-           See: https://github.com/goblint/analyzer/issues/290#issuecomment-881258091. *)
-        let l = UpdateCil.getLoc n in
-        let f = Node.find_fundec n in
-        let add_fun  = BatISet.add l.line in
-        let add_file = StringMap.modify_def BatISet.empty f.svar.vname add_fun in
-        let is_dead = LT.for_all (fun (_,x,f) -> Spec.D.is_bot x) v in
-        if is_dead then (
-          dead_lines := StringMap.modify_def StringMap.empty l.file add_file !dead_lines;
-          Deadcode.Locmap.add dead_locations l ();
-        ) else (
-          live_lines := StringMap.modify_def StringMap.empty l.file add_file !live_lines;
-          NH.add live_nodes n ()
-        );
+  (* print out information about dead code *)
+  let print_dead_code (xs:Result.t) uncalled_fn_loc =
+    let dead_locations : unit Deadcode.Locmap.t = Deadcode.Locmap.create 10 in
+    let module NH = Hashtbl.Make (Node) in
+    let live_nodes : unit NH.t = NH.create 10 in
+    let count = ref 0 in (* Is only populated if "dbg.print_dead_code" is true *)
+    let module StringMap = BatMap.Make (String) in
+    let open BatPrintf in
+    let live_lines = ref StringMap.empty in
+    let dead_lines = ref StringMap.empty in
+    let add_one n v =
+      (* Not using Node.location here to have updated locations in incremental analysis.
+          See: https://github.com/goblint/analyzer/issues/290#issuecomment-881258091. *)
+      let l = UpdateCil.getLoc n in
+      let f = Node.find_fundec n in
+      let add_fun  = BatISet.add l.line in
+      let add_file = StringMap.modify_def BatISet.empty f.svar.vname add_fun in
+      let is_dead = LT.for_all (fun (_,x,f) -> Spec.D.is_bot x) v in
+      if is_dead then (
+        dead_lines := StringMap.modify_def StringMap.empty l.file add_file !dead_lines;
+        Deadcode.Locmap.add dead_locations l ();
+      ) else (
+        live_lines := StringMap.modify_def StringMap.empty l.file add_file !live_lines;
+        NH.add live_nodes n ()
+      );
+    in
+    Result.iter add_one xs;
+    let live_count = StringMap.fold (fun _ file_lines acc ->
+        StringMap.fold (fun _ fun_lines acc ->
+            acc + ISet.cardinal fun_lines
+          ) file_lines acc
+      ) !live_lines 0
+    in
+    printf "Live lines: %d\n" live_count;
+    let live file fn =
+      try StringMap.find fn (StringMap.find file !live_lines)
+      with Not_found -> BatISet.empty
+    in
+    dead_lines := StringMap.mapi (fun fi -> StringMap.mapi (fun fu ded -> BatISet.diff ded (live fi fu))) !dead_lines;
+    dead_lines := StringMap.map (StringMap.filter (fun _ x -> not (BatISet.is_empty x))) !dead_lines;
+    dead_lines := StringMap.filter (fun _ x -> not (StringMap.is_empty x)) !dead_lines;
+    let print_func f xs =
+      let one_range b e first =
+        count := !count + (e - b + 1);
+        if not first then printf ", ";
+        if b=e then
+          printf "%d" b
+        else
+          printf "%d..%d" b e;
+        false
       in
-      Result.iter add_one xs;
-      let live_count = StringMap.fold (fun _ file_lines acc ->
-          StringMap.fold (fun _ fun_lines acc ->
-              acc + ISet.cardinal fun_lines
-            ) file_lines acc
-        ) !live_lines 0
-      in
-      printf "Live lines: %d\n" live_count;
-      let live file fn =
-        try StringMap.find fn (StringMap.find file !live_lines)
-        with Not_found -> BatISet.empty
-      in
-      dead_lines := StringMap.mapi (fun fi -> StringMap.mapi (fun fu ded -> BatISet.diff ded (live fi fu))) !dead_lines;
-      dead_lines := StringMap.map (StringMap.filter (fun _ x -> not (BatISet.is_empty x))) !dead_lines;
-      dead_lines := StringMap.filter (fun _ x -> not (StringMap.is_empty x)) !dead_lines;
-      let print_func f xs =
-        let one_range b e first =
-          count := !count + (e - b + 1);
-          if not first then printf ", ";
-          if b=e then
-            printf "%d" b
+      printf "  function '%s' has dead code on lines: " f;
+      ignore (BatISet.fold_range one_range xs true);
+      printf "\n"
+    in
+    let print_file f =
+      printf "File '%s':\n" f;
+      StringMap.iter print_func
+    in
+    if get_bool "dbg.print_dead_code" then (
+      if StringMap.is_empty !dead_lines
+      then printf "No lines with dead code found by solver (there might still be dead code removed by CIL).\n" (* TODO https://github.com/goblint/analyzer/issues/94 *)
+      else (
+        StringMap.iter print_file !dead_lines; (* populates count by side-effect *)
+        let total_dead = !count + uncalled_fn_loc in
+        printf "Found dead code on %d line%s%s!\n" total_dead (if total_dead>1 then "s" else "") (if uncalled_fn_loc > 0 then Printf.sprintf " (including %d in uncalled functions)" uncalled_fn_loc else "")
+      );
+      printf "Total lines (logical LoC): %d\n" (live_count + !count + uncalled_fn_loc); (* We can only give total LoC if we counted dead code *)
+    );
+    let str = function true -> "then" | false -> "else" in
+    let report tv (loc, dead) =
+      if Deadcode.Locmap.mem dead_locations loc then
+        match dead, Deadcode.Locmap.find_option Deadcode.dead_branches_cond loc with
+        | true, Some exp -> ignore (Pretty.printf "Dead code: the %s branch over expression '%a' is dead! (%a)\n" (str tv) d_exp exp CilType.Location.pretty loc)
+        | true, None     -> ignore (Pretty.printf "Dead code: an %s branch is dead! (%a)\n" (str tv) CilType.Location.pretty loc)
+        | _ -> ()
+    in
+    if get_bool "dbg.print_dead_code" then (
+      let by_fst (a,_) (b,_) = Stdlib.compare a b in
+      Deadcode.Locmap.to_list Deadcode.dead_branches_then |> List.sort by_fst |> List.iter (report true) ;
+      Deadcode.Locmap.to_list Deadcode.dead_branches_else |> List.sort by_fst |> List.iter (report false) ;
+      Deadcode.Locmap.clear Deadcode.dead_branches_then;
+      Deadcode.Locmap.clear Deadcode.dead_branches_else
+    );
+    NH.mem live_nodes
+
+  (* convert result that can be out-put *)
+  let solver2source_result h : Result.t =
+    (* processed result *)
+    let res = Result.create 113 in
+
+    (* Adding the state at each system variable to the final result *)
+    let add_local_var (n,es) state =
+      (* Not using Node.location here to have updated locations in incremental analysis.
+          See: https://github.com/goblint/analyzer/issues/290#issuecomment-881258091. *)
+      let loc = UpdateCil.getLoc n in
+      if loc <> locUnknown then try
+          let fundec = Node.find_fundec n in
+          if Result.mem res n then
+            (* If this source location has been added before, we look it up
+              * and add another node to it information to it. *)
+            let prev = Result.find res n in
+            Result.replace res n (LT.add (es,state,fundec) prev)
           else
-            printf "%d..%d" b e;
-          false
-        in
-        printf "  function '%s' has dead code on lines: " f;
-        ignore (BatISet.fold_range one_range xs true);
-        printf "\n"
-      in
-      let print_file f =
-        printf "File '%s':\n" f;
-        StringMap.iter print_func
-      in
-      if get_bool "dbg.print_dead_code" then (
-        if StringMap.is_empty !dead_lines
-        then printf "No lines with dead code found by solver (there might still be dead code removed by CIL).\n" (* TODO https://github.com/goblint/analyzer/issues/94 *)
-        else (
-          StringMap.iter print_file !dead_lines; (* populates count by side-effect *)
-          let total_dead = !count + uncalled_fn_loc in
-          printf "Found dead code on %d line%s%s!\n" total_dead (if total_dead>1 then "s" else "") (if uncalled_fn_loc > 0 then Printf.sprintf " (including %d in uncalled functions)" uncalled_fn_loc else "")
-        );
-        printf "Total lines (logical LoC): %d\n" (live_count + !count + uncalled_fn_loc); (* We can only give total LoC if we counted dead code *)
-      );
-      let str = function true -> "then" | false -> "else" in
-      let report tv (loc, dead) =
-        if Deadcode.Locmap.mem dead_locations loc then
-          match dead, Deadcode.Locmap.find_option Deadcode.dead_branches_cond loc with
-          | true, Some exp -> ignore (Pretty.printf "Dead code: the %s branch over expression '%a' is dead! (%a)\n" (str tv) d_exp exp CilType.Location.pretty loc)
-          | true, None     -> ignore (Pretty.printf "Dead code: an %s branch is dead! (%a)\n" (str tv) CilType.Location.pretty loc)
-          | _ -> ()
-      in
-      if get_bool "dbg.print_dead_code" then (
-        let by_fst (a,_) (b,_) = Stdlib.compare a b in
-        Deadcode.Locmap.to_list Deadcode.dead_branches_then |> List.sort by_fst |> List.iter (report true) ;
-        Deadcode.Locmap.to_list Deadcode.dead_branches_else |> List.sort by_fst |> List.iter (report false) ;
-        Deadcode.Locmap.clear Deadcode.dead_branches_then;
-        Deadcode.Locmap.clear Deadcode.dead_branches_else
-      );
-      NH.mem live_nodes
+            Result.add res n (LT.singleton (es,state,fundec))
+        (* If the function is not defined, and yet has been included to the
+          * analysis result, we generate a warning. *)
+        with Not_found ->
+          Messages.warn ("Calculated state for undefined function: unexpected node "^Ana.sprint Node.pretty_plain n)
     in
+    LHT.iter add_local_var h;
+    res
 
-    (* convert result that can be out-put *)
-    let solver2source_result h : Result.t =
-      (* processed result *)
-      let res = Result.create 113 in
-
-      (* Adding the state at each system variable to the final result *)
-      let add_local_var (n,es) state =
-        (* Not using Node.location here to have updated locations in incremental analysis.
-           See: https://github.com/goblint/analyzer/issues/290#issuecomment-881258091. *)
-        let loc = UpdateCil.getLoc n in
-        if loc <> locUnknown then try
-            let fundec = Node.find_fundec n in
-            if Result.mem res n then
-              (* If this source location has been added before, we look it up
-               * and add another node to it information to it. *)
-              let prev = Result.find res n in
-              Result.replace res n (LT.add (es,state,fundec) prev)
-            else
-              Result.add res n (LT.singleton (es,state,fundec))
-          (* If the function is not defined, and yet has been included to the
-           * analysis result, we generate a warning. *)
-          with Not_found ->
-            Messages.warn ("Calculated state for undefined function: unexpected node "^Ana.sprint Node.pretty_plain n)
-      in
-      LHT.iter add_local_var h;
-      res
-    in
+  (** The main function to preform the selected analyses. *)
+  let analyze (file: file) (startfuns, exitfuns, otherfuns: Analyses.fundecs) =
 
     (* exctract global xml from result *)
     let make_global_fast_xml f g =
@@ -586,22 +582,20 @@ struct
 
     if get_bool "dbg.verbose" && get_string "result" <> "none" then print_endline ("Generating output: " ^ get_string "result");
     Result.output (lazy local_xml) gh make_global_fast_xml file
-
-
-  let analyze file fs change_info =
-    analyze file fs (get_spec ()) change_info
-
-  let rec analyze_loop file fs change_info =
-    try
-      analyze file fs change_info
-    with Refinement.RestartAnalysis ->
-      (* Tail-recursively restart the analysis again, when requested.
-         All solving starts from scratch.
-         Whoever raised the exception should've modified some global state
-         to do a more precise analysis next time. *)
-      (* TODO: do some more incremental refinement and reuse parts of solution *)
-      analyze_loop file fs change_info
 end
+
+let rec analyze_loop (module CFG : CfgBidir) file fs change_info =
+  try
+    let (module Spec) = get_spec () in
+    let module A = AnalyzeCFG (CFG) (Spec) (struct let increment = change_info end) in
+    A.analyze file fs
+  with Refinement.RestartAnalysis ->
+    (* Tail-recursively restart the analysis again, when requested.
+        All solving starts from scratch.
+        Whoever raised the exception should've modified some global state
+        to do a more precise analysis next time. *)
+    (* TODO: do some more incremental refinement and reuse parts of solution *)
+    analyze_loop (module CFG) file fs change_info
 
 let compute_cfg file =
   let cfgF, cfgB = CfgTools.getCFG file in
@@ -616,5 +610,4 @@ let compute_cfg file =
 let analyze change_info (file: file) fs =
   if (get_bool "dbg.verbose") then print_endline "Generating the control flow graph.";
   let (module CFG) = compute_cfg file in
-  let module A = AnalyzeCFG (CFG) in
-  A.analyze_loop file fs change_info
+  analyze_loop (module CFG) file fs change_info


### PR DESCRIPTION
This way, module definitions like `EQSys`, `LHT`, `GHT` & `Slvr` and functions like `solver2source_result` & `print_dead_code` become accessible from other modules. I also pulled `analyze_loop` out of `AnalyzeCFG` and modified it a bit to keep the recursive restarting behavior.