### PR TITLE
Make malloc-ed variables non-unique

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -127,7 +127,7 @@ struct
     | b -> (fun x y -> (ID.top_of result_ik))
 
   (* Evaluate binop for two abstract values: *)
-  let evalbinop (st: store) (op: binop) (t1:typ) (a1:value) (t2:typ) (a2:value) (t:typ) :value =
+  let evalbinop (a: Q.ask) (st: store) (op: binop) (t1:typ) (a1:value) (t2:typ) (a2:value) (t:typ) :value =
     if M.tracing then M.tracel "eval" "evalbinop %a %a %a\n" d_binop op VD.pretty a1 VD.pretty a2;
     (* We define a conversion function for the easy cases when we can just use
      * the integer domain operations. *)
@@ -219,7 +219,7 @@ struct
               else (
                 (* If the address id definite, it should be one or no variables *)
                 assert (List.length v = 1);
-                if WeakUpdates.mem (List.hd v) st.weak then
+                if a.f (Q.IsMultiple (List.hd v)) then
                   None
                 else
                   Some true
@@ -734,13 +734,13 @@ struct
         else
           let a1 = eval_rv a gs st c1 in
           let a2 = eval_rv a gs st c2 in
-          evalbinop st op t1 a1 t2 a2 typ
+          evalbinop a st op t1 a1 t2 a2 typ
       | BinOp (op,arg1,arg2,typ) ->
         let a1 = eval_rv a gs st arg1 in
         let a2 = eval_rv a gs st arg2 in
         let t1 = Cilfacade.typeOf arg1 in
         let t2 = Cilfacade.typeOf arg2 in
-        evalbinop st op t1 a1 t2 a2 typ
+        evalbinop a st op t1 a1 t2 a2 typ
       (* Unary operators *)
       | UnOp (op,arg1,typ) ->
         let a1 = eval_rv a gs st arg1 in

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -544,7 +544,7 @@ struct
           ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
           ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
           ; sideg  = (fun v g    -> sides := (v, (n, repr g)) :: !sides)
-          (* sideg is forbidden in query, because they would bypass sides grouping in other transfer functions.
+          (* sideg is discouraged in query, because they would bypass sides grouping in other transfer functions.
              See https://github.com/goblint/analyzer/pull/214. *)
           ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in query context.")
           }

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -527,6 +527,7 @@ struct
       Result.top () (* query cycle *)
     else
       let asked' = QuerySet.add (Any q) asked in
+      let sides = ref [] in
       let f a (n,(module S:MCPSpec),d) =
         let ctx' : (S.D.t, S.G.t, S.C.t) ctx =
           { local  = obj d
@@ -542,7 +543,7 @@ struct
           ; global = (fun v      -> ctx.global v |> assoc n |> obj)
           ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
           ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
-          ; sideg  = (fun v g    -> failwith "Cannot \"sideg\" in query context.")
+          ; sideg  = (fun v g    -> sides := (v, (n, repr g)) :: !sides)
           (* sideg is forbidden in query, because they would bypass sides grouping in other transfer functions.
              See https://github.com/goblint/analyzer/pull/214. *)
           ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in query context.")
@@ -560,7 +561,9 @@ struct
         (* 2x speed difference on SV-COMP nla-digbench-scaling/ps6-ll_valuebound5.c *)
         f (Result.top ()) (!base_id, spec !base_id, assoc !base_id ctx.local) *)
       | _ ->
-        fold_left f (Result.top ()) @@ spec_list ctx.local
+        let r = fold_left f (Result.top ()) @@ spec_list ctx.local in
+        do_sideg ctx !sides;
+        r
 
   and query: type a. (D.t, G.t, C.t) ctx -> a Queries.t -> a Queries.result = fun ctx q ->
     query' QuerySet.empty ctx q

--- a/src/analyses/mallocWrapperAnalysis.ml
+++ b/src/analyses/mallocWrapperAnalysis.ml
@@ -56,8 +56,14 @@ struct
   let exitstate  v = D.top ()
 
   let heap_hash = Hashtbl.create 113
+  (* This hashtable is not marshaled, which is a problem.
+     But since Goblintutil.create_var is deterministic w.r.t the name containing location,
+     then it gets identically reconstructed when unmarshaling and verifying. *)
 
   let get_heap_var sideg loc =
+    (* Use existing varinfo instead of allocating a duplicate,
+       which would be equal by determinism of create_var though. *)
+    (* TODO: is this poor man's hashconsing? *)
     try Hashtbl.find heap_hash loc
     with Not_found ->
       let name = "(alloc@" ^ CilType.Location.show loc ^ ")" in

--- a/src/analyses/mallocWrapperAnalysis.ml
+++ b/src/analyses/mallocWrapperAnalysis.ml
@@ -76,6 +76,8 @@ struct
       `Lifted (get_heap_var loc)
     | Q.IsHeapVar v ->
       Hashtbl.mem heap_vars v.vid
+    | Q.IsMultiple v ->
+      Hashtbl.mem heap_vars v.vid
     | _ -> Queries.Result.top q
 
     let init () =

--- a/tests/regression/02-base/60-malloc-nonrefl.c
+++ b/tests/regression/02-base/60-malloc-nonrefl.c
@@ -9,11 +9,11 @@ int main() {
     int* ptr1 = malloc_2(sizeof(int));
     int* ptr2 = malloc_2(sizeof(int));
 
-    // This is technically UB (comparing unrelated pointers)
-    assert(ptr1==ptr2); // UNKNOWN!
+    // will fail in the concrete
+    assert(ptr1==ptr2); // UNKNOWN
 
-    // CIL turn this into the following, that is not UB and will fail in the concrete
-    assert((unsigned long) ptr1 == (unsigned long) ptr2); // UNKNOWN!
+    // CIL turns this into the following
+    assert((unsigned long) ptr1 == (unsigned long) ptr2); // UNKNOWN
 
     // Here, we do not claim it holds, as we cast our abstract values to the type for ints on assignment
     int i1 =  (int)ptr1;

--- a/tests/regression/02-base/60-malloc-nonrefl.c
+++ b/tests/regression/02-base/60-malloc-nonrefl.c
@@ -1,0 +1,25 @@
+#include<stdlib.h>
+#include<stdint.h>
+
+void* malloc_2(size_t s) {
+    return malloc(s);
+}
+
+int main() {
+    int* ptr1 = malloc_2(sizeof(int));
+    int* ptr2 = malloc_2(sizeof(int));
+
+    // This is technically UB (comparing unrelated pointers)
+    assert(ptr1==ptr2);
+
+    // CIL turn this into the following, that is not UB and will fail in the concrete
+    // Goblint claims that this holds
+    assert((unsigned long) ptr1 == (unsigned long) ptr2); // UNKNOWN!
+
+    // Here, we do not claim it holds, as we cast our abstract values to the type for ints on assignment
+    int i1 =  (int)ptr1;
+    int i2 =  (int)ptr2;
+    assert(i1 == i2);
+
+    return 0;
+}

--- a/tests/regression/02-base/60-malloc-nonrefl.c
+++ b/tests/regression/02-base/60-malloc-nonrefl.c
@@ -13,7 +13,6 @@ int main() {
     assert(ptr1==ptr2); // UNKNOWN!
 
     // CIL turn this into the following, that is not UB and will fail in the concrete
-    // Goblint claims that this holds
     assert((unsigned long) ptr1 == (unsigned long) ptr2); // UNKNOWN!
 
     // Here, we do not claim it holds, as we cast our abstract values to the type for ints on assignment

--- a/tests/regression/02-base/60-malloc-nonrefl.c
+++ b/tests/regression/02-base/60-malloc-nonrefl.c
@@ -10,7 +10,7 @@ int main() {
     int* ptr2 = malloc_2(sizeof(int));
 
     // This is technically UB (comparing unrelated pointers)
-    assert(ptr1==ptr2);
+    assert(ptr1==ptr2); // UNKNOWN!
 
     // CIL turn this into the following, that is not UB and will fail in the concrete
     // Goblint claims that this holds
@@ -19,7 +19,7 @@ int main() {
     // Here, we do not claim it holds, as we cast our abstract values to the type for ints on assignment
     int i1 =  (int)ptr1;
     int i2 =  (int)ptr2;
-    assert(i1 == i2);
+    assert(i1 == i2); // UNKNOWN!
 
     return 0;
 }


### PR DESCRIPTION
Closes #316.

This implements the solution proposed in https://github.com/goblint/analyzer/pull/310#discussion_r700056687. By answering `IsMultiple` query for malloc-ed variables with false, the address set equality check introduced in #310 automatically considers this non-uniqueness information.

This should be sound and good enough until we design a more precise malloc uniqueness analysis (#186).