### PR TITLE
Make Apron domain configurable 

### DIFF
--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -6,17 +6,17 @@ open ApronDomain
 
 module M = Messages
 
-module SpecFunctor (Priv: ApronPriv.S) : Analyses.MCPSpec =
+module SpecFunctor (AD: ApronDomain.S2) (Priv: ApronPriv.S) : Analyses.MCPSpec =
 struct
   include Analyses.DefaultSpec
 
   let name () = "apron"
 
-  module D = ApronComponents (Priv.AD) (Priv.D)
+  module Priv = Priv(AD)
+  module D = ApronComponents (AD) (Priv.D)
   module G = Priv.G
   module C = D
 
-  module AD = Priv.AD
   open AD
 
   let should_join = Priv.should_join
@@ -390,8 +390,10 @@ end
 
 let spec_module: (module MCPSpec) Lazy.t =
   lazy (
+    let module Man = (val ApronDomain.get_manager ()) in
+    let module AD = ApronDomain.D2 (Man) in
     let module Priv = (val ApronPriv.get_priv ()) in
-    let module Spec = SpecFunctor (Priv) in
+    let module Spec = SpecFunctor (AD) (Priv) in
     (module Spec)
   )
 

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -27,8 +27,8 @@ struct
     else
       D.bot () (* just like startstate, heterogeneous AD.bot () means top over empty set of variables *)
 
-  let exitstate  _ = { oct = AD.bot (); priv = Priv.startstate () }
-  let startstate _ = { oct = AD.bot (); priv = Priv.startstate () }
+  let exitstate  _ = { apr = AD.bot (); priv = Priv.startstate () }
+  let startstate _ = { apr = AD.bot (); priv = Priv.startstate () }
 
   (* Functions for manipulating globals as temporary locals. *)
 
@@ -36,12 +36,12 @@ struct
     if ThreadFlag.is_multi ask then
       Priv.read_global ask getg st g x
     else (
-      let oct = st.oct in
+      let apr = st.apr in
       let g_var = V.global g in
       let x_var = V.local x in
-      let oct' = AD.add_vars oct [g_var] in
-      let oct' = AD.assign_var oct' x_var g_var in
-      oct'
+      let apr' = AD.add_vars apr [g_var] in
+      let apr' = AD.assign_var apr' x_var g_var in
+      apr'
     )
 
   module VH = BatHashtbl.Make (Basetype.Variables)
@@ -67,35 +67,35 @@ struct
     end
     in
     let e' = visitCilExpr visitor e in
-    let oct = AD.add_vars st.oct (List.map V.local (VH.values v_ins |> List.of_enum)) in (* add temporary g#in-s *)
-    let oct' = VH.fold (fun v v_in oct ->
+    let apr = AD.add_vars st.apr (List.map V.local (VH.values v_ins |> List.of_enum)) in (* add temporary g#in-s *)
+    let apr' = VH.fold (fun v v_in apr ->
         if M.tracing then M.trace "apron" "read_global %a %a\n" d_varinfo v d_varinfo v_in;
-        read_global ask getg {st with oct = oct} v v_in (* g#in = g; *)
-      ) v_ins oct
+        read_global ask getg {st with apr = apr} v v_in (* g#in = g; *)
+      ) v_ins apr
     in
-    (oct', e', v_ins)
+    (apr', e', v_ins)
 
   let read_from_globals_wrapper ask getg st e f =
-    let (oct', e', _) = read_globals_to_locals ask getg st e in
-    f oct' e' (* no need to remove g#in-s *)
+    let (apr', e', _) = read_globals_to_locals ask getg st e in
+    f apr' e' (* no need to remove g#in-s *)
 
   let assign_from_globals_wrapper ask getg st e f =
-    let (oct', e', v_ins) = read_globals_to_locals ask getg st e in
+    let (apr', e', v_ins) = read_globals_to_locals ask getg st e in
     if M.tracing then M.trace "apron" "assign_from_globals_wrapper %a\n" d_exp e';
-    let oct' = f oct' e' in (* x = e; *)
-    let oct'' = AD.remove_vars oct' (List.map V.local (VH.values v_ins |> List.of_enum)) in (* remove temporary g#in-s *)
-    oct''
+    let apr' = f apr' e' in (* x = e; *)
+    let apr'' = AD.remove_vars apr' (List.map V.local (VH.values v_ins |> List.of_enum)) in (* remove temporary g#in-s *)
+    apr''
 
   let write_global ask getg sideg st g x =
     if ThreadFlag.is_multi ask then
       Priv.write_global ask getg sideg st g x
     else (
-      let oct = st.oct in
+      let apr = st.apr in
       let g_var = V.global g in
       let x_var = V.local x in
-      let oct' = AD.add_vars oct [g_var] in
-      let oct' = AD.assign_var oct' g_var x_var in
-      {st with oct = oct'}
+      let apr' = AD.add_vars apr [g_var] in
+      let apr' = AD.assign_var apr' g_var x_var in
+      {st with apr = apr'}
     )
 
   let assign_to_global_wrapper ask getg sideg st lv f =
@@ -105,32 +105,32 @@ struct
     (* and no special handling for them is required (https://github.com/goblint/analyzer/pull/310) *)
     | (Var v, NoOffset) when AD.varinfo_tracked v ->
       if not v.vglob then
-        {st with oct = f st v}
+        {st with apr = f st v}
       else (
         let v_out = Goblintutil.create_var @@ makeVarinfo false (v.vname ^ "#out") v.vtype in (* temporary local g#out for global g *)
-        let st = {st with oct = AD.add_vars st.oct [V.local v_out]} in (* add temporary g#out *)
-        let st' = {st with oct = f st v_out} in (* g#out = e; *)
+        let st = {st with apr = AD.add_vars st.apr [V.local v_out]} in (* add temporary g#out *)
+        let st' = {st with apr = f st v_out} in (* g#out = e; *)
         if M.tracing then M.trace "apron" "write_global %a %a\n" d_varinfo v d_varinfo v_out;
         let st' = write_global ask getg sideg st' v v_out in (* g = g#out; *)
-        let oct'' = AD.remove_vars st'.oct [V.local v_out] in (* remove temporary g#out *)
-        {st' with oct = oct''}
+        let apr'' = AD.remove_vars st'.apr [V.local v_out] in (* remove temporary g#out *)
+        {st' with apr = apr''}
       )
     (* Ignoring all other assigns *)
     | _ ->
       st
 
-  let assert_type_bounds oct x =
+  let assert_type_bounds apr x =
     assert (AD.varinfo_tracked x);
     let ik = Cilfacade.get_ikind x.vtype in
     if not (IntDomain.should_ignore_overflow ik) then ( (* don't add type bounds for signed when assume_none *)
       let (type_min, type_max) = IntDomain.Size.range_big_int ik in
       (* TODO: don't go through CIL exp? *)
-      let oct = AD.assert_inv oct (BinOp (Le, Lval (Cil.var x), (Cil.kintegerCilint ik (Cilint.cilint_of_big_int type_max)), intType)) false in
-      let oct = AD.assert_inv oct (BinOp (Ge, Lval (Cil.var x), (Cil.kintegerCilint ik (Cilint.cilint_of_big_int type_min)), intType)) false in
-      oct
+      let apr = AD.assert_inv apr (BinOp (Le, Lval (Cil.var x), (Cil.kintegerCilint ik (Cilint.cilint_of_big_int type_max)), intType)) false in
+      let apr = AD.assert_inv apr (BinOp (Ge, Lval (Cil.var x), (Cil.kintegerCilint ik (Cilint.cilint_of_big_int type_min)), intType)) false in
+      apr
     )
     else
-      oct
+      apr
 
 
   (* Basic transfer functions. *)
@@ -138,13 +138,13 @@ struct
   let assign ctx (lv:lval) e =
     let st = ctx.local in
     if !GU.global_initialization && e = MyCFG.unknown_exp then
-      st (* ignore extern inits because there's no body before assign, so octagon env is empty... *)
+      st (* ignore extern inits because there's no body before assign, so the apron env is empty... *)
     else (
       if M.tracing then M.traceli "apron" "assign %a = %a\n" d_lval lv d_exp e;
       let ask = Analyses.ask_of_ctx ctx in
       let r = assign_to_global_wrapper ask ctx.global ctx.sideg st lv (fun st v ->
-          assign_from_globals_wrapper ask ctx.global st e (fun oct' e' ->
-              AD.assign_exp oct' (V.local v) e'
+          assign_from_globals_wrapper ask ctx.global st e (fun apr' e' ->
+              AD.assign_exp apr' (V.local v) e'
             )
         )
       in
@@ -154,13 +154,13 @@ struct
 
   let branch ctx e b =
     let st = ctx.local in
-    let res = assign_from_globals_wrapper (Analyses.ask_of_ctx ctx) ctx.global st e (fun oct' e' ->
+    let res = assign_from_globals_wrapper (Analyses.ask_of_ctx ctx) ctx.global st e (fun apr' e' ->
         (* not an assign, but must remove g#in-s still *)
-        AD.assert_inv oct' e' (not b)
+        AD.assert_inv apr' e' (not b)
       )
     in
     if AD.is_bot_env res then raise Deadcode;
-    {st with oct = res}
+    {st with apr = res}
 
 
   (* Function call transfer functions. *)
@@ -176,69 +176,69 @@ struct
       |> List.map (Tuple2.map1 V.arg)
     in
     let arg_vars = List.map fst arg_assigns in
-    let new_oct = AD.add_vars st.oct arg_vars in
+    let new_apr = AD.add_vars st.apr arg_vars in
     (* AD.assign_exp_parallel_with new_oct arg_assigns; (* doesn't need to be parallel since exps aren't arg vars directly *) *)
     (* TODO: parallel version of assign_from_globals_wrapper? *)
     let ask = Analyses.ask_of_ctx ctx in
-    let new_oct = List.fold_left (fun new_oct (var, e) ->
-        assign_from_globals_wrapper ask ctx.global {st with oct = new_oct} e (fun oct' e' ->
-            AD.assign_exp oct' var e'
+    let new_apr = List.fold_left (fun new_apr (var, e) ->
+        assign_from_globals_wrapper ask ctx.global {st with apr = new_apr} e (fun apr' e' ->
+            AD.assign_exp apr' var e'
           )
-      ) new_oct arg_assigns
+      ) new_apr arg_assigns
     in
-    AD.remove_filter_with new_oct (fun var ->
+    AD.remove_filter_with new_apr (fun var ->
         match V.find_metadata var with
         | Some Local -> true (* remove caller locals *)
         | Some Arg when not (List.mem_cmp Var.compare var arg_vars) -> true (* remove caller args, but keep just added args *)
         | _ -> false (* keep everything else (just added args, globals, global privs) *)
       );
-    if M.tracing then M.tracel "combine" "apron enter newd: %a\n" AD.pretty new_oct;
-    [st, {st with oct = new_oct}]
+    if M.tracing then M.tracel "combine" "apron enter newd: %a\n" AD.pretty new_apr;
+    [st, {st with apr = new_apr}]
 
   let body ctx f =
     let st = ctx.local in
     let formals = List.filter AD.varinfo_tracked f.sformals in
     let locals = List.filter AD.varinfo_tracked f.slocals in
-    let new_oct = AD.add_vars st.oct (List.map V.local (formals @ locals)) in
+    let new_apr = AD.add_vars st.apr (List.map V.local (formals @ locals)) in
     (* TODO: do this after local_assigns? *)
-    let new_oct = List.fold_left (fun new_oct x ->
-        assert_type_bounds new_oct x
-      ) new_oct (formals @ locals)
+    let new_apr = List.fold_left (fun new_apr x ->
+        assert_type_bounds new_apr x
+      ) new_apr (formals @ locals)
     in
     let local_assigns = List.map (fun x -> (V.local x, V.arg x)) formals in
-    AD.assign_var_parallel_with new_oct local_assigns; (* doesn't need to be parallel since arg vars aren't local vars *)
-    {st with oct = new_oct}
+    AD.assign_var_parallel_with new_apr local_assigns; (* doesn't need to be parallel since arg vars aren't local vars *)
+    {st with apr = new_apr}
 
   let return ctx e f =
     let st = ctx.local in
-    let new_oct =
+    let new_apr =
       if AD.type_tracked (Cilfacade.fundec_return_type f) then (
-        let oct' = AD.add_vars st.oct [V.return] in
+        let apr' = AD.add_vars st.apr [V.return] in
         match e with
         | Some e ->
-          assign_from_globals_wrapper (Analyses.ask_of_ctx ctx) ctx.global {st with oct = oct'} e (fun oct' e' ->
-              AD.assign_exp oct' V.return e'
+          assign_from_globals_wrapper (Analyses.ask_of_ctx ctx) ctx.global {st with apr = apr'} e (fun apr' e' ->
+              AD.assign_exp apr' V.return e'
             )
         | None ->
-          oct' (* leaves V.return unconstrained *)
+          apr' (* leaves V.return unconstrained *)
       )
       else
-        AD.copy st.oct
+        AD.copy st.apr
     in
     let local_vars =
       f.sformals @ f.slocals
       |> List.filter AD.varinfo_tracked
       |> List.map V.local
     in
-    AD.remove_vars_with new_oct local_vars;
-    {st with oct = new_oct}
+    AD.remove_vars_with new_apr local_vars;
+    {st with apr = new_apr}
 
   let combine ctx r fe f args fc fun_st =
     let st = ctx.local in
     if M.tracing then M.tracel "combine" "apron f: %a\n" d_varinfo f.svar;
     if M.tracing then M.tracel "combine" "apron formals: %a\n" (d_list "," d_varinfo) f.sformals;
     if M.tracing then M.tracel "combine" "apron args: %a\n" (d_list "," d_exp) args;
-    let new_fun_oct = AD.add_vars fun_st.oct (AD.vars st.oct) in
+    let new_fun_apr = AD.add_vars fun_st.apr (AD.vars st.apr) in
     let arg_substitutes =
       Goblintutil.zip f.sformals args
       |> List.filter (fun (x, _) -> AD.varinfo_tracked x)
@@ -247,36 +247,36 @@ struct
     (* AD.substitute_exp_parallel_with new_fun_oct arg_substitutes; (* doesn't need to be parallel since exps aren't arg vars directly *) *)
     (* TODO: parallel version of assign_from_globals_wrapper? *)
     let ask = Analyses.ask_of_ctx ctx in
-    let new_fun_oct = List.fold_left (fun new_fun_oct (var, e) ->
-        assign_from_globals_wrapper ask ctx.global {st with oct = new_fun_oct} e (fun oct' e' ->
+    let new_fun_apr = List.fold_left (fun new_fun_apr (var, e) ->
+        assign_from_globals_wrapper ask ctx.global {st with apr = new_fun_apr} e (fun apr' e' ->
             (* not an assign, but still works? *)
-            AD.substitute_exp oct' var e'
+            AD.substitute_exp apr' var e'
           )
-      ) new_fun_oct arg_substitutes
+      ) new_fun_apr arg_substitutes
     in
     let arg_vars = List.map fst arg_substitutes in
     if M.tracing then M.tracel "combine" "apron remove vars: %a\n" (docList (fun v -> Pretty.text (Var.to_string v))) arg_vars;
-    AD.remove_vars_with new_fun_oct arg_vars; (* fine to remove arg vars that also exist in caller because unify from new_oct adds them back with proper constraints *)
-    let new_oct = AD.keep_filter st.oct (fun var ->
+    AD.remove_vars_with new_fun_apr arg_vars; (* fine to remove arg vars that also exist in caller because unify from new_apr adds them back with proper constraints *)
+    let new_apr = AD.keep_filter st.apr (fun var ->
         match V.find_metadata var with
         | Some Local -> true (* keep caller locals *)
         | Some Arg -> true (* keep caller args *)
         | _ -> false (* remove everything else (globals, global privs) *)
       )
     in
-    let unify_oct = A.unify Man.mgr new_oct new_fun_oct in (* TODO: unify_with *)
-    if M.tracing then M.tracel "combine" "apron unifying %a %a = %a\n" AD.pretty new_oct AD.pretty new_fun_oct AD.pretty unify_oct;
-    let unify_st = {fun_st with oct = unify_oct} in
+    let unify_apr = A.unify Man.mgr new_apr new_fun_apr in (* TODO: unify_with *)
+    if M.tracing then M.tracel "combine" "apron unifying %a %a = %a\n" AD.pretty new_apr AD.pretty new_fun_apr AD.pretty unify_apr;
+    let unify_st = {fun_st with apr = unify_apr} in
     if AD.type_tracked (Cilfacade.fundec_return_type f) then (
       let unify_st' = match r with
         | Some lv ->
           assign_to_global_wrapper (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg unify_st lv (fun st v ->
-              AD.assign_var st.oct (V.local v) V.return
+              AD.assign_var st.apr (V.local v) V.return
             )
         | None ->
           unify_st
       in
-      AD.remove_vars_with unify_st'.oct [V.return]; (* mutates! *)
+      AD.remove_vars_with unify_st'.apr [V.return]; (* mutates! *)
       unify_st'
     )
     else
@@ -294,8 +294,8 @@ struct
       let ask = Analyses.ask_of_ctx ctx in
       let invalidate_one st lv =
         assign_to_global_wrapper ask ctx.global ctx.sideg st lv (fun st v ->
-            let oct' = AD.forget_vars st.oct [V.local v] in
-            assert_type_bounds oct' v (* re-establish type bounds after forget *)
+            let apr' = AD.forget_vars st.apr [V.local v] in
+            assert_type_bounds apr' v (* re-establish type bounds after forget *)
           )
       in
       let st' = match LibraryFunctions.get_invalidate_action f.vname with
@@ -327,8 +327,8 @@ struct
     match q with
     | EvalInt e ->
       if M.tracing then M.traceli "evalint" "apron query %a\n" d_exp e;
-      let r = read_from_globals_wrapper (Analyses.ask_of_ctx ctx) ctx.global st e (fun oct' e' ->
-          AD.eval_int oct' e'
+      let r = read_from_globals_wrapper (Analyses.ask_of_ctx ctx) ctx.global st e (fun apr' e' ->
+          AD.eval_int apr' e'
         )
       in
       if M.tracing then M.traceu "evalint" "apron query %a -> %a\n" d_exp e ID.pretty r;
@@ -354,8 +354,8 @@ struct
         |> List.filter AD.varinfo_tracked
         |> List.map V.arg
       in
-      let new_oct = AD.add_vars st'.oct arg_vars in
-      [{st' with oct = new_oct}]
+      let new_apr = AD.add_vars st'.apr arg_vars in
+      [{st' with apr = new_apr}]
     | exception Not_found ->
       (* Unknown functions *)
       (* TODO: do something like base? *)
@@ -364,16 +364,16 @@ struct
   let threadspawn ctx lval f args fctx =
     ctx.local
 
-  let event ctx e octx =
+  let event ctx e aprx =
     let st = ctx.local in
     match e with
     | Events.Lock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      Priv.lock (Analyses.ask_of_ctx octx) octx.global st addr
+      Priv.lock (Analyses.ask_of_ctx aprx) aprx.global st addr
     | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      Priv.unlock (Analyses.ask_of_ctx octx) octx.global octx.sideg st addr
+      Priv.unlock (Analyses.ask_of_ctx aprx) aprx.global aprx.sideg st addr
     (* No need to handle escape because escaped variables are always referenced but this analysis only considers unreferenced variables. *)
     | Events.EnterMultiThreaded ->
-      Priv.enter_multithreaded (Analyses.ask_of_ctx octx) octx.global octx.sideg st
+      Priv.enter_multithreaded (Analyses.ask_of_ctx aprx) aprx.global aprx.sideg st
     | _ ->
       st
 

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -12,11 +12,12 @@ struct
 
   let name () = "apron"
 
-  module D = ApronComponents (Priv.D)
+  module D = ApronComponents (Priv.AD) (Priv.D)
   module G = Priv.G
   module C = D
 
-  module AD = ApronDomain.D2
+  module AD = Priv.AD
+  open AD
 
   let should_join = Priv.should_join
 

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -683,7 +683,6 @@ let priv_module: (module S) Lazy.t =
   lazy (
     let module Man = (val ApronDomain.get_manager ()) in
     let module AD: ApronDomain.S2 = ApronDomain.D2 (Man) in
-    let module ApronComponents = ApronDomain.ApronComponents (AD) in
     let module Priv: S =
       (val match get_string "exp.apron.privatization" with
          | "dummy" -> (module Dummy (AD): S)

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -49,7 +49,7 @@ struct
   let startstate () = ()
   let should_join _ _ = true
 
-  let read_global ask getg st g x = st.AD.apr
+  let read_global ask getg st g x = st.ApronDomain.apr
   let write_global ?(invariant=false) ask getg sideg st g x = st
 
   let lock ask getg st m = st

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -829,33 +829,9 @@ end
 module type S2 =
 sig
   module Man: Manager
-  type t = Man.mt A.t
-  val top_env : Environment.t -> t
-  val bot_env : Environment.t -> t
-  val is_top_env : t -> bool
-  val is_bot_env : t -> bool
-  val equal : t -> t -> bool
-  val hash : t -> int
-  val compare : t -> t -> int
-  val show : t -> string
-  val pretty : unit -> t -> doc
-  val printXml : 'a BatInnerIO.output -> t -> unit
-  val name : unit -> string
-  val to_yojson : t -> Printable.json
-  val invariant : Invariant.context -> t -> Invariant.t
-  val tag : t -> int
-  val arbitrary : unit -> t QCheck.arbitrary
-  val relift : t -> t
-  val leq : t -> t -> bool
-  val join : t -> t -> t
-  val meet : t -> t -> t
-  val widen : t -> t -> t
-  val narrow : t -> t -> t
-  val pretty_diff : unit -> t * t -> doc
-  val bot : unit -> t
-  val is_bot : t -> bool
-  val top : unit -> t
-  val is_top : t -> bool
+  include SLattice with type t = Man.mt A.t
+  type 'a aproncomponents_t = { apr : t; priv : 'a; }
+
   module Bounds :
     sig
       val bound_texpr : t -> Texpr1.t -> Z.t option * Z.t option
@@ -918,7 +894,7 @@ sig
   val check_assert : t -> exp -> [> `False | `Top | `True ]
   val eval_interval_expr : t -> exp -> Z.t option * Z.t option
   val eval_int : t -> exp -> IntDomain.IntDomTuple.t
-  type 'a aproncomponents_t = { apr : t; priv : 'a; }
+
   val equal_aproncomponents_t :
     ('a -> 'a -> bool) ->
     'a aproncomponents_t -> 'a aproncomponents_t -> bool

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -1,7 +1,7 @@
 open Prelude
 open Cil
 open Pretty
-(* For Apron implementation of octagons *)
+(* A binding to a selection of Apron-Domains *)
 open Apron
 
 module BI = IntOps.BigIntOps
@@ -821,7 +821,7 @@ struct
   module Man = Man
   (* Copy-paste from BaseDomain... *)
   type 'a aproncomponents_t = {
-    oct: t; (* TODO: rename not to be just "oct" *)
+    apr: t;
     priv: 'a;
   } [@@deriving eq, ord, to_yojson]
 end
@@ -918,7 +918,7 @@ sig
   val check_assert : t -> exp -> [> `False | `Top | `True ]
   val eval_interval_expr : t -> exp -> Z.t option * Z.t option
   val eval_int : t -> exp -> IntDomain.IntDomTuple.t
-  type 'a aproncomponents_t = { oct : t; priv : 'a; }
+  type 'a aproncomponents_t = { apr : t; priv : 'a; }
   val equal_aproncomponents_t :
     ('a -> 'a -> bool) ->
     'a aproncomponents_t -> 'a aproncomponents_t -> bool
@@ -949,51 +949,51 @@ struct
 
   include Printable.Std
   open Pretty
-  let hash (r: t)  = D2.hash r.oct + PrivD.hash r.priv * 33
+  let hash (r: t)  = D2.hash r.apr + PrivD.hash r.priv * 33
 
   let show r =
-    let first  = D2.show r.D2.oct in
+    let first  = D2.show r.D2.apr in
     let third  = PrivD.show r.D2.priv in
     "(" ^ first ^ ", " ^ third  ^ ")"
 
   let pretty () r =
     text "(" ++
-    D2.pretty () r.D2.oct
+    D2.pretty () r.D2.apr
     ++ text ", " ++
     PrivD.pretty () r.D2.priv
     ++ text ")"
 
   let printXml f r =
-    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (Goblintutil.escape (D2.name ())) D2.printXml r.D2.oct (Goblintutil.escape (PrivD.name ())) PrivD.printXml r.D2.priv
+    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (Goblintutil.escape (D2.name ())) D2.printXml r.D2.apr (Goblintutil.escape (PrivD.name ())) PrivD.printXml r.D2.priv
 
   let name () = D2.name () ^ " * " ^ PrivD.name ()
 
-  let invariant c {D2.oct; priv} =
-    Invariant.(D2.invariant c oct && PrivD.invariant c priv)
+  let invariant c {D2.apr; priv} =
+    Invariant.(D2.invariant c apr && PrivD.invariant c priv)
 
-  let of_tuple(oct, priv):t = {oct; priv}
-  let to_tuple r = (r.D2.oct, r.D2.priv)
+  let of_tuple(apr, priv):t = {apr; priv}
+  let to_tuple r = (r.D2.apr, r.D2.priv)
 
   let arbitrary () =
     let tr = QCheck.pair (D2.arbitrary ()) (PrivD.arbitrary ()) in
     QCheck.map ~rev:to_tuple of_tuple tr
 
-  let bot () = { D2.oct = D2.bot (); priv = PrivD.bot ()}
-  let is_bot {D2.oct; priv} = D2.is_bot oct && PrivD.is_bot priv
-  let top () = {D2.oct = D2.top (); priv = PrivD.bot ()}
-  let is_top {D2.oct; priv} = D2.is_top oct && PrivD.is_top priv
+  let bot () = { D2.apr = D2.bot (); priv = PrivD.bot ()}
+  let is_bot {D2.apr; priv} = D2.is_bot apr && PrivD.is_bot priv
+  let top () = {D2.apr = D2.top (); priv = PrivD.bot ()}
+  let is_top {D2.apr; priv} = D2.is_top apr && PrivD.is_top priv
 
-  let leq {D2.oct=x1; priv=x3 } {D2.oct=y1; priv=y3} =
+  let leq {D2.apr=x1; priv=x3 } {D2.apr=y1; priv=y3} =
     D2.leq x1 y1 && PrivD.leq x3 y3
 
-  let pretty_diff () (({oct=x1; priv=x3}:t),({oct=y1; priv=y3}:t)): Pretty.doc =
+  let pretty_diff () (({apr=x1; priv=x3}:t),({apr=y1; priv=y3}:t)): Pretty.doc =
     if not (D2.leq x1 y1) then
       D2.pretty_diff () (x1,y1)
     else
       PrivD.pretty_diff () (x3,y3)
 
-  let op_scheme op1 op3 {D2.oct=x1; priv=x3} {D2.oct=y1; priv=y3}: t =
-    {oct = op1 x1 y1; priv = op3 x3 y3 }
+  let op_scheme op1 op3 {D2.apr=x1; priv=x3} {D2.apr=y1; priv=y3}: t =
+    {apr = op1 x1 y1; priv = op3 x3 y3 }
   let join = op_scheme D2.join PrivD.join
   let meet = op_scheme D2.meet PrivD.meet
   let widen = op_scheme D2.widen PrivD.widen

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -24,20 +24,42 @@ struct
 end
 
 
-module Man =
+
+(** Manager for the Polka domain, i.e. a polyhedra domain.
+For Documentation for the domain see: https://antoinemine.github.io/Apron/doc/api/ocaml/Oct.html *)
+module OctagonManager =
 struct
-  (* Manager type, parameter for the command below *)
+
   type mt = Oct.t
-  (* type mt = Polka.equalities Polka.t *)
-  (* type mt = Polka.loose Polka.t *)
-  (* A type of manager allocated by the underlying octagon domain *)
+
+  (* Type of the manager *)
   type t = mt Manager.t
 
-  (* Allocate a new manager to manipulate octagons *)
-  let mgr = Oct.manager_alloc ()
-  (* let mgr = Polka.manager_alloc_equalities () *)
-  (* let mgr = Polka.manager_alloc_loose () *)
+  (* Create the manager *)
+  let mgr =  Oct.manager_alloc ()
 end
+
+(** Manager for the Polka domain, i.e. a polyhedra domain.
+For Documentation for the domain see: https://antoinemine.github.io/Apron/doc/api/ocaml/Polka.html *)
+module PolyhedraManager =
+struct
+  (** We chose a the loose polyhedra here, i.e. with polyhedra with no strict inequalities *)
+  type mt = Polka.loose Polka.t
+  type t = mt Manager.t
+  (* Create manager that fits to loose polyhedra *)
+  let mgr = Polka.manager_alloc_loose
+end
+
+(** Manager for the Box domain, i.e. an interval domain.
+For Documentation for the domain see: https://antoinemine.github.io/Apron/doc/api/ocaml/Box.html*)
+module BoxManager =
+struct
+  type mt = Box.t
+  type t = mt Manager.t
+  let mgr = Box.manager_alloc ()
+end
+
+module Man = OctagonManager
 
 module type Tracked =
 sig

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -905,18 +905,10 @@ sig
     ('a -> Printable.json) -> 'a aproncomponents_t -> Printable.json
 end
 
-module type ApronComponentsS =
-sig
-  module D2: S2
-  type priv_t
-  include Lattice.S with type t = priv_t D2.aproncomponents_t
-end
-
 module ApronComponents (D2: S2) (PrivD: Lattice.S):
 sig
   module AD: S2 with type Man.mt = D2.Man.mt
   include Lattice.S with type t = PrivD.t D2.aproncomponents_t
-  (* include ApronComponentsS with type priv_t = PrivD.t and type t = PrivD.t D2.aproncomponents_t and type D2.t = D2.t *)
   val op_scheme: (D2.t -> D2.t -> D2.t) -> (PrivD.t -> PrivD.t -> PrivD.t) -> t -> t -> t
 end =
 struct

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -815,17 +815,6 @@ struct
     dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
 end
 
-module D2 (Man: Manager) =
-struct
-  include DWithOps (Man) (DHetero (Man))
-  module Man = Man
-  (* Copy-paste from BaseDomain... *)
-  type 'a aproncomponents_t = {
-    apr: t;
-    priv: 'a;
-  } [@@deriving eq, ord, to_yojson]
-end
-
 module type S2 =
 sig
   module Man: Manager
@@ -899,6 +888,17 @@ sig
     'a aproncomponents_t -> 'a aproncomponents_t -> int
   val aproncomponents_t_to_yojson :
     ('a -> Printable.json) -> 'a aproncomponents_t -> Printable.json
+end
+
+module D2 (Man: Manager) : S2 =
+struct
+  include DWithOps (Man) (DHetero (Man))
+  module Man = Man
+  (* Copy-paste from BaseDomain... *)
+  type 'a aproncomponents_t = {
+    apr: t;
+    priv: 'a;
+  } [@@deriving eq, ord, to_yojson]
 end
 
 module ApronComponents (D2: S2) (PrivD: Lattice.S):

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -833,30 +833,30 @@ sig
   type 'a aproncomponents_t = { apr : t; priv : 'a; }
 
   module Bounds :
-    sig
-      val bound_texpr : t -> Texpr1.t -> Z.t option * Z.t option
-    end
+  sig
+    val bound_texpr : t -> Texpr1.t -> Z.t option * Z.t option
+  end
   module Tracked :
-    sig
-      val type_tracked : typ -> bool
-      val varinfo_tracked : varinfo -> bool
-    end
+  sig
+    val type_tracked : typ -> bool
+    val varinfo_tracked : varinfo -> bool
+  end
   module Convert :
+  sig
+    module Bounds :
     sig
-      module Bounds :
-        sig
-          val bound_texpr :
-            t -> Texpr1.t -> Z.t option * Z.t option
-        end
-      exception Unsupported_CilExp
-      val is_cast_injective : typ -> typ -> bool
-      val texpr1_expr_of_cil_exp :
-        t -> Environment.t -> exp -> Texpr1.expr
-      val texpr1_of_cil_exp :
-        t -> Environment.t -> exp -> Texpr1.t
-      val tcons1_of_cil_exp :
-        t -> Environment.t -> exp -> bool -> Tcons1.t
+      val bound_texpr :
+        t -> Texpr1.t -> Z.t option * Z.t option
     end
+    exception Unsupported_CilExp
+    val is_cast_injective : typ -> typ -> bool
+    val texpr1_expr_of_cil_exp :
+      t -> Environment.t -> exp -> Texpr1.expr
+    val texpr1_of_cil_exp :
+      t -> Environment.t -> exp -> Texpr1.t
+    val tcons1_of_cil_exp :
+      t -> Environment.t -> exp -> bool -> Tcons1.t
+  end
   val copy : t -> t
   val vars : 'a A.t -> Var.t list
   val mem_var : 'a A.t -> Var.t -> bool

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -836,11 +836,7 @@ sig
   sig
     val bound_texpr : t -> Texpr1.t -> Z.t option * Z.t option
   end
-  module Tracked :
-  sig
-    val type_tracked : typ -> bool
-    val varinfo_tracked : varinfo -> bool
-  end
+  module Tracked : Tracked
   module Convert :
   sig
     module Bounds :

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -31,7 +31,7 @@ module type Manager =
     val name : string
   end
 
-(** Manager for the Polka domain, i.e. a polyhedra domain.
+(** Manager for the Oct domain, i.e. an octagon domain.
 For Documentation for the domain see: https://antoinemine.github.io/Apron/doc/api/ocaml/Oct.html *)
 module OctagonManager =
 struct

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -824,7 +824,6 @@ sig
   include Tracked
   include SLattice with type t = Man.mt A.t
 
-  type 'a aproncomponents_t = { apr : t; priv : 'a; }
 
   val exp_is_cons : exp -> bool
   val assert_cons : t -> exp -> bool -> t
@@ -832,75 +831,63 @@ sig
   val check_assert : t -> exp -> [> `False | `Top | `True ]
   val eval_interval_expr : t -> exp -> Z.t option * Z.t option
   val eval_int : t -> exp -> IntDomain.IntDomTuple.t
-
-  val equal_aproncomponents_t :
-    ('a -> 'a -> bool) ->
-    'a aproncomponents_t -> 'a aproncomponents_t -> bool
-  val compare_aproncomponents_t :
-    ('a -> 'a -> int) ->
-    'a aproncomponents_t -> 'a aproncomponents_t -> int
-  val aproncomponents_t_to_yojson :
-    ('a -> Printable.json) -> 'a aproncomponents_t -> Printable.json
 end
+
+type ('a, 'b) aproncomponents_t = { apr : 'a; priv : 'b; } [@@deriving eq, ord, to_yojson]
 
 module D2 (Man: Manager) : S2 =
 struct
   include DWithOps (Man) (DHetero (Man))
   module Man = Man
-  (* Copy-paste from BaseDomain... *)
-  type 'a aproncomponents_t = {
-    apr: t;
-    priv: 'a;
-  } [@@deriving eq, ord, to_yojson]
 end
 
 module ApronComponents (D2: S2) (PrivD: Lattice.S):
 sig
   module AD: S2 with type Man.mt = D2.Man.mt
-  include Lattice.S with type t = PrivD.t D2.aproncomponents_t
+  include Lattice.S with type t = (D2.t, PrivD.t) aproncomponents_t
   val op_scheme: (D2.t -> D2.t -> D2.t) -> (PrivD.t -> PrivD.t -> PrivD.t) -> t -> t -> t
 end =
 struct
   module AD = D2
-  type t = PrivD.t D2.aproncomponents_t [@@deriving eq, ord, to_yojson]
+  type t = (D2.t, PrivD.t) aproncomponents_t [@@deriving eq, ord, to_yojson]
 
   include Printable.Std
   open Pretty
   let hash (r: t)  = D2.hash r.apr + PrivD.hash r.priv * 33
 
   let show r =
-    let first  = D2.show r.D2.apr in
-    let third  = PrivD.show r.D2.priv in
+    let first  = D2.show r.apr in
+    let third  = PrivD.show r.priv in
     "(" ^ first ^ ", " ^ third  ^ ")"
 
   let pretty () r =
     text "(" ++
-    D2.pretty () r.D2.apr
+    D2.pretty () r.apr
     ++ text ", " ++
-    PrivD.pretty () r.D2.priv
+    PrivD.pretty () r.priv
     ++ text ")"
 
   let printXml f r =
-    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (Goblintutil.escape (D2.name ())) D2.printXml r.D2.apr (Goblintutil.escape (PrivD.name ())) PrivD.printXml r.D2.priv
+    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (Goblintutil.escape (D2.name ())) D2.printXml r.apr (Goblintutil.escape (PrivD.name ())) PrivD.printXml r.priv
 
   let name () = D2.name () ^ " * " ^ PrivD.name ()
 
-  let invariant c {D2.apr; priv} =
+  let invariant c {apr; priv} =
     Invariant.(D2.invariant c apr && PrivD.invariant c priv)
 
   let of_tuple(apr, priv):t = {apr; priv}
-  let to_tuple r = (r.D2.apr, r.D2.priv)
+  let to_tuple r = (r.apr, r.priv)
 
   let arbitrary () =
     let tr = QCheck.pair (D2.arbitrary ()) (PrivD.arbitrary ()) in
     QCheck.map ~rev:to_tuple of_tuple tr
 
-  let bot () = { D2.apr = D2.bot (); priv = PrivD.bot ()}
-  let is_bot {D2.apr; priv} = D2.is_bot apr && PrivD.is_bot priv
-  let top () = {D2.apr = D2.top (); priv = PrivD.bot ()}
-  let is_top {D2.apr; priv} = D2.is_top apr && PrivD.is_top priv
+  let bot () = {apr = D2.bot (); priv = PrivD.bot ()}
+  let is_bot {apr; priv} = D2.is_bot apr && PrivD.is_bot priv
+  let top () = {apr = D2.top (); priv = PrivD.bot ()}
+  let is_top {apr; priv} = D2.is_top apr && PrivD.is_top priv
 
-  let leq {D2.apr=x1; priv=x3 } {D2.apr=y1; priv=y3} =
+  let leq {apr=x1; priv=x3 } {apr=y1; priv=y3} =
     D2.leq x1 y1 && PrivD.leq x3 y3
 
   let pretty_diff () (({apr=x1; priv=x3}:t),({apr=y1; priv=y3}:t)): Pretty.doc =
@@ -909,7 +896,7 @@ struct
     else
       PrivD.pretty_diff () (x3,y3)
 
-  let op_scheme op1 op3 {D2.apr=x1; priv=x3} {D2.apr=y1; priv=y3}: t =
+  let op_scheme op1 op3 {apr=x1; priv=x3} {apr=y1; priv=y3}: t =
     {apr = op1 x1 y1; priv = op3 x3 y3 }
   let join = op_scheme D2.join PrivD.join
   let meet = op_scheme D2.meet PrivD.meet

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -67,19 +67,21 @@ struct
   let name = "Interval Manager"
 end
 
-let get_manager () =
-  let options =
-    ["octagon", (module OctagonManager: Manager);
-     "interval", (module IntervalManager: Manager);
-     "polyhedra", (module PolyhedraManager: Manager)]
-  in
-  let domain = (GobConfig.get_string "ana.apron.domain") in
-  print_endline "checking optionS!!!!";
-  match List.assoc_opt domain options with
-  | Some man -> man
-  | None -> failwith @@ "Apron domain " ^ domain ^ " is not supported. Please check the ana.apron.domain setting."
+let priv_manager =
+  lazy (
+    let options =
+      ["octagon", (module OctagonManager: Manager);
+       "interval", (module IntervalManager: Manager);
+       "polyhedra", (module PolyhedraManager: Manager)]
+    in
+    let domain = (GobConfig.get_string "ana.apron.domain") in
+    match List.assoc_opt domain options with
+    | Some man -> man
+    | None -> failwith @@ "Apron domain " ^ domain ^ " is not supported. Please check the ana.apron.domain setting."
+  )
 
-module Man_ = (val get_manager ())
+let get_manager (): (module Manager) =
+  Lazy.force priv_manager
 
 module type Tracked =
 sig

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -818,61 +818,14 @@ end
 module type S2 =
 sig
   module Man: Manager
+  module Tracked : Tracked
+  module Bounds : module type of Bounds (Man)
+  include module type of AOps (Tracked) (Man)
+  include Tracked
   include SLattice with type t = Man.mt A.t
+
   type 'a aproncomponents_t = { apr : t; priv : 'a; }
 
-  module Bounds :
-  sig
-    val bound_texpr : t -> Texpr1.t -> Z.t option * Z.t option
-  end
-  module Tracked : Tracked
-  module Convert :
-  sig
-    module Bounds :
-    sig
-      val bound_texpr :
-        t -> Texpr1.t -> Z.t option * Z.t option
-    end
-    exception Unsupported_CilExp
-    val is_cast_injective : typ -> typ -> bool
-    val texpr1_expr_of_cil_exp :
-      t -> Environment.t -> exp -> Texpr1.expr
-    val texpr1_of_cil_exp :
-      t -> Environment.t -> exp -> Texpr1.t
-    val tcons1_of_cil_exp :
-      t -> Environment.t -> exp -> bool -> Tcons1.t
-  end
-  val copy : t -> t
-  val vars : 'a A.t -> Var.t list
-  val mem_var : 'a A.t -> Var.t -> bool
-  val add_vars_with : t -> Var.t list -> unit
-  val add_vars : t -> Var.t list -> t
-  val remove_vars_with : t -> Var.t list -> unit
-  val remove_vars : t -> Var.t list -> t
-  val remove_filter_with : t -> (Var.t -> bool) -> unit
-  val remove_filter : t -> (Var.t -> bool) -> t
-  val keep_vars_with : t -> Var.t list -> unit
-  val keep_vars : t -> Var.t list -> t
-  val keep_filter_with : t -> (Var.t -> bool) -> unit
-  val keep_filter : t -> (Var.t -> bool) -> t
-  val forget_vars_with : t -> Var.t list -> unit
-  val forget_vars : t -> Var.t list -> t
-  val assign_exp_with : t -> Var.t -> exp -> unit
-  val assign_exp : t -> Var.t -> exp -> t
-  val assign_exp_parallel_with : t -> (Var.t * exp) list -> unit
-  val assign_var_with : t -> Var.t -> Var.t -> unit
-  val assign_var : t -> Var.t -> Var.t -> t
-  val assign_var_parallel_with : t -> (Var.t * Var.t) list -> unit
-  val assign_var_parallel' :
-    t -> Var.t list -> Var.t list -> t
-  val substitute_exp_with : t -> Var.t -> exp -> unit
-  val substitute_exp : t -> Var.t -> exp -> t
-  val substitute_exp_parallel_with :
-    t -> (Var.t * exp) list -> unit
-  val substitute_var_with : t -> Var.t -> Var.t -> unit
-  val meet_tcons : t -> Tcons1.t -> t
-  val type_tracked : typ -> bool
-  val varinfo_tracked : varinfo -> bool
   val exp_is_cons : exp -> bool
   val assert_cons : t -> exp -> bool -> t
   val assert_inv : t -> exp -> bool -> t

--- a/src/dune
+++ b/src/dune
@@ -13,7 +13,7 @@
     ; Alternative dependencies seem like the only way to optionally depend on optional dependencies.
     ; See: https://dune.readthedocs.io/en/stable/concepts.html#alternative-dependencies.
     (select apronDomain.ml from
-      (apron apron.octMPQ -> apronDomain.apron.ml)
+      (apron apron.octMPQ apron.boxMPQ apron.polkaMPQ -> apronDomain.apron.ml)
       (-> apronDomain.no-apron.ml)
     )
     (select apronAnalysis.ml from

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -144,6 +144,7 @@ let _ = ()
       ; reg Analyses "ana.base.context.int"    "true" "Integer values in function contexts."
       ; reg Analyses "ana.base.context.interval" "true" "Integer values of the Interval domain in function contexts."
       ; reg Analyses "ana.apron.context" "true" "Entire relation in function contexts."
+      ; reg Analyses "ana.apron.domain" "'octagon'" "Which domain should be used for the APRON analysis. Can be 'octagon', 'interval' or 'polyhedra'"
       ; reg Analyses "ana.context.widen"     "false" "Do widening on contexts. Keeps a map of function to call state; enter will then return the widened local state for recursive calls."
 
 (* {4 category [Incremental]} *)

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -144,7 +144,7 @@ let _ = ()
       ; reg Analyses "ana.base.context.int"    "true" "Integer values in function contexts."
       ; reg Analyses "ana.base.context.interval" "true" "Integer values of the Interval domain in function contexts."
       ; reg Analyses "ana.apron.context" "true" "Entire relation in function contexts."
-      ; reg Analyses "ana.apron.domain" "'octagon'" "Which domain should be used for the APRON analysis. Can be 'octagon', 'interval' or 'polyhedra'"
+      ; reg Analyses "ana.apron.domain" "'octagon'" "Which domain should be used for the Apron analysis. Can be 'octagon', 'interval' or 'polyhedra'"
       ; reg Analyses "ana.context.widen"     "false" "Do widening on contexts. Keeps a map of function to call state; enter will then return the widened local state for recursive calls."
 
 (* {4 category [Incremental]} *)
@@ -178,7 +178,7 @@ let _ = ()
       ; reg Experimental "exp.privatization"     "'protection-read'" "Which privatization to use? none/protection-old/mutex-oplus/mutex-meet/protection/protection-read/protection-vesal/mine/mine-nothread/mine-W/mine-W-noinit/lock/write/write+lock"
       ; reg Experimental "exp.priv-prec-dump"    "''"    "File to dump privatization precision data to."
       ; reg Experimental "exp.priv-distr-init"   "false"  "Distribute global initializations to all global invariants for more consistent widening dynamics."
-      ; reg Experimental "exp.apron.privatization" "'mutex-meet'" "Which apron privatization to use? dummy/protection/protection-path/mutex-meet"
+      ; reg Experimental "exp.apron.privatization" "'mutex-meet'" "Which Apron privatization to use? dummy/protection/protection-path/mutex-meet"
       ; reg Experimental "exp.cfgdot"            "false" "Output CFG to dot files"
       ; reg Experimental "exp.mincfg"            "false" "Try to minimize the number of CFG nodes."
       ; reg Experimental "exp.earlyglobs"        "false" "Side-effecting of globals right after initialization."

--- a/tests/regression/36-apron/71-simple-apron-interval.c
+++ b/tests/regression/36-apron/71-simple-apron-interval.c
@@ -1,0 +1,23 @@
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set exp.privatization none --set exp.apron.privatization dummy --set ana.apron.domain "interval"
+// Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf, adapted
+void main(void) {
+  int X = 0;
+  int N = rand();
+  if(N < 0) { N = 0; }
+
+  while(X < N) {
+    X++;
+  }
+
+  assert(X-N == 0); //UNKNOWN
+  assert(X == N); //UNKNOWN
+
+  if(X == N) {
+    N = 8;
+  } else {
+    N = 42;
+  }
+  assert(N == 8); // UNKNOWN
+  assert(N >= 8);
+  assert(N <= 42);
+}

--- a/tests/regression/36-apron/72-simple-polyhedra.c
+++ b/tests/regression/36-apron/72-simple-polyhedra.c
@@ -1,0 +1,19 @@
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set exp.privatization none --set exp.apron.privatization dummy --set ana.apron.domain "polyhedra"
+// Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf, adapted
+void main(void) {
+  int X = 0;
+  int N = rand();
+  if(N < 0 || N > 10000) { N = 0; }
+
+  X = 2 * N;
+
+  assert(X - 2 * N == 0);
+  assert(X == 2 * N);
+
+  if(X == 2 * N) {
+    N = 8;
+  } else {
+    N = 42; //DEAD
+  }
+
+}


### PR DESCRIPTION
This PR makes the Apron domain configurable using the option `"ana.apron.domain"`. The supported options right now are 'octagon', 'interval' and 'polyhedra'.
Making the Apron-Domain configurable required making several modules a functor that directly or indirectly depend on the `Manager` that is needed for interfacing with the corresponding Apron domain.

Closes #415 