### PR TITLE
Add CITATION file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,25 +1,32 @@
 cff-version: 1.2.0
 
-preferred-citation:
-  type: conference-paper # this corresponds to inproceedings in BibTex: https://github.com/citation-file-format/ruby-cff/blob/d5b8dac597946d01e52967cf160325bf6218f9f6/lib/cff/formatter/bibtex_formatter.rb#L86-L87
-  authors:
-    - given-names: Vesal
-      family-names: Vojdani
-    - given-names: Kalmer
-      family-names: Apinis
-    - given-names: Vootele
-      family-names: Rõtov
-    - given-names: Helmut
-      family-names: Seidl
-    - given-names: Varmo
-      family-names: Vene
-    - given-names: Ralf
-      family-names: Vogler
-  title: "Static race detection for device drivers: the Goblint approach"
-  collection-title: "Proceedings of the 31st IEEE/ACM International Conference on Automated Software Engineering, ASE 2016" # not used by GitHub
-  start: 391
-  end: 402
-  publisher:
-    name: ACM # not used by GitHub
-  year: 2016 # not used by GitHub
-  doi: 10.1145/2970276.2970337
+message: "If you use this software, please cite it using the metadata from this file." # message required
+
+title: "Goblint"
+abstract: "Static analysis framework for C"
+authors: # same authors as in dune-project
+  - given-names: Vesal
+    family-names: Vojdani
+    affiliation: "University of Tartu"
+  - given-names: Kalmer
+    family-names: Apinis
+    affiliation: "University of Tartu"
+  - given-names: Ralf
+    family-names: Vogler
+    affiliation: "Technische Universität München"
+  - given-names: Michael
+    family-names: Schwarz
+    affiliation: "Technische Universität München"
+  - given-names: Julian
+    family-names: Erhard
+    affiliation: "Technische Universität München"
+  - given-names: Simmo
+    family-names: Saan
+    orcid: "https://orcid.org/0000-0003-4553-1350"
+    affiliation: "University of Tartu"
+
+license: MIT
+repository-code: "https://github.com/goblint/analyzer"
+url: "https://goblint.in.tum.de"
+
+# TODO: concept doi after publishing on Zenodo

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 
 preferred-citation:
-  type: conference # CFF doesn't have inproceedings, but in BibTex conference is an alias for inproceedings
+  type: conference-paper # this corresponds to inproceedings in BibTex: https://github.com/citation-file-format/ruby-cff/blob/d5b8dac597946d01e52967cf160325bf6218f9f6/lib/cff/formatter/bibtex_formatter.rb#L86-L87
   authors:
     - given-names: Vesal
       family-names: Vojdani

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,7 @@
 cff-version: 1.2.0
+
 preferred-citation:
-  type: proceedings
+  type: conference # CFF doesn't have inproceedings, but in BibTex conference is an alias for inproceedings
   authors:
     - given-names: Vesal
       family-names: Vojdani
@@ -15,10 +16,10 @@ preferred-citation:
     - given-names: Ralf
       family-names: Vogler
   title: "Static race detection for device drivers: the Goblint approach"
-  collection-title: "Proceedings of the 31st IEEE/ACM International Conference on Automated Software Engineering, ASE 2016"
+  collection-title: "Proceedings of the 31st IEEE/ACM International Conference on Automated Software Engineering, ASE 2016" # not used by GitHub
   start: 391
   end: 402
   publisher:
-    name: ACM
-  year: 2016
+    name: ACM # not used by GitHub
+  year: 2016 # not used by GitHub
   doi: 10.1145/2970276.2970337

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+preferred-citation:
+  type: proceedings
+  authors:
+    - given-names: Vesal
+      family-names: Vojdani
+    - given-names: Kalmer
+      family-names: Apinis
+    - given-names: Vootele
+      family-names: Rõtov
+    - given-names: Helmut
+      family-names: Seidl
+    - given-names: Varmo
+      family-names: Vene
+    - given-names: Ralf
+      family-names: Vogler
+  title: "Static race detection for device drivers: the Goblint approach"
+  collection-title: "Proceedings of the 31st IEEE/ACM International Conference on Automated Software Engineering, ASE 2016"
+  start: 391
+  end: 402
+  publisher:
+    name: ACM
+  year: 2016
+  doi: 10.1145/2970276.2970337

--- a/dune-project
+++ b/dune-project
@@ -14,13 +14,13 @@
 (source (github goblint/analyzer))
 (homepage "https://goblint.in.tum.de")
 (documentation "https://goblint.readthedocs.io/en/latest/")
-(authors "Vesal Vojdani" "Kalmer Apinis" "Ralf Vogler" "Michael Schwarz" "Julian Erhard" "Simmo Saan")
+(authors "Vesal Vojdani" "Kalmer Apinis" "Ralf Vogler" "Michael Schwarz" "Julian Erhard" "Simmo Saan") ; same authors as in CITATION.cff
 (maintainers "Michael Schwarz <michael.schwarz93@gmail.com>" "Simmo Saan <simmo.saan@gmail.com>" "Ralf Vogler <ralf.vogler@gmail.com>")
 (license MIT)
 
 (package
   (name goblint)
-  (synopsis "Static analysis framework for concurrent C")
+  (synopsis "Static analysis framework for C")
   (depends
     (ocaml (>= 4.09))
     dune


### PR DESCRIPTION
GitHub seems to have this new feature, where citation information can be added to a repository: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files.

I decided to try it out and make the citation to be the same ASE 2016 paper as our website suggests: http://goblint.in.tum.de/downloads. **Do we still want this or maybe a different one or maybe have no `preferred-citation` at all and have citation of the code repository specifically?**

You can see it in action on the right here: https://github.com/goblint/analyzer/tree/cff.
It's still quite limited as the CFF → BibTex conversion doesn't add all the data, so the output is just this:
```bibtex
@inproceedings{Vojdani_Static_race_detection,
author = {Vojdani, Vesal and Apinis, Kalmer and Rõtov, Vootele and Seidl, Helmut and Vene, Varmo and Vogler, Ralf},
doi = {10.1145/2970276.2970337},
pages = {391--402},
title = {{Static race detection for device drivers: the Goblint approach}}
}
```
Slightly weird since it doesn't even have the conference name and year, but at least the DOI is there.