### PR TITLE
Incremental/reluctant-destabilization

### DIFF
--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -76,16 +76,18 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_id
       | _ -> ()
     with Failure m -> ()
   in
-  let reset_changed_fun (f: fundec) (old_f: fundec) =
+  let reset_changed_fun (f: fundec) (old_f: fundec) unchangedHeader =
     f.svar.vid <- old_f.svar.vid;
     update_vid_max f.svar.vid;
     List.iter (fun l -> l.vid <- make_vid ()) f.slocals;
-    List.iter (fun f -> f.vid <- make_vid ()) f.sformals;
+    if unchangedHeader then
+      List.iter (fun (f,old_f) -> f.vid <- old_f.vid; update_vid_max f.vid) (List.combine f.sformals old_f.sformals)
+    else List.iter (fun f -> f.vid <- make_vid ()) f.sformals;
     List.iter (fun s -> s.sid <- make_sid ()) f.sallstmts;
   in
   let reset_changed_globals (changed: changed_global) =
     match (changed.current, changed.old) with
-    | GFun (nw, _), GFun (old, _) -> reset_changed_fun nw old
+    | GFun (nw, _), GFun (old, _) -> reset_changed_fun nw old changed.unchangedHeader
     | _ -> ()
   in
   let update_fun (f: fundec) =

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -269,12 +269,11 @@ module WP =
         let obsolete_funs = filter_map (fun c -> match c.old with GFun (f,l) -> Some f | _ -> None) S.increment.changes.changed in
         let removed_funs = filter_map (fun g -> match g with GFun (f,l) -> Some f | _ -> None) S.increment.changes.removed in
         (* TODO: don't use string-based nodes, make obsolete of type Node.t BatSet.t *)
-        let obsolete = Set.union (Set.of_list (List.map (fun a -> Node.show_id (Function a))  obsolete_funs))
-                                 (Set.of_list (List.map (fun a -> Node.show_id (FunctionEntry a))  obsolete_funs)) in
+        let obsolete = Set.of_list (List.map (fun a -> Node.show_id (Function a))  obsolete_funs) in
 
         List.iter (fun a -> print_endline ("Obsolete function: " ^ a.svar.vname)) obsolete_funs;
 
-        (* Actually destabilize all nodes contained in changed functions. TODO only destabilize fun_... nodes *)
+        (* Actually destabilize all nodes contained in changed functions. *)
         HM.iter (fun k v -> if Set.mem (S.Var.var_id k) obsolete then destabilize k) stable; (* TODO: don't use string-based nodes *)
 
         (* We remove all unknowns for program points in changed or removed functions from rho, stable, infl and wpoint *)

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -284,8 +284,6 @@ module WP =
             let old_rho = HM.find rho k in
             let old_infl = HM.find_default infl k VS.empty in
             Hashtbl.replace old_ret k (old_rho, old_infl))) rho;
-          (* Do not destabilize changed functions immediately, instead remove ret nodes from stable and wait for result of function-only solve *)
-          Hashtbl.iter (fun k v -> HM.remove stable k) old_ret
         ) else (
           HM.iter (fun k _ -> if Set.mem (S.Var.var_id k) obsolete_entry then destabilize k) stable
         );

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -328,7 +328,8 @@ module WP =
               destabilize x; HM.replace stable x ())
           ) old_ret;
 
