### PR TITLE
Optimize recursive struct type comparison in `CompareAST`

### DIFF
--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -78,8 +78,11 @@ and eq_lhost (a: lhost) (b: lhost) = match a, b with
   | _, _ -> false
 
 and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
+  (* if Messages.tracing then Messages.tracei "compare" "eq_typ_acc %a vs %a\n" d_type a d_type b; *)
+  if Messages.tracing then Messages.tracei "compare" "eq_typ_acc %a vs %a (%d)\n" d_type a d_type b (List.length acc); (* TODO: remove because always calls List.length *)
+  let r =
   if( List.exists (fun x-> match x with (x,y)-> a==x && b == y) acc)
-  then true
+  then (if Messages.tracing then Messages.trace "compare" "in acc\n"; true)
   else (let acc = List.cons (a,b) acc in
         match a, b with
         | TPtr (typ1, attr1), TPtr (typ2, attr2) -> eq_typ_acc typ1 typ2 acc && eq_list eq_attribute attr1 attr2
@@ -99,6 +102,9 @@ and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
         | TEnum (enuminfo1, attr1), TEnum (enuminfo2, attr2) -> let res = eq_enuminfo enuminfo1 enuminfo2 && eq_list eq_attribute attr1 attr2 in (if res && enuminfo1.ename <> enuminfo2.ename then enuminfo2.ename <- enuminfo1.ename); res
         | TBuiltin_va_list attr1, TBuiltin_va_list attr2 -> eq_list eq_attribute attr1 attr2
         | _, _ -> a = b)
+  in
+  if Messages.tracing then Messages.traceu "compare" "eq_typ_acc %a vs %a\n" d_type a d_type b;
+  r
 
 and eq_typ (a: typ) (b: typ) = eq_typ_acc a b []
 
@@ -159,7 +165,10 @@ and eq_compinfo (a: compinfo) (b: compinfo) (acc: (typ * typ) list) =
   a.cdefined = b.cdefined (* Ignore ckey, and ignore creferenced *)
 
 and eq_fieldinfo (a: fieldinfo) (b: fieldinfo) (acc: (typ * typ) list)=
-  a.fname = b.fname && eq_typ_acc a.ftype b.ftype acc && a.fbitfield = b.fbitfield &&  eq_list eq_attribute a.fattr b.fattr
+  if Messages.tracing then Messages.tracei "compare" "fieldinfo %s vs %s\n" a.fname b.fname;
+  let r = a.fname = b.fname && eq_typ_acc a.ftype b.ftype acc && a.fbitfield = b.fbitfield &&  eq_list eq_attribute a.fattr b.fattr in
+  if Messages.tracing then Messages.traceu "compare" "fieldinfo %s vs %s\n" a.fname b.fname;
+  r
 
 and eq_offset (a: offset) (b: offset) = match a, b with
     NoOffset, NoOffset -> true

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -89,7 +89,7 @@ and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
         | TArray (typ1, (Some lenExp1), attr1), TArray (typ2, (Some lenExp2), attr2) -> eq_typ_acc typ1 typ2 acc && eq_exp lenExp1 lenExp2 &&  eq_list eq_attribute attr1 attr2
         | TArray (typ1, None, attr1), TArray (typ2, None, attr2) -> eq_typ_acc typ1 typ2 acc && eq_list eq_attribute attr1 attr2
         | TFun (typ1, (Some list1), varArg1, attr1), TFun (typ2, (Some list2), varArg2, attr2)
-          ->  eq_typ_acc typ1 typ2 acc && eq_list eq_args list1 list2 && varArg1 = varArg2 &&
+          ->  eq_typ_acc typ1 typ2 acc && eq_list (eq_args acc) list1 list2 && varArg1 = varArg2 &&
               eq_list eq_attribute attr1 attr2
         | TFun (typ1, None, varArg1, attr1), TFun (typ2, None, varArg2, attr2)
           ->  eq_typ_acc typ1 typ2 acc && varArg1 = varArg2 &&
@@ -118,8 +118,8 @@ and eq_enuminfo (a: enuminfo) (b: enuminfo) =
   eq_list eq_eitems a.eitems b.eitems
 (* Ignore ereferenced *)
 
