### PR TITLE
Congruence: Account for overflow for definite values in normalize

### DIFF
--- a/tests/regression/38-int-refinements/03-more-problem.c
+++ b/tests/regression/38-int-refinements/03-more-problem.c
@@ -1,0 +1,17 @@
+//PARAM: --sets ana.int.refinement once --enable ana.int.interval --enable ana.int.congruence --disable ana.int.def_exc
+
+int main(void)
+{
+  int ret = 0;
+  unsigned int s__version;
+  if (s__version + 65280 != 768)
+  {
+    ret = 0;
+  }
+  else
+  {
+    ret = 1;
+  }
+
+  assert(ret == 0); //UNKNOWN!
+}


### PR DESCRIPTION
Previosuly, we did not account for overflows of definite values in normalize for congruences.
With refinement enabled, this can lead to erroneous bottom values and therefore false claims of unrechability.

Fixes #333  