### PR TITLE
Apron threshold widening

### DIFF
--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -19,7 +19,7 @@ let widening_thresholds_apron = lazy (
   (* Adding double value of all constants so that we can establish for single variables that they are <= const*)
   let t = List.append (!Cilfacade.widening_thresholds) (List.map (fun x-> 2*x) (!Cilfacade.widening_thresholds)) in
   let ts = List.sort_uniq compare t in
-  Array.of_list (List.map (fun x -> Printf.printf "one is: %i" x; Apron.Scalar.of_int x) ts)
+  Array.of_list (List.map (Apron.Scalar.of_int) ts)
 )
 
 module Var =

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -16,10 +16,9 @@ module M = Messages
     - heterogeneous environments: https://link.springer.com/chapter/10.1007%2F978-3-030-17184-1_26 (Section 4.1) *)
 
 let widening_thresholds_apron = lazy (
-  (* Adding double value of all constants so that we can establish for single variables that they are <= const*)
-  let t = List.append (!Cilfacade.widening_thresholds) (List.map (fun x-> 2*x) (!Cilfacade.widening_thresholds)) in
-  let ts = List.sort_uniq compare t in
-  Array.of_list (List.map (Apron.Scalar.of_int) ts)
+  let t = WideningThresholds.thresholds () in
+  let r = List.map (fun x -> Apron.Scalar.of_mpqf @@ Mpqf.of_string @@ Z.to_string x) t in
+  Array.of_list r
 )
 
 module Var =

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -765,7 +765,7 @@ struct
     let y_env = A.env y in
     if Environment.equal x_env y_env then
       (* widen if env didn't increase *)
-      if GobConfig.get_bool "ana.apron.threshhold_widening" then
+      if GobConfig.get_bool "ana.apron.threshold_widening" then
         let ts = Lazy.force widening_thresholds_apron in
         let r = Oct.widening_thresholds Man.mgr (Abstract1.abstract0 x) (Abstract1.abstract0 y) ts in
         {x with abstract0 = r}

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -97,7 +97,7 @@ let end_basic_blocks f =
   let thisVisitor = new allBBVisitor in
   visitCilFileSameGlobals thisVisitor f
 
-let compute_widening_threshholds f =
+let compute_widening_thresholds f =
   let thisVisitor = new extractConstantsVisitor(widening_thresholds) in
   visitCilFileSameGlobals thisVisitor f
 
@@ -122,7 +122,7 @@ let createCFG (fileAST: file) =
   (* Since we want the output of justcil to compile, we do not run allBB visitor if justcil is enable, regardless of  *)
   (* exp.basic-blocks. This does not matter, as we will not run any analysis anyway, when justcil is enabled.         *)
   if not (get_bool "exp.basic-blocks") && not (get_bool "justcil") then end_basic_blocks fileAST;
-  if get_bool "ana.apron.threshhold_widening" then compute_widening_threshholds fileAST;
+  if get_bool "ana.apron.threshold_widening" then compute_widening_thresholds fileAST;
 
   (* We used to renumber vids but CIL already generates them fresh, so no need.
    * Renumbering is problematic for using [Cabs2cil.environment], e.g. in witness invariant generation to use original variable names.

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -145,7 +145,7 @@ let _ = ()
       ; reg Analyses "ana.base.context.interval" "true" "Integer values of the Interval domain in function contexts."
       ; reg Analyses "ana.apron.context" "true" "Entire relation in function contexts."
       ; reg Analyses "ana.context.widen"     "false" "Do widening on contexts. Keeps a map of function to call state; enter will then return the widened local state for recursive calls."
-      ; reg Analyses "ana.apron.threshhold_widening" "false" "Use constants appearing in program as threshold for widening"
+      ; reg Analyses "ana.apron.threshold_widening" "false" "Use constants appearing in program as threshold for widening"
 
 (* {4 category [Incremental]} *)
 let _ = ()

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -145,6 +145,7 @@ let _ = ()
       ; reg Analyses "ana.base.context.interval" "true" "Integer values of the Interval domain in function contexts."
       ; reg Analyses "ana.apron.context" "true" "Entire relation in function contexts."
       ; reg Analyses "ana.context.widen"     "false" "Do widening on contexts. Keeps a map of function to call state; enter will then return the widened local state for recursive calls."
+      ; reg Analyses "ana.apron.threshhold_widening" "false" "Use constants appearing in program as threshold for widening"
 
 (* {4 category [Incremental]} *)
 let _ = ()

--- a/src/util/wideningThresholds.ml
+++ b/src/util/wideningThresholds.ml
@@ -20,11 +20,11 @@ class extractConstantsVisitor(widening_thresholds) = object
     | _ -> DoChildren
 end
 
-let thresholds () =
+let widening_thresholds = lazy (
   let set = ref Thresholds.empty in
-  let widening_thresholds = lazy (
-    let thisVisitor = new extractConstantsVisitor(set) in
-    visitCilFileSameGlobals thisVisitor (!Cilfacade.current_file);
-    Thresholds.elements !set)
-  in
+  let thisVisitor = new extractConstantsVisitor(set) in
+  visitCilFileSameGlobals thisVisitor (!Cilfacade.current_file);
+  Thresholds.elements !set)
+
+let thresholds () =
   Lazy.force widening_thresholds

--- a/src/util/wideningThresholds.ml
+++ b/src/util/wideningThresholds.ml
@@ -1,0 +1,30 @@
+open Cil
+module Thresholds = Set.Make(Z)
+
+
+class extractConstantsVisitor(widening_thresholds) = object
+  inherit nopCilVisitor
+
+  method! vexpr e =
+    match e with
+    | Const (CInt64(i,ik,str)) ->
+      let bi = match str with
+        | Some t -> Z.of_string t
+        | None -> Z.of_int64 i
+      in
+      widening_thresholds := Thresholds.add bi !widening_thresholds;
+      (* Adding double value of all constants so that we can establish for single variables that they are <= const*)
+      (* This is only needed for Apron, one might want to remove it later *)
+      widening_thresholds := Thresholds.add (Z.mul (Z.of_int 2) bi) !widening_thresholds;
+      DoChildren
+    | _ -> DoChildren
+end
+
+let thresholds () =
+  let set = ref Thresholds.empty in
+  let widening_thresholds = lazy (
+    let thisVisitor = new extractConstantsVisitor(set) in
+    visitCilFileSameGlobals thisVisitor (!Cilfacade.current_file);
+    Thresholds.elements !set)
+  in
+  Lazy.force widening_thresholds

--- a/src/util/wideningThresholds.mli
+++ b/src/util/wideningThresholds.mli
@@ -1,0 +1,1 @@
+val thresholds : unit -> Z.t list

--- a/tests/regression/36-apron/88-mine14-no-threshhold.c
+++ b/tests/regression/36-apron/88-mine14-no-threshhold.c
@@ -1,5 +1,4 @@
 // SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins
-// Fig 5a from Miné 2014
 #include <pthread.h>
 #include <stdio.h>
 

--- a/tests/regression/36-apron/89-mine14.c
+++ b/tests/regression/36-apron/89-mine14.c
@@ -1,11 +1,10 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --enable ana.apron.threshhold_widening
 // Fig 5a from Miné 2014
-// Adding additional constant 100 does not help :(
+// Fig 5a from Miné 2014
 #include <pthread.h>
 #include <stdio.h>
 
 int x;
-int hundred = 100;
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
@@ -30,7 +29,7 @@ int main(void) {
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_create(&id2, NULL, t_fun, NULL);
   pthread_mutex_lock(&mutex);
-  assert(x <= 100); // TODO
+  assert(x <= 100);
   pthread_mutex_unlock(&mutex);
   return 0;
 }

--- a/tests/regression/36-apron/89-mine14.c
+++ b/tests/regression/36-apron/89-mine14.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --enable ana.apron.threshhold_widening
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --enable ana.apron.threshold_widening
 // Fig 5a from Miné 2014
 // Fig 5a from Miné 2014
 #include <pthread.h>

--- a/tests/regression/36-apron/89-mine14.c
+++ b/tests/regression/36-apron/89-mine14.c
@@ -1,6 +1,5 @@
 // SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --enable ana.apron.threshold_widening
 // Fig 5a from Miné 2014
-// Fig 5a from Miné 2014
 #include <pthread.h>
 #include <stdio.h>
 

--- a/tests/regression/36-apron/90-mine14-5b.c
+++ b/tests/regression/36-apron/90-mine14-5b.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --enable ana.apron.threshhold_widening
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --enable ana.apron.threshold_widening
 // Fig 5 from Miné 2014
 #include <pthread.h>
 #include <stdio.h>

--- a/tests/regression/36-apron/91-mine14-5b-no-threshhold.c
+++ b/tests/regression/36-apron/91-mine14-5b-no-threshhold.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --disable ana.apron.threshhold_widening
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --disable ana.apron.threshold_widening
 // Fig 5 from Miné 2014
 // This only succeeds if we use a different widening strategy (no widening :())
 #include <pthread.h>

--- a/tests/regression/36-apron/91-mine14-5b-no-threshhold.c
+++ b/tests/regression/36-apron/91-mine14-5b-no-threshhold.c
@@ -1,5 +1,6 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --enable ana.apron.threshhold_widening
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --disable ana.apron.threshhold_widening
 // Fig 5 from Miné 2014
+// This only succeeds if we use a different widening strategy (no widening :())
 #include <pthread.h>
 #include <stdio.h>
 
@@ -44,7 +45,7 @@ int main(void) {
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_create(&id2, NULL, t_fun2, NULL);
   pthread_mutex_lock(&mutex);
-  assert(x==y);
+  assert(x==y); //TODO
   pthread_mutex_unlock(&mutex);
   return 0;
 }


### PR DESCRIPTION
This adds a simple threshold widening to our Apron analysis:

- Thresholds are all syntactic constants that appear in the program (and their value `*2` so that the octagon can keep constraints for `x<=C` which it represents as `x+x <= 2C`).
- It is controlled by means of an option `ana.apron.threshold_widening` which defaults to false now.
- Some programs from our related work require this option, so I added  it.

The following things remain TODO should be investigated (but probably not for the current deadline):

- My suspicion is that for larger programs using all constants from a program is too expensive. We want to be smarter here! (cue @ivanazuzic Machine Learning things maybe, or just using constants appearing in comparisons or some such thing)
- There is no reason that the base analysis should not also be able to make use of such thresholds: Any precision that is lost for globals once they are published can never be restored by narrowing.


Closes #420. :wink: 