### PR TITLE
`OPAMCLI=2.0` for `make deps` to allow `--unlock-base` for opam 2.1.0

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -88,7 +88,7 @@ rule() {
 
     # setup, dependencies
     ;; deps)
-      opam update; OPAMCLI=2.0 opam install -y . --deps-only --locked --unlock-base
+      opam update; OPAMCLI=2.0 opam install -y . --deps-only --locked --unlock-base; opam upgrade $(opam list --pinned -s)
     ;; setup)
       echo "Make sure you have the following installed: opam >= 2.0.0, git, patch, m4, autoconf, libgmp-dev, libmpfr-dev"
       echo "For the --html output you also need: javac, ant, dot (graphviz)"


### PR DESCRIPTION
opam 2.1.0 otherwise fails:

--unlock-base was removed in version 2.1 of the opam CLI, but version 2.1 has been requested. Use --update-invariant instead or set OPAMCLI environment variable to 2.0.

Was there a need to have it?