### PR TITLE
Mukherjee benchmarks

### DIFF
--- a/tests/regression/36-apron/73-mukherjee_reorder_2.c
+++ b/tests/regression/36-apron/73-mukherjee_reorder_2.c
@@ -1,8 +1,7 @@
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
+#include "assert.h"
 
 static int a = 0;
 static int b = 0;
@@ -13,8 +12,6 @@ void *iSet_1(void *param);
 void *iSet_2(void *param);
 void *iCheck_1(void *param);
 void *iCheck_2(void *param);
-void set();
-int check();
 
 int main(int argc, char *argv[]) {
     int i, err;
@@ -24,47 +21,16 @@ int main(int argc, char *argv[]) {
     pthread_t t3;
     pthread_t t4;
 
-    if (0 != (err = pthread_create(&t1, NULL, &iSet_1, NULL))) {
-        fprintf(stderr, "Error [%d] found creating set thread.\n", err);
-        exit(-1);
-    }
+    pthread_create(&t1, NULL, &iSet_1, NULL);
+    pthread_create(&t2, NULL, &iSet_2, NULL);
+    pthread_create(&t3, NULL, &iCheck_1, NULL);
+    pthread_create(&t4, NULL, &iCheck_2, NULL);
 
-    if (0 != (err = pthread_create(&t2, NULL, &iSet_2, NULL))) {
-        fprintf(stderr, "Error [%d] found creating set thread.\n", err);
-        exit(-1);
-    }
-
-    if (0 != (err = pthread_create(&t3, NULL, &iCheck_1,
-                                    NULL))) {
-        fprintf(stderr, "Error [%d] found creating check thread.\n", err);
-        exit(-1);
-    }
-
-    if (0 != (err = pthread_create(&t4, NULL, &iCheck_2,
-                                    NULL))) {
-        fprintf(stderr, "Error [%d] found creating check thread.\n", err);
-        exit(-1);
-    }
-
-    if (0 != (err = pthread_join(t1, NULL))) {
-        fprintf(stderr, "pthread join error: %d\n", err);
-        exit(-1);
-    }
-
-    if (0 != (err = pthread_join(t2, NULL))) {
-        fprintf(stderr, "pthread join error: %d\n", err);
-        exit(-1);
-    }
-
-    if (0 != (err = pthread_join(t3, NULL))) {
-        fprintf(stderr, "pthread join error: %d\n", err);
-        exit(-1);
-    }
-
-    if (0 != (err = pthread_join(t4, NULL))) {
-        fprintf(stderr, "pthread join error: %d\n", err);
-        exit(-1);
-    }
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+    pthread_join(t3, NULL);
+    pthread_join(t4, NULL);
+   
 
     return 0;
 }
@@ -87,11 +53,7 @@ void *iSet_2(void *param) {
 
 void *iCheck_1(void *param) {
     pthread_mutex_lock(&mut_lock);
-    if (! (a + b == 0)) {
-        fprintf(stderr, "Bug found!\n");
-    	ERROR: __VERIFIER_error();
-    	goto ERROR;
-    }
+    assert(a + b == 0);
     pthread_mutex_unlock(&mut_lock);
 
     return NULL;
@@ -99,11 +61,7 @@ void *iCheck_1(void *param) {
 
 void *iCheck_2(void *param) {
     pthread_mutex_lock(&mut_lock);
-    if (! (a + b == 0)) {
-        fprintf(stderr, "Bug found!\n");
-    	ERROR: __VERIFIER_error();
-    	goto ERROR;
-    }
+    assert(a + b == 0);
     pthread_mutex_unlock(&mut_lock);
 
     return NULL;

--- a/tests/regression/36-apron/73-mukherjee_reorder_2.c
+++ b/tests/regression/36-apron/73-mukherjee_reorder_2.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>

--- a/tests/regression/36-apron/73-mukherjee_reorder_2.c
+++ b/tests/regression/36-apron/73-mukherjee_reorder_2.c
@@ -1,0 +1,110 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+static int a = 0;
+static int b = 0;
+
+pthread_mutex_t mut_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void *iSet_1(void *param);
+void *iSet_2(void *param);
+void *iCheck_1(void *param);
+void *iCheck_2(void *param);
+void set();
+int check();
+
+int main(int argc, char *argv[]) {
+    int i, err;
+
+    pthread_t t1;
+    pthread_t t2;
+    pthread_t t3;
+    pthread_t t4;
+
+    if (0 != (err = pthread_create(&t1, NULL, &iSet_1, NULL))) {
+        fprintf(stderr, "Error [%d] found creating set thread.\n", err);
+        exit(-1);
+    }
+
+    if (0 != (err = pthread_create(&t2, NULL, &iSet_2, NULL))) {
+        fprintf(stderr, "Error [%d] found creating set thread.\n", err);
+        exit(-1);
+    }
+
+    if (0 != (err = pthread_create(&t3, NULL, &iCheck_1,
+                                    NULL))) {
+        fprintf(stderr, "Error [%d] found creating check thread.\n", err);
+        exit(-1);
+    }
+
+    if (0 != (err = pthread_create(&t4, NULL, &iCheck_2,
+                                    NULL))) {
+        fprintf(stderr, "Error [%d] found creating check thread.\n", err);
+        exit(-1);
+    }
+
+    if (0 != (err = pthread_join(t1, NULL))) {
+        fprintf(stderr, "pthread join error: %d\n", err);
+        exit(-1);
+    }
+
+    if (0 != (err = pthread_join(t2, NULL))) {
+        fprintf(stderr, "pthread join error: %d\n", err);
+        exit(-1);
+    }
+
+    if (0 != (err = pthread_join(t3, NULL))) {
+        fprintf(stderr, "pthread join error: %d\n", err);
+        exit(-1);
+    }
+
+    if (0 != (err = pthread_join(t4, NULL))) {
+        fprintf(stderr, "pthread join error: %d\n", err);
+        exit(-1);
+    }
+
+    return 0;
+}
+        
+void *iSet_1(void *param) {
+    pthread_mutex_lock(&mut_lock);
+    a = 1;
+    b = -1;
+    pthread_mutex_unlock(&mut_lock);
+    return NULL;
+}
+
+void *iSet_2(void *param) {
+    pthread_mutex_lock(&mut_lock);
+    a = 1;
+    b = -1;
+    pthread_mutex_unlock(&mut_lock);
+    return NULL;
+}
+
+void *iCheck_1(void *param) {
+    pthread_mutex_lock(&mut_lock);
+    if (! (a + b == 0)) {
+        fprintf(stderr, "Bug found!\n");
+    	ERROR: __VERIFIER_error();
+    	goto ERROR;
+    }
+    pthread_mutex_unlock(&mut_lock);
+
+    return NULL;
+}
+
+void *iCheck_2(void *param) {
+    pthread_mutex_lock(&mut_lock);
+    if (! (a + b == 0)) {
+        fprintf(stderr, "Bug found!\n");
+    	ERROR: __VERIFIER_error();
+    	goto ERROR;
+    }
+    pthread_mutex_unlock(&mut_lock);
+
+    return NULL;
+}

--- a/tests/regression/36-apron/74-mukherjee_sigma.c
+++ b/tests/regression/36-apron/74-mukherjee_sigma.c
@@ -1,10 +1,7 @@
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
 #include <stdlib.h>
 #include <pthread.h>
 #include <string.h>
-
-void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error();}; return; }
+#include "assert.h"
 
 const int SIGMA = 4;
 
@@ -15,7 +12,7 @@ pthread_mutex_t mut_lock = PTHREAD_MUTEX_INITIALIZER;
 
 void *thread1(void * arg)
 {
-    __VERIFIER_assert(array_index <= 4);
+    assert(array_index <= 4);
     pthread_mutex_lock(&mut_lock);
 	switch (array_index) {
         case 0: 
@@ -37,7 +34,7 @@ void *thread1(void * arg)
 
 void *thread2(void * arg)
 {
-    __VERIFIER_assert(array_index <= 4);
+    assert(array_index <= 4);
     pthread_mutex_lock(&mut_lock);
 	switch (array_index) {
         case 0: 
@@ -59,7 +56,7 @@ void *thread2(void * arg)
 
 void *thread3(void * arg)
 {
-    __VERIFIER_assert(array_index <= 4);
+    assert(array_index <= 4);
     pthread_mutex_lock(&mut_lock);
 	switch (array_index) {
         case 0: 
@@ -81,7 +78,7 @@ void *thread3(void * arg)
 
 void *thread4(void * arg)
 {
-    __VERIFIER_assert(array_index <= 4);
+    assert(array_index <= 4);
     pthread_mutex_lock(&mut_lock);
 	switch (array_index) {
         case 0: 
@@ -138,7 +135,7 @@ int main()
 
 	sum = array_0 + array_1 + array_2 + array_3;
 
-	__VERIFIER_assert(sum == SIGMA);  // <-- wrong, different threads might use the same array offset when writing
+	assert(sum == SIGMA);  // <-- wrong, different threads might use the same array offset when writing
 
 	return 0;
 }

--- a/tests/regression/36-apron/74-mukherjee_sigma.c
+++ b/tests/regression/36-apron/74-mukherjee_sigma.c
@@ -1,0 +1,144 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+#include <stdlib.h>
+#include <pthread.h>
+#include <string.h>
+
+void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error();}; return; }
+
+const int SIGMA = 4;
+
+int array_0, array_1, array_2, array_3;
+int array_index;
+
+pthread_mutex_t mut_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void *thread1(void * arg)
+{
+    __VERIFIER_assert(array_index <= 4);
+    pthread_mutex_lock(&mut_lock);
+	switch (array_index) {
+        case 0: 
+            array_0 = 1; 
+            break;
+        case 1: 
+            array_1 = 1; 
+            break;
+        case 2: 
+            array_2 = 1; 
+            break;
+        case 3: 
+            array_3 = 1; 
+            break;
+    }
+    pthread_mutex_unlock(&mut_lock);
+	return 0;
+}
+
+void *thread2(void * arg)
+{
+    __VERIFIER_assert(array_index <= 4);
+    pthread_mutex_lock(&mut_lock);
+	switch (array_index) {
+        case 0: 
+            array_0 = 1; 
+            break;
+        case 1: 
+            array_1 = 1; 
+            break;
+        case 2: 
+            array_2 = 1; 
+            break;
+        case 3: 
+            array_3 = 1; 
+            break;
+    }
+    pthread_mutex_unlock(&mut_lock);
+	return 0;
+}
+
+void *thread3(void * arg)
+{
+    __VERIFIER_assert(array_index <= 4);
+    pthread_mutex_lock(&mut_lock);
+	switch (array_index) {
+        case 0: 
+            array_0 = 1; 
+            break;
+        case 1: 
+            array_1 = 1; 
+            break;
+        case 2: 
+            array_2 = 1; 
+            break;
+        case 3: 
+            array_3 = 1; 
+            break;
+    }
+    pthread_mutex_unlock(&mut_lock);
+	return 0;
+}
+
+void *thread4(void * arg)
+{
+    __VERIFIER_assert(array_index <= 4);
+    pthread_mutex_lock(&mut_lock);
+	switch (array_index) {
+        case 0: 
+            array_0 = 1; 
+            break;
+        case 1: 
+            array_1 = 1; 
+            break;
+        case 2: 
+            array_2 = 1; 
+            break;
+        case 3: 
+            array_3 = 1; 
+            break;
+    }
+    pthread_mutex_unlock(&mut_lock);
+	return 0;
+}
+
+
+int main()
+{
+	int sum;
+
+	pthread_t t1;
+    pthread_t t2;
+    pthread_t t3;
+    pthread_t t4;
+
+    pthread_create(&t1, 0, thread1, 0);
+    pthread_mutex_lock(&mut_lock);
+    array_index++;
+    pthread_mutex_unlock(&mut_lock);
+
+    pthread_create(&t2, 0, thread2, 0);
+    pthread_mutex_lock(&mut_lock);
+    array_index++;
+    pthread_mutex_unlock(&mut_lock);
+
+    pthread_create(&t3, 0, thread3, 0);
+    pthread_mutex_lock(&mut_lock);
+    array_index++;
+    pthread_mutex_unlock(&mut_lock);
+
+    pthread_create(&t4, 0, thread4, 0);
+    pthread_mutex_lock(&mut_lock);
+    array_index++;
+    pthread_mutex_unlock(&mut_lock);
+
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+    pthread_join(t3, 0);
+    pthread_join(t4, 0);
+
+	sum = array_0 + array_1 + array_2 + array_3;
+
+	__VERIFIER_assert(sum == SIGMA);  // <-- wrong, different threads might use the same array offset when writing
+
+	return 0;
+}

--- a/tests/regression/36-apron/74-mukherjee_sigma.c
+++ b/tests/regression/36-apron/74-mukherjee_sigma.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <stdlib.h>
 #include <pthread.h>
 #include <string.h>

--- a/tests/regression/36-apron/75-mukherjee_sssc12.c
+++ b/tests/regression/36-apron/75-mukherjee_sssc12.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <pthread.h>
 #include "assert.h"
 
@@ -50,7 +52,7 @@ void* thr2(void* arg) {
     return NULL;
 }
 
-void main(int argc, char* argv[]) {
+int main(int argc, char* argv[]) {
     pthread_t t1;
     pthread_t t2;
     next = 0;
@@ -60,4 +62,5 @@ void main(int argc, char* argv[]) {
         pthread_join(t1, 0);
         pthread_join(t2, 0);
     }
+    return 0;
 }

--- a/tests/regression/36-apron/75-mukherjee_sssc12.c
+++ b/tests/regression/36-apron/75-mukherjee_sssc12.c
@@ -1,0 +1,63 @@
+#include <pthread.h>
+#include "assert.h"
+
+volatile int len;
+volatile int next;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* thr1(void* arg) {
+    int c, end, temp;
+    c = 0;
+    end = 0;
+    pthread_mutex_lock(&lock);
+    temp = len;
+    
+    if(next + 10 <= len) {
+        c = next;
+        end = next + 10;
+        next = next + 10;
+    }
+    pthread_mutex_unlock(&lock);
+    
+    while(c < end) {
+        assert(c >= 0);
+        assert(c <= temp);
+        c = c +1;
+    }
+    return NULL;
+}
+
+void* thr2(void* arg) {
+    int c, end, temp;
+    c = 0;
+    end = 0;
+    pthread_mutex_lock(&lock);
+    temp = len;
+    
+    if(next + 10 <= len) {
+        c = next;
+        end = next + 10;
+        next = next + 10;
+    }
+    pthread_mutex_unlock(&lock);
+    
+    while(c < end) {
+        assert(c >= 0);
+        assert(c <= temp);
+        c = c +1;
+    }
+    return NULL;
+}
+
+void main(int argc, char* argv[]) {
+    pthread_t t1;
+    pthread_t t2;
+    next = 0;
+    if (len > 0) {
+	    pthread_create(&t1, 0, thr1, 0);
+	    pthread_create(&t2, 0, thr2, 0);
+        pthread_join(t1, 0);
+        pthread_join(t2, 0);
+    }
+}

--- a/tests/regression/36-apron/76-mukherjee_spin2003.c
+++ b/tests/regression/36-apron/76-mukherjee_spin2003.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <pthread.h>
 #include "assert.h"
 
@@ -33,4 +35,5 @@ int main(){
     pthread_create(&t2, 0, T2_Spin, 0);
     pthread_join(t1, 0);
     pthread_join(t2, 0);
+    return 0;
 }

--- a/tests/regression/36-apron/76-mukherjee_spin2003.c
+++ b/tests/regression/36-apron/76-mukherjee_spin2003.c
@@ -1,0 +1,36 @@
+#include <pthread.h>
+#include "assert.h"
+
+unsigned int x;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1_Spin(void* arg){
+    pthread_mutex_lock(&lock);
+    x = 0;
+    x = 1;
+    
+    assert(x >= 1);
+    pthread_mutex_unlock(&lock);
+    return NULL;
+}
+
+void* T2_Spin(void* arg){
+    pthread_mutex_lock(&lock);
+    x = 0;
+    x = 1;
+    
+    assert(x >= 1);
+    pthread_mutex_unlock(&lock);
+    return NULL;
+}
+
+int main(){
+    x = 1;
+    pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, T1_Spin, 0);
+    pthread_create(&t2, 0, T2_Spin, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+}

--- a/tests/regression/36-apron/77-mukherjee_simpleLoop.c
+++ b/tests/regression/36-apron/77-mukherjee_simpleLoop.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <pthread.h>
 #include "assert.h"
 
@@ -42,4 +44,5 @@ int main(){
     pthread_create(&t2, 0, T2_SL, 0);
     pthread_join(t1, 0);
     pthread_join(t2, 0);
+    return 0;
 }

--- a/tests/regression/36-apron/77-mukherjee_simpleLoop.c
+++ b/tests/regression/36-apron/77-mukherjee_simpleLoop.c
@@ -1,0 +1,45 @@
+#include <pthread.h>
+#include "assert.h"
+
+unsigned int x, y, z;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1_SL(void* arg){
+    int i = 0, j = 0, k = 0;
+		
+    for(i = 0; i < x; i++) {
+        for(j = i + 1; j < y; j++) {
+            for(k = j; k < z; k++) {
+                pthread_mutex_lock(&lock);
+                assert(k > i);
+                pthread_mutex_unlock(&lock);
+            }
+        }
+    }
+    return NULL;
+}
+
+void* T2_SL(void* arg){
+    int i = 0, j = 0, k = 0;
+		
+    for(i = 0; i < x; i++) {
+        for(j = i + 1; j < y; j++) {
+            for(k = j; k < z; k++) {
+                pthread_mutex_lock(&lock);
+                assert(k > i);
+                pthread_mutex_unlock(&lock);
+            }
+        }
+    }
+    return NULL;
+}
+
+int main(){
+    pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, T1_SL, 0);
+    pthread_create(&t2, 0, T2_SL, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+}

--- a/tests/regression/36-apron/78-mukherjee_simpleLoop5.c
+++ b/tests/regression/36-apron/78-mukherjee_simpleLoop5.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <pthread.h>
 #include "assert.h"
 
@@ -51,4 +53,5 @@ int main(){
     pthread_join(t1, 0);
     pthread_join(t2, 0);
     pthread_join(t3, 0);
+    return 0;
 }

--- a/tests/regression/36-apron/78-mukherjee_simpleLoop5.c
+++ b/tests/regression/36-apron/78-mukherjee_simpleLoop5.c
@@ -1,0 +1,54 @@
+#include <pthread.h>
+#include "assert.h"
+
+unsigned int a, b, c;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1_SL5(void* arg){
+    while(1) {
+        pthread_mutex_lock(&lock);
+        assert(a != b);
+        pthread_mutex_unlock(&lock);
+    }
+    return NULL;
+}
+
+void* T2_SL5(void* arg){
+    while(1) {
+        pthread_mutex_lock(&lock);
+        int temp = a;
+        a = b;
+        b = c;
+        c = temp;
+        pthread_mutex_unlock(&lock);
+    }
+    return NULL;
+}
+
+void* T3_SL5(void* arg){
+    while(1) {
+        pthread_mutex_lock(&lock);
+        int temp = a;
+        a = b;
+        b = c;
+        c = temp;
+        pthread_mutex_unlock(&lock);
+    }
+    return NULL;
+}
+
+int main(){
+    a = 1;
+    b = 2;
+    c = 3;
+    pthread_t t1;
+    pthread_t t2;
+    pthread_t t3;
+    pthread_create(&t1, 0, T1_SL5, 0);
+    pthread_create(&t2, 0, T2_SL5, 0);
+    pthread_create(&t3, 0, T3_SL5, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+    pthread_join(t3, 0);
+}

--- a/tests/regression/36-apron/79-mukherjee_DoubleLock_P3.c
+++ b/tests/regression/36-apron/79-mukherjee_DoubleLock_P3.c
@@ -1,0 +1,37 @@
+#include <pthread.h>
+#include "assert.h"
+
+unsigned int count;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1_DLP3(void* arg){
+    pthread_mutex_lock(&lock);
+    count++;
+    count--;
+    pthread_mutex_unlock(&lock);
+
+    pthread_mutex_lock(&lock);
+    count--;
+    count++;
+    pthread_mutex_unlock(&lock);
+    return NULL;
+}
+
+void* T2_DLP3(void* arg){
+    pthread_mutex_lock(&lock);
+    assert(count >= -1);  
+    pthread_mutex_unlock(&lock);
+    return NULL;
+}
+
+int main(){
+    count = 0;
+    
+    pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, T1_DLP3, 0);
+    pthread_create(&t2, 0, T2_DLP3, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+}

--- a/tests/regression/36-apron/79-mukherjee_DoubleLock_P3.c
+++ b/tests/regression/36-apron/79-mukherjee_DoubleLock_P3.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <pthread.h>
 #include "assert.h"
 
@@ -34,4 +36,5 @@ int main(){
     pthread_create(&t2, 0, T2_DLP3, 0);
     pthread_join(t1, 0);
     pthread_join(t2, 0);
+    return 0;
 }

--- a/tests/regression/36-apron/80-mukherjee_unverif.c
+++ b/tests/regression/36-apron/80-mukherjee_unverif.c
@@ -1,0 +1,50 @@
+#include <pthread.h>
+#include "assert.h"
+
+unsigned int r = 0;
+unsigned int s = 0;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* thr1(void* arg){
+    pthread_mutex_lock(&lock);
+    r = r + 1;
+    pthread_mutex_unlock(&lock);
+    unsigned int l = 0;
+
+    pthread_mutex_lock(&lock);
+    if(r == 1){
+        s = s + 1;
+        l = l + 1;
+        assert(s == l);
+    }
+    pthread_mutex_unlock(&lock);
+
+    return 0;
+}
+
+void* thr2(void* arg){
+    pthread_mutex_lock(&lock);
+    r = r + 1;
+    pthread_mutex_unlock(&lock);
+    unsigned int l = 0;
+
+    pthread_mutex_lock(&lock);
+    if(r == 1){
+        s = s + 1;
+        l = l + 1;
+        assert(s == l);
+    }
+    pthread_mutex_unlock(&lock);
+
+    return 0;
+}
+
+int main() {
+    pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, thr1, 0);
+    pthread_create(&t2, 0, thr2, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+}

--- a/tests/regression/36-apron/80-mukherjee_unverif.c
+++ b/tests/regression/36-apron/80-mukherjee_unverif.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <pthread.h>
 #include "assert.h"
 
@@ -47,4 +49,5 @@ int main() {
     pthread_create(&t2, 0, thr2, 0);
     pthread_join(t1, 0);
     pthread_join(t2, 0);
+    return 0;
 }

--- a/tests/regression/36-apron/81-mukherjee_fib_Bench.c
+++ b/tests/regression/36-apron/81-mukherjee_fib_Bench.c
@@ -1,0 +1,42 @@
+#include <pthread.h>
+#include "assert.h"
+
+int i, j, NUM;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* W1_Fib_Bench_False_Unreach_Call(void* arg){
+    for(int k = 0; k < NUM; k++) {
+        pthread_mutex_lock(&lock);
+        i += j;
+        pthread_mutex_unlock(&lock);
+    }
+    return 0;
+}
+
+void* W2_Fib_Bench_False_Unreach_Call(void* arg){
+    for(int k = 0; k < NUM; k++) {
+        pthread_mutex_lock(&lock);
+        j += i;
+        pthread_mutex_unlock(&lock);
+    }
+    return 0;
+}
+
+
+int main() {
+		i = 1;
+		j = 1;
+		
+		NUM = 5;
+		
+		pthread_t t1;
+        pthread_t t2;
+        pthread_create(&t1, 0, W1_Fib_Bench_False_Unreach_Call, 0);
+        pthread_create(&t2, 0, W2_Fib_Bench_False_Unreach_Call, 0);
+        pthread_join(t1, 0);
+        pthread_join(t2, 0);
+		
+		assert(i < 144);
+		assert(j < 144);
+}

--- a/tests/regression/36-apron/81-mukherjee_fib_Bench.c
+++ b/tests/regression/36-apron/81-mukherjee_fib_Bench.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <pthread.h>
 #include "assert.h"
 
@@ -25,18 +27,20 @@ void* W2_Fib_Bench_False_Unreach_Call(void* arg){
 
 
 int main() {
-		i = 1;
-		j = 1;
-		
-		NUM = 5;
-		
-		pthread_t t1;
-        pthread_t t2;
-        pthread_create(&t1, 0, W1_Fib_Bench_False_Unreach_Call, 0);
-        pthread_create(&t2, 0, W2_Fib_Bench_False_Unreach_Call, 0);
-        pthread_join(t1, 0);
-        pthread_join(t2, 0);
-		
-		assert(i < 144);
-		assert(j < 144);
+    i = 1;
+    j = 1;
+    
+    NUM = 5;
+    
+    pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, W1_Fib_Bench_False_Unreach_Call, 0);
+    pthread_create(&t2, 0, W2_Fib_Bench_False_Unreach_Call, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+    
+    assert(i < 144);
+    assert(j < 144);
+    
+    return 0;
 }

--- a/tests/regression/36-apron/82-mukherjee_fib_Bench_Longer.c
+++ b/tests/regression/36-apron/82-mukherjee_fib_Bench_Longer.c
@@ -1,0 +1,42 @@
+#include <pthread.h>
+#include "assert.h"
+
+int i, j, NUM;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* W1_Fib_Bench_False_Unreach_Call(void* arg){
+    for(int k = 0; k < NUM; k++) {
+        pthread_mutex_lock(&lock);
+        i += j;
+        pthread_mutex_unlock(&lock);
+    }
+    return 0;
+}
+
+void* W2_Fib_Bench_False_Unreach_Call(void* arg){
+    for(int k = 0; k < NUM; k++) {
+        pthread_mutex_lock(&lock);
+        j += i;
+        pthread_mutex_unlock(&lock);
+    }
+    return 0;
+}
+
+
+int main() {
+    i = 1;
+    j = 1;
+    
+    NUM = 6;
+    
+    pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, W1_Fib_Bench_False_Unreach_Call, 0);
+    pthread_create(&t2, 0, W2_Fib_Bench_False_Unreach_Call, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+    
+    assert(i < 377);
+    assert(j < 377);
+}

--- a/tests/regression/36-apron/82-mukherjee_fib_Bench_Longer.c
+++ b/tests/regression/36-apron/82-mukherjee_fib_Bench_Longer.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <pthread.h>
 #include "assert.h"
 
@@ -39,4 +41,6 @@ int main() {
     
     assert(i < 377);
     assert(j < 377);
+
+    return 0;
 }

--- a/tests/regression/36-apron/83-mukherjee_indexer.c
+++ b/tests/regression/36-apron/83-mukherjee_indexer.c
@@ -1,0 +1,74 @@
+#include <pthread.h>
+#include "assert.h"
+
+int MAX, SIZE, array;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* W1_Indexer(void* arg){
+    int m = 0;
+    int w = 0;
+    int h = 0, rv = 0;
+    
+    while(m < MAX) {
+        w = (++m) * 12;
+        h = (w*7) % SIZE;
+        
+        assert(h>=0);
+        
+        rv = 0;
+        h = rv + 1;
+        
+        while(rv == 0) {
+            pthread_mutex_lock(&lock);
+            if(array == 0) {
+                array = h;
+                rv = 1;
+            }
+            else
+                h = (h + 1) % SIZE;
+            pthread_mutex_unlock(&lock);
+        }
+    }
+    return 0;
+}
+
+void* W2_Indexer(void* arg){
+    int m = 0;
+    int w = 0;
+    int h = 0, rv = 0;
+    
+    while(m < MAX) {
+        w = (++m) * 12;
+        h = (w*7) % SIZE;
+        
+        assert(h>=0);
+        
+        rv = 0;
+        h = rv + 1;
+        
+        while(rv == 0) {
+            pthread_mutex_lock(&lock);
+            if(array == 0) {
+                array = h;
+                rv = 1;
+            }
+            else
+                h = (h + 1) % SIZE;
+            pthread_mutex_unlock(&lock);
+        }
+    }
+    return 0;   
+}
+
+int main() {
+    SIZE = 128;
+    MAX = 4;
+    array = 0;
+    pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, W1_Indexer, 0);
+    pthread_create(&t2, 0, W2_Indexer, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+}

--- a/tests/regression/36-apron/83-mukherjee_indexer.c
+++ b/tests/regression/36-apron/83-mukherjee_indexer.c
@@ -1,3 +1,5 @@
+// SKIP
+
 #include <pthread.h>
 #include "assert.h"
 
@@ -71,4 +73,6 @@ int main() {
     pthread_create(&t2, 0, W2_Indexer, 0);
     pthread_join(t1, 0);
     pthread_join(t2, 0);
+
+    return 0;
 }

--- a/tests/regression/36-apron/84-mukherjee_twostage_3.c
+++ b/tests/regression/36-apron/84-mukherjee_twostage_3.c
@@ -1,0 +1,64 @@
+// SKIP
+
+#include <pthread.h>
+#include "assert.h"
+
+int data1value = 0;
+int data2value = 0;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* iTThread_1(void* arg){
+    pthread_mutex_lock(&lock);
+    data1value = 1;
+    pthread_mutex_unlock(&lock);
+    
+    pthread_mutex_lock(&lock);
+    data2value = data1value + 1;
+    pthread_mutex_unlock(&lock);
+    return 0;
+}
+
+void* iTThread_2(void* arg){
+    pthread_mutex_lock(&lock);
+    data1value = 1;
+    pthread_mutex_unlock(&lock);
+    
+    pthread_mutex_lock(&lock);
+    data2value = data1value + 1;
+    pthread_mutex_unlock(&lock);
+	return 0;
+}
+
+void* iRThread_1(void* arg){
+	int t1 = -1;
+	int t2 = -1;
+	
+	pthread_mutex_lock(&lock);
+	t1 = data1value;
+	t2 = data2value;
+	pthread_mutex_unlock(&lock);
+	
+	if(t1 != 0) {
+		assert(t2 != (t1+1));
+		assert(t2 == (t1+1));
+	}
+	return 0;
+}
+
+int main() {
+	data1value = 0;
+	data2value = 0;
+	
+	pthread_t t1;
+    pthread_t t2;
+    pthread_t t3;
+    pthread_create(&t1, 0, iTThread_1, 0);
+    pthread_create(&t2, 0, iTThread_2, 0);
+    pthread_create(&t3, 0, iRThread_1, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+    pthread_join(t3, 0);
+
+	return 0;
+}

--- a/tests/regression/36-apron/85-mukherjee_singleton_with_uninit.c
+++ b/tests/regression/36-apron/85-mukherjee_singleton_with_uninit.c
@@ -1,0 +1,34 @@
+// SKIP
+
+#include <pthread.h>
+#include "assert.h"
+
+int x = 0;
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1_Singleton_With_Uninit(void* arg){
+	pthread_mutex_lock(&lock);
+	x = 3;
+	pthread_mutex_unlock(&lock);
+	return NULL;
+}
+
+void* T2_Singleton_With_Uninit(void* arg){
+	pthread_mutex_lock(&lock);
+	x = 5;
+	pthread_mutex_unlock(&lock);
+	return NULL;
+}
+
+int main() {
+	pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, T1_Singleton_With_Uninit, 0);
+    pthread_create(&t2, 0, T2_Singleton_With_Uninit, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+	
+	assert(x <= 5);
+	return 0;
+}

--- a/tests/regression/36-apron/86-mukherjee_stack.c
+++ b/tests/regression/36-apron/86-mukherjee_stack.c
@@ -1,0 +1,59 @@
+// SKIP
+
+#include <pthread.h>
+#include "assert.h"
+
+int SIZE = 2;
+int OVERFLOW  = -1;
+int top = 0;
+int flag = 0;
+int arr1;
+int arr2;
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1_Stack(void* arg) {
+    int i;
+    int j;
+    pthread_mutex_lock(&m);
+    j = SIZE;
+    pthread_mutex_unlock(&m);
+    for(i=0; i<j; i++) {
+        pthread_mutex_lock(&m);
+        assert(top < SIZE);
+        
+        if (top < SIZE) {
+            top++;
+        }
+        flag = 1;
+        pthread_mutex_lock(&m);
+    }
+    return NULL;
+}
+
+void* T2_Stack(void* arg) {
+    int i;
+    int j;
+    pthread_mutex_lock(&m);
+    j = SIZE;
+    pthread_mutex_unlock(&m);
+    for(i=0; i<j; i++) {
+    pthread_mutex_lock(&m);
+    if (flag == 1) {
+        if (top != 0)
+            top--;
+    }
+    pthread_mutex_unlock(&m);
+    }
+    return NULL;
+}
+
+int main() {
+    pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, T1_Stack, 0);
+    pthread_create(&t2, 0, T2_Stack, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+	return 0;
+}

--- a/tests/regression/36-apron/87-mukherjee_Stack_Longer.c
+++ b/tests/regression/36-apron/87-mukherjee_Stack_Longer.c
@@ -1,0 +1,52 @@
+// SKIP
+
+#include <pthread.h>
+#include "assert.h"
+
+int SIZE = 400;
+int OVERFLOW  = -1;
+int top = 0;
+int flag = 0;
+int arr1;
+int arr2;
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1_Stack_Longer(void* arg) {
+	int i;
+	for(i=0; i<SIZE; i++) {
+		pthread_mutex_lock(&m);
+		assert(top != SIZE);
+		
+		if (top != SIZE) {
+			top++;
+		}
+		flag = 1;
+		pthread_mutex_unlock(&m);
+	}
+	return NULL;
+}
+
+void* T2_Stack_Longer(void* arg) {
+	int i;
+	for(i=0; i<SIZE; i++) {
+		pthread_mutex_lock(&m);
+		if (flag == 1) {
+			assert(top != 0);
+			if (top != 0)
+				top--;
+		}
+		pthread_mutex_unlock(&m);
+	}
+	return NULL;
+}
+
+int main() {
+	pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, T1_Stack_Longer, 0);
+    pthread_create(&t2, 0, T2_Stack_Longer, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+	return 0;
+}

--- a/tests/regression/36-apron/88-mukherjee_Stack_Longest.c
+++ b/tests/regression/36-apron/88-mukherjee_Stack_Longest.c
@@ -1,0 +1,52 @@
+// SKIP
+
+#include <pthread.h>
+#include "assert.h"
+
+int SIZE = 800;
+int OVERFLOW  = -1;
+int top = 0;
+int flag = 0;
+int arr1;
+int arr2;
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1_Stack_Longest(void* arg) {
+    int i;
+    for(i=0; i<SIZE; i++) {
+        pthread_mutex_lock(&m);
+        assert(top != SIZE);
+        
+        if (top != SIZE) {
+            top++;
+        }
+        flag = 1;
+        pthread_mutex_unlock(&m);
+    }
+    return NULL;
+}
+
+void* T2_Stack_Longest(void* arg) {
+    int i;
+    for(i=0; i<SIZE; i++) {
+        pthread_mutex_lock(&m);
+        if (flag == 1) {
+            assert(top != 0);
+            if (top != 0)
+                top--;
+        }
+        pthread_mutex_unlock(&m);
+    }
+    return NULL;
+}
+
+int main() {
+	pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, T1_Stack_Longest, 0);
+    pthread_create(&t2, 0, T2_Stack_Longest, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+    return 0;
+}

--- a/tests/regression/36-apron/89-mukherjee_sync01.c
+++ b/tests/regression/36-apron/89-mukherjee_sync01.c
@@ -1,0 +1,39 @@
+// SKIP
+
+#include <pthread.h>
+#include "assert.h"
+
+int num = 1;
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1_Sync01(void* arg) {
+    pthread_mutex_lock(&m);
+    while(num > 0) 
+        num++;
+    pthread_mutex_unlock(&m);
+    return NULL;
+}
+
+void* T2_Sync01(void* arg) {
+    pthread_mutex_lock(&m);
+    while(num == 0) 
+        num--;
+    pthread_mutex_unlock(&m);
+    return NULL;
+}
+
+int main() {
+    pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, T1_Sync01, 0);
+    pthread_create(&t2, 0, T2_Sync01, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+    
+    assert(num >= 0);
+    
+    assert(num <= 1);
+
+    return 0;
+}

--- a/tests/regression/36-apron/90-mukherjee_qw2004.c
+++ b/tests/regression/36-apron/90-mukherjee_qw2004.c
@@ -1,0 +1,66 @@
+// SKIP
+
+#include <pthread.h>
+#include "assert.h"
+
+int pendingIo, stoppingEvent, stopped, status;
+int conjunct_flag;
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1_QW2004(void* arg) {
+    int pending;
+    pthread_mutex_lock(&m);
+    pendingIo--;
+    pending = pendingIo;
+    if (pending == 0) {
+        stoppingEvent = 1;
+        stopped = 0;
+    }
+    else
+        stopped--;
+    
+    assert(pendingIo == stopped);
+    pthread_mutex_unlock(&m);
+    return NULL;
+}
+
+int main() {
+    int status, pending;
+    pendingIo = 1;
+    stoppingEvent = 0;
+    stopped = 1;
+
+    status = 0;
+
+    pthread_t t1;
+    pthread_create(&t1, 0, T1_QW2004, 0);
+
+    pthread_mutex_lock(&m);
+        if (stopped==0)
+            status = -1;
+        else {
+            pendingIo++;
+            stopped++;
+            status = 0;
+        }
+        assert(pendingIo == stopped);
+    pthread_mutex_unlock(&m);
+
+    pthread_mutex_lock(&m);
+    if (status == 0)
+        assert(pendingIo == stopped);
+    pthread_mutex_unlock(&m);
+
+    pthread_mutex_lock(&m);
+    if (pendingIo > 0) {
+        pendingIo--;
+        stopped--;
+    }
+    pending = pendingIo;
+    if (pending == 0)
+        stoppingEvent = 1;
+    
+    assert(pendingIo == stopped);
+    pthread_mutex_unlock(&m);
+    return 0;
+}

--- a/tests/regression/36-apron/91-mukherjee_fig_3_11.c
+++ b/tests/regression/36-apron/91-mukherjee_fig_3_11.c
@@ -1,0 +1,44 @@
+// SKIP
+
+#include <pthread.h>
+#include "assert.h"
+
+int x;
+int y;
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void* T1(void* arg) {
+    while(0 == 0) {
+        pthread_mutex_lock(&m);
+        if (x > 0) {
+            x = x - 1;
+            y = y - 1;
+        }
+        pthread_mutex_unlock(&m);
+    }
+    return NULL;
+}
+
+void* T2(void* arg) {
+    while(0 == 0) {
+        pthread_mutex_lock(&m);
+        if (x < 10) {
+            x = x + 1;
+            y = y + 1;
+        }
+        pthread_mutex_unlock(&m);
+    }
+    return NULL;
+}
+
+int main() {
+    pthread_t t1;
+    pthread_t t2;
+    pthread_create(&t1, 0, T1, 0);
+    pthread_create(&t2, 0, T2, 0);
+    pthread_join(t1, 0);
+    pthread_join(t2, 0);
+
+    return 0;
+}


### PR DESCRIPTION
These benchmarks have been added according to Table 2 from paper [A Thread-Local Semantics and Efficient Static
Analyses for Race Free Programs](https://arxiv.org/pdf/2009.02775.pdf). They are converted to C from [this RATCOP tests](https://bitbucket.org/suvam/ratcop/src/master/src/svcomp15/).