### PR TITLE
Use fork of Zarith

### DIFF
--- a/goblint.opam
+++ b/goblint.opam
@@ -50,4 +50,5 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 pin-depends: [
   [ "goblint-cil.1.8.1" "git+https://github.com/goblint/cil.git#208d2a2f9e51a42ee0a036f4587624ac7ac23ccb" ]
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
+  [ "zarith.1.12-gob0" "git+https://github.com/goblint/Zarith.git#goblint-release-1.12" ]
 ]

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -48,7 +48,7 @@ depends: [
   "sexplib0" {= "v0.14.0"}
   "stdlib-shims" {= "0.3.0"}
   "yojson" {= "1.7.0"}
-  "zarith" {= "1.12"}
+  "zarith" {= "1.12-gob0"}
   "zarith_stubs_js" {= "v0.14.0"}
 ]
 build: [
@@ -69,6 +69,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 pin-depends: [
   [ "goblint-cil.1.8.1" "git+https://github.com/goblint/cil.git#208d2a2f9e51a42ee0a036f4587624ac7ac23ccb" ]
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
+  [ "zarith.1.12-gob0" "git+https://github.com/goblint/Zarith.git#goblint-release-1.12" ]
 ]
 name: "goblint"
 version: "dev"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -1,4 +1,5 @@
 pin-depends: [
   [ "goblint-cil.1.8.1" "git+https://github.com/goblint/cil.git#208d2a2f9e51a42ee0a036f4587624ac7ac23ccb" ]
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
+  [ "zarith.1.12-gob0" "git+https://github.com/goblint/Zarith.git#goblint-release-1.12" ]
 ]


### PR DESCRIPTION
Use [this fork](https://github.com/goblint/Zarith/tree/goblint) of Zarith to support the deserialization of small ints in the browser. You can read [this document](https://github.com/goblint/Zarith/raw/goblint/goblint/main.pdf) to learn more about the complete rationale behind the changes I made.

For the release branch of this fork, I bundle all my changes in [a single patch file](https://github.com/goblint/Zarith/blob/goblint-release-1.12/goblint.patch). Opam applies it only when Js_of_ocaml appears to be available in the opam environment. As a result, switching to this fork should be fairly safe because, in most cases, the code will not differ in any way from the original Zarith code.