### PR TITLE
Relational mutex-meet clustering

### DIFF
--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -474,7 +474,7 @@ struct
   let finalize () = ()
 end
 
-(* May written variables *)
+(** May written variables. *)
 module W =
 struct
   include MayVars
@@ -492,6 +492,7 @@ sig
   val unlock: W.t -> AD.t -> LAD.t
 end
 
+(** No clustering. *)
 module NoCluster: ClusterArg =
 struct
   open CommonPerMutex
@@ -511,6 +512,7 @@ struct
     oct_side
 end
 
+(** All clusters of size 1 and 2. *)
 module Cluster12: ClusterArg =
 struct
   open CommonPerMutex

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -709,7 +709,7 @@ struct
     let oct = st.oct in
     (* lock *)
     let tmp = (get_mutex_global_g_with_mutex_inits (not (LMust.mem m lmust)) ask getg g) in
-    let local_m = BatOption.default (LAD.bot ()) (L.find_opt m l) in
+    let local_m = LAD.bot () in (* apparently must ignore local here to pass 36-apron/90-mine14-5b *)
     (* Additionally filter get_m in case it contains variables it no longer protects. E.g. in 36/22. *)
     let tmp = Cluster.lock local_m tmp in
     let oct = AD.meet oct tmp in

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -527,6 +527,7 @@ struct
 end
 
 (** All clusters of size 2. *)
+(** Caution: It is questionable if this works 100%, see comment https://github.com/goblint/analyzer/pull/417/files#diff-58830344d2e5f5b8023333061fe1170c8a94a5e1ba32b98ccf6739eaf20d9123 *)
 module Clustering2: ClusteringArg =
 struct
   let generate gs =

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -535,6 +535,12 @@ struct
     module V = ApronDomain.V
 
     let keep_only_protected_globals ask m octs =
+      let octs =
+        (* must filter by protection to avoid later meeting with non-protecting *)
+        LAD.filter (fun gs _ ->
+            VS.for_all (is_protected_by ask m) gs
+          ) octs
+      in
       LAD.map (fun oct ->
           let protected var = match V.find_metadata var with
             | Some (Global g) -> is_protected_by ask m g

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -572,21 +572,37 @@ struct
   end
   module LAD = MapDomain.MapBot (VS) (AD)
 
+  let filter_map' f m =
+    LAD.fold (fun k v acc ->
+        match f k v with
+        | Some (k', v') ->
+          LAD.add k' (AD.join (LAD.find k' acc) v') acc
+        | None ->
+          acc
+      ) m (LAD.empty ())
+
   let keep_only_protected_globals ask m octs =
-    let octs =
-      (* must filter by protection to avoid later meeting with non-protecting *)
-      LAD.filter (fun gs _ ->
-          VS.for_all (is_protected_by ask m) gs (* TODO: is this subset check right? *)
-        ) octs
-    in
-    LAD.map (keep_only_protected_globals ask m) octs (* TODO: is this even necessary if keys are filtered above? *)
-    (* octs *)
+    filter_map' (fun gs oct ->
+        (* must filter by protection to avoid later meeting with non-protecting *)
+        let gs' = VS.filter (is_protected_by ask m) gs in
+        if VS.is_empty gs' then
+          None
+        else
+          (* must restrict cluster down to protected (join) *)
+          Some (gs', keep_only_protected_globals ask m oct)
+      ) octs
 
   let keep_global g octs =
-    let g' = VS.singleton g in
-    let oct = LAD.find g' octs in
-    let g_var = V.global g in
-    LAD.singleton g' (AD.keep_vars oct [g_var])
+    filter_map' (fun gs oct ->
+        (* must filter by protection to avoid later meeting with non-protecting *)
+        if VS.mem g gs then (
+          let g_var = V.global g in
+          (* must restrict cluster down to m_g (join) *)
+          Some (VS.singleton g, AD.keep_vars oct [g_var])
+        )
+        else
+          None
+      ) octs
 
   let lock local_m get_m =
     let joined = LAD.join local_m get_m in

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -530,9 +530,12 @@ end
 module Clustering2: ClusteringArg =
 struct
   let generate gs =
-    List.cartesian_product gs gs
-    |> List.filter (fun (g1, g2) -> CilType.Varinfo.compare g1 g2 < 0) (* filter flipped ordering, forbid equals for just clusters of size 2 *)
-    |> List.map (fun (g1, g2) -> [g1; g2])
+    match gs with
+    | [_] -> [gs] (* use clusters of size 1 if only 1 variable *)
+    | _ ->
+      List.cartesian_product gs gs
+      |> List.filter (fun (g1, g2) -> CilType.Varinfo.compare g1 g2 < 0) (* filter flipped ordering, forbid equals for just clusters of size 2 *)
+      |> List.map (fun (g1, g2) -> [g1; g2])
 end
 
 (** All subset clusters. *)

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -828,7 +828,7 @@ struct
       ) (AD.vars oct)
     in
     let oct_side = AD.keep_vars oct g_vars in
