### PR TITLE
Add option incremental.only-rename that only renames Cil-IDs,

### DIFF
--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -355,8 +355,9 @@ let do_html_output () =
       eprintf "Warning: jar file %s not found.\n" jar
   )
 
+let eprint_color m = eprintf "%s\n" (MessageUtil.colorize ~fd:Unix.stderr m)
+
 let check_arguments () =
-  let eprint_color m = eprintf "%s\n" (MessageUtil.colorize ~fd:Unix.stderr m) in
   (* let fail m = let m = "Option failure: " ^ m in eprint_color ("{red}"^m); failwith m in *) (* unused now, but might be useful for future checks here *)
   let warn m = eprint_color ("{yellow}Option warning: "^m) in
   if get_bool "allfuns" && not (get_bool "exp.earlyglobs") then (set_bool "exp.earlyglobs" true; warn "allfuns enables exp.earlyglobs.\n");
@@ -364,7 +365,8 @@ let check_arguments () =
   if get_string "ana.osek.oil" <> "" && not (get_string "exp.privatization" = "protection-vesal" || get_string "exp.privatization" = "protection-old") then (set_string "exp.privatization" "protection-vesal"; warn "oil requires protection-old/protection-vesal privatization");
   if get_bool "ana.base.context.int" && not (get_bool "ana.base.context.non-ptr") then (set_bool "ana.base.context.int" false; warn "ana.base.context.int implicitly disabled by ana.base.context.non-ptr");
   (* order matters: non-ptr=false, int=true -> int=false cascades to interval=false with warning *)
-  if get_bool "ana.base.context.interval" && not (get_bool "ana.base.context.int") then (set_bool "ana.base.context.interval" false; warn "ana.base.context.interval implicitly disabled by ana.base.context.int")
+  if get_bool "ana.base.context.interval" && not (get_bool "ana.base.context.int") then (set_bool "ana.base.context.interval" false; warn "ana.base.context.interval implicitly disabled by ana.base.context.int");
+  if get_bool "incremental.only-rename" then (set_bool "incremental.load" true; warn "incremental.only-rename implicitly activates incremental.rename-load. Previous AST is loaded for diff and rename, but analyis results are not reused.")
 
 let handle_extraspecials () =
   let funs = get_string_list "exp.extraspecials" in
@@ -374,17 +376,24 @@ let handle_extraspecials () =
 let diff_and_rename current_file =
   (* Create change info, either from old results, or from scratch if there are no previous results. *)
   let change_info: Analyses.increment_data =
-    let (changes, old_file, solver_data, version_map, max_ids) =
+    if GobConfig.get_bool "incremental.load" && not (Serialize.results_exist ()) then begin
+      let warn m = eprint_color ("{yellow}Warning: "^m) in
+      warn "incremental.load is activated but no data exists that can be loaded."
+    end;
+    let (changes, old_file, version_map, max_ids) =
       if Serialize.results_exist () && GobConfig.get_bool "incremental.load" then begin
         let old_file = Serialize.load_data Serialize.CilFile in
         let (version_map, changes, max_ids) = VersionLookup.load_and_update_map old_file current_file in
         let max_ids = UpdateCil.update_ids old_file max_ids current_file version_map changes in
-        let solver_data = Serialize.load_data Serialize.SolverData in
-        (changes, Some old_file, Some solver_data, version_map, max_ids)
+        (changes, Some old_file, version_map, max_ids)
       end else begin
         let (version_map, max_ids) = VersionLookup.create_map current_file in
-        (CompareAST.empty_change_info (), None, None, version_map, max_ids)
+        (CompareAST.empty_change_info (), None, version_map, max_ids)
       end
+    in
+    let solver_data = if Serialize.results_exist () && GobConfig.get_bool "incremental.load" && not (GobConfig.get_bool "incremental.only-rename")
+      then Some (Serialize.load_data Serialize.SolverData)
+      else None
     in
     if GobConfig.get_bool "incremental.save" then begin
       Serialize.store_data current_file Serialize.CilFile;

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -148,10 +148,11 @@ let _ = ()
 
 (* {4 category [Incremental]} *)
 let _ = ()
-      ; reg Incremental "incremental.load"   "false" "Load incremental analysis results, in case any exist."
-      ; reg Incremental "incremental.save"   "false" "Store incremental analysis results."
-      ; reg Incremental "incremental.stable" "true"  "Reuse the stable set and selectively destabilize it (recommended)."
-      ; reg Incremental "incremental.wpoint" "false" "Reuse the wpoint set (not recommended). Reusing the wpoint will combine existing results at previous widening points."
+      ; reg Incremental "incremental.load"        "false" "Load incremental analysis results, in case any exist."
+      ; reg Incremental "incremental.only-rename" "false" "Only reset IDs of unchanged objects in the AST. Do  not reuse solver results. This option is mainly useful for benchmarking purposes."
+      ; reg Incremental "incremental.save"        "false" "Store incremental analysis results."
+      ; reg Incremental "incremental.stable"      "true"  "Reuse the stable set and selectively destabilize it (recommended)."
+      ; reg Incremental "incremental.wpoint"      "false" "Reuse the wpoint set (not recommended). Reusing the wpoint will combine existing results at previous widening points."
       ; reg Incremental "incremental.reluctant.on" "true" "Destabilize nodes in changed functions reluctantly"
       ; reg Incremental "incremental.reluctant.compare" "'leq'" "In order to reuse the function's old abstract value the new abstract value must be leq (focus on efficiency) or equal (focus on precision) compared to the old."
 


### PR DESCRIPTION
 Add option incremental.only-rename that only renames Cil-IDs, but does not reuse solver data.

This option is intended for comparing incremental with non-incremental runs.
closes #401 