-          if !numDest = 0 then print_endline "no actual destabilization needed!"
+          if !numDest = 0 then print_endline "no actual destabilization needed!";
+          print_endline "final solve"
           (* ignore (Pretty.printf "vars = %d    evals = %d  \n" !Goblintutil.vars !Goblintutil.evals) *)
         )
       );

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -269,25 +269,35 @@ module WP =
         let obsolete_funs = filter_map (fun c -> match c.old with GFun (f,l) -> Some f | _ -> None) S.increment.changes.changed in
         let removed_funs = filter_map (fun g -> match g with GFun (f,l) -> Some f | _ -> None) S.increment.changes.removed in
         (* TODO: don't use string-based nodes, make obsolete of type Node.t BatSet.t *)
-        let obsolete = Set.of_list (List.map (fun a -> Node.show_id (Function a))  obsolete_funs) in
+        let obsolete_ret = Set.of_list (List.map (fun a -> Node.show_id (Function a))  obsolete_funs) in
 
         List.iter (fun a -> print_endline ("Obsolete function: " ^ a.svar.vname)) obsolete_funs;
 
-        (* Actually destabilize all nodes contained in changed functions. *)
-        HM.iter (fun k v -> if Set.mem (S.Var.var_id k) obsolete then destabilize k) stable; (* TODO: don't use string-based nodes *)
+
+        (* save entries of changed functions in rho for the comparison whether the result has changed after a function specific solve *)
+        let old_ret = Hashtbl.create 103 in
+        HM.iter (fun k v -> if Set.mem (S.Var.var_id k) obsolete_ret then ( (* TODO: don't use string-based nodes *)
+          print_endline (S.Var.var_id k);
+          ignore @@ Pretty.printf "%a\n" S.Var.pretty_trace k;
+          let old_rho = HM.find rho k in
+          let old_infl = HM.find_default infl k VS.empty in
+          Hashtbl.replace old_ret k (old_rho, old_infl))) rho;
+
+        (* Do not destabilize changed functions immediately, instead remove ret nodes from stable and wait for result of function-only solve *)
+        Hashtbl.iter (fun k v -> HM.remove stable k) old_ret;
 
         (* We remove all unknowns for program points in changed or removed functions from rho, stable, infl and wpoint *)
         (* TODO: don't use string-based nodes, make marked_for_deletion of type unit (Hashtbl.Make (Node)).t *)
-        let add_nodes_of_fun (functions: fundec list) (nodes)=
+        let add_nodes_of_fun (functions: fundec list) (nodes) withEntry =
           let add_stmts (f: fundec) =
             List.iter (fun s -> Hashtbl.replace nodes (Node.show_id (Statement s)) ()) (f.sallstmts)
           in
-          List.iter (fun f -> Hashtbl.replace nodes (Node.show_id (FunctionEntry f)) (); Hashtbl.replace nodes (Node.show_id (Function f)) (); add_stmts f; Hashtbl.replace nodes (string_of_int (CfgTools.get_pseudo_return_id f)) ()) functions;
+          List.iter (fun f -> if withEntry then Hashtbl.replace nodes (Node.show_id (FunctionEntry f)) (); Hashtbl.replace nodes (Node.show_id (Function f)) (); add_stmts f; Hashtbl.replace nodes (string_of_int (CfgTools.get_pseudo_return_id f)) ()) functions;
         in
 
         let marked_for_deletion = Hashtbl.create 103 in
-        add_nodes_of_fun obsolete_funs marked_for_deletion;
-        add_nodes_of_fun removed_funs marked_for_deletion;
+        add_nodes_of_fun obsolete_funs marked_for_deletion false;
+        add_nodes_of_fun removed_funs marked_for_deletion true;
 
         print_endline "Removing data for changed and removed functions...";
         let delete_marked s = HM.iter (fun k v -> if Hashtbl.mem  marked_for_deletion (S.Var.var_id k) then HM.remove s k ) s in (* TODO: don't use string-based nodes *)
@@ -296,10 +306,27 @@ module WP =
         delete_marked wpoint;
         delete_marked stable;
 
-        print_data data "Data after clean-up"
+
+        print_data data "Data after clean-up";
+
+        (* solve on the return node of changed functions. Only destabilize influenced nodes outside the function if the analysis result changed *)
+        print_endline "solving changed functions";
+        List.iter set_start st;
+        let numDest = ref 0 in
+        Hashtbl.iter (fun x (old_rho, old_infl) -> ignore @@ Pretty.printf "test for %a\n" Node.pretty_trace (S.Var.node x);
+          ignore @@ Pretty.printf "solving for %a\n" Node.pretty_trace (S.Var.node x);
+          solve x Widen;
+          if not (S.Dom.leq (HM.find rho x) old_rho) then (
+            numDest := !numDest + 1; print_endline "actually destabilize...";
+            HM.replace infl x old_infl;
+            destabilize x; HM.replace stable x ())
+        ) old_ret;
+
+        if !numDest = 0 && !Goblintutil.evals = 0 then print_endline "no actual destabilization needed!"
+        (* ignore (Pretty.printf "vars = %d    evals = %d  \n" !Goblintutil.vars !Goblintutil.evals); *)
       );
 
-      List.iter set_start st;
+      if !incremental_mode = "off" then List.iter set_start st;
       List.iter init vs;
       (* If we have multiple start variables vs, we might solve v1, then while solving v2 we side some global which v1 depends on with a new value. Then v1 is no longer stable and we have to solve it again. *)
       let i = ref 0 in

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -246,6 +246,8 @@ module WP =
          *   if exp.earlyglobs: the contexts will be the same since they don't contain the global, but the start state will be different!
          *)
         print_endline "Destabilizing start functions if their start state changed...";
+        (* record whether any function's start state changed. In that case do not use reluctant destabilization *)
+        let any_changed_start_state = ref false in
         (* ignore @@ Pretty.printf "st: %d, data.st: %d\n" (List.length st) (List.length data.st); *)
         List.iter (fun (v,d) ->
           match GU.assoc_eq v data.st S.Var.equal with
@@ -255,9 +257,10 @@ module WP =
                 ()
               else (
                 ignore @@ Pretty.printf "Function %a has changed start state: %a\n" S.Var.pretty_trace v S.Dom.pretty_diff (d, d');
+                any_changed_start_state := true;
                 destabilize v
               )
-          | None -> ignore @@ Pretty.printf "New start function %a not found in old list!\n" S.Var.pretty_trace v
+          | None -> any_changed_start_state := true; ignore @@ Pretty.printf "New start function %a not found in old list!\n" S.Var.pretty_trace v
         ) st;
 
         print_endline "Destabilizing changed functions...";
@@ -269,22 +272,23 @@ module WP =
         let obsolete_funs = filter_map (fun c -> match c.old with GFun (f,l) -> Some f | _ -> None) S.increment.changes.changed in
         let removed_funs = filter_map (fun g -> match g with GFun (f,l) -> Some f | _ -> None) S.increment.changes.removed in
         (* TODO: don't use string-based nodes, make obsolete of type Node.t BatSet.t *)
-        let obsolete_ret = Set.of_list (List.map (fun a -> Node.show_id (Function a))  obsolete_funs) in
+        let obsolete_ret = Set.of_list (List.map (fun f -> Node.show_id (Function f))  obsolete_funs) in
+        let obsolete_entry = Set.of_list (List.map (fun f -> Node.show_id (FunctionEntry f)) obsolete_funs) in
 
         List.iter (fun a -> print_endline ("Obsolete function: " ^ a.svar.vname)) obsolete_funs;
 
-
-        (* save entries of changed functions in rho for the comparison whether the result has changed after a function specific solve *)
         let old_ret = Hashtbl.create 103 in
-        HM.iter (fun k v -> if Set.mem (S.Var.var_id k) obsolete_ret then ( (* TODO: don't use string-based nodes *)
-          print_endline (S.Var.var_id k);
-          ignore @@ Pretty.printf "%a\n" S.Var.pretty_trace k;
-          let old_rho = HM.find rho k in
-          let old_infl = HM.find_default infl k VS.empty in
-          Hashtbl.replace old_ret k (old_rho, old_infl))) rho;
-
-        (* Do not destabilize changed functions immediately, instead remove ret nodes from stable and wait for result of function-only solve *)
-        Hashtbl.iter (fun k v -> HM.remove stable k) old_ret;
+        if not !any_changed_start_state then (
+          (* save entries of changed functions in rho for the comparison whether the result has changed after a function specific solve *)
+          HM.iter (fun k v -> if Set.mem (S.Var.var_id k) obsolete_ret then ( (* TODO: don't use string-based nodes *)
+            let old_rho = HM.find rho k in
+            let old_infl = HM.find_default infl k VS.empty in
+            Hashtbl.replace old_ret k (old_rho, old_infl))) rho;
+          (* Do not destabilize changed functions immediately, instead remove ret nodes from stable and wait for result of function-only solve *)
+          Hashtbl.iter (fun k v -> HM.remove stable k) old_ret
+        ) else (
+          HM.iter (fun k _ -> if Set.mem (S.Var.var_id k) obsolete_entry then destabilize k) stable
+        );
 
         (* We remove all unknowns for program points in changed or removed functions from rho, stable, infl and wpoint *)
         (* TODO: don't use string-based nodes, make marked_for_deletion of type unit (Hashtbl.Make (Node)).t *)
@@ -296,7 +300,7 @@ module WP =
         in
 
         let marked_for_deletion = Hashtbl.create 103 in
-        add_nodes_of_fun obsolete_funs marked_for_deletion false;
+        add_nodes_of_fun obsolete_funs marked_for_deletion !any_changed_start_state;
         add_nodes_of_fun removed_funs marked_for_deletion true;
 
         print_endline "Removing data for changed and removed functions...";
@@ -309,21 +313,24 @@ module WP =
 
         print_data data "Data after clean-up";
 
-        (* solve on the return node of changed functions. Only destabilize influenced nodes outside the function if the analysis result changed *)
-        print_endline "solving changed functions";
         List.iter set_start st;
-        let numDest = ref 0 in
-        Hashtbl.iter (fun x (old_rho, old_infl) -> ignore @@ Pretty.printf "test for %a\n" Node.pretty_trace (S.Var.node x);
-          ignore @@ Pretty.printf "solving for %a\n" Node.pretty_trace (S.Var.node x);
-          solve x Widen;
-          if not (S.Dom.leq (HM.find rho x) old_rho) then (
-            numDest := !numDest + 1; print_endline "actually destabilize...";
-            HM.replace infl x old_infl;
-            destabilize x; HM.replace stable x ())
-        ) old_ret;
 
-        if !numDest = 0 && !Goblintutil.evals = 0 then print_endline "no actual destabilization needed!"
-        (* ignore (Pretty.printf "vars = %d    evals = %d  \n" !Goblintutil.vars !Goblintutil.evals); *)
+        if not !any_changed_start_state then (
+          (* solve on the return node of changed functions. Only destabilize influenced nodes outside the function if the analysis result changed *)
+          print_endline "solving changed functions";
+          let numDest = ref 0 in
+          Hashtbl.iter (fun x (old_rho, old_infl) -> ignore @@ Pretty.printf "test for %a\n" Node.pretty_trace (S.Var.node x);
+            ignore @@ Pretty.printf "solving for %a\n" Node.pretty_trace (S.Var.node x);
+            solve x Widen;
+            if not (S.Dom.leq (HM.find rho x) old_rho) then (
+              numDest := !numDest + 1; print_endline "actually destabilize...";
+              HM.replace infl x old_infl;
+              destabilize x; HM.replace stable x ())
+          ) old_ret;
+
+          if !numDest = 0 then print_endline "no actual destabilization needed!"
+          (* ignore (Pretty.printf "vars = %d    evals = %d  \n" !Goblintutil.vars !Goblintutil.evals) *)
+        )
       );
 
       if !incremental_mode = "off" then List.iter set_start st;

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -152,6 +152,7 @@ let _ = ()
       ; reg Incremental "incremental.save"   "false" "Store incremental analysis results."
       ; reg Incremental "incremental.stable" "true"  "Reuse the stable set and selectively destabilize it (recommended)."
       ; reg Incremental "incremental.wpoint" "false" "Reuse the wpoint set (not recommended). Reusing the wpoint will combine existing results at previous widening points."
+      ; reg Incremental "incremental.reluctant" "true" "Destabilize nodes in changed functions reluctantly"
 
 (* {4 category [Semantics]} *)
 let _ = ()


### PR DESCRIPTION
This pull request contains an improvement for the incremental analysis in the td3 solver (#351). With this, the changed functions are not destabilized right away anymore before solving once completely. Instead it is split as follows:

- The changed functions are solved separately for the contexts from the previous run. For each, the found abstract value for the return node is compared to the one from the previous run. The functions return node needs to be destabilized only further if the found abstract value is not `leq` then the old one.
- After every changed function has been solved separately `solve` is called on the queried unknown. This ensures, that possibly new side-effects affecting the queried unknown are taken into account.

Note that for this to work, it is necessary to adopt the previous ids for formal parameters of changed functions when possible. This way, the contexts of different versions for a function entry node of a changed function can coincide. Then the result from the separate solving phase for changed functions can actually be used and is not unnecessarily re-analyzed in the final `solve`.

A config parameter has been introduced to deactivate the reluctant destabilization when needed.