### PR TITLE
Fix `minimal` and `maximal` in `Enum`

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1976,25 +1976,25 @@ module Enums : S with type int_t = BigInt.t = struct
   let maximal = function
     | Inc xs when not (BISet.is_empty xs) -> Some (BISet.max_elt xs)
     | Exc (excl,r) ->
-      let range_max = Exclusion.max_of_range r in
-      let rec decrement_while_contained v s =
-        if BISet.mem range_max s
-        then decrement_while_contained (BI.sub v (BI.one)) s
+      let rec decrement_while_contained v =
+        if BISet.mem v excl
+        then decrement_while_contained (BI.sub v (BI.one))
         else v
       in
-      Some (decrement_while_contained range_max excl)
+      let range_max = Exclusion.max_of_range r in
+      Some (decrement_while_contained range_max)
     | _ (* bottom case *) -> None
 
   let minimal = function
     | Inc xs when not (BISet.is_empty xs) -> Some (BISet.min_elt xs)
     | Exc (excl,r) ->
-      let range_min = Exclusion.min_of_range r in
-      let rec increment_while_contained v s =
-        if BISet.mem range_min s
-        then increment_while_contained (BI.add v (BI.one)) s
+      let rec increment_while_contained v =
+        if BISet.mem v excl
+        then increment_while_contained (BI.add v (BI.one))
         else v
       in
-      Some (increment_while_contained range_min excl)
+      let range_min = Exclusion.min_of_range r in
+      Some (increment_while_contained range_min)
     | _ (* bottom case *) -> None
 
   let lt ik x y =

--- a/tests/regression/02-base/64-enums-minmax.c
+++ b/tests/regression/02-base/64-enums-minmax.c
@@ -1,0 +1,17 @@
+// PARAM: --enable ana.int.enums
+int main(void) {
+    unsigned char c;
+    int top;
+
+    if(c != 0) {
+        if(c < 43) {
+            top =12;
+        }
+    }
+
+    if(c != 255) {
+        if(c < 43) {
+            top = 12;
+        }
+    }
+}


### PR DESCRIPTION
@jerhard and I have traced a bug (starting from a traces benchmark), where Goblint loops indefinitely when determining the maximum or minimum values for an Enum, whenever the maximal (minimal) element is excluded.

It is a very simple bug that is due to using the wrong variable, but was a bit of a nightmare to chase down. After understanding what happens, we now also have constructed a minimal example to reproduce it.