### PR TITLE
Fix invalid interval widening calls

### DIFF
--- a/src/cdomains/addressDomain.ml
+++ b/src/cdomains/addressDomain.ml
@@ -5,6 +5,7 @@ open IntOps
 let fast_addr_sets = false (* unknown addresses for fast sets == top, for slow == {?}*)
 
 module GU = Goblintutil
+module M = Messages
 
 module type S =
 sig
@@ -26,6 +27,12 @@ struct
 
   module Addr = Lval.NormalLat (Idx)
   include HoareDomain.HoarePO (Addr)
+
+  let widen x y =
+    if M.tracing then M.traceli "ad" "widen %a %a\n" pretty x pretty y;
+    let r = widen x y in
+    if M.tracing then M.traceu "ad" "-> %a\n" pretty r;
+    r
 
   type field = Addr.field
   type idx = Idx.t

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -462,6 +462,7 @@ struct
       (e1, (op xl1 xl2, op xm1 xm2, op xr1 xr2))
     | `Lifted e1e, `Lifted e2e ->
       if get_string "exp.partition-arrays.keep-expr" = "last" || get_bool "exp.partition-arrays.smart-join" then
+        let op = Val.join in (* widen between different components isn't called validly *)
         let over_all_x1 = op (op xl1 xm1) xr1 in
         let over_all_x2 = op (op xl2 xm2) xr2 in
         let e1e_in_state_of_x2 = x2_eval_int e1e in

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -634,7 +634,8 @@ struct
       norm ik @@ Some (l2,u2)
   let widen ik x y =
     let r = widen ik x y in
-    if M.tracing then M.trace "int" "interval widen %a %a -> %a\n" pretty x pretty y pretty r;
+    if M.tracing then M.tracel "int" "interval widen %a %a -> %a\n" pretty x pretty y pretty r;
+    assert (leq x y); (* TODO: remove for performance reasons? *)
     r
 
   let narrow ik x y =

--- a/src/domains/lattice.ml
+++ b/src/domains/lattice.ml
@@ -18,7 +18,8 @@ sig
   val leq: t -> t -> bool
   val join: t -> t -> t
   val meet: t -> t -> t
-  val widen: t -> t -> t (** [widen x y] assumes `[leq x y]`. Solvers guarantee this by calling [widen old (join old new)]. *)
+  val widen: t -> t -> t (** [widen x y] assumes [leq x y]. Solvers guarantee this by calling [widen old (join old new)]. *)
+
   val narrow: t -> t -> t
 
   (** If [leq x y = false], then [pretty_diff () (x, y)] should explain why. *)

--- a/src/domains/lattice.ml
+++ b/src/domains/lattice.ml
@@ -18,7 +18,7 @@ sig
   val leq: t -> t -> bool
   val join: t -> t -> t
   val meet: t -> t -> t
-  val widen: t -> t -> t
+  val widen: t -> t -> t (** [widen x y] assumes `[leq x y]`. Solvers guarantee this by calling [widen old (join old new)]. *)
   val narrow: t -> t -> t
 
   (** If [leq x y = false], then [pretty_diff () (x, y)] should explain why. *)

--- a/src/domains/octagonMapDomain.ml
+++ b/src/domains/octagonMapDomain.ml
@@ -57,27 +57,23 @@ struct
   include Lattice.Liszt (E)
   module B = E
 
-  let rec map2 ?(widening=false) keep f x y =
+  let rec map2 keep f x y =
     let concat elt ls = if keep then elt::ls else ls in
     match x, y with
     | [], [] -> []
     | hd::tl, [] | [], hd::tl ->
-      concat hd (map2 ~widening keep f [] tl)
+      concat hd (map2 keep f [] tl)
     | ((xhsign,xhvar,_ ) as xh) :: xs, ((yhsign,yhvar,_ ) as yh) :: ys when (B.compare_sign_and_var (xhsign,xhvar) (yhsign,yhvar)) = 0 ->
-      if not widening || B.leq xh yh then ( (* must be leq to apply widen *)
-        let res = f xh yh in
-        if B.is_top res then
-          (map2 ~widening keep f xs ys)
-        else
-          res :: (map2 ~widening keep f xs ys)
-      )
+      let res = f xh yh in
+      if B.is_top res then
+        (map2 keep f xs ys)
       else
-        (map2 ~widening keep f xs ys) (* TODO: is the non-leq case correct? *)
+        res :: (map2 keep f xs ys)
     | ((xhsign,xhvar,_ ) as xh) :: xs, ((yhsign,yhvar,_ ) as yh) :: ys ->
       if (B.compare_sign_and_var (xhsign,xhvar) (yhsign,yhvar)) < 0 then
-        concat xh (map2 ~widening keep f xs y)
+        concat xh (map2 keep f xs y)
       else
-        concat yh (map2 ~widening keep f x ys)
+        concat yh (map2 keep f x ys)
 
   (* on meets we want to preserve the value of one octagon if *)
   (* the other octagon does not have a value at that position *)
@@ -85,7 +81,7 @@ struct
   let meet a b = map2 true B.meet a b
   let join a b = map2 false B.join a b
   let narrow a b = map2 true B.narrow a b
-  let widen a b = map2 ~widening:true false B.widen a b
+  let widen a b = map2 false B.widen a b
 
   let rec filter f x =
     match x with

--- a/src/domains/octagonMapDomain.ml
+++ b/src/domains/octagonMapDomain.ml
@@ -706,7 +706,9 @@ module MapOctagon : S
     let filter_constraints (inv, consts) = (inv, List.filter (fun (_,v,_) -> List.mem v vars) consts) in
     map filter_constraints oct_keys_filtered
 
-  let widen a b = widen a (strong_closure b) (* strong closure must not(!) be called for the result (https://arxiv.org/pdf/cs/0703084.pdf)  *)
+  (* TODO: why was strong_closure on b necessary at all? b should be joined already *)
+  (* TODO: strong_closure is not idempotent, somehow breaks valid widen use *)
+  let widen a b = widen a b (* strong closure must not(!) be called for the result (https://arxiv.org/pdf/cs/0703084.pdf)  *)
 
   let narrow a b =
     (* Some constraints may involve a variable that is not there in the result. These need to be removed *)

--- a/src/domains/octagonMapDomain.ml
+++ b/src/domains/octagonMapDomain.ml
@@ -57,23 +57,27 @@ struct
   include Lattice.Liszt (E)
   module B = E
 
-  let rec map2 keep f x y =
+  let rec map2 ?(widening=false) keep f x y =
     let concat elt ls = if keep then elt::ls else ls in
     match x, y with
     | [], [] -> []
     | hd::tl, [] | [], hd::tl ->
-      concat hd (map2 keep f [] tl)
+      concat hd (map2 ~widening keep f [] tl)
     | ((xhsign,xhvar,_ ) as xh) :: xs, ((yhsign,yhvar,_ ) as yh) :: ys when (B.compare_sign_and_var (xhsign,xhvar) (yhsign,yhvar)) = 0 ->
-      let res = f xh yh in
-      if B.is_top res then
-        (map2 keep f xs ys)
+      if not widening || B.leq xh yh then ( (* must be leq to apply widen *)
+        let res = f xh yh in
+        if B.is_top res then
+          (map2 ~widening keep f xs ys)
+        else
+          res :: (map2 ~widening keep f xs ys)
+      )
       else
-        res :: (map2 keep f xs ys)
+        (map2 ~widening keep f xs ys) (* TODO: is the non-leq case correct? *)
     | ((xhsign,xhvar,_ ) as xh) :: xs, ((yhsign,yhvar,_ ) as yh) :: ys ->
       if (B.compare_sign_and_var (xhsign,xhvar) (yhsign,yhvar)) < 0 then
-        concat xh (map2 keep f xs y)
+        concat xh (map2 ~widening keep f xs y)
       else
-        concat yh (map2 keep f x ys)
+        concat yh (map2 ~widening keep f x ys)
 
   (* on meets we want to preserve the value of one octagon if *)
   (* the other octagon does not have a value at that position *)
@@ -81,7 +85,7 @@ struct
   let meet a b = map2 true B.meet a b
   let join a b = map2 false B.join a b
   let narrow a b = map2 true B.narrow a b
-  let widen a b = map2 false B.widen a b
+  let widen a b = map2 ~widening:true false B.widen a b
 
   let rec filter f x =
     match x with


### PR DESCRIPTION
Our `widen` is famously called like `widen old (join old new)`, which ensures `leq old new`. And some lattice implementations also rely on this fact (and don't do a duplicate join themselves).

I added an `assert (leq x y);` into the `widen` of intervals, which assumes this contract and found a bunch of failures. I then found and hopefully fixed a bunch of places which called `widen` blindly pairwise on things without filtering to just the pairs which satisfy the contract.

I realized this problem when I found the address domain doing some inconsistent things with index offsets, by applying widening to such invalid pairs like `[-2147483648,2147483647]` and `[0, 0]` to give `[-9223372036854775808,9223372036854775807]`. Meanwhile def_exc correctly kept the `[-31,31]` range. This mismatch of the ranges didn't make sense.

I'm not super confident about these fixes, but at least they're enough to fix the crash on our regression suite. There might also be some performance impact since this does make the address set widening more expensive.