### PR TITLE
Incremental TD3: incrementalize analysis within functions

### DIFF
--- a/scripts/incremental.sh
+++ b/scripts/incremental.sh
@@ -53,8 +53,8 @@ trap finish EXIT
 
 outp=$out/$(basename $repo_path)
 
-rm -rf "$outp"
-rm -rf "incremental_data"
+rm -r "$outp"
+rm -r "incremental_data"
 function log {
   echo "$*" | tee -a $outp/incremental.log
 }

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -386,13 +386,13 @@ type analyzed_data = {
 type increment_data = {
   old_data: analyzed_data option;
   new_file: Cil.file;
-  changes: CompareCFG.change_info
+  changes: CompareCIL.change_info
 }
 
 let empty_increment_data file = {
   old_data = None;
   new_file = file;
-  changes = CompareCFG.empty_change_info ()
+  changes = CompareCIL.empty_change_info ()
 }
 
 (** A side-effecting system. *)

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -386,13 +386,13 @@ type analyzed_data = {
 type increment_data = {
   old_data: analyzed_data option;
   new_file: Cil.file;
-  changes: CompareAST.change_info
+  changes: CompareCFG.change_info
 }
 
 let empty_increment_data file = {
   old_data = None;
   new_file = file;
-  changes = CompareAST.empty_change_info ()
+  changes = CompareCFG.empty_change_info ()
 }
 
 (** A side-effecting system. *)

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -257,7 +257,7 @@ let createCFG (file: file) =
         let pseudo_return = lazy (
           let newst = mkStmt (Return (None, fd_loc)) in
           newst.sid <- get_pseudo_return_id fd;
-          fd.sallstmts <- fd.sallstmts @ [newst]; (* TODO: anything bad happen from changing sallstmts? should also update smaxid? *)
+          Cilfacade.StmtH.add Cilfacade.pseudo_return_to_fun newst fd;
           let newst_node = Statement newst in
           addEdge newst_node (fd_loc, Ret (None, fd)) (Function fd);
           newst_node

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -68,7 +68,7 @@ let location (node: t) =
   | Function fd -> fd.svar.vdecl
   | FunctionEntry fd -> fd.svar.vdecl
 
-(** Find [fundec] which the node is in. *)
+(** Find [fundec] which the node is in. In an incremental run this might yield old fundecs for pseudo-return nodes from the old file. *)
 let find_fundec (node: t) =
   match node with
   | Statement stmt -> Cilfacade.find_stmt_fundec stmt

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -1,20 +1,5 @@
 open Cil
 
-type changed_global = {
-  old: global;
-  current: global;
-  unchangedHeader: bool
-}
-
-type change_info = {
-  mutable changed: changed_global list;
-  mutable unchanged: global list;
-  mutable removed: global list;
-  mutable added: global list
-}
-
-let empty_change_info () : change_info = {added = []; removed = []; changed = []; unchanged = []}
-
 type global_type = Fun | Decl | Var | Other
 
 and global_identifier = {name: string ; global_t: global_type} [@@deriving ord]
@@ -160,8 +145,8 @@ and eq_attribute (a: attribute) (b: attribute) = match a, b with
     Attr (name1, params1), Attr (name2, params2) -> name1 = name2 && eq_list eq_attrparam params1 params2
 
 and eq_varinfo (a: varinfo) (b: varinfo) = a.vname = b.vname && eq_typ a.vtype b.vtype && eq_list eq_attribute a.vattr b.vattr &&
-                                           a.vstorage = b.vstorage && a.vglob = b.vglob && a.vinline = b.vinline && a.vaddrof = b.vaddrof
-(* Ignore the location, vid, vreferenced, vdescr, vdescrpure *)
+                                           a.vstorage = b.vstorage && a.vglob = b.vglob && a.vaddrof = b.vaddrof
+(* Ignore the location, vid, vreferenced, vdescr, vdescrpure, vinline *)
 
 (* Accumulator is needed because of recursive types: we have to assume that two types we already encountered in a previous step of the recursion are equivalent *)
 and eq_compinfo (a: compinfo) (b: compinfo) (acc: (typ * typ) list) =
@@ -191,6 +176,7 @@ let eq_instr (a: instr) (b: instr) = match a, b with
   | Call (Some lv1, f1, args1, _l1), Call (Some lv2, f2, args2, _l2) -> eq_lval lv1 lv2 && eq_exp f1 f2 && eq_list eq_exp args1 args2
   | Call (None, f1, args1, _l1), Call (None, f2, args2, _l2) -> eq_exp f1 f2 && eq_list eq_exp args1 args2
   | Asm (attr1, tmp1, ci1, dj1, rk1, l1), Asm (attr2, tmp2, ci2, dj2, rk2, l2) -> eq_list String.equal tmp1 tmp2 && eq_list(fun (x1,y1,z1) (x2,y2,z2)-> x1 = x2 && y1 = y2 && eq_lval z1 z2) ci1 ci2 && eq_list(fun (x1,y1,z1) (x2,y2,z2)-> x1 = x2 && y1 = y2 && eq_exp z1 z2) dj1 dj2 && eq_list String.equal rk1 rk2(* ignore attributes and locations *)
+  | VarDecl (v1, _l1), VarDecl (v2, _l2) -> eq_varinfo v1 v2
   | _, _ -> false
 
 let eq_label (a: label) (b: label) = match a, b with
@@ -205,45 +191,32 @@ let eq_stmt_with_location ((a, af): stmt * fundec) ((b, bf): stmt * fundec) =
   let offsetB = b.sid - (List.hd bf.sallstmts).sid in
   eq_list eq_label a.labels b.labels && offsetA = offsetB
 
-let rec eq_stmtkind ((a, af): stmtkind * fundec) ((b, bf): stmtkind * fundec) =
-  let eq_block' = fun x y -> eq_block (x, af) (y, bf) in
+(* cfg_comp: blocks need only be compared in the AST comparison. For cfg comparison of functions one instead walks through the cfg and only compares the currently visited node,
+   Switch, break and continue statements are removed during cfg preparation and therefore need not to be handeled *)
+let rec eq_stmtkind ?(cfg_comp = false) ((a, af): stmtkind * fundec) ((b, bf): stmtkind * fundec) =
+  let eq_block' = fun x y -> if cfg_comp then true else eq_block (x, af) (y, bf) in
   match a, b with
   | Instr is1, Instr is2 -> eq_list eq_instr is1 is2
   | Return (Some exp1, _l1), Return (Some exp2, _l2) -> eq_exp exp1 exp2
   | Return (None, _l1), Return (None, _l2) -> true
   | Return _, Return _ -> false
   | Goto (st1, _l1), Goto (st2, _l2) -> eq_stmt_with_location (!st1, af) (!st2, bf)
-  | Break _, Break _ -> true
-  | Continue _, Continue _ -> true
+  | Break _, Break _ -> if cfg_comp then failwith "CompareCFG: Invalid stmtkind in CFG" else true
+  | Continue _, Continue _ -> if cfg_comp then failwith "CompareCFG: Invalid stmtkind in CFG" else true
   | If (exp1, then1, else1, _l1), If (exp2, then2, else2, _l2) -> eq_exp exp1 exp2 && eq_block' then1 then2 && eq_block' else1 else2
-  | Switch (exp1, block1, stmts1, _l1), Switch (exp2, block2, stmts2, _l2) -> eq_exp exp1 exp2 && eq_block' block1 block2 && eq_list (fun a b -> eq_stmt (a,af) (b,bf)) stmts1 stmts2
+  | Switch (exp1, block1, stmts1, _l1), Switch (exp2, block2, stmts2, _l2) -> if cfg_comp then failwith "CompareCFG: Invalid stmtkind in CFG" else eq_exp exp1 exp2 && eq_block' block1 block2 && eq_list (fun a b -> eq_stmt (a,af) (b,bf)) stmts1 stmts2
   | Loop (block1, _l1, _con1, _br1), Loop (block2, _l2, _con2, _br2) -> eq_block' block1 block2
   | Block block1, Block block2 -> eq_block' block1 block2
   | TryFinally (tryBlock1, finallyBlock1, _l1), TryFinally (tryBlock2, finallyBlock2, _l2) -> eq_block' tryBlock1 tryBlock2 && eq_block' finallyBlock1 finallyBlock2
   | TryExcept (tryBlock1, exn1, exceptBlock1, _l1), TryExcept (tryBlock2, exn2, exceptBlock2, _l2) -> eq_block' tryBlock1 tryBlock2 && eq_block' exceptBlock1 exceptBlock2
   | _, _ -> false
 
-and eq_stmt ((a, af): stmt * fundec) ((b, bf): stmt * fundec) =
+and eq_stmt ?(cfg_comp = false) ((a, af): stmt * fundec) ((b, bf): stmt * fundec) =
   List.for_all (fun (x,y) -> eq_label x y) (List.combine a.labels b.labels) &&
-  eq_stmtkind (a.skind, af) (b.skind, bf)
+  eq_stmtkind ~cfg_comp (a.skind, af) (b.skind, bf)
 
 and eq_block ((a, af): Cil.block * fundec) ((b, bf): Cil.block * fundec) =
   a.battrs = b.battrs && List.for_all (fun (x,y) -> eq_stmt (x, af) (y, bf)) (List.combine a.bstmts b.bstmts)
-
-let eqF (a: Cil.fundec) (b: Cil.fundec) =
-  let unchangedHeader =
-    try
-      eq_varinfo a.svar b.svar &&
-      List.for_all (fun (x, y) -> eq_varinfo x y) (List.combine a.sformals b.sformals)
-    with Invalid_argument _ -> false in
-  let identical =
-    try
-      unchangedHeader &&
-      List.for_all (fun (x, y) -> eq_varinfo x y) (List.combine a.slocals b.slocals) &&
-      eq_block (a.sbody, a) (b.sbody, b)
-    with Invalid_argument _ -> (* The combine failed because the lists have differend length *)
-      false in
-  identical, unchangedHeader, None
 
 let rec eq_init (a: init) (b: init) = match a, b with
   | SingleInit e1, SingleInit e2 -> eq_exp e1 e2

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -191,7 +191,9 @@ let eq_stmt_with_location ((a, af): stmt * fundec) ((b, bf): stmt * fundec) =
   let offsetB = b.sid - (List.hd bf.sallstmts).sid in
   eq_list eq_label a.labels b.labels && offsetA = offsetB
 
-(* cfg_comp: blocks need only be compared in the AST comparison. For cfg comparison of functions one instead walks through the cfg and only compares the currently visited node,
+(* cfg_comp: blocks need only be compared in the AST comparison. For cfg comparison of functions one instead walks
+   through the cfg and only compares the currently visited node (The cil blocks inside an if statement should not be
+   compared together with its condition to avoid a to early and not precise detection of a changed node inside).
    Switch, break and continue statements are removed during cfg preparation and therefore need not to be handeled *)
 let rec eq_stmtkind ?(cfg_comp = false) ((a, af): stmtkind * fundec) ((b, bf): stmtkind * fundec) =
   let eq_block' = fun x y -> if cfg_comp then true else eq_block (x, af) (y, bf) in

--- a/src/incremental/compareCFG.ml
+++ b/src/incremental/compareCFG.ml
@@ -1,6 +1,7 @@
 open MyCFG
 open Queue
 open Cil
+open CompareAST
 
 module StdS = Set.Make (
   struct
@@ -18,32 +19,47 @@ module DiffS = Set.Make (
 
 let waitingList : (node * node) t = Queue.create ()
 
+(* in contrast to the original eq_varinfo in CompareAST, this method also ignores location, vid, vreferenced, vdescr, vdescrpure, vinline, vaddrof *)
+let eq_varinfo' (a: varinfo) (b: varinfo) = a.vname = b.vname && eq_typ a.vtype b.vtype && eq_list eq_attribute a.vattr b.vattr &&
+                                           a.vstorage = b.vstorage && a.vglob = b.vglob
+
+let eq_instr' (a: instr) (b: instr) = match a, b with
+  | Set (lv1, exp1, _l1), Set (lv2, exp2, _l2) -> eq_lval lv1 lv2 && eq_exp exp1 exp2
+  | Call (Some lv1, f1, args1, _l1), Call (Some lv2, f2, args2, _l2) -> eq_lval lv1 lv2 && eq_exp f1 f2 && eq_list eq_exp args1 args2
+  | Call (None, f1, args1, _l1), Call (None, f2, args2, _l2) -> eq_exp f1 f2 && eq_list eq_exp args1 args2
+  | Asm (attr1, tmp1, ci1, dj1, rk1, l1), Asm (attr2, tmp2, ci2, dj2, rk2, l2) ->
+      eq_list String.equal tmp1 tmp2 && eq_list(fun (x1,y1,z1) (x2,y2,z2)-> x1 = x2 && y1 = y2
+      && eq_lval z1 z2) ci1 ci2 && eq_list(fun (x1,y1,z1) (x2,y2,z2)-> x1 = x2 && y1 = y2
+      && eq_exp z1 z2) dj1 dj2 && eq_list String.equal rk1 rk2(* ignore attributes and locations *)
+  | VarDecl (v1, _l1), VarDecl (v2, _l2) -> eq_varinfo' v1 v2
+  | _, _ -> false
+
 (* in contrast to the similar method eq_stmtkind in CompareAST,
 this method does not compare the inner body, that is sub blocks,
 of if and switch statements *)
-let rec eq_stmtkind' ((a, af): stmtkind * fundec) ((b, bf): stmtkind * fundec) =
-  let eq_block' = fun x y -> CompareAST.eq_block (x, af) (y, bf) in
+let eq_stmtkind' ((a, af): stmtkind * fundec) ((b, bf): stmtkind * fundec) =
+  let eq_block' = fun x y -> eq_block (x, af) (y, bf) in
   match a, b with
-  | Instr is1, Instr is2 -> CompareAST.eq_list CompareAST.eq_instr is1 is2
-  | Return (Some exp1, _l1), Return (Some exp2, _l2) -> CompareAST.eq_exp exp1 exp2
+  | Instr is1, Instr is2 -> eq_list eq_instr' is1 is2
+  | Return (Some exp1, _l1), Return (Some exp2, _l2) -> eq_exp exp1 exp2
   | Return (None, _l1), Return (None, _l2) -> true
   | Return _, Return _ -> false
-  | Goto (st1, _l1), Goto (st2, _l2) -> CompareAST.eq_stmt_with_location (!st1, af) (!st2, bf)
+  | Goto (st1, _l1), Goto (st2, _l2) -> eq_stmt_with_location (!st1, af) (!st2, bf)
   | Break _, Break _ -> true
   | Continue _, Continue _ -> true
   | If (exp1, then1, else1, _l1), If (exp2, then2, else2, _l2) ->
-      CompareAST.eq_exp exp1 exp2 (* && eq_block' then1 then2 && eq_block' else1 else2 *)
+      eq_exp exp1 exp2 (* && eq_block' then1 then2 && eq_block' else1 else2 *)
   | Switch (exp1, block1, stmts1, _l1), Switch (exp2, block2, stmts2, _l2) ->
-      CompareAST.eq_exp exp1 exp2 (* && eq_block' block1 block2 && CompareAST.eq_list (fun a b -> eq_stmt (a,af) (b,bf)) stmts1 stmts2 *)
-  | Loop (block1, _l1, _con1, _br1), Loop (block2, _l2, _con2, _br2) -> eq_block' block1 block2
+      eq_exp exp1 exp2 (* && eq_block' block1 block2 && eq_list (fun a b -> eq_stmt (a,af) (b,bf)) stmts1 stmts2 *)
+  | Loop (block1, _l1, _con1, _br1), Loop (block2, _l2, _con2, _br2) -> true (* eq_block' block1 block2 *)
   | Block block1, Block block2 -> eq_block' block1 block2
-  | TryFinally (tryBlock1, finallyBlock1, _l1), TryFinally (tryBlock2, finallyBlock2, _l2) ->
-      eq_block' tryBlock1 tryBlock2 && eq_block' finallyBlock1 finallyBlock2
-  | TryExcept (tryBlock1, exn1, exceptBlock1, _l1), TryExcept (tryBlock2, exn2, exceptBlock2, _l2) ->
-      eq_block' tryBlock1 tryBlock2 && eq_block' exceptBlock1 exceptBlock2
+  | TryFinally (tryBlock1, finallyBlock1, _l1), TryFinally (tryBlock2, finallyBlock2, _l2) -> assert false
+      (* eq_block' tryBlock1 tryBlock2 && eq_block' finallyBlock1 finallyBlock2 *)
+  | TryExcept (tryBlock1, exn1, exceptBlock1, _l1), TryExcept (tryBlock2, exn2, exceptBlock2, _l2) -> assert false
+      (* eq_block' tryBlock1 tryBlock2 && eq_block' exceptBlock1 exceptBlock2 *)
   | _, _ -> false
 
-and eq_stmt' ((a, af): stmt * fundec) ((b, bf): stmt * fundec) =
+let eq_stmt' ((a, af): stmt * fundec) ((b, bf): stmt * fundec) =
   (* catch Invalid Argument exception which is thrown by List.combine if the label lists are of different length *)
   try List.for_all (fun (x,y) -> CompareAST.eq_label x y) (List.combine a.labels b.labels)
     && eq_stmtkind' (a.skind, af) (b.skind, bf)
@@ -52,8 +68,8 @@ and eq_stmt' ((a, af): stmt * fundec) ((b, bf): stmt * fundec) =
 let eq_node (x, fun1) (y, fun2) =
   match x,y with
   | Statement s1, Statement s2 -> eq_stmt' (s1, fun1) (s2, fun2)
-  | Function f1, Function f2 -> CompareAST.eq_varinfo f1.svar f2.svar
-  | FunctionEntry f1, FunctionEntry f2 -> CompareAST.eq_varinfo f1.svar f2.svar
+  | Function f1, Function f2 -> eq_varinfo' f1.svar f2.svar
+  | FunctionEntry f1, FunctionEntry f2 -> eq_varinfo' f1.svar f2.svar
   | _ -> false
 
 let eq_edge x y = match x, y with
@@ -61,19 +77,19 @@ let eq_edge x y = match x, y with
   | Proc (None,f1,ars1), Proc (None,f2,ars2) -> CompareAST.eq_exp f1 f2 && CompareAST.eq_list CompareAST.eq_exp ars1 ars2
   | Proc (Some r1,f1,ars1), Proc (Some r2,f2,ars2) ->
       CompareAST.eq_lval r1 r2 && CompareAST.eq_exp f1 f2 && CompareAST.eq_list CompareAST.eq_exp ars1 ars2
-  | Entry f1, Entry f2 -> CompareAST.eq_varinfo f1.svar f2.svar
-  | Ret (None,fd1), Ret (None,fd2) -> CompareAST.eq_varinfo fd1.svar fd2.svar
-  | Ret (Some r1,fd1), Ret (Some r2,fd2) -> CompareAST.eq_exp r1 r2 && CompareAST.eq_varinfo fd1.svar fd2.svar
+  | Entry f1, Entry f2 -> eq_varinfo' f1.svar f2.svar
+  | Ret (None,fd1), Ret (None,fd2) -> eq_varinfo' fd1.svar fd2.svar
+  | Ret (Some r1,fd1), Ret (Some r2,fd2) -> CompareAST.eq_exp r1 r2 && eq_varinfo' fd1.svar fd2.svar
   | Test (p1,b1), Test (p2,b2) -> CompareAST.eq_exp p1 p2 && b1 = b2
   | ASM _, ASM _ -> false
   | Skip, Skip -> true
-  | VDecl v1, VDecl v2 -> CompareAST.eq_varinfo v1 v2
+  | VDecl v1, VDecl v2 -> eq_varinfo' v1 v2
   | SelfLoop, SelfLoop -> true
   | _ -> false
 
 (* The order of the edges in the list is relevant. Therefor compare
 them one to one without sorting first*)
-let eq_edge_list xs ys = CompareAST.eq_list eq_edge xs ys
+let eq_edge_list xs ys = eq_list eq_edge xs ys
 
 let to_edge_list ls = List.map (fun (loc, edge) -> edge) ls
 

--- a/src/incremental/compareCFG.ml
+++ b/src/incremental/compareCFG.ml
@@ -123,7 +123,10 @@ let compare (module Cfg1 : CfgForward) (module Cfg2 : CfgForward) fun1 fun2 =
           | [] -> (stdSet, diffSet)
           | (locEdgeList2, toNode2) :: ls2' ->
               let edgeList2 = to_edge_list locEdgeList2 in
-              let (stdSet', (diffSet' : DiffS.t)) = findEquiv (edgeList2, toNode2) outList1 stdSet diffSet in
+              let isActualEdge = match List.hd edgeList2 with
+                | Test (p,b) -> not (p = Cil.one && b = false)
+                | _ -> true in
+              let (stdSet', diffSet') = if isActualEdge then findEquiv (edgeList2, toNode2) outList1 stdSet diffSet else (stdSet, diffSet) in
             iterOuts ls2' stdSet' diffSet' in
       compareNext (iterOuts outList2 stdSet diffSet) in
 

--- a/src/incremental/compareCFG.ml
+++ b/src/incremental/compareCFG.ml
@@ -1,0 +1,116 @@
+open MyCFG
+open Queue
+open Cil
+
+module StdS = Set.Make (
+  struct
+    let compare = compare
+    type t = (node * node) * (edge list * edge list) * (node * node)
+  end
+)
+
+module DiffS = Set.Make (
+  struct
+    let compare = compare
+    type t = (node * node) * edge list * node
+  end
+)
+
+let waitingList : (node * node) t = Queue.create ()
+
+(* in contrast to the similar method eq_stmtkind in CompareAST,
+this method does not compare the inner body, that is sub blocks,
+of if and switch statements *)
+let rec eq_stmtkind' ((a, af): stmtkind * fundec) ((b, bf): stmtkind * fundec) =
+  let eq_block' = fun x y -> CompareAST.eq_block (x, af) (y, bf) in
+  match a, b with
+  | Instr is1, Instr is2 -> CompareAST.eq_list CompareAST.eq_instr is1 is2
+  | Return (Some exp1, _l1), Return (Some exp2, _l2) -> CompareAST.eq_exp exp1 exp2
+  | Return (None, _l1), Return (None, _l2) -> true
+  | Return _, Return _ -> false
+  | Goto (st1, _l1), Goto (st2, _l2) -> CompareAST.eq_stmt_with_location (!st1, af) (!st2, bf)
+  | Break _, Break _ -> true
+  | Continue _, Continue _ -> true
+  | If (exp1, then1, else1, _l1), If (exp2, then2, else2, _l2) ->
+      CompareAST.eq_exp exp1 exp2 (* && eq_block' then1 then2 && eq_block' else1 else2 *)
+  | Switch (exp1, block1, stmts1, _l1), Switch (exp2, block2, stmts2, _l2) ->
+      CompareAST.eq_exp exp1 exp2 (* && eq_block' block1 block2 && CompareAST.eq_list (fun a b -> eq_stmt (a,af) (b,bf)) stmts1 stmts2 *)
+  | Loop (block1, _l1, _con1, _br1), Loop (block2, _l2, _con2, _br2) -> eq_block' block1 block2
+  | Block block1, Block block2 -> eq_block' block1 block2
+  | TryFinally (tryBlock1, finallyBlock1, _l1), TryFinally (tryBlock2, finallyBlock2, _l2) ->
+      eq_block' tryBlock1 tryBlock2 && eq_block' finallyBlock1 finallyBlock2
+  | TryExcept (tryBlock1, exn1, exceptBlock1, _l1), TryExcept (tryBlock2, exn2, exceptBlock2, _l2) ->
+      eq_block' tryBlock1 tryBlock2 && eq_block' exceptBlock1 exceptBlock2
+  | _, _ -> false
+
+and eq_stmt' ((a, af): stmt * fundec) ((b, bf): stmt * fundec) =
+  (* catch Invalid Argument exception which is thrown by List.combine if the label lists are of different length *)
+  try List.for_all (fun (x,y) -> CompareAST.eq_label x y) (List.combine a.labels b.labels)
+    && eq_stmtkind' (a.skind, af) (b.skind, bf)
+  with Invalid_argument _ -> false
+
+let eq_node (x, fun1) (y, fun2) =
+  match x,y with
+  | Statement s1, Statement s2 -> eq_stmt' (s1, fun1) (s2, fun2)
+  | Function f1, Function f2 -> CompareAST.eq_varinfo f1.svar f2.svar
+  | FunctionEntry f1, FunctionEntry f2 -> CompareAST.eq_varinfo f1.svar f2.svar
+  | _ -> false
+
+let eq_edge x y = match x, y with
+  | Assign (lv1, rv1), Assign (lv2, rv2) -> CompareAST.eq_lval lv1 lv2 && CompareAST.eq_exp rv1 rv2
+  | Proc (None,f1,ars1), Proc (None,f2,ars2) -> CompareAST.eq_exp f1 f2 && CompareAST.eq_list CompareAST.eq_exp ars1 ars2
+  | Proc (Some r1,f1,ars1), Proc (Some r2,f2,ars2) ->
+      CompareAST.eq_lval r1 r2 && CompareAST.eq_exp f1 f2 && CompareAST.eq_list CompareAST.eq_exp ars1 ars2
+  | Entry f1, Entry f2 -> CompareAST.eq_varinfo f1.svar f2.svar
+  | Ret (None,fd1), Ret (None,fd2) -> CompareAST.eq_varinfo fd1.svar fd2.svar
+  | Ret (Some r1,fd1), Ret (Some r2,fd2) -> CompareAST.eq_exp r1 r2 && CompareAST.eq_varinfo fd1.svar fd2.svar
+  | Test (p1,b1), Test (p2,b2) -> CompareAST.eq_exp p1 p2 && b1 = b2
+  | ASM _, ASM _ -> false
+  | Skip, Skip -> true
+  | VDecl v1, VDecl v2 -> CompareAST.eq_varinfo v1 v2
+  | SelfLoop, SelfLoop -> true
+  | _ -> false
+
+(* The order of the edges in the list is relevant. Therefor compare
+them one to one without sorting first*)
+let eq_edge_list xs ys = CompareAST.eq_list eq_edge xs ys
+
+let to_edge_list ls = List.map (fun (loc, edge) -> edge) ls
+
+let compare (module Cfg1 : CfgForward) (module Cfg2 : CfgForward) fun1 fun2 =
+    let rec compareNext (stdSet, diffSet) =
+      if Queue.is_empty waitingList then (stdSet, diffSet)
+      else
+        let fromNode1, fromNode2 = Queue.take waitingList in
+        let outList1 = Cfg1.next fromNode1 in
+        let outList2 = Cfg2.next fromNode2 in
+
+        let findEquiv (edgeList2, toNode2) ls1 stdSet diffSet =
+          let rec aux ls1 stdSet diffSet =
+            match ls1 with
+            | [] -> let diffSet' = DiffS.add ((fromNode1, fromNode2), edgeList2, toNode2) diffSet in stdSet, diffSet'
+            | (locEdgeList1, toNode1) :: ls1' ->
+              let edgeList1 = to_edge_list locEdgeList1 in
+              if eq_node (toNode1, fun1) (toNode2, fun2) && eq_edge_list edgeList1 edgeList2 then
+                begin
+                  let notIn = StdS.for_all
+                      (fun (fromNodes', edges, (toNode1', toNode2')) -> not (Node.equal toNode1 toNode1' && Node.equal toNode2 toNode2')) stdSet in
+                  if notIn then Queue.add (toNode1, toNode2) waitingList;
+                  let stdSet' = StdS.add ((fromNode1, fromNode2), (edgeList1, edgeList2), (toNode1, toNode2)) stdSet
+                  in stdSet', diffSet
+                end
+              else aux ls1' stdSet diffSet in
+          aux ls1 stdSet diffSet in
+
+        let rec iterOuts ls2 stdSet diffSet =
+          match ls2 with
+          | [] -> (stdSet, diffSet)
+          | (locEdgeList2, toNode2) :: ls2' ->
+              let edgeList2 = to_edge_list locEdgeList2 in
+              let (stdSet', (diffSet' : DiffS.t)) = findEquiv (edgeList2, toNode2) outList1 stdSet diffSet in
+            iterOuts ls2' stdSet' diffSet' in
+      compareNext (iterOuts outList2 stdSet diffSet) in
+
+    let initSets = (StdS.empty, DiffS.empty) in
+    let entryNode1, entryNode2 = (FunctionEntry fun1, FunctionEntry fun2) in
+  Queue.push (entryNode1,entryNode2) waitingList; (compareNext initSets)

--- a/src/incremental/compareCFG.ml
+++ b/src/incremental/compareCFG.ml
@@ -226,6 +226,7 @@ let eq_glob' (a: global) (module Cfg1 : MyCFG.CfgForward) (b: global) (module Cf
 let compareCilFiles (oldAST: file) (newAST: file) =
   let oldCfg, _ = CfgTools.getCFG oldAST in
   let newCfg, _ = CfgTools.getCFG newAST in
+
   let module OldCfg: MyCFG.CfgForward = struct let next = oldCfg end in
   let module NewCfg: MyCFG.CfgForward = struct let next = newCfg end in
 

--- a/src/incremental/compareCFG.ml
+++ b/src/incremental/compareCFG.ml
@@ -34,8 +34,8 @@ let to_edge_list ls = List.map (fun (loc, edge) -> edge) ls
 module NH = Hashtbl.Make(Node)
 module NTH = Hashtbl.Make(
   struct
-    type t = node * node
-    let equal (n1,n2) (n1',n2') = Node.equal n1 n1' && Node.equal n2 n2'
+    type t = Node.t * Node.t
+    [@@deriving eq]
     let hash (n1,n2) = (Node.hash n1 * 13) + Node.hash n2
   end)
 

--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -1,0 +1,99 @@
+open Cil
+open MyCFG
+include CompareAST
+include CompareCFG
+
+type nodes_diff = {
+  unchangedNodes: (node * node) list;
+  primObsoleteNodes: node list;
+  primNewNodes: node list
+}
+
+type changed_global = {
+  old: global;
+  current: global;
+  unchangedHeader: bool;
+  diff: nodes_diff option
+}
+
+type change_info = {
+  mutable changed: changed_global list;
+  mutable unchanged: global list;
+  mutable removed: global list;
+  mutable added: global list
+}
+
+let empty_change_info () : change_info = {added = []; removed = []; changed = []; unchanged = []}
+
+(* If some CFGs of the two functions to be compared are provided, a fine-grained CFG is done that also determines which
+ * nodes of the function changed. If on the other hand no CFGs are provided, the "old" AST comparison on the CIL.file is
+ * used for functions. Then no information is collected regarding which parts/nodes of the function changed. *)
+let eqF (a: Cil.fundec) (b: Cil.fundec) (cfgs : (cfg * cfg) option) =
+  let unchangedHeader =
+    try
+      eq_varinfo a.svar b.svar &&
+      List.for_all (fun (x, y) -> eq_varinfo x y) (List.combine a.sformals b.sformals)
+    with Invalid_argument _ -> false in
+  let identical, diffOpt =
+    try
+      let sameDef = unchangedHeader && List.for_all (fun (x, y) -> eq_varinfo x y) (List.combine a.slocals b.slocals) in
+      match cfgs with
+      | None -> sameDef && eq_block (a.sbody, a) (b.sbody, b), None
+      | Some (cfgOld, cfgNew) ->
+        let module CfgOld : MyCFG.CfgForward = struct let next = cfgOld end in
+        let module CfgNew : MyCFG.CfgForward = struct let next = cfgNew end in
+        let matches, diffNodes1, diffNodes2 = compareFun (module CfgOld) (module CfgNew) a b in
+        if not sameDef then (false, None)
+        else if List.length diffNodes1 = 0 && List.length diffNodes2 = 0 then (true, None)
+        else (false, Some {unchangedNodes = matches; primObsoleteNodes = diffNodes1; primNewNodes = diffNodes2})
+    with Invalid_argument _ -> (* The combine failed because the lists have differend length *)
+      false, None in
+  identical, unchangedHeader, diffOpt
+
+let eq_glob (a: global) (b: global) (cfgs : (cfg * cfg) option) = match a, b with
+  | GFun (f,_), GFun (g,_) -> eqF f g cfgs
+  | GVar (x, init_x, _), GVar (y, init_y, _) -> eq_varinfo x y, false, None (* ignore the init_info - a changed init of a global will lead to a different start state *)
+  | GVarDecl (x, _), GVarDecl (y, _) -> eq_varinfo x y, false, None
+  | _ -> print_endline @@ "Not comparable: " ^ (Pretty.sprint ~width:100 (Cil.d_global () a)) ^ " and " ^ (Pretty.sprint ~width:100 (Cil.d_global () a)); false, false, None
+
+let compareCilFiles (oldAST: file) (newAST: file) =
+  let cfgs = if GobConfig.get_bool "incremental.within_functions"
+    then Some (CfgTools.getCFG oldAST |> fst, CfgTools.getCFG newAST |> fst)
+    else None in
+
+  let addGlobal map global  =
+    try
+      GlobalMap.add (identifier_of_global global) global map
+    with
+      e -> map
+  in
+  let changes = empty_change_info () in
+  global_typ_acc := [];
+  let checkUnchanged map global =
+    try
+      let ident = identifier_of_global global in
+      (try
+         let old_global = GlobalMap.find ident map in
+         (* Do a (recursive) equal comparision ignoring location information *)
+         let identical, unchangedHeader, diff = eq_glob old_global global cfgs in
+         if identical
+         then changes.unchanged <- global :: changes.unchanged
+         else changes.changed <- {current = global; old = old_global; unchangedHeader; diff} :: changes.changed
+       with Not_found -> ())
+    with NoGlobalIdentifier _ -> () (* Global was no variable or function, it does not belong into the map *)  in
+  let checkExists map global =
+    let name = identifier_of_global global in
+    GlobalMap.mem name map
+  in
+  (* Store a map from functionNames in the old file to the function definition*)
+  let oldMap = Cil.foldGlobals oldAST addGlobal GlobalMap.empty in
+  let newMap = Cil.foldGlobals newAST addGlobal GlobalMap.empty in
+  (*  For each function in the new file, check whether a function with the same name
+      already existed in the old version, and whether it is the same function. *)
+  Cil.iterGlobals newAST
+    (fun glob -> checkUnchanged oldMap glob);
+
+  (* We check whether functions have been added or removed *)
+  Cil.iterGlobals newAST (fun glob -> try if not (checkExists oldMap glob) then changes.added <- (glob::changes.added) with e -> ());
+  Cil.iterGlobals oldAST (fun glob -> try if not (checkExists newMap glob) then changes.removed <- (glob::changes.removed) with e -> ());
+  changes

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -77,7 +77,6 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_id
       | _ -> ()
     with Failure m -> ()
   in
-
   let reset_unchanged_nodes (matches: (node * node) list) =
     let assign_same_id (old_n, n) = match old_n, n with
       | Statement old_s, Statement s -> s.sid <- old_s.sid; update_sid_max s.sid
@@ -89,8 +88,7 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_id
   let reset_changed_stmts (changed: node list) =
     let assign_new_id n = match n with
       | Statement s -> s.sid <- make_sid ()
-      (* function id is explicitly assigned in reset_changed_fun. Other than that there should be no other id generation
-         through the Function node in the change set to avoid incorrect re-generation *)
+      (* function id is explicitly assigned in reset_changed_fun *)
       | FunctionEntry f -> ()
       | Function f -> () in
     List.iter (fun n -> assign_new_id n) changed;
@@ -110,7 +108,7 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_id
     | Some d -> List.iter (fun (l, o_l) -> l.vid <- o_l.vid) (List.combine f.slocals old_f.slocals);
       List.iter (fun l -> update_vid_max l.vid) f.slocals;
       reset_unchanged_nodes d.unchangedNodes;
-      reset_changed_stmts d.changedNodes
+      reset_changed_stmts d.newNodes
   in
   let reset_changed_globals (changed: changed_global) =
     match (changed.current, changed.old) with

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -17,8 +17,6 @@ let getLoc (node: Node.t) =
 let store_node_location (n: Node.t) (l: location): unit =
   NodeMap.add !location_map n l
 
-let zero_ids = {max_sid = 0; max_vid = 0}
-
 let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_identifier, Cil.global) Hashtbl.t) (changes: change_info) =
   let vid_max = ref ids.max_vid in
   let sid_max = ref ids.max_sid in

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -1,5 +1,5 @@
 open Cil
-open CompareCFG
+open CompareCIL
 open VersionLookup
 open MyCFG
 
@@ -92,7 +92,7 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_id
     if unchangedHeader then
       List.iter (fun (f,old_f) -> f.vid <- old_f.vid; update_vid_max f.vid) (List.combine f.sformals old_f.sformals)
     else List.iter (fun f -> f.vid <- make_vid ()) f.sformals;
-    (* diff is None if the function header changed or locals and the cfg was not compared. In this case, preceed as before
+    (* diff is None if the function header changed or locals and the cfg was not compared. In this case, proceed as before
        and renew all ids of the function. Otherwise the function header and locals are unchanged and the cfg was compared.
        Then we can reset all ids of f's varinfo, its locals, formals and unchanged nodes and renew all ids of the remaining nodes*)
     match diff with

--- a/src/incremental/versionLookup.ml
+++ b/src/incremental/versionLookup.ml
@@ -1,4 +1,4 @@
-open CompareCFG
+open CompareCIL
 open Cil
 
 type max_ids = {

--- a/src/incremental/versionLookup.ml
+++ b/src/incremental/versionLookup.ml
@@ -1,4 +1,4 @@
-open CompareAST
+open CompareCFG
 open Cil
 
 type max_ids = {

--- a/src/incremental/versionLookup.ml
+++ b/src/incremental/versionLookup.ml
@@ -20,7 +20,9 @@ let create_map (new_file: Cil.file) =
   let update_vid vid = if vid > !max_vid then max_vid := vid in
   let add_to_hashtbl tbl (global: Cil.global) =
     match global with
-    | GFun (fund, _) as f -> update_vid fund.svar.vid; update_sid fund.smaxid; Hashtbl.replace tbl (identifier_of_global f) f
+    | GFun (fund, _) as f -> (match fund.smaxstmtid with
+        | Some i -> update_vid fund.svar.vid; update_sid i; Hashtbl.replace tbl (identifier_of_global f) f
+        | None -> failwith "smaxstmtid should have been computed when calling Cil.computeCFGInfo")
     | GVar (var, _, _) as v -> update_vid var.vid; Hashtbl.replace tbl (identifier_of_global v) v
     | GVarDecl (var, _) as v -> update_vid var.vid; Hashtbl.replace tbl (identifier_of_global v) v
     | other -> ()

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -388,7 +388,7 @@ let diff_and_rename current_file =
         (changes, Some old_file, version_map, max_ids)
       end else begin
         let (version_map, max_ids) = VersionLookup.create_map current_file in
-        (CompareAST.empty_change_info (), None, version_map, max_ids)
+        (CompareCFG.empty_change_info (), None, version_map, max_ids)
       end
     in
     let solver_data = if Serialize.results_exist () && GobConfig.get_bool "incremental.load" && not (GobConfig.get_bool "incremental.only-rename")

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -388,7 +388,7 @@ let diff_and_rename current_file =
         (changes, Some old_file, version_map, max_ids)
       end else begin
         let (version_map, max_ids) = VersionLookup.create_map current_file in
-        (CompareCFG.empty_change_info (), None, version_map, max_ids)
+        (CompareCIL.empty_change_info (), None, version_map, max_ids)
       end
     in
     let solver_data = if Serialize.results_exist () && GobConfig.get_bool "incremental.load" && not (GobConfig.get_bool "incremental.only-rename")

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -261,7 +261,7 @@ module WP =
         in
         let changed_funs = filter_map (fun c -> match c.old, c.diff with GFun (f,l), None -> Some f | _ -> None) S.increment.changes.changed in
         let part_changed_funs = filter_map (fun c -> match c.old, c.diff with GFun (f,l), Some nd -> Some (f,nd.primObsoleteNodes,nd.unchangedNodes) | _ -> None) S.increment.changes.changed in
-        let prim_old_nodes_ids = Set.of_list (List.concat_map (fun (_,pn,_) -> List.map Node.show_id pn) part_changed_funs) in
+        let prim_old_nodes_ids = Set.of_list (List.concat (List.map (fun (_,pn,_) -> List.map Node.show_id pn) part_changed_funs)) in
         let removed_funs = filter_map (fun g -> match g with GFun (f,l) -> Some f | _ -> None) S.increment.changes.removed in
         (* TODO: don't use string-based nodes, make obsolete of type Node.t BatSet.t *)
         let obsolete_ret = Set.union (Set.of_list (List.map (fun f -> Node.show_id (Function f)) changed_funs))

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -260,16 +260,17 @@ module WP =
           List.fold_left (fun acc el -> match f el with Some x -> x::acc | _ -> acc) [] l
         in
         let changed_funs = filter_map (fun c -> match c.old, c.diff with GFun (f,l), None -> Some f | _ -> None) S.increment.changes.changed in
-        let partially_changed_funs = filter_map (fun c -> match c.old, c.diff with GFun (f,l), Some nd -> Some (f,nd.primChangedNodes,nd.changedNodes) | _ -> None) S.increment.changes.changed in
-        let prim_old_nodes_ids = Set.of_list (List.concat_map (fun (_,pn,_) -> List.map Node.show_id pn) partially_changed_funs) in
+        let part_changed_funs = filter_map (fun c -> match c.old, c.diff with GFun (f,l), Some nd -> Some (f,nd.primObsoleteNodes,nd.obsoleteNodes) | _ -> None) S.increment.changes.changed in
+        let prim_old_nodes_ids = Set.of_list (List.concat_map (fun (_,pn,_) -> List.map Node.show_id pn) part_changed_funs) in
+
         let removed_funs = filter_map (fun g -> match g with GFun (f,l) -> Some f | _ -> None) S.increment.changes.removed in
         (* TODO: don't use string-based nodes, make obsolete of type Node.t BatSet.t *)
         let obsolete_ret = Set.union (Set.of_list (List.map (fun f -> Node.show_id (Function f)) changed_funs))
-                                     (Set.of_list (List.map (fun (f,_,_) -> Node.show_id (Function f)) partially_changed_funs)) in
+                                     (Set.of_list (List.map (fun (f,_,_) -> Node.show_id (Function f)) part_changed_funs)) in
         let obsolete_entry = Set.of_list (List.map (fun f -> Node.show_id (FunctionEntry f)) changed_funs) in
 
         List.iter (fun a -> print_endline ("Completely changed function: " ^ a.svar.vname)) changed_funs;
-        List.iter (fun (f,_,_) -> print_endline ("Partially changed function: " ^ (f.svar.vname))) partially_changed_funs;
+        List.iter (fun (f,_,_) -> print_endline ("Partially changed function: " ^ (f.svar.vname))) part_changed_funs;
 
         let old_ret = Hashtbl.create 103 in
         if GobConfig.get_bool "incremental.reluctant.on" then (
@@ -294,7 +295,7 @@ module WP =
         let marked_for_deletion = Hashtbl.create 103 in
         add_nodes_of_fun changed_funs marked_for_deletion (not (GobConfig.get_bool "incremental.reluctant.on"));
         add_nodes_of_fun removed_funs marked_for_deletion true;
-        List.iter (fun (f,_,_) -> Hashtbl.replace marked_for_deletion (Node.show_id (Function f)) ()) partially_changed_funs;
+        List.iter (fun (f,_,_) -> Hashtbl.replace marked_for_deletion (Node.show_id (Function f)) ()) part_changed_funs;
 
         print_endline "Removing data for changed and removed functions...";
         let delete_marked s = HM.filteri_inplace (fun k _ -> not (Hashtbl.mem  marked_for_deletion (S.Var.var_id k))) s in (* TODO: don't use string-based nodes *)

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -259,13 +259,17 @@ module WP =
         let filter_map f l =
           List.fold_left (fun acc el -> match f el with Some x -> x::acc | _ -> acc) [] l
         in
-        let obsolete_funs = filter_map (fun c -> match c.old with GFun (f,l) -> Some f | _ -> None) S.increment.changes.changed in
+        let changed_funs = filter_map (fun c -> match c.old, c.diff with GFun (f,l), None -> Some f | _ -> None) S.increment.changes.changed in
+        let partially_changed_funs = filter_map (fun c -> match c.old, c.diff with GFun (f,l), Some nd -> Some (f,nd.primChangedNodes,nd.changedNodes) | _ -> None) S.increment.changes.changed in
+        let prim_old_nodes_ids = Set.of_list (List.concat_map (fun (_,pn,_) -> List.map Node.show_id pn) partially_changed_funs) in
         let removed_funs = filter_map (fun g -> match g with GFun (f,l) -> Some f | _ -> None) S.increment.changes.removed in
         (* TODO: don't use string-based nodes, make obsolete of type Node.t BatSet.t *)
-        let obsolete_ret = Set.of_list (List.map (fun f -> Node.show_id (Function f))  obsolete_funs) in
-        let obsolete_entry = Set.of_list (List.map (fun f -> Node.show_id (FunctionEntry f)) obsolete_funs) in
+        let obsolete_ret = Set.union (Set.of_list (List.map (fun f -> Node.show_id (Function f)) changed_funs))
+                                     (Set.of_list (List.map (fun (f,_,_) -> Node.show_id (Function f)) partially_changed_funs)) in
+        let obsolete_entry = Set.of_list (List.map (fun f -> Node.show_id (FunctionEntry f)) changed_funs) in
 
-        List.iter (fun a -> print_endline ("Obsolete function: " ^ a.svar.vname)) obsolete_funs;
+        List.iter (fun a -> print_endline ("Completely changed function: " ^ a.svar.vname)) changed_funs;
+        List.iter (fun (f,_,_) -> print_endline ("Partially changed function: " ^ (f.svar.vname))) partially_changed_funs;
 
         let old_ret = Hashtbl.create 103 in
         if GobConfig.get_bool "incremental.reluctant.on" then (
@@ -275,7 +279,7 @@ module WP =
             let old_infl = HM.find_default infl k VS.empty in
             Hashtbl.replace old_ret k (old_rho, old_infl))) rho;
         ) else (
-          HM.iter (fun k _ -> if Set.mem (S.Var.var_id k) obsolete_entry then destabilize k) stable
+          HM.iter (fun k _ -> if Set.mem (S.Var.var_id k) obsolete_entry || Set.mem (S.Var.var_id k) prim_old_nodes_ids then destabilize k) stable;
         );
 
         (* We remove all unknowns for program points in changed or removed functions from rho, stable, infl and wpoint *)
@@ -288,8 +292,9 @@ module WP =
         in
 
         let marked_for_deletion = Hashtbl.create 103 in
-        add_nodes_of_fun obsolete_funs marked_for_deletion (not (GobConfig.get_bool "incremental.reluctant.on"));
+        add_nodes_of_fun changed_funs marked_for_deletion (not (GobConfig.get_bool "incremental.reluctant.on"));
         add_nodes_of_fun removed_funs marked_for_deletion true;
+        List.iter (fun (f,_,_) -> Hashtbl.replace marked_for_deletion (Node.show_id (Function f)) ()) partially_changed_funs;
 
         print_endline "Removing data for changed and removed functions...";
         let delete_marked s = HM.filteri_inplace (fun k _ -> not (Hashtbl.mem  marked_for_deletion (S.Var.var_id k))) s in (* TODO: don't use string-based nodes *)

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -13,7 +13,7 @@ open Prelude
 open Analyses
 open Constraints
 open Messages
-open CompareAST
+open CompareCFG
 open Cil
 
 module WP =

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -260,17 +260,16 @@ module WP =
           List.fold_left (fun acc el -> match f el with Some x -> x::acc | _ -> acc) [] l
         in
         let changed_funs = filter_map (fun c -> match c.old, c.diff with GFun (f,l), None -> Some f | _ -> None) S.increment.changes.changed in
-        let part_changed_funs = filter_map (fun c -> match c.old, c.diff with GFun (f,l), Some nd -> Some (f,nd.primObsoleteNodes,nd.obsoleteNodes) | _ -> None) S.increment.changes.changed in
-        let prim_old_nodes_ids = Set.of_list (List.concat_map (fun (_,pn,_) -> List.map Node.show_id pn) part_changed_funs) in
-
+        let part_changed_funs = filter_map (fun c -> match c.old, c.diff with GFun (f,l), Some nd -> Some (f,nd.primObsoleteNodes) | _ -> None) S.increment.changes.changed in
+        let prim_old_nodes_ids = Set.of_list (List.concat_map (fun (_,pn) -> List.map Node.show_id pn) part_changed_funs) in
         let removed_funs = filter_map (fun g -> match g with GFun (f,l) -> Some f | _ -> None) S.increment.changes.removed in
         (* TODO: don't use string-based nodes, make obsolete of type Node.t BatSet.t *)
         let obsolete_ret = Set.union (Set.of_list (List.map (fun f -> Node.show_id (Function f)) changed_funs))
-                                     (Set.of_list (List.map (fun (f,_,_) -> Node.show_id (Function f)) part_changed_funs)) in
+                                     (Set.of_list (List.map (fun (f,_) -> Node.show_id (Function f)) part_changed_funs)) in
         let obsolete_entry = Set.of_list (List.map (fun f -> Node.show_id (FunctionEntry f)) changed_funs) in
 
         List.iter (fun a -> print_endline ("Completely changed function: " ^ a.svar.vname)) changed_funs;
-        List.iter (fun (f,_,_) -> print_endline ("Partially changed function: " ^ (f.svar.vname))) part_changed_funs;
+        List.iter (fun (f,_) -> print_endline ("Partially changed function: " ^ (f.svar.vname))) part_changed_funs;
 
         let old_ret = Hashtbl.create 103 in
         if GobConfig.get_bool "incremental.reluctant.on" then (
@@ -295,7 +294,7 @@ module WP =
         let marked_for_deletion = Hashtbl.create 103 in
         add_nodes_of_fun changed_funs marked_for_deletion (not (GobConfig.get_bool "incremental.reluctant.on"));
         add_nodes_of_fun removed_funs marked_for_deletion true;
-        List.iter (fun (f,_,_) -> Hashtbl.replace marked_for_deletion (Node.show_id (Function f)) ()) part_changed_funs;
+        List.iter (fun (f,_) -> Hashtbl.replace marked_for_deletion (Node.show_id (Function f)) ()) part_changed_funs;
 
         print_endline "Removing data for changed and removed functions...";
         let delete_marked s = HM.filteri_inplace (fun k _ -> not (Hashtbl.mem  marked_for_deletion (S.Var.var_id k))) s in (* TODO: don't use string-based nodes *)

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -13,7 +13,7 @@ open Prelude
 open Analyses
 open Constraints
 open Messages
-open CompareCFG
+open CompareCIL
 open Cil
 
 module WP =

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -430,8 +430,12 @@ let stmt_fundecs: fundec StmtH.t Lazy.t =
     h
   )
 
+let pseudo_return_to_fun = StmtH.create 113
+
 (** Find [fundec] which the [stmt] is in. *)
-let find_stmt_fundec stmt = StmtH.find (Lazy.force stmt_fundecs) stmt (* stmt argument must be explicit, otherwise force happens immediately *)
+let find_stmt_fundec stmt =
+  try StmtH.find pseudo_return_to_fun stmt
+  with _ -> StmtH.find (Lazy.force stmt_fundecs) stmt (* stmt argument must be explicit, otherwise force happens immediately *)
 
 
 module VarinfoH = Hashtbl.Make (CilType.Varinfo)

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -435,7 +435,7 @@ let pseudo_return_to_fun = StmtH.create 113
 (** Find [fundec] which the [stmt] is in. *)
 let find_stmt_fundec stmt =
   try StmtH.find pseudo_return_to_fun stmt
-  with _ -> StmtH.find (Lazy.force stmt_fundecs) stmt (* stmt argument must be explicit, otherwise force happens immediately *)
+  with Not_found -> StmtH.find (Lazy.force stmt_fundecs) stmt (* stmt argument must be explicit, otherwise force happens immediately *)
 
 
 module VarinfoH = Hashtbl.Make (CilType.Varinfo)

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -155,7 +155,7 @@ let _ = ()
       ; reg Incremental "incremental.wpoint"      "false" "Reuse the wpoint set (not recommended). Reusing the wpoint will combine existing results at previous widening points."
       ; reg Incremental "incremental.reluctant.on" "true" "Destabilize nodes in changed functions reluctantly"
       ; reg Incremental "incremental.reluctant.compare" "'leq'" "In order to reuse the function's old abstract value the new abstract value must be leq (focus on efficiency) or equal (focus on precision) compared to the old."
-      ; reg Incremental "incremental.within_functions" "false" "Use Cfg comparison to differentiate between unchanged and changed nodes within functions"
+      ; reg Incremental "incremental.within_functions" "false" "Use CFG comparison to differentiate between unchanged and changed nodes within functions"
 
 (* {4 category [Semantics]} *)
 let _ = ()

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -155,7 +155,7 @@ let _ = ()
       ; reg Incremental "incremental.wpoint"      "false" "Reuse the wpoint set (not recommended). Reusing the wpoint will combine existing results at previous widening points."
       ; reg Incremental "incremental.reluctant.on" "true" "Destabilize nodes in changed functions reluctantly"
       ; reg Incremental "incremental.reluctant.compare" "'leq'" "In order to reuse the function's old abstract value the new abstract value must be leq (focus on efficiency) or equal (focus on precision) compared to the old."
-      ; reg Incremental "incremental.within_functions" "false" "Use CFG comparison to differentiate between unchanged and changed nodes within functions"
+      ; reg Incremental "incremental.compare" "'ast'" "Which comparison should be used for functions? 'ast'/'cfg' (cfg comparison also differentiates which nodes of a function have changed)"
 
 (* {4 category [Semantics]} *)
 let _ = ()

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -155,6 +155,7 @@ let _ = ()
       ; reg Incremental "incremental.wpoint"      "false" "Reuse the wpoint set (not recommended). Reusing the wpoint will combine existing results at previous widening points."
       ; reg Incremental "incremental.reluctant.on" "true" "Destabilize nodes in changed functions reluctantly"
       ; reg Incremental "incremental.reluctant.compare" "'leq'" "In order to reuse the function's old abstract value the new abstract value must be leq (focus on efficiency) or equal (focus on precision) compared to the old."
+      ; reg Incremental "incremental.within_functions" "false" "Use Cfg comparison to differentiate between unchanged and changed nodes within functions"
 
 (* {4 category [Semantics]} *)
 let _ = ()


### PR DESCRIPTION
Closes #351

This PR contains the refinement for the incremental analysis which allows to reuse previous results for the unchanged nodes in changed functions. Instead of differentiating only between changed, unchanged, removed and added functions, changed functions can now be compared more detailed based on their control flow graph to determine the `unchangedNodes`, `primObsoleteNodes` and `primNewNodes` in the function. The unchanged nodes are tuples of old and new nodes that match and that only have incoming edges from other matching nodes. The primary obsolete nodes are nodes from the old CFG for which no match could be found and that suffice to be destabilized in an incremental analysis run. That means, that all changed nodes can be reached from the primary obsolete nodes. The primary new nodes are the equivalent to the primary obsolete nodes in the new CFG.

The changes of this PR include
- configuration option for activating this refinement
- change detection on control flow graphs for different versions of a function
- extending the preparation for the incremental analysis in TD3 to handle the more detailed change info (it should also allow to activate refinement #369 at the same time)
- adapting the updateIds function to differentiate between unchanged and changed nodes in changed functions when updating the ids
- extending the script for incremental test runs on repository to reset the incremental data when starting and also measure the total internal runtime