-    let oct_side = Cluster.unlock (W.top ()) oct_side in
+    let oct_side = Cluster.unlock (W.top ()) oct_side in (* top W to avoid any filtering *)
     let tid = ask.f Queries.CurrentThreadId in
     let sidev = GMutex.singleton tid oct_side in
     let vi = mutex_inits () in

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -177,7 +177,7 @@ let _ = ()
       ; reg Experimental "exp.privatization"     "'protection-read'" "Which privatization to use? none/protection-old/mutex-oplus/mutex-meet/protection/protection-read/protection-vesal/mine/mine-nothread/mine-W/mine-W-noinit/lock/write/write+lock"
       ; reg Experimental "exp.priv-prec-dump"    "''"    "File to dump privatization precision data to."
       ; reg Experimental "exp.priv-distr-init"   "false"  "Distribute global initializations to all global invariants for more consistent widening dynamics."
-      ; reg Experimental "exp.apron.privatization" "'mutex-meet-tid'" "Which apron privatization to use? dummy/protection/protection-path/mutex-meet"
+      ; reg Experimental "exp.apron.privatization" "'mutex-meet-tid-cluster12'" "Which apron privatization to use? dummy/protection/protection-path/mutex-meet"
       ; reg Experimental "exp.apron.priv.not-started" "true" "Exclude writes from threads that may not be started yet"
       ; reg Experimental "exp.apron.priv.must-joined" "true" "Exclude writes from threads that must have been joined"
       ; reg Experimental "exp.cfgdot"            "false" "Output CFG to dot files"

--- a/tests/regression/36-apron/91-traces-mutex-meet-cluster12.c
+++ b/tests/regression/36-apron/91-traces-mutex-meet-cluster12.c
@@ -1,0 +1,43 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag
+extern int __VERIFIER_nondet_int();
+
+#include <pthread.h>
+#include <assert.h>
+
+int g = 0;
+int h = 0;
+int i = 0;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  int x;
+  pthread_mutex_lock(&A);
+  x = h;
+  i = x;
+  pthread_mutex_unlock(&A);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_mutex_lock(&A);
+  g = __VERIFIER_nondet_int();
+  h = __VERIFIER_nondet_int();
+  i = __VERIFIER_nondet_int();
+  pthread_mutex_unlock(&A);
+
+  pthread_mutex_lock(&A);
+  int y = __VERIFIER_nondet_int();
+  g = y;
+  h = y;
+  i = y;
+  pthread_mutex_unlock(&A);
+
+  pthread_mutex_lock(&A);
+  assert(g == h);
+  assert(h == i);
+  pthread_mutex_unlock(&A);
+  return 0;
+}

--- a/tests/regression/36-apron/92-traces-mutex-meet-cluster2.c
+++ b/tests/regression/36-apron/92-traces-mutex-meet-cluster2.c
@@ -1,0 +1,44 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag
+extern int __VERIFIER_nondet_int();
+
+#include <pthread.h>
+#include <assert.h>
+
+int g = 0;
+int h = 0;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&A);
+  g = 16;
+  pthread_mutex_unlock(&A);
+  return NULL;
+}
+
+void *t_fun2(void *arg) {
+  pthread_mutex_lock(&A);
+  h = __VERIFIER_nondet_int();
+  h = 12;
+  pthread_mutex_unlock(&A);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id, id2;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_create(&id2, NULL, t_fun2, NULL);
+
+  pthread_mutex_lock(&A);
+  h = 31;
+  pthread_mutex_unlock(&A);
+
+  pthread_mutex_lock(&A);
+  h = 12;
+  pthread_mutex_unlock(&A);
+
+  pthread_mutex_lock(&A);
+  int z = h;
+  assert(z != 31);
+  pthread_mutex_unlock(&A);
+  return 0;
+}


### PR DESCRIPTION
Instead of duplicating the entire mutex-meet-tid analysis, which would be annoying to merge if #379 gets some refactorings, I managed to surgically generalize one domain it uses to make it work for the current no-clustering case and also the clustering case.

The trick is replacing the values in the `L` domain from relations (`AD`) with maps cluster→relation. Exactly the same is done in the global domain for mutexes (under thread IDs).
Since the no-clustering logic joins the compatible thread relations, now that join happens over the clustering maps pointwise. This naturally performs the inner join at clustered `lock`. Since the global and local structures use the same abstraction, the joining of those also happens naturally pointwise.
The only real logic for the clustering case is then to meet over the values of the resulting map.

For unlocking, the clustering just explodes the side-effected relation into the map. The clustering has clusters of size 1 or 2, although it'd be very easy to also support full powerset for experimental reasons.

It passes all the previous tests and also the clustering examples from the more traces article. Moreover, if disabling 1-clusters (and only keeping 2-clusters) the second example fails as expected.