-and eq_args (a: string * typ * attributes) (b: string * typ * attributes) = match a, b with
-    (name1, typ1, attr1), (name2, typ2, attr2) -> name1 = name2 && eq_typ typ1 typ2 && eq_list eq_attribute attr1 attr2
+and eq_args (acc: (typ * typ) list) (a: string * typ * attributes) (b: string * typ * attributes) = match a, b with
+    (name1, typ1, attr1), (name2, typ2, attr2) -> name1 = name2 && eq_typ_acc typ1 typ2 acc && eq_list eq_attribute attr1 attr2
 
 and eq_typsig (a: typsig) (b: typsig) =
   match a, b with

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -81,9 +81,10 @@ and global_typ_acc: (typ * typ) list ref = ref [] (* TODO: optimize with physica
 
 and mem_typ_acc (a: typ) (b: typ) acc = List.exists (fun p -> match p with (x, y) -> a == x && b == y) acc (* TODO: seems slightly more efficient to not use "fun (x, y) ->" directly to avoid caml_tuplify2 *)
 
+and pretty_length () l = Pretty.num (List.length l)
+
 and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
-  if Messages.tracing then Messages.tracei "compareast" "eq_typ_acc %a vs %a\n" d_type a d_type b;
-  (* if Messages.tracing then Messages.tracei "compareast" "eq_typ_acc %a vs %a (%d)\n" d_type a d_type b (List.length acc); (* TODO: remove because always calls List.length *) *)
+  if Messages.tracing then Messages.tracei "compareast" "eq_typ_acc %a vs %a (%a, %a)\n" d_type a d_type b pretty_length acc pretty_length !global_typ_acc; (* %a makes List.length calls lazy if compareast isn't being traced *)
   let r = (match a, b with
         | TPtr (typ1, attr1), TPtr (typ2, attr2) -> eq_typ_acc typ1 typ2 acc && eq_list eq_attribute attr1 attr2
         | TArray (typ1, (Some lenExp1), attr1), TArray (typ2, (Some lenExp2), attr2) -> eq_typ_acc typ1 typ2 acc && eq_exp lenExp1 lenExp2 &&  eq_list eq_attribute attr1 attr2

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -84,14 +84,7 @@ and mem_typ_acc (a: typ) (b: typ) acc = List.exists (fun p -> match p with (x, y
 and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
   if Messages.tracing then Messages.tracei "compare" "eq_typ_acc %a vs %a\n" d_type a d_type b;
   (* if Messages.tracing then Messages.tracei "compare" "eq_typ_acc %a vs %a (%d)\n" d_type a d_type b (List.length acc); (* TODO: remove because always calls List.length *) *)
-  let r =
-  if mem_typ_acc a b acc || mem_typ_acc a b !global_typ_acc then (
-    if Messages.tracing then Messages.trace "compare" "in acc\n";
-    true
-  )
-  else (let acc = List.cons (a,b) acc in
-        let r =
-        match a, b with
+  let r = (match a, b with
         | TPtr (typ1, attr1), TPtr (typ2, attr2) -> eq_typ_acc typ1 typ2 acc && eq_list eq_attribute attr1 attr2
         | TArray (typ1, (Some lenExp1), attr1), TArray (typ2, (Some lenExp2), attr2) -> eq_typ_acc typ1 typ2 acc && eq_exp lenExp1 lenExp2 &&  eq_list eq_attribute attr1 attr2
         | TArray (typ1, None, attr1), TArray (typ2, None, attr2) -> eq_typ_acc typ1 typ2 acc && eq_list eq_attribute attr1 attr2
@@ -105,18 +98,26 @@ and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
         | TNamed (tinf, attr), b -> eq_typ_acc tinf.ttype b acc (* Ignore tname, treferenced. TODO: dismiss attributes, or not? *)
         | a, TNamed (tinf, attr) -> eq_typ_acc a tinf.ttype acc (* Ignore tname, treferenced . TODO: dismiss attributes, or not? *)
         (* The following two lines are a hack to ensure that anonymous types get the same name and thus, the same typsig *)
-        | TComp (compinfo1, attr1), TComp (compinfo2, attr2) -> let res = eq_compinfo compinfo1 compinfo2 acc &&  eq_list eq_attribute attr1 attr2 in (if res && compinfo1.cname <> compinfo2.cname then compinfo2.cname <- compinfo1.cname); res
+        | TComp (compinfo1, attr1), TComp (compinfo2, attr2) ->
+          if mem_typ_acc a b acc || mem_typ_acc a b !global_typ_acc then (
+            if Messages.tracing then Messages.trace "compare" "in acc\n";
+            true
+          )
+          else (
+            let acc = (a, b) :: acc in
+            let res = eq_compinfo compinfo1 compinfo2 acc && eq_list eq_attribute attr1 attr2 in
+            if res && compinfo1.cname <> compinfo2.cname then
+              compinfo2.cname <- compinfo1.cname;
+            if res then
+              global_typ_acc := (a, b) :: !global_typ_acc;
+            res
+          )
         | TEnum (enuminfo1, attr1), TEnum (enuminfo2, attr2) -> let res = eq_enuminfo enuminfo1 enuminfo2 && eq_list eq_attribute attr1 attr2 in (if res && enuminfo1.ename <> enuminfo2.ename then enuminfo2.ename <- enuminfo1.ename); res
         | TBuiltin_va_list attr1, TBuiltin_va_list attr2 -> eq_list eq_attribute attr1 attr2
         | TVoid attr1, TVoid attr2 -> eq_list eq_attribute attr1 attr2
         | TInt (ik1, attr1), TInt (ik2, attr2) -> ik1 = ik2 && eq_list eq_attribute attr1 attr2
         | TFloat (fk1, attr1), TFloat (fk2, attr2) -> fk1 = fk2 && eq_list eq_attribute attr1 attr2
-        | _, _ -> false
-        in
-        if r then (* TODO: only do for nontrivial types? *)
-          global_typ_acc := (a, b) :: !global_typ_acc;
-        r
-        )
+        | _, _ -> false)
   in
   if Messages.tracing then Messages.traceu "compare" "eq_typ_acc %a vs %a\n" d_type a d_type b;
   r

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -82,8 +82,8 @@ and global_typ_acc: (typ * typ) list ref = ref [] (* TODO: optimize with physica
 and mem_typ_acc (a: typ) (b: typ) acc = List.exists (fun p -> match p with (x, y) -> a == x && b == y) acc (* TODO: seems slightly more efficient to not use "fun (x, y) ->" directly to avoid caml_tuplify2 *)
 
 and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
-  if Messages.tracing then Messages.tracei "compare" "eq_typ_acc %a vs %a\n" d_type a d_type b;
-  (* if Messages.tracing then Messages.tracei "compare" "eq_typ_acc %a vs %a (%d)\n" d_type a d_type b (List.length acc); (* TODO: remove because always calls List.length *) *)
+  if Messages.tracing then Messages.tracei "compareast" "eq_typ_acc %a vs %a\n" d_type a d_type b;
+  (* if Messages.tracing then Messages.tracei "compareast" "eq_typ_acc %a vs %a (%d)\n" d_type a d_type b (List.length acc); (* TODO: remove because always calls List.length *) *)
   let r = (match a, b with
         | TPtr (typ1, attr1), TPtr (typ2, attr2) -> eq_typ_acc typ1 typ2 acc && eq_list eq_attribute attr1 attr2
         | TArray (typ1, (Some lenExp1), attr1), TArray (typ2, (Some lenExp2), attr2) -> eq_typ_acc typ1 typ2 acc && eq_exp lenExp1 lenExp2 &&  eq_list eq_attribute attr1 attr2
@@ -100,7 +100,7 @@ and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
         (* The following two lines are a hack to ensure that anonymous types get the same name and thus, the same typsig *)
         | TComp (compinfo1, attr1), TComp (compinfo2, attr2) ->
           if mem_typ_acc a b acc || mem_typ_acc a b !global_typ_acc then (
-            if Messages.tracing then Messages.trace "compare" "in acc\n";
+            if Messages.tracing then Messages.trace "compareast" "in acc\n";
             true
           )
           else (
@@ -119,7 +119,7 @@ and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
         | TFloat (fk1, attr1), TFloat (fk2, attr2) -> fk1 = fk2 && eq_list eq_attribute attr1 attr2
         | _, _ -> false)
   in
-  if Messages.tracing then Messages.traceu "compare" "eq_typ_acc %a vs %a\n" d_type a d_type b;
+  if Messages.tracing then Messages.traceu "compareast" "eq_typ_acc %a vs %a\n" d_type a d_type b;
   r
 
 and eq_typ (a: typ) (b: typ) = eq_typ_acc a b []
@@ -170,9 +170,9 @@ and eq_compinfo (a: compinfo) (b: compinfo) (acc: (typ * typ) list) =
   a.cdefined = b.cdefined (* Ignore ckey, and ignore creferenced *)
 
 and eq_fieldinfo (a: fieldinfo) (b: fieldinfo) (acc: (typ * typ) list)=
-  if Messages.tracing then Messages.tracei "compare" "fieldinfo %s vs %s\n" a.fname b.fname;
+  if Messages.tracing then Messages.tracei "compareast" "fieldinfo %s vs %s\n" a.fname b.fname;
   let r = a.fname = b.fname && eq_typ_acc a.ftype b.ftype acc && a.fbitfield = b.fbitfield &&  eq_list eq_attribute a.fattr b.fattr in
-  if Messages.tracing then Messages.traceu "compare" "fieldinfo %s vs %s\n" a.fname b.fname;
+  if Messages.tracing then Messages.traceu "compareast" "fieldinfo %s vs %s\n" a.fname b.fname;
   r
 
 and eq_offset (a: offset) (b: offset) = match a, b with

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -82,8 +82,8 @@ and global_typ_acc: (typ * typ) list ref = ref [] (* TODO: optimize with physica
 and mem_typ_acc (a: typ) (b: typ) acc = List.exists (fun p -> match p with (x, y) -> a == x && b == y) acc (* TODO: seems slightly more efficient to not use "fun (x, y) ->" directly to avoid caml_tuplify2 *)
 
 and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
-  (* if Messages.tracing then Messages.tracei "compare" "eq_typ_acc %a vs %a\n" d_type a d_type b; *)
-  if Messages.tracing then Messages.tracei "compare" "eq_typ_acc %a vs %a (%d)\n" d_type a d_type b (List.length acc); (* TODO: remove because always calls List.length *)
+  if Messages.tracing then Messages.tracei "compare" "eq_typ_acc %a vs %a\n" d_type a d_type b;
+  (* if Messages.tracing then Messages.tracei "compare" "eq_typ_acc %a vs %a (%d)\n" d_type a d_type b (List.length acc); (* TODO: remove because always calls List.length *) *)
   let r =
   if mem_typ_acc a b acc || mem_typ_acc a b !global_typ_acc then (
     if Messages.tracing then Messages.trace "compare" "in acc\n";

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -137,18 +137,6 @@ and eq_enuminfo (a: enuminfo) (b: enuminfo) =
 and eq_args (acc: (typ * typ) list) (a: string * typ * attributes) (b: string * typ * attributes) = match a, b with
     (name1, typ1, attr1), (name2, typ2, attr2) -> name1 = name2 && eq_typ_acc typ1 typ2 acc && eq_list eq_attribute attr1 attr2
 
-(* TODO: why unused? *)
-and eq_typsig (a: typsig) (b: typsig) =
-  match a, b with
-  | TSArray (ts1, i1, attr1), TSArray (ts2, i2, attr2) -> eq_typsig ts1 ts2 && i1 = i2 && eq_list eq_attribute attr1 attr2
-  | TSPtr (ts1, attr1), TSPtr (ts2, attr2) -> eq_typsig ts1 ts2 && eq_list eq_attribute attr1 attr2
-  | TSComp (b1, str1, attr1), TSComp (b2, str2, attr2) -> b1 = b2 && str1 = str2 && eq_list eq_attribute attr1 attr2
-  | TSFun (ts1, Some tsList1, b1, attr1), TSFun (ts2, Some tsList2, b2, attr2) -> eq_typsig ts1 ts2 && eq_list eq_typsig tsList1 tsList2 && b1 = b2 && eq_list eq_attribute attr1 attr2
-  | TSFun (ts1, None, b1, attr1), TSFun (ts2, None, b2, attr2) -> eq_typsig ts1 ts2 && b1 = b2 && eq_list eq_attribute attr1 attr2
-  | TSEnum (str1, attr1), TSEnum (str2, attr2) -> str1 = str2 && eq_list eq_attribute attr1 attr2
-  | TSBase typ1, TSBase typ2 -> eq_typ_acc typ1 typ2 []
-  | _, _ -> false
-
 and eq_attrparam (a: attrparam) (b: attrparam) = match a, b with
   | ACons (str1, attrparams1), ACons (str2, attrparams2) -> str1 = str2 && eq_list eq_attrparam attrparams1 attrparams2
   | ASizeOf typ1, ASizeOf typ2 -> eq_typ typ1 typ2

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -121,6 +121,7 @@ and eq_enuminfo (a: enuminfo) (b: enuminfo) =
 and eq_args (acc: (typ * typ) list) (a: string * typ * attributes) (b: string * typ * attributes) = match a, b with
     (name1, typ1, attr1), (name2, typ2, attr2) -> name1 = name2 && eq_typ_acc typ1 typ2 acc && eq_list eq_attribute attr1 attr2
 
+(* TODO: why unused? *)
 and eq_typsig (a: typsig) (b: typsig) =
   match a, b with
   | TSArray (ts1, i1, attr1), TSArray (ts2, i2, attr2) -> eq_typsig ts1 ts2 && i1 = i2 && eq_list eq_attribute attr1 attr2

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -108,7 +108,10 @@ and eq_typ_acc (a: typ) (b: typ) (acc: (typ * typ) list) =
         | TComp (compinfo1, attr1), TComp (compinfo2, attr2) -> let res = eq_compinfo compinfo1 compinfo2 acc &&  eq_list eq_attribute attr1 attr2 in (if res && compinfo1.cname <> compinfo2.cname then compinfo2.cname <- compinfo1.cname); res
         | TEnum (enuminfo1, attr1), TEnum (enuminfo2, attr2) -> let res = eq_enuminfo enuminfo1 enuminfo2 && eq_list eq_attribute attr1 attr2 in (if res && enuminfo1.ename <> enuminfo2.ename then enuminfo2.ename <- enuminfo1.ename); res
         | TBuiltin_va_list attr1, TBuiltin_va_list attr2 -> eq_list eq_attribute attr1 attr2
-        | _, _ -> a = b
+        | TVoid attr1, TVoid attr2 -> eq_list eq_attribute attr1 attr2
+        | TInt (ik1, attr1), TInt (ik2, attr2) -> ik1 = ik2 && eq_list eq_attribute attr1 attr2
+        | TFloat (fk1, attr1), TFloat (fk2, attr2) -> fk1 = fk2 && eq_list eq_attribute attr1 attr2
+        | _, _ -> false
         in
         if r then (* TODO: only do for nontrivial types? *)
           global_typ_acc := (a, b) :: !global_typ_acc;

--- a/src/incremental/versionLookup.ml
+++ b/src/incremental/versionLookup.ml
@@ -7,7 +7,7 @@ type max_ids = {
 }
 
 let updateMap (oldFile: Cil.file) (newFile: Cil.file) (ht: (global_identifier, Cil.global) Hashtbl.t) =
-  let changes = compareCilFiles oldFile newFile in
+  let changes = Stats.time "compareCilFiles" (fun () -> compareCilFiles oldFile newFile) () in
   (* TODO: For updateCIL, we have to show whether the new data is from an changed or added functiong  *)
   List.iter (fun (glob: global) ->  Hashtbl.replace ht (identifier_of_global glob) glob) (List.map (fun a -> a.current) changes.changed);
   List.iter (fun (glob: global) ->  Hashtbl.replace ht (identifier_of_global glob) glob) changes.added;


### PR DESCRIPTION
To be merged after #358.

Closes #359.

### Fixes
First, there was a catch-all exception handler which was also catching `Stack_overflow` exceptions coming from recursive type comparison and hiding the problem. Those stack overflows just took time to happen.

Second, function argument type comparison was ignoring the `acc` structure that's supposed to avoid infinite recursion. A mix of recursive struct types with function pointer types to those structs caused the infinite recursion.

Thirdly, a global `acc` is added to reuse the recursive type equivalences between multiple globals, instead of having to go through all the trouble again.

Fourthly, the `acc` structure is only used for structs now, because that's what causes recursive types. By doing this the `acc` list is made significantly smaller, so checking it with `List.exists` is also much faster. There's no point in putting trivial equivalences like `(int, int)` into the structure because they're trivially computed from scratch.


### Performance improvement
Before (in #359):
```
Timings:
TOTAL                          104.756 s
  parse                           0.079 s
  convert to CIL                  0.093 s
  compareCilFiles                104.194 s
  analysis                        0.390 s
    global_inits                    0.078 s
    solving                         0.044 s
    verify                          0.021 s
```

After:
```
Timings:
TOTAL                           0.691 s
  parse                           0.074 s
  convert to CIL                  0.086 s
  compareCilFiles                 0.073 s
  analysis                        0.458 s
    global_inits                    0.074 s
    solving                         0.066 s
      S.Dom.equal                     0.001 s
    verify                          0.021 s
```

This makes `compareCilFiles` on the regression test **1400 times faster**!

And as you see, all these fixes were necessary to bring the comparison time of two unchanged ASTs down to be more like its parsing and conversion time, which is how it should be. Previously comparison of ASTs could be much bigger bottleneck than parsing itself!