### PR TITLE
Fix over/underflow handling in OctApron EvalInt

### DIFF
--- a/src/cdomains/apron/octApronDomain.apron.ml
+++ b/src/cdomains/apron/octApronDomain.apron.ml
@@ -525,8 +525,8 @@ struct
     else
       match eval_interval_expr d e with
       | (Some min, Some max) -> ID.of_interval ik (min, max)
-      | (Some min, None) -> ID.starting ik min
-      | (None, Some max) -> ID.ending ik max
+      | (Some min, None) -> if GobConfig.get_bool "ana.octapron.no_signed_overflow" && Cil.isSigned ik then ID.starting ik min else ID.top ()
+      | (None, Some max) -> if GobConfig.get_bool "ana.octapron.no_signed_overflow" && Cil.isSigned ik then ID.ending ik max else ID.top ()
       | (None, None) -> ID.top ()
 
 

--- a/tests/regression/36-octapron/61-problem.c
+++ b/tests/regression/36-octapron/61-problem.c
@@ -1,0 +1,10 @@
+// SKIP PARAM: --sets ana.activated[+] octApron --enable ana.int.interval
+int main(void) {
+  unsigned int x = 10;
+
+  while (x >= 10) {
+    x += 2;
+  }
+
+  assert(1);
+}


### PR DESCRIPTION
In `EvalInt` in Octapron we evaluate the expression to an interval, and then create an `ID.interval`.
If the octagon has both an upper and a lower bound, this is done via `ID.of_interval ik`, which correctly checks if `min` or `max` are outside the bounds and goes to top.

However, if one of the bounds is missing, we used `Id.starting ik` and `ID.ending ik`, replacing the missing bound with the limit of the corresponding type. However, this is only sound when no overflow can have occurred (which we cannot know if we don't have one of the bounds) or the type is signed and we assume NO UB.

For assignments, this is correctly handled by `assign_var_handling_underflow_overflow`.

Closes #318.