### PR TITLE
Optimize TD3 to not unnecessarily store bottom for just eval-ed variables

### DIFF
--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -158,16 +158,16 @@ module WP =
         | Some f -> f get set
       and simple_solve l x y =
         if tracing then trace "sol2" "simple_solve %a (rhs: %b)\n" S.Var.pretty_trace y (S.system y <> None);
-        if S.system y = None then (init y; HM.find rho y) else
-        if HM.mem rho y || not space then (solve y Widen; HM.find rho y) else
-        if HM.mem called y then (init y; HM.remove l y; HM.find rho y) else
-        (* if HM.mem called y then (init y; let y' = HM.find_default l y (S.Dom.bot ()) in HM.replace rho y y'; HM.remove l y; y') else *)
+        if S.system y = None then (init y; add_infl y x; HM.find rho y) else
+        if HM.mem rho y || not space then (solve y Widen; add_infl y x; HM.find rho y) else
+        if HM.mem called y then (init y; HM.remove l y; add_infl y x; HM.find rho y) else
+        (* if HM.mem called y then (init y; let y' = HM.find_default l y (S.Dom.bot ()) in HM.replace rho y y'; HM.remove l y; add_infl y x; y') else *)
         if cache && HM.mem l y then HM.find l y
         else (
           HM.replace called y ();
           let tmp = eq y (eval l x) (side x) in
           HM.remove called y;
-          if HM.mem rho y then (HM.remove l y; solve y Widen; HM.find rho y)
+          if HM.mem rho y then (HM.remove l y; solve y Widen; add_infl y x; HM.find rho y)
           else (if cache then HM.replace l y tmp; tmp)
         )
       and eval l x y =
@@ -175,7 +175,6 @@ module WP =
         get_var_event y;
         if HM.mem called y then HM.replace wpoint y ();
         let tmp = simple_solve l x y in
-        if HM.mem rho y then add_infl y x;
         tmp
       and side x y d = (* side from x to y; only to variables y w/o rhs; x only used for trace *)
         if tracing then trace "sol2" "side to %a (wpx: %b) from %a ## value: %a\n" S.Var.pretty_trace y (HM.mem wpoint y) S.Var.pretty_trace x S.Dom.pretty d;

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -384,7 +384,7 @@ module WP =
             | Some x -> one_constraint x
           )
         and one_constraint f =
-          ignore (f (fun x -> one_var x; try HM.find rho x with Not_found -> ignore @@ Pretty.printf "reachability: one_constraint: could not find variable %a\n" S.Var.pretty_trace x; S.Dom.bot ()) (fun x _ -> one_var x))
+          ignore (f (fun x -> one_var x; try HM.find rho x with Not_found -> S.Dom.bot ()) (fun x _ -> one_var x))
         in
         List.iter one_var xs;
         HM.iter (fun x v -> if not (HM.mem reachable x) then HM.remove rho x) rho;

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -73,10 +73,10 @@ module WP =
       let cache = GobConfig.get_bool "exp.solver.td3.space_cache" in
 
       let init_bot_all = false in (* init stores bot in rho for all vars *)
-      let init_bot_rhs = true in (* init stores bot in rho for vars with rhs *)
+      let init_bot_rhs = false in (* init stores bot in rho for vars with rhs *)
       (* all=true gives old behavior, where just read globals also store bot *)
-      (* all=false, rhs=false stores no bots, but also means no dead code detected by solver (never added to rho) and local dead code sections get repeatedly recomputed (as bot) *)
-      (* all=false, rhs=true gives intermediate behavior, where dead code behaves as before, but just read globals don't store bot (no cascading bot recomputation is possible because they don't have rhs) *)
+      (* all=false, rhs=false stores no bots, but also means rhs with bot value get recomputed (as bot) repeatedly, doesn't affect dead code since dead code bot is lifted in local variant, which isn't bot of Lift2 *)
+      (* all=false, rhs=true gives intermediate behavior, where just read globals don't store bot (no cascading bot recomputation is possible because they don't have rhs) *)
 
       let called = HM.create 10 in
 

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -156,7 +156,10 @@ module WP =
         match S.system x with
         | None -> S.Dom.bot ()
         | Some f -> f get set
-      and simple_solve l x y =
+      and eval l x y =
+        if tracing then trace "sol2" "eval %a ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y;
+        get_var_event y;
+        if HM.mem called y then HM.replace wpoint y ();
         if tracing then trace "sol2" "simple_solve %a (rhs: %b)\n" S.Var.pretty_trace y (S.system y <> None);
         if S.system y = None then (init y; add_infl y x; HM.find rho y) else
         if HM.mem rho y || not space then (solve y Widen; add_infl y x; HM.find rho y) else
@@ -170,12 +173,6 @@ module WP =
           if HM.mem rho y then (HM.remove l y; solve y Widen; add_infl y x; HM.find rho y)
           else (if cache then HM.replace l y tmp; tmp)
         )
-      and eval l x y =
-        if tracing then trace "sol2" "eval %a ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y;
-        get_var_event y;
-        if HM.mem called y then HM.replace wpoint y ();
-        let tmp = simple_solve l x y in
-        tmp
       and side x y d = (* side from x to y; only to variables y w/o rhs; x only used for trace *)
         if tracing then trace "sol2" "side to %a (wpx: %b) from %a ## value: %a\n" S.Var.pretty_trace y (HM.mem wpoint y) S.Var.pretty_trace x S.Dom.pretty d;
         if S.system y <> None then (

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -162,7 +162,7 @@ module WP =
         if HM.mem called y then HM.replace wpoint y ();
         if tracing then trace "sol2" "simple_solve %a (rhs: %b)\n" S.Var.pretty_trace y (S.system y <> None);
         if S.system y = None then (init y; add_infl y x; try HM.find rho y with Not_found -> S.Dom.bot ()) else
-        if HM.mem rho y || not space then (solve y Widen; add_infl y x; try HM.find rho y with Not_found -> S.Dom.bot ()) else
+        if not space || HM.mem wpoint y then (solve y Widen; add_infl y x; try HM.find rho y with Not_found -> S.Dom.bot ()) else
         if HM.mem called y then (init y; HM.remove l y; add_infl y x; try HM.find rho y with Not_found -> S.Dom.bot ()) else
         (* if HM.mem called y then (init y; let y' = HM.find_default l y (S.Dom.bot ()) in HM.replace rho y y'; HM.remove l y; add_infl y x; y') else *)
         if cache && HM.mem l y then HM.find l y
@@ -170,7 +170,7 @@ module WP =
           HM.replace called y ();
           let tmp = eq y (eval l x) (side x) in
           HM.remove called y;
-          if HM.mem rho y then (HM.remove l y; solve y Widen; add_infl y x; HM.find rho y)
+          if HM.mem wpoint y then (HM.remove l y; solve y Widen; add_infl y x; HM.find rho y)
           else (if cache then HM.replace l y tmp; tmp)
         )
       and side x y d = (* side from x to y; only to variables y w/o rhs; x only used for trace *)


### PR DESCRIPTION
This was revealed by #345.
Simply `get`-ing/`eval`-ing global constraint variables added bottom to `rho`.
This unnecessarily increases rho with default values.

This PR changes TD3 such that it doesn't store those bottoms eagerly when a constraint variable is just read and never receives a real value. Thus most `HM.find rho` are wrapped with catching `Not_found` to return bottom. Is there maybe some reason I'm not aware of why TD3 doesn't use implicit bottom values already?

There were a few places where `HM.mem rho` was used, for which it matters whether the bottom value has been added or not. From what I can tell, these are just for the _space_ variant and actually correspond to `HM.mem wpoint`, which is how those checks are presented in the TD3 paper.

I added two static variables to tune the bottom insertion behavior of `init` such that the old behavior can easily be toggled as well.