### PR TITLE
Add per-function partial contexts using attributes

### DIFF
--- a/conf/minimal_incremental.json
+++ b/conf/minimal_incremental.json
@@ -12,11 +12,13 @@
       "context": {
         "non-ptr": false
       }
+    },
+    "context": {
+      "widen": true
     }
   },
   "exp": {
     "earlyglobs": true,
-    "widen-context": true,
     "solver": {
       "td3": {
         "term": true,

--- a/conf/minimal_incremental.json
+++ b/conf/minimal_incremental.json
@@ -7,11 +7,15 @@
       "interval": false,
       "trier ": true
     },
-    "hashcons": true
+    "hashcons": true,
+    "base": {
+      "context": {
+        "non-ptr": false
+      }
+    }
   },
   "exp": {
     "earlyglobs": true,
-    "non-ptr-context": false,
     "widen-context": true,
     "solver": {
       "td3": {

--- a/conf/minimal_incremental.json
+++ b/conf/minimal_incremental.json
@@ -11,7 +11,7 @@
   },
   "exp": {
     "earlyglobs": true,
-    "addr-context": true,
+    "non-ptr-context": false,
     "widen-context": true,
     "solver": {
       "td3": {

--- a/conf/svcomp.json
+++ b/conf/svcomp.json
@@ -21,13 +21,15 @@
       "symb_locks",
       "region",
       "thread"
-    ]
+    ],
+    "context": {
+      "widen": false
+    }
   },
   "exp": {
     "witness": {
       "id": "enumerate"
     },
-    "widen-context": false,
     "partition-arrays": {
       "enabled": true
     },

--- a/conf/svcomp21.json
+++ b/conf/svcomp21.json
@@ -21,13 +21,15 @@
       "symb_locks",
       "region",
       "thread"
-    ]
+    ],
+    "context": {
+      "widen": false
+    }
   },
   "exp": {
     "witness": {
       "id": "enumerate"
     },
-    "widen-context": false,
     "partition-arrays": {
       "enabled": true
     },

--- a/docs/user-guide/annotating.md
+++ b/docs/user-guide/annotating.md
@@ -1,0 +1,27 @@
+# Annotating code
+
+The analysis can be fine-tuned by annotating the source code.
+This page gives an overview of the supported means.
+
+## Attributes
+Attributes (`__attribute__`) can be attached to various source code elements.
+
+### Function attributes
+Attributes cannot be attached to a function definition directly, rather must be attached to a separate declaration.
+For example:
+```c
+int f(int x) __attribute__((goblint_context("no-widen")));
+int f(int x) {
+  // ...
+}
+```
+
+#### Context attributes
+The attribute `goblint_context` can be used to fine-tune function contexts.
+The following string arguments are supported:
+
+1. `base.interval`/`base.no-interval` to override the `ana.base.context.interval` option.
+2. `base.int`/`base.no-int` to override the `ana.base.context.interval` option.
+3. `base.non-ptr`/`base.no-non-ptr` to override the `ana.base.context.non-ptr` option.
+4. `apron.context`/`apron.no-context` to override the `ana.apron.context` option.
+5. `widen`/`no-widen` to override the `ana.context.widen` option.

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -29,4 +29,4 @@ For a list of all options and their possible configurations, run:
 In some cases, when using the default configuration, Goblint might not terminate in reasonable time on recursive programs, or
 crash in a stack overflow (indicated by the error message `exception Stack overflow`). If the stack overflow occurs within a C function called by Goblint, it will result in the following error message: `Command terminated by signal 11`.
 
-Adding the option `--enable exp.widen-context` will enable widening on the contexts in which functions are analyzed. This avoids stack overflows possibly caused by the analysis of recursive functions.
+Adding the option `--enable ana.context.widen` will enable widening on the contexts in which functions are analyzed. This avoids stack overflows possibly caused by the analysis of recursive functions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
   - 'User guide':
     - user-guide/running.md
     - user-guide/inspecting.md
+    - user-guide/annotating.md
   - 'Developer guide':
     - developer-guide/developing.md
     - developer-guide/firstanalysis.md

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -21,17 +21,10 @@ struct
   let should_join = Priv.should_join
 
   let context fd x =
-    let contextAttribute s = ContextUtil.hasAttribute s fd.svar.vattr in
-    match GobConfig.get_bool "ana.apron.no-context", contextAttribute "apron.no-context", contextAttribute "apron.context" with
-    | _, true, true ->
-      failwith ("conflicting apron context attributes on " ^ CilType.Fundec.show fd)
-    | _, false, true
-    | false, false, false ->
-      x (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
-    | true, _, false
-    | _, true, false ->
-      D.bot ()
-
+    if ContextUtil.shouldRemove ~removeOption:"ana.apron.no-context" ~removeAttr:"apron.no-context" ~keepAttr:"apron.context" fd then
+      D.bot () (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
+    else
+      x
 
   let exitstate  _ = { oct = AD.bot (); priv = Priv.startstate () }
   let startstate _ = { oct = AD.bot (); priv = Priv.startstate () }

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -21,7 +21,16 @@ struct
   let should_join = Priv.should_join
 
   let context fd x =
-    if GobConfig.get_bool "ana.apron.no-context" || Cilfacade.hasGoblintContextAttribute "apron.no-context" fd.svar.vattr then D.bot () else x (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
+    let contextAttribute s = Cilfacade.hasGoblintContextAttribute s fd.svar.vattr in
+    match GobConfig.get_bool "ana.apron.no-context", contextAttribute "apron.no-context", contextAttribute "apron.context" with
+    | _, true, true ->
+      failwith ("conflicting apron context attributes on " ^ CilType.Fundec.show fd)
+    | _, false, true
+    | false, false, false ->
+      x (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
+    | true, _, false
+    | _, true, false ->
+      D.bot ()
 
 
   let exitstate  _ = { oct = AD.bot (); priv = Priv.startstate () }

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -20,7 +20,8 @@ struct
 
   let should_join = Priv.should_join
 
-  let context fd x = if GobConfig.get_bool "ana.apron.no-context" then D.bot () else x (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
+  let context fd x =
+    if GobConfig.get_bool "ana.apron.no-context" || Cilfacade.hasGoblintContextAttribute "apron.no-context" fd.svar.vattr then D.bot () else x (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
 
 
   let exitstate  _ = { oct = AD.bot (); priv = Priv.startstate () }

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -21,10 +21,10 @@ struct
   let should_join = Priv.should_join
 
   let context fd x =
-    if ContextUtil.should_remove ~keepOption:"ana.apron.context" ~removeAttr:"apron.no-context" ~keepAttr:"apron.context" fd then
-      D.bot () (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
-    else
+    if ContextUtil.should_keep ~keepOption:"ana.apron.context" ~removeAttr:"apron.no-context" ~keepAttr:"apron.context" fd then
       x
+    else
+      D.bot () (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
 
   let exitstate  _ = { oct = AD.bot (); priv = Priv.startstate () }
   let startstate _ = { oct = AD.bot (); priv = Priv.startstate () }

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -21,7 +21,7 @@ struct
   let should_join = Priv.should_join
 
   let context fd x =
-    if ContextUtil.shouldRemove ~removeOption:"ana.apron.no-context" ~removeAttr:"apron.no-context" ~keepAttr:"apron.context" fd then
+    if ContextUtil.should_remove ~removeOption:"ana.apron.no-context" ~removeAttr:"apron.no-context" ~keepAttr:"apron.context" fd then
       D.bot () (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
     else
       x

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -21,7 +21,7 @@ struct
   let should_join = Priv.should_join
 
   let context fd x =
-    let contextAttribute s = Cilfacade.hasGoblintContextAttribute s fd.svar.vattr in
+    let contextAttribute s = ContextUtil.hasAttribute s fd.svar.vattr in
     match GobConfig.get_bool "ana.apron.no-context", contextAttribute "apron.no-context", contextAttribute "apron.context" with
     | _, true, true ->
       failwith ("conflicting apron context attributes on " ^ CilType.Fundec.show fd)

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -21,7 +21,7 @@ struct
   let should_join = Priv.should_join
 
   let context fd x =
-    if ContextUtil.should_remove ~removeOption:"ana.apron.no-context" ~removeAttr:"apron.no-context" ~keepAttr:"apron.context" fd then
+    if ContextUtil.should_remove ~keepOption:"ana.apron.context" ~removeAttr:"apron.no-context" ~keepAttr:"apron.context" fd then
       D.bot () (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
     else
       x

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -20,7 +20,7 @@ struct
 
   let should_join = Priv.should_join
 
-  let context x = if GobConfig.get_bool "ana.apron.no-context" then D.bot () else x (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
+  let context fd x = if GobConfig.get_bool "ana.apron.no-context" then D.bot () else x (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
 
 
   let exitstate  _ = { oct = AD.bot (); priv = Priv.startstate () }

--- a/src/analyses/arinc.ml
+++ b/src/analyses/arinc.ml
@@ -94,7 +94,7 @@ struct
 
   let sprint_map f xs = String.concat ", " @@ List.map (sprint f) xs
 
-  let context d = { d with pred = Pred.bot (); ctx = Ctx.bot () }
+  let context fd d = { d with pred = Pred.bot (); ctx = Ctx.bot () }
 
   (* function for creating a new intermediate node (will generate a new sid every time!) *)
   let mkDummyNode ?loc line =
@@ -261,7 +261,7 @@ struct
     (* if not (is_single ctx || !Goblintutil.global_initialization || fst (ctx.global part_mode_var)) then raise Analyses.Deadcode; *)
     (* checkPredBot ctx.local "body" f.svar [] *)
     let module BaseMain = (val Base.get_main ()) in
-    let base_context = BaseMain.context_cpa @@ Obj.obj @@ List.assoc "base" ctx.presub in
+    let base_context = BaseMain.context_cpa f @@ Obj.obj @@ List.assoc "base" ctx.presub in
     let context_hash = Hashtbl.hash (base_context, ctx.local.pid) in
     { ctx.local with ctx = Ctx.of_int (Int64.of_int context_hash) }
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -469,7 +469,6 @@ struct
   let drop_interval = CPA.map (function `Int x -> `Int (ID.no_interval x) | x -> x)
 
   let context (fd: fundec) (st: store): store =
-    (* TODO: use fd attrs *)
     let f keep drop_fn (st: store) = if keep then st else { st with cpa = drop_fn st.cpa} in
     st |>
     f (not !GU.earlyglobs) (CPA.filter (fun k v -> not (V.is_global k) || is_precious_glob k))

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -470,12 +470,12 @@ struct
 
   let context (fd: fundec) (st: store): store =
     (* TODO: use fd attrs *)
-    let f t f (st: store) = if t then { st with cpa = f st.cpa} else st in
+    let f keep drop_fn (st: store) = if keep then st else { st with cpa = drop_fn st.cpa} in
     st |>
-    f !GU.earlyglobs (CPA.filter (fun k v -> not (V.is_global k) || is_precious_glob k))
-    %> f (not (get_bool "exp.non-ptr-context")) drop_non_ptrs
-    %> f (not (get_bool "exp.int-context")) drop_ints
-    %> f (not (get_bool "exp.interval-context")) drop_interval
+    f (not !GU.earlyglobs) (CPA.filter (fun k v -> not (V.is_global k) || is_precious_glob k))
+    %> f (get_bool "exp.non-ptr-context") drop_non_ptrs
+    %> f (get_bool "exp.int-context") drop_ints
+    %> f (get_bool "exp.interval-context") drop_interval
 
   let context_cpa fd (st: store) = (context fd st).cpa
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -474,7 +474,7 @@ struct
     st |>
     f !GU.earlyglobs (CPA.filter (fun k v -> not (V.is_global k) || is_precious_glob k))
     %> f (get_bool "exp.addr-context") drop_non_ptrs
-    %> f (get_bool "exp.no-int-context") drop_ints
+    %> f (not (get_bool "exp.int-context")) drop_ints
     %> f (not (get_bool "exp.interval-context")) drop_interval
 
   let context_cpa fd (st: store) = (context fd st).cpa

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -469,6 +469,7 @@ struct
   let drop_interval = CPA.map (function `Int x -> `Int (ID.no_interval x) | x -> x)
 
   let context (fd: fundec) (st: store): store =
+    (* TODO: use fd attrs *)
     let f t f (st: store) = if t then { st with cpa = f st.cpa} else st in
     st |>
     f !GU.earlyglobs (CPA.filter (fun k v -> not (V.is_global k) || is_precious_glob k))

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -473,7 +473,7 @@ struct
     let f t f (st: store) = if t then { st with cpa = f st.cpa} else st in
     st |>
     f !GU.earlyglobs (CPA.filter (fun k v -> not (V.is_global k) || is_precious_glob k))
-    %> f (get_bool "exp.addr-context") drop_non_ptrs
+    %> f (not (get_bool "exp.non-ptr-context")) drop_non_ptrs
     %> f (not (get_bool "exp.int-context")) drop_ints
     %> f (not (get_bool "exp.interval-context")) drop_interval
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -473,9 +473,9 @@ struct
     let f keep drop_fn (st: store) = if keep then st else { st with cpa = drop_fn st.cpa} in
     st |>
     f (not !GU.earlyglobs) (CPA.filter (fun k v -> not (V.is_global k) || is_precious_glob k))
-    %> f (get_bool "ana.base.context.non-ptr") drop_non_ptrs
-    %> f (get_bool "ana.base.context.int") drop_ints
-    %> f (get_bool "ana.base.context.interval") drop_interval
+    %> f (ContextUtil.should_keep ~keepOption:"ana.base.context.non-ptr" ~removeAttr:"base.no-non-ptr" ~keepAttr:"base.non-ptr" fd) drop_non_ptrs
+    %> f (ContextUtil.should_keep ~keepOption:"ana.base.context.int" ~removeAttr:"base.no-int" ~keepAttr:"base.int" fd) drop_ints
+    %> f (ContextUtil.should_keep ~keepOption:"ana.base.context.interval" ~removeAttr:"base.no-interval" ~keepAttr:"base.interval" fd) drop_interval
 
   let context_cpa fd (st: store) = (context fd st).cpa
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -473,9 +473,9 @@ struct
     let f keep drop_fn (st: store) = if keep then st else { st with cpa = drop_fn st.cpa} in
     st |>
     f (not !GU.earlyglobs) (CPA.filter (fun k v -> not (V.is_global k) || is_precious_glob k))
-    %> f (get_bool "exp.non-ptr-context") drop_non_ptrs
-    %> f (get_bool "exp.int-context") drop_ints
-    %> f (get_bool "exp.interval-context") drop_interval
+    %> f (get_bool "ana.base.context.non-ptr") drop_non_ptrs
+    %> f (get_bool "ana.base.context.int") drop_ints
+    %> f (get_bool "ana.base.context.interval") drop_interval
 
   let context_cpa fd (st: store) = (context fd st).cpa
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -475,7 +475,7 @@ struct
     f !GU.earlyglobs (CPA.filter (fun k v -> not (V.is_global k) || is_precious_glob k))
     %> f (get_bool "exp.addr-context") drop_non_ptrs
     %> f (get_bool "exp.no-int-context") drop_ints
-    %> f (get_bool "exp.no-interval-context") drop_interval
+    %> f (not (get_bool "exp.interval-context")) drop_interval
 
   let context_cpa fd (st: store) = (context fd st).cpa
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -468,7 +468,7 @@ struct
 
   let drop_interval = CPA.map (function `Int x -> `Int (ID.no_interval x) | x -> x)
 
-  let context (st: store): store =
+  let context (fd: fundec) (st: store): store =
     let f t f (st: store) = if t then { st with cpa = f st.cpa} else st in
     st |>
     f !GU.earlyglobs (CPA.filter (fun k v -> not (V.is_global k) || is_precious_glob k))
@@ -476,7 +476,7 @@ struct
     %> f (get_bool "exp.no-int-context") drop_ints
     %> f (get_bool "exp.no-interval-context") drop_interval
 
-  let context_cpa (st: store) = (context st).cpa
+  let context_cpa fd (st: store) = (context fd st).cpa
 
   let convertToQueryLval x =
     let rec offsNormal o =
@@ -2336,7 +2336,7 @@ module type MainSpec = sig
   val return_lval: unit -> Cil.lval
   val return_varinfo: unit -> Cil.varinfo
   type extra = (varinfo * Offs.t * bool) list
-  val context_cpa: D.t -> BaseDomain.CPA.t
+  val context_cpa: fundec -> D.t -> BaseDomain.CPA.t
 end
 
 let main_module: (module MainSpec) Lazy.t =

--- a/src/analyses/extract_arinc.ml
+++ b/src/analyses/extract_arinc.ml
@@ -216,7 +216,7 @@ struct
     | Some base ->
       let pid, ctxh, pred = ctx.local in
       let module BaseMain = (val Base.get_main ()) in
-      let base_context = BaseMain.context_cpa @@ Obj.obj base in
+      let base_context = BaseMain.context_cpa f @@ Obj.obj base in
       let context_hash = Hashtbl.hash (base_context, pid) in
       pid, Ctx.of_int (Int64.of_int context_hash), pred
     | None -> ctx.local (* TODO when can this happen? *)

--- a/src/analyses/extract_osek.ml
+++ b/src/analyses/extract_osek.ml
@@ -209,7 +209,7 @@ struct
     | Some base ->
       let pid, ctxh, pred = ctx.local in
       let module BaseMain = (val Base.get_main ()) in
-      let base_context = BaseMain.context_cpa @@ Obj.obj base in
+      let base_context = BaseMain.context_cpa f @@ Obj.obj base in
       let context_hash = Hashtbl.hash (base_context, pid) in
       pid, Ctx.of_int (Int64.of_int context_hash), pred
     | None -> ctx.local (* TODO when can this happen? *)

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -296,11 +296,11 @@ struct
     let ys = fold_left one_el [] xs in
     List.rev ys, !dead
 
-  let context x =
+  let context fd x =
     let x = spec_list x in
     map (fun (n,(module S:MCPSpec),d) ->
         let d' = if mem n !cont_inse then S.D.top () else obj d in
-        n, repr @@ S.context d'
+        n, repr @@ S.context fd d'
       ) x
 
   let should_join x y =

--- a/src/analyses/tutorials/constants.ml
+++ b/src/analyses/tutorials/constants.ml
@@ -19,7 +19,7 @@ struct
   module C = Lattice.Unit
 
   include Analyses.IdentitySpec
-  let context _ = ()
+  let context _ _ = ()
 
   let is_integer_var (v: varinfo) =
     match v.vtype with

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2480,7 +2480,7 @@ module IntDomTupleImpl = struct
 
   let name () = "intdomtuple"
 
-  (* The Interval domain can lead to too many contexts for recursive functions (top is [min,max]), but we don't want to drop all ints as with `exp.int-context`. TODO better solution? *)
+  (* The Interval domain can lead to too many contexts for recursive functions (top is [min,max]), but we don't want to drop all ints as with `ana.base.context.int`. TODO better solution? *)
   let no_interval = Tuple4.map2 (const None)
 
   type 'a m = (module S with type t = 'a)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2480,7 +2480,7 @@ module IntDomTupleImpl = struct
 
   let name () = "intdomtuple"
 
-  (* The Interval domain can lead to too many contexts for recursive functions (top is [min,max]), but we don't want to drop all ints as with `exp.no-int-context`. TODO better solution? *)
+  (* The Interval domain can lead to too many contexts for recursive functions (top is [min,max]), but we don't want to drop all ints as with `exp.int-context`. TODO better solution? *)
   let no_interval = Tuple4.map2 (const None)
 
   type 'a m = (module S with type t = 'a)

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -325,7 +325,7 @@ sig
   val exitstate  : varinfo -> D.t
 
   val should_join : D.t -> D.t -> bool
-  val context : D.t -> C.t
+  val context : fundec -> D.t -> C.t
   val call_descr : fundec -> C.t -> string
 
   val sync  : (D.t, G.t, C.t) ctx -> [`Normal | `Join | `Return] -> D.t
@@ -478,7 +478,7 @@ struct
   let sync ctx _ = ctx.local
   (* Most domains do not have a global part. *)
 
-  let context x = x
+  let context fd x = x
   (* Everything is context sensitive --- override in MCP and maybe elsewhere*)
 end
 

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -361,7 +361,7 @@ struct
   let enter ctx r f args =
     let m = snd ctx.local in
     let d' v_cur =
-      if ContextUtil.should_keep ~keepOption:"exp.widen-context" ~keepAttr:"widen" ~removeAttr:"no-widen" f then (
+      if ContextUtil.should_keep ~keepOption:"ana.context.widen" ~keepAttr:"widen" ~removeAttr:"no-widen" f then (
         let v_old = M.find f.svar m in (* S.D.bot () if not found *)
         let v_new = S.D.widen v_old (S.D.join v_old v_cur) in
         Messages.(if tracing && not (S.D.equal v_old v_new) then tracel "widen-context" "enter results in new context for function %s\n" f.svar.vname);

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -30,7 +30,7 @@ struct
   let exitstate  v = D.lift (S.exitstate  v)
   let morphstate v d = D.lift (S.morphstate v (D.unlift d))
 
-  let context = S.context % D.unlift
+  let context fd = S.context fd % D.unlift
   let call_descr = S.call_descr
 
   let conv ctx =
@@ -106,7 +106,7 @@ struct
   let exitstate  = S.exitstate
   let morphstate = S.morphstate
 
-  let context = C.lift % S.context
+  let context fd = C.lift % S.context fd
   let call_descr f = S.call_descr f % C.unlift
 
   let conv ctx =
@@ -199,7 +199,7 @@ struct
   let exitstate  v = (S.exitstate  v, !start_level)
   let morphstate v (d,l) = (S.morphstate v d, l)
 
-  let context (d,_) = S.context d
+  let context fd (d,_) = S.context fd d
   let call_descr f = S.call_descr f
 
   let conv ctx =
@@ -334,7 +334,7 @@ struct
   let exitstate  = inj S.exitstate
   let morphstate v (d,m) = S.morphstate v d, m
 
-  let context (d,m) = S.context d (* just the child analysis' context *)
+  let context fd (d,m) = S.context fd d (* just the child analysis' context *)
   let call_descr = S.call_descr
 
   let conv ctx =
@@ -398,7 +398,7 @@ struct
   let exitstate  v = `Lifted (S.exitstate  v)
   let morphstate v d = try `Lifted (S.morphstate v (D.unlift d)) with Deadcode -> d
 
-  let context = S.context % D.unlift
+  let context fd = S.context fd % D.unlift
   let call_descr f = S.call_descr f
 
   let conv ctx =
@@ -495,7 +495,7 @@ struct
           spawns := (lval, f, args, d) :: !spawns;
           match Cilfacade.find_varinfo_fundec f with
           | fd ->
-            let c = S.context d in
+            let c = S.context fd d in
             sidel (FunctionEntry fd, c) d;
             ignore (getl (Function fd, c))
           | exception Not_found ->
@@ -605,7 +605,7 @@ struct
       r
     in
     let paths = S.enter ctx lv f args in
-    let paths = List.map (fun (c,v) -> (c, S.context v, v)) paths in
+    let paths = List.map (fun (c,v) -> (c, S.context f v, v)) paths in
     List.iter (fun (c,fc,v) -> if not (S.D.is_bot v) then sidel (FunctionEntry f, fc) v) paths;
     let paths = List.map (fun (c,fc,v) -> (c, fc, if S.D.is_bot v then v else getl (Function f, fc))) paths in
     let paths = List.filter (fun (c,fc,v) -> not (D.is_bot v)) paths in
@@ -901,11 +901,11 @@ struct
 
   let call_descr = Spec.call_descr
 
-  let context l =
+  let context fd l =
     if D.cardinal l <> 1 then
       failwith "PathSensitive2.context must be called with a singleton set."
     else
-      Spec.context @@ D.choose l
+      Spec.context fd @@ D.choose l
 
   let conv ctx x =
     let rec ctx' = { ctx with ask   = (fun (type a) (q: a Queries.t) -> Spec.query ctx' q)

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -361,10 +361,14 @@ struct
   let enter ctx r f args =
     let m = snd ctx.local in
     let d' v_cur =
-      let v_old = M.find f.svar m in (* S.D.bot () if not found *)
-      let v_new = S.D.widen v_old (S.D.join v_old v_cur) in
-      Messages.(if tracing && not (S.D.equal v_old v_new) then tracel "widen-context" "enter results in new context for function %s\n" f.svar.vname);
-      v_new, M.add f.svar v_new m
+      if ContextUtil.should_keep ~keepOption:"exp.widen-context" ~keepAttr:"widen" ~removeAttr:"no-widen" f then (
+        let v_old = M.find f.svar m in (* S.D.bot () if not found *)
+        let v_new = S.D.widen v_old (S.D.join v_old v_cur) in
+        Messages.(if tracing && not (S.D.equal v_old v_new) then tracel "widen-context" "enter results in new context for function %s\n" f.svar.vname);
+        v_new, M.add f.svar v_new m
+      )
+      else
+        v_cur, m
     in
     S.enter (conv ctx) r f args
     |> List.map (fun (c,v) -> (c,m), d' v) (* c: caller, v: callee *)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -15,7 +15,7 @@ let get_spec () : (module Spec) =
   let lift opt (module F : S2S) (module X : Spec) = (module (val if opt then (module F (X)) else (module X) : Spec) : Spec) in
   let module S1 = (val
             (module MCP.MCP2 : Spec)
-            |> lift (get_bool "exp.widen-context") (module WidenContextLifterSide)
+            |> lift true (module WidenContextLifterSide) (* option checked in functor *)
             (* hashcons before witness to reduce duplicates, because witness re-uses contexts in domain and requires tag for PathSensitive3 *)
             |> lift (get_bool "ana.opt.hashcons" || get_bool "ana.sv-comp.enabled") (module HashconsContextLifter)
             |> lift (get_bool "ana.sv-comp.enabled") (module HashconsLifter)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -372,12 +372,12 @@ struct
 
     let startvars' =
       if get_bool "exp.forward" then
-        List.map (fun (n,e) -> (MyCFG.FunctionEntry n, Spec.context e)) startvars
+        List.map (fun (n,e) -> (MyCFG.FunctionEntry n, Spec.context n e)) startvars
       else
-        List.map (fun (n,e) -> (MyCFG.Function n, Spec.context e)) startvars
+        List.map (fun (n,e) -> (MyCFG.Function n, Spec.context n e)) startvars
     in
 
-    let entrystates = List.map (fun (n,e) -> (MyCFG.FunctionEntry n, Spec.context e), e) startvars in
+    let entrystates = List.map (fun (n,e) -> (MyCFG.FunctionEntry n, Spec.context n e), e) startvars in
     let entrystates_global = GHT.to_list gh in
 
     let uncalled_dead = ref 0 in

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -361,7 +361,10 @@ let check_arguments () =
   let warn m = eprint_color ("{yellow}Option warning: "^m) in
   if get_bool "allfuns" && not (get_bool "exp.earlyglobs") then (set_bool "exp.earlyglobs" true; warn "allfuns enables exp.earlyglobs.\n");
   if not @@ List.mem "escape" @@ get_string_list "ana.activated" then warn "Without thread escape analysis, every local variable whose address is taken is considered escaped, i.e., global!";
-  if get_string "ana.osek.oil" <> "" && not (get_string "exp.privatization" = "protection-vesal" || get_string "exp.privatization" = "protection-old") then (set_string "exp.privatization" "protection-vesal"; warn "oil requires protection-old/protection-vesal privatization")
+  if get_string "ana.osek.oil" <> "" && not (get_string "exp.privatization" = "protection-vesal" || get_string "exp.privatization" = "protection-old") then (set_string "exp.privatization" "protection-vesal"; warn "oil requires protection-old/protection-vesal privatization");
+  if get_bool "ana.base.context.int" && not (get_bool "ana.base.context.non-ptr") then (set_bool "ana.base.context.int" false; warn "ana.base.context.int implicitly disabled by ana.base.context.non-ptr");
+  (* order matters: non-ptr=false, int=true -> int=false cascades to interval=false with warning *)
+  if get_bool "ana.base.context.interval" && not (get_bool "ana.base.context.int") then (set_bool "ana.base.context.interval" false; warn "ana.base.context.interval implicitly disabled by ana.base.context.int")
 
 let handle_extraspecials () =
   let funs = get_string_list "exp.extraspecials" in

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -539,12 +539,3 @@ let stmt_pretty_short () x =
   | Instr (y::ys) -> dn_instr () y
   | If (exp,_,_,_) -> dn_exp () exp
   | _ -> dn_stmt () x
-
-let hasGoblintContextAttribute s al =
-  List.exists (function
-      | Attr ("goblint_context", args) when List.exists (function
-          | AStr s' when s = s' -> true
-          | _ -> false
-        ) args -> true
-      | _ -> false
-    ) al

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -539,3 +539,12 @@ let stmt_pretty_short () x =
   | Instr (y::ys) -> dn_instr () y
   | If (exp,_,_,_) -> dn_exp () exp
   | _ -> dn_stmt () x
+
+let hasGoblintContextAttribute s al =
+  List.exists (function
+      | Attr ("goblint_context", args) when List.exists (function
+          | AStr s' when s = s' -> true
+          | _ -> false
+        ) args -> true
+      | _ -> false
+    ) al

--- a/src/util/contextUtil.ml
+++ b/src/util/contextUtil.ml
@@ -9,14 +9,14 @@ let has_attribute s al =
       | _ -> false
     ) al
 
-let should_remove ~keepOption ~removeAttr ~keepAttr fd =
+let should_keep ~keepOption ~removeAttr ~keepAttr fd =
   let al = fd.svar.vattr in
   match GobConfig.get_bool keepOption, has_attribute removeAttr al, has_attribute keepAttr al with
   | _, true, true ->
     failwith (Printf.sprintf "ContextUtil.should_remove: conflicting context attributes %s and %s on %s" removeAttr keepAttr (CilType.Fundec.show fd))
   | _, false, true
   | true, false, false ->
-    false
+    true
   | false, _, false
   | _, true, false ->
-    true
+    false

--- a/src/util/contextUtil.ml
+++ b/src/util/contextUtil.ml
@@ -8,3 +8,15 @@ let hasAttribute s al =
         ) args -> true
       | _ -> false
     ) al
+
+let shouldRemove ~removeOption ~removeAttr ~keepAttr fd =
+  let al = fd.svar.vattr in
+  match GobConfig.get_bool removeOption, hasAttribute removeAttr al, hasAttribute keepAttr al with
+  | _, true, true ->
+    failwith (Printf.sprintf "ContextUtil.shouldRemove: conflicting context attributes %s and %s on %s" removeAttr keepAttr (CilType.Fundec.show fd))
+  | _, false, true
+  | false, false, false ->
+    false
+  | true, _, false
+  | _, true, false ->
+    true

--- a/src/util/contextUtil.ml
+++ b/src/util/contextUtil.ml
@@ -1,0 +1,10 @@
+open Cil
+
+let hasAttribute s al =
+  List.exists (function
+      | Attr ("goblint_context", args) when List.exists (function
+          | AStr s' when s = s' -> true
+          | _ -> false
+        ) args -> true
+      | _ -> false
+    ) al

--- a/src/util/contextUtil.ml
+++ b/src/util/contextUtil.ml
@@ -9,14 +9,14 @@ let has_attribute s al =
       | _ -> false
     ) al
 
-let should_remove ~removeOption ~removeAttr ~keepAttr fd =
+let should_remove ~keepOption ~removeAttr ~keepAttr fd =
   let al = fd.svar.vattr in
-  match GobConfig.get_bool removeOption, has_attribute removeAttr al, has_attribute keepAttr al with
+  match GobConfig.get_bool keepOption, has_attribute removeAttr al, has_attribute keepAttr al with
   | _, true, true ->
     failwith (Printf.sprintf "ContextUtil.should_remove: conflicting context attributes %s and %s on %s" removeAttr keepAttr (CilType.Fundec.show fd))
   | _, false, true
-  | false, false, false ->
+  | true, false, false ->
     false
-  | true, _, false
+  | false, _, false
   | _, true, false ->
     true

--- a/src/util/contextUtil.ml
+++ b/src/util/contextUtil.ml
@@ -1,6 +1,6 @@
 open Cil
 
-let hasAttribute s al =
+let has_attribute s al =
   List.exists (function
       | Attr ("goblint_context", args) when List.exists (function
           | AStr s' when s = s' -> true
@@ -9,11 +9,11 @@ let hasAttribute s al =
       | _ -> false
     ) al
 
-let shouldRemove ~removeOption ~removeAttr ~keepAttr fd =
+let should_remove ~removeOption ~removeAttr ~keepAttr fd =
   let al = fd.svar.vattr in
-  match GobConfig.get_bool removeOption, hasAttribute removeAttr al, hasAttribute keepAttr al with
+  match GobConfig.get_bool removeOption, has_attribute removeAttr al, has_attribute keepAttr al with
   | _, true, true ->
-    failwith (Printf.sprintf "ContextUtil.shouldRemove: conflicting context attributes %s and %s on %s" removeAttr keepAttr (CilType.Fundec.show fd))
+    failwith (Printf.sprintf "ContextUtil.should_remove: conflicting context attributes %s and %s on %s" removeAttr keepAttr (CilType.Fundec.show fd))
   | _, false, true
   | false, false, false ->
     false

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -172,7 +172,7 @@ let _ = ()
       ; reg Experimental "exp.forward"           "false" "Use implicit forward propagation instead of the demand driven approach."
       ; reg Experimental "exp.addr-context"      "false" "Ignore non-address values in function contexts."
       ; reg Experimental "exp.no-int-context"    "false" "Ignore all integer values in function contexts."
-      ; reg Experimental "exp.no-interval-context" "false" "Ignore integer values of the Interval domain in function contexts."
+      ; reg Experimental "exp.interval-context" "true" "Integer values of the Interval domain in function contexts."
       ; reg Experimental "exp.malloc.fail"       "false" "Consider the case where malloc or calloc fails."
       ; reg Experimental "exp.malloc.wrappers"   "['kmalloc','__kmalloc','usb_alloc_urb','__builtin_alloca','kzalloc']"  "Loads a list of known malloc wrapper functions." (* When something new that maps to malloc or calloc is added to libraryFunctions.ml, it should also be added here.*)
       ; reg Experimental "exp.volatiles_are_top" "true"  "volatile and extern keywords set variables permanently to top"

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -171,7 +171,7 @@ let _ = ()
       ; reg Experimental "exp.unique"            "[]"    "For types that have only one value."
       ; reg Experimental "exp.forward"           "false" "Use implicit forward propagation instead of the demand driven approach."
       ; reg Experimental "exp.addr-context"      "false" "Ignore non-address values in function contexts."
-      ; reg Experimental "exp.no-int-context"    "false" "Ignore all integer values in function contexts."
+      ; reg Experimental "exp.int-context"    "true" "Integer values in function contexts."
       ; reg Experimental "exp.interval-context" "true" "Integer values of the Interval domain in function contexts."
       ; reg Experimental "exp.malloc.fail"       "false" "Consider the case where malloc or calloc fails."
       ; reg Experimental "exp.malloc.wrappers"   "['kmalloc','__kmalloc','usb_alloc_urb','__builtin_alloca','kzalloc']"  "Loads a list of known malloc wrapper functions." (* When something new that maps to malloc or calloc is added to libraryFunctions.ml, it should also be added here.*)

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -170,7 +170,7 @@ let _ = ()
       ; reg Experimental "exp.region-offsets"    "false" "Considers offsets for region accesses."
       ; reg Experimental "exp.unique"            "[]"    "For types that have only one value."
       ; reg Experimental "exp.forward"           "false" "Use implicit forward propagation instead of the demand driven approach."
-      ; reg Experimental "exp.addr-context"      "false" "Ignore non-address values in function contexts."
+      ; reg Experimental "exp.non-ptr-context"      "true" "Non-address values in function contexts."
       ; reg Experimental "exp.int-context"    "true" "Integer values in function contexts."
       ; reg Experimental "exp.interval-context" "true" "Integer values of the Interval domain in function contexts."
       ; reg Experimental "exp.malloc.fail"       "false" "Consider the case where malloc or calloc fails."

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -139,6 +139,9 @@ let _ = ()
       ; reg Analyses "ana.specification"   "" "SV-COMP specification (path or string)"
       ; reg Analyses "ana.wp"              "false" "Weakest precondition feasibility analysis for SV-COMP violations"
       ; reg Analyses "ana.arrayoob"        "false"        "Array out of bounds check"
+      ; reg Analyses "ana.base.context.non-ptr"      "true" "Non-address values in function contexts."
+      ; reg Analyses "ana.base.context.int"    "true" "Integer values in function contexts."
+      ; reg Analyses "ana.base.context.interval" "true" "Integer values of the Interval domain in function contexts."
       ; reg Analyses "ana.apron.context" "true" "Entire relation in function contexts."
 
 (* {4 category [Semantics]} *)
@@ -170,9 +173,6 @@ let _ = ()
       ; reg Experimental "exp.region-offsets"    "false" "Considers offsets for region accesses."
       ; reg Experimental "exp.unique"            "[]"    "For types that have only one value."
       ; reg Experimental "exp.forward"           "false" "Use implicit forward propagation instead of the demand driven approach."
-      ; reg Experimental "exp.non-ptr-context"      "true" "Non-address values in function contexts."
-      ; reg Experimental "exp.int-context"    "true" "Integer values in function contexts."
-      ; reg Experimental "exp.interval-context" "true" "Integer values of the Interval domain in function contexts."
       ; reg Experimental "exp.malloc.fail"       "false" "Consider the case where malloc or calloc fails."
       ; reg Experimental "exp.malloc.wrappers"   "['kmalloc','__kmalloc','usb_alloc_urb','__builtin_alloca','kzalloc']"  "Loads a list of known malloc wrapper functions." (* When something new that maps to malloc or calloc is added to libraryFunctions.ml, it should also be added here.*)
       ; reg Experimental "exp.volatiles_are_top" "true"  "volatile and extern keywords set variables permanently to top"

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -143,6 +143,7 @@ let _ = ()
       ; reg Analyses "ana.base.context.int"    "true" "Integer values in function contexts."
       ; reg Analyses "ana.base.context.interval" "true" "Integer values of the Interval domain in function contexts."
       ; reg Analyses "ana.apron.context" "true" "Entire relation in function contexts."
+      ; reg Analyses "ana.context.widen"     "false" "Do widening on contexts. Keeps a map of function to call state; enter will then return the widened local state for recursive calls."
 
 (* {4 category [Semantics]} *)
 let _ = ()
@@ -184,7 +185,6 @@ let _ = ()
       ; reg Experimental "exp.extraspecials"     "[]"    "List of functions that must be analyzed as unknown extern functions"
       ; reg Experimental "exp.no-narrow"         "false" "Overwrite narrow a b = a"
       ; reg Experimental "exp.basic-blocks"      "false" "Only keep values for basic blocks instead of for every node. Should take longer but need less space."
-      ; reg Experimental "exp.widen-context"     "false" "Do widening on contexts. Keeps a map of function to call state; enter will then return the widened local state for recursive calls."
       ; reg Experimental "exp.solver.td3.term"   "true"  "Should the td3 solver use the phased/terminating strategy?"
       ; reg Experimental "exp.solver.td3.side_widen" "'sides'" "When to widen in side. never: never widen, always: always widen, sides: widen if there are multiple side-effects from the same var resulting in a new value, cycle: widen if a called or a start var get destabilized, unstable_called: widen if any called var gets destabilized, unstable_self: widen if side-effected var gets destabilized."
       ; reg Experimental "exp.solver.td3.space"  "false" "Should the td3 solver only keep values at widening points?"

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -139,7 +139,7 @@ let _ = ()
       ; reg Analyses "ana.specification"   "" "SV-COMP specification (path or string)"
       ; reg Analyses "ana.wp"              "false" "Weakest precondition feasibility analysis for SV-COMP violations"
       ; reg Analyses "ana.arrayoob"        "false"        "Array out of bounds check"
-      ; reg Analyses "ana.apron.no-context" "false" "Ignore entire relation in function contexts."
+      ; reg Analyses "ana.apron.context" "true" "Entire relation in function contexts."
 
 (* {4 category [Semantics]} *)
 let _ = ()

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -166,11 +166,11 @@ struct
 
   let call_descr = Spec.call_descr
 
-  let context (l, _) =
+  let context fd (l, _) =
     if Dom.cardinal l <> 1 then
       failwith "PathSensitive3.context must be called with a singleton set."
     else
-      Spec.context @@ Dom.choose l
+      Spec.context fd @@ Dom.choose l
 
   let conv ctx x =
     (* TODO: R.bot () isn't right here *)

--- a/sv-comp/benchexec/my-bench/goblint.xml
+++ b/sv-comp/benchexec/my-bench/goblint.xml
@@ -10,7 +10,7 @@
   <option name="--enable">ana.int.enums</option>
   <option name="--enable">ana.int.interval</option>
   <!-- <option name="-sets solver td3"/> -->
-  <option name="--enable">exp.widen-context</option>
+  <option name="--enable">ana.context.widen</option>
   <option name="--enable">exp.partition-arrays.enabled</option>
 
 <rundefinition name="sv-comp20_prop-reachsafety">

--- a/tests/regression/02-base/61-no-int-context.c
+++ b/tests/regression/02-base/61-no-int-context.c
@@ -1,0 +1,15 @@
+// PARAM: --enable ana.int.interval --disable exp.widen-context --disable ana.base.context.int
+#include <assert.h>
+
+int f(int x) {
+  if (x)
+    return f(x+1);
+  else
+    return x;
+}
+
+int main () {
+  int a = f(1);
+  assert(!a);
+  return 0;
+}

--- a/tests/regression/02-base/61-no-int-context.c
+++ b/tests/regression/02-base/61-no-int-context.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --disable exp.widen-context --disable ana.base.context.int
+// PARAM: --enable ana.int.interval --disable ana.context.widen --disable ana.base.context.int
 #include <assert.h>
 
 int f(int x) {

--- a/tests/regression/02-base/62-no-int-context-attribute.c
+++ b/tests/regression/02-base/62-no-int-context-attribute.c
@@ -1,0 +1,16 @@
+// PARAM: --enable ana.int.interval --disable exp.widen-context --enable ana.base.context.int
+#include <assert.h>
+
+int f(int x) __attribute__((goblint_context("base.no-int"))); // attributes are not permitted in a function definition
+int f(int x) {
+  if (x)
+    return f(x+1);
+  else
+    return x;
+}
+
+int main () {
+  int a = f(1);
+  assert(!a);
+  return 0;
+}

--- a/tests/regression/02-base/62-no-int-context-attribute.c
+++ b/tests/regression/02-base/62-no-int-context-attribute.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --disable exp.widen-context --enable ana.base.context.int
+// PARAM: --enable ana.int.interval --disable ana.context.widen --enable ana.base.context.int
 #include <assert.h>
 
 int f(int x) __attribute__((goblint_context("base.no-int"))); // attributes are not permitted in a function definition

--- a/tests/regression/02-base/63-int-context-attribute.c
+++ b/tests/regression/02-base/63-int-context-attribute.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --disable exp.widen-context --disable ana.base.context.int
+// PARAM: --enable ana.int.interval --disable ana.context.widen --disable ana.base.context.int
 #include <assert.h>
 
 int f(int x) __attribute__((goblint_context("base.int"))); // attributes are not permitted in a function definition

--- a/tests/regression/02-base/63-int-context-attribute.c
+++ b/tests/regression/02-base/63-int-context-attribute.c
@@ -1,0 +1,16 @@
+// PARAM: --enable ana.int.interval --disable exp.widen-context --disable ana.base.context.int
+#include <assert.h>
+
+int f(int x) __attribute__((goblint_context("base.int"))); // attributes are not permitted in a function definition
+int f(int x) {
+  if (x)
+    return x * f(x - 1);
+  else
+    return 1;
+}
+
+int main () {
+  int a = f(10);
+  assert(a == 3628800);
+  return 0;
+}

--- a/tests/regression/20-slr_term/01-no-int-context.c
+++ b/tests/regression/20-slr_term/01-no-int-context.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set solver slr3t --disable exp.int-context
+// PARAM: --enable ana.int.interval --set solver slr3t --disable ana.base.context.int
 
 int f (int i) { // -2
 	return i+1; } // -3

--- a/tests/regression/20-slr_term/01-no-int-context.c
+++ b/tests/regression/20-slr_term/01-no-int-context.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set solver slr3t --enable exp.no-int-context
+// PARAM: --enable ana.int.interval --set solver slr3t --disable exp.int-context
 
 int f (int i) { // -2
 	return i+1; } // -3

--- a/tests/regression/29-svcomp/06-isp1362-widen-context.c
+++ b/tests/regression/29-svcomp/06-isp1362-widen-context.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --enable exp.widen-context
+// SKIP PARAM: --enable ana.context.widen
 #include <stdlib.h>
 
 typedef unsigned long __kernel_ulong_t;

--- a/tests/regression/32-widen-context/01-on.c
+++ b/tests/regression/32-widen-context/01-on.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable exp.widen-context
+// PARAM: --set solver td3 --enable ana.int.interval --enable ana.context.widen
 #include <assert.h>
 
 int f(int x) {

--- a/tests/regression/32-widen-context/02-on-attribute.c
+++ b/tests/regression/32-widen-context/02-on-attribute.c
@@ -1,0 +1,16 @@
+// PARAM: --set solver td3 --enable ana.int.interval --disable exp.widen-context
+#include <assert.h>
+
+int f(int x) __attribute__((goblint_context("widen"))); // attributes are not permitted in a function definition
+int f(int x) {
+  if (x)
+    return f(x+1);
+  else
+    return x;
+}
+
+int main () {
+  int a = f(1);
+  assert(!a);
+  return 0;
+}

--- a/tests/regression/32-widen-context/02-on-attribute.c
+++ b/tests/regression/32-widen-context/02-on-attribute.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.widen-context
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.context.widen
 #include <assert.h>
 
 int f(int x) __attribute__((goblint_context("widen"))); // attributes are not permitted in a function definition

--- a/tests/regression/32-widen-context/03-off-attribute.c
+++ b/tests/regression/32-widen-context/03-off-attribute.c
@@ -1,0 +1,16 @@
+// PARAM: --enable ana.int.interval --enable exp.widen-context
+#include <assert.h>
+
+int f(int x) __attribute__((goblint_context("no-widen"))); // attributes are not permitted in a function definition
+int f(int x) {
+  if (x)
+    return x * f(x - 1);
+  else
+    return 1;
+}
+
+int main () {
+  int a = f(10);
+  assert(a == 3628800);
+  return 0;
+}

--- a/tests/regression/32-widen-context/03-off-attribute.c
+++ b/tests/regression/32-widen-context/03-off-attribute.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --enable exp.widen-context
+// PARAM: --enable ana.int.interval --enable ana.context.widen
 #include <assert.h>
 
 int f(int x) __attribute__((goblint_context("no-widen"))); // attributes are not permitted in a function definition

--- a/tests/regression/36-apron/45-context.c
+++ b/tests/regression/36-apron/45-context.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --enable ana.int.interval --disable ana.apron.no-context
+// SKIP PARAM: --set ana.activated[+] apron --enable ana.int.interval --enable ana.apron.context
 #include <assert.h>
 
 int oct(int x, int y) {

--- a/tests/regression/36-apron/46-no-context.c
+++ b/tests/regression/36-apron/46-no-context.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --enable ana.int.interval --enable ana.apron.no-context
+// SKIP PARAM: --set ana.activated[+] apron --enable ana.int.interval --disable ana.apron.context
 #include <assert.h>
 
 int oct(int x, int y) {
@@ -14,7 +14,7 @@ void main() {
   int x, y, res;
   if (x <= y) {
     res = oct(x, y);
-    assert(res == 1); // UNKNOWN (indended by no-context)
+    assert(res == 1); // UNKNOWN (indended by disabled context)
   }
 
   res = oct(x, y);

--- a/tests/regression/36-apron/47-no-context-attribute.c
+++ b/tests/regression/36-apron/47-no-context-attribute.c
@@ -1,0 +1,22 @@
+// SKIP PARAM: --set ana.activated[+] apron --enable ana.int.interval --disable ana.apron.no-context
+#include <assert.h>
+
+int oct(int x, int y) __attribute__((goblint_context("apron.no-context"))); // attributes are not permitted in a function definition
+int oct(int x, int y) {
+  int s;
+  if (x <= y)
+    s = 1;
+  else
+    s = 0;
+  return s;
+}
+
+void main() {
+  int x, y, res;
+  if (x <= y) {
+    res = oct(x, y);
+    assert(res == 1); // UNKNOWN (indended by no-context attribute)
+  }
+
+  res = oct(x, y);
+}

--- a/tests/regression/36-apron/47-no-context-attribute.c
+++ b/tests/regression/36-apron/47-no-context-attribute.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --enable ana.int.interval --disable ana.apron.no-context
+// SKIP PARAM: --set ana.activated[+] apron --enable ana.int.interval --enable ana.apron.context
 #include <assert.h>
 
 int oct(int x, int y) __attribute__((goblint_context("apron.no-context"))); // attributes are not permitted in a function definition

--- a/tests/regression/36-apron/48-context-attribute.c
+++ b/tests/regression/36-apron/48-context-attribute.c
@@ -1,0 +1,22 @@
+// SKIP PARAM: --set ana.activated[+] apron --enable ana.int.interval --enable ana.apron.no-context
+#include <assert.h>
+
+int oct(int x, int y) __attribute__((goblint_context("apron.context"))); // attributes are not permitted in a function definition
+int oct(int x, int y) {
+  int s;
+  if (x <= y)
+    s = 1;
+  else
+    s = 0;
+  return s;
+}
+
+void main() {
+  int x, y, res;
+  if (x <= y) {
+    res = oct(x, y);
+    assert(res == 1);
+  }
+
+  res = oct(x, y);
+}

--- a/tests/regression/36-apron/48-context-attribute.c
+++ b/tests/regression/36-apron/48-context-attribute.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --enable ana.int.interval --enable ana.apron.no-context
+// SKIP PARAM: --set ana.activated[+] apron --enable ana.int.interval --disable ana.apron.context
 #include <assert.h>
 
 int oct(int x, int y) __attribute__((goblint_context("apron.context"))); // attributes are not permitted in a function definition


### PR DESCRIPTION
### Changes
1. Add `fundec` argument to `Spec.context` to allow accessing the attributes of the function whose partial context is being constructed.
2. Flip and rename existing context options, e.g. `exp.no-int-context` → `ana.base.context.int`.
3. Allow both enabling and disabling a partial context option per-function relative to the global option. This allows making the analysis more precise or faster, respectively.
4. Extend context attribute support to context widening. This allows applying context widening just to particular recursive functions for termination or disabling it for particular recursive functions for precision.

See the added tests for example usage and use cases.

### TODO
- [x] Add documentation about Goblint's attributes.