### PR TITLE
Add semgrep for custom scanning of Goblint code

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,51 @@
+name: Semgrep
+
+on:
+  # Scan changed files in PRs, block on new issues only (existing issues ignored)
+  pull_request: {}
+
+  # Scan all files on branches, block on any issues
+  # push:
+  #   branches: ["master", "main"]
+
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    # Skip any PR created by dependabot to avoid permission issues
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      # Fetch project source
+      - uses: actions/checkout@v2
+
+      - uses: returntocorp/semgrep-action@v1
+        with:
+          config: >- # more at semgrep.dev/explore
+            p/security-audit
+            p/secrets
+
+        # == Optional settings in the `with:` block
+
+        # Instead of `config:`, use rules set in Semgrep App.
+        # Get your credentials from semgrep.dev/manage/settings.
+        #   publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
+        #   publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
+
+        # Never fail the build due to findings on pushes.
+        # Instead, just collect findings for semgrep.dev/manage/findings
+        #   auditOn: push
+
+        # Upload findings to GitHub Advanced Security Dashboard [step 1/2]
+        # See also the next step.
+        #   generateSarif: "1"
+
+        # Change job timeout (default is 1800 seconds; set to 0 to disable)
+        # env:
+        #   SEMGREP_TIMEOUT: 300
+
+      # Upload findings to GitHub Advanced Security Dashboard [step 2/2]
+      # - name: Upload SARIF file for GitHub Advanced Security Dashboard
+      #   uses: github/codeql-action/upload-sarif@v1
+      #   with:
+      #     sarif_file: semgrep.sarif
+      #   if: always()

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,51 +1,26 @@
-name: Semgrep
+name: semgrep
 
 on:
-  # Scan changed files in PRs, block on new issues only (existing issues ignored)
-  pull_request: {}
-
-  # Scan all files on branches, block on any issues
-  # push:
-  #   branches: ["master", "main"]
+  push:
+  pull_request:
 
 jobs:
   semgrep:
-    name: Scan
     runs-on: ubuntu-latest
-    # Skip any PR created by dependabot to avoid permission issues
-    if: (github.actor != 'dependabot[bot]')
+
     steps:
-      # Fetch project source
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-      - uses: returntocorp/semgrep-action@v1
+      - name: Run semgrep
+        uses: returntocorp/semgrep-action@v1
         with:
-          config: >- # more at semgrep.dev/explore
-            p/security-audit
-            p/secrets
+          config: >-
+            .semgrep/
+          generateSarif: "1"
 
-        # == Optional settings in the `with:` block
-
-        # Instead of `config:`, use rules set in Semgrep App.
-        # Get your credentials from semgrep.dev/manage/settings.
-        #   publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
-        #   publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
-
-        # Never fail the build due to findings on pushes.
-        # Instead, just collect findings for semgrep.dev/manage/findings
-        #   auditOn: push
-
-        # Upload findings to GitHub Advanced Security Dashboard [step 1/2]
-        # See also the next step.
-        #   generateSarif: "1"
-
-        # Change job timeout (default is 1800 seconds; set to 0 to disable)
-        # env:
-        #   SEMGREP_TIMEOUT: 300
-
-      # Upload findings to GitHub Advanced Security Dashboard [step 2/2]
-      # - name: Upload SARIF file for GitHub Advanced Security Dashboard
-      #   uses: github/codeql-action/upload-sarif@v1
-      #   with:
-      #     sarif_file: semgrep.sarif
-      #   if: always()
+      - name: Upload SARIF file to GitHub Advanced Security Dashboard
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: semgrep.sarif
+        if: always()

--- a/.semgrep/cil.yml
+++ b/.semgrep/cil.yml
@@ -1,0 +1,14 @@
+rules:
+  - id: cilfacade
+    pattern-either:
+      - pattern: Cil.typeOf
+      - pattern: Cil.typeOfLval
+      - pattern: Cil.typeOfInit
+      - pattern: Cil.typeOffset
+      - pattern: Cil.get_stmtLoc
+    paths:
+      exclude:
+        - cilfacade.ml
+    message: use Cilfacade instead
+    languages: [ocaml]
+    severity: WARNING

--- a/.semgrep/tracing.yml
+++ b/.semgrep/tracing.yml
@@ -1,0 +1,14 @@
+rules:
+  - id: trace-not-in-tracing
+    patterns:
+      - pattern-either:
+        - pattern: Messages.trace
+        - pattern: Messages.tracel
+        - pattern: Messages.tracei
+        - pattern: Messages.tracec
+        - pattern: Messages.traceu
+        - pattern: Messages.traceli
+      - pattern-not-inside: if Messages.tracing then ...
+    message: trace functions should only be called if tracing is enabled at compile time
+    languages: [ocaml]
+    severity: WARNING

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -429,7 +429,7 @@ module Size = struct (* size in bits as int, range as int64 *)
       else if lt_big_int y a then add_big_int y c
       else y
     in
-    M.tracel "cast_int" "Cast %s to range [%s, %s] (%s) = %s (%s in int64)\n" (string_of_big_int x) (string_of_big_int a) (string_of_big_int b) (string_of_big_int c) (string_of_big_int y) (if is_int64_big_int y then "fits" else "does not fit");
+    if M.tracing then M.tracel "cast_int" "Cast %s to range [%s, %s] (%s) = %s (%s in int64)\n" (string_of_big_int x) (string_of_big_int a) (string_of_big_int b) (string_of_big_int c) (string_of_big_int y) (if is_int64_big_int y then "fits" else "does not fit");
     y
   let cast t x =
     let x' = big_int_of_int64 x in

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -161,7 +161,7 @@ let createCFG (file: file) =
     NH.replace fd_nodes toNode ();
     H.add cfgB toNode (edges,fromNode);
     H.add cfgF fromNode (edges,toNode);
-    Messages.trace "cfg" "done\n\n"
+    if Messages.tracing then Messages.trace "cfg" "done\n\n"
   in
   let addEdge fromNode edge toNode = addEdges fromNode [edge] toNode in
   let addEdge_fromLoc fromNode edge toNode = addEdge fromNode (Node.location fromNode, edge) toNode in

--- a/src/solvers/generic.ml
+++ b/src/solvers/generic.ml
@@ -520,7 +520,7 @@ module SoundBoxSolverImpl =
           H.remove infl x;
           H.replace infl x [x];
           if full_trace
-          then Messages.trace "sol" "Need to review %d deps.\n" (List.length deps);
+          then Messages.trace "sol" "Need to review %d deps.\n" (List.length deps); (* nosemgrep: semgrep.trace-not-in-tracing *)
           (* solve all dependencies *)
           solve_all deps
         end


### PR DESCRIPTION
I heard about this [semgrep](https://semgrep.dev/) tool and tried it out on Goblint's own code since it supports OCaml. It allows writing custom code scanning rules (e.g. specific to our tracing like I did here) fairly easily and running them on the CI (with SARIF output to GitHub Security tab!). Semgrep itself is open-source and runs independently of whatever (possibly paid) services they offer on their own, so there shouldn't be excessive vendor lock-in.

This might be useful if we can encode common student code issues using semgrep rules for future automatic checking. If anyone has any other rule ideas right away, feel free to suggest them.