### PR TITLE
Fix symb_locks combine to use returned lockset

### DIFF
--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -44,7 +44,7 @@ struct
     List.fold_right D.remove_var (fundec.sformals@fundec.slocals) ctx.local
 
   let enter ctx lval f args = [(ctx.local,ctx.local)]
-  let combine ctx lval fexp f args fc st2 = ctx.local
+  let combine ctx lval fexp f args fc st2 = st2
 
   let get_locks e st =
     let add_perel x xs =

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -140,7 +140,10 @@ struct
     let no_casts = S.map Expcompare.stripCastsDeepForPtrArith (eq_set ask e) in
     let addrs = S.filter (function AddrOf _ -> true | _ -> false) no_casts in
     S.union addrs st
-  let remove ask e st = S.diff st (eq_set ask e)
+  let remove ask e st = 
+    let no_casts = S.map Expcompare.stripCastsDeepForPtrArith (eq_set ask e) in
+    let addrs = S.filter (function AddrOf _ -> true | _ -> false) no_casts in
+    S.diff st addrs
   let remove_var v st = S.filter (fun x -> not (Exp.contains_var v x)) st
 
   let kill_lval (host,offset) st =

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -141,6 +141,7 @@ struct
     let addrs = S.filter (function AddrOf _ -> true | _ -> false) no_casts in
     S.union addrs st
   let remove ask e st = 
+    (* TODO: Removing based on must-equality sets is not sound! *)
     let no_casts = S.map Expcompare.stripCastsDeepForPtrArith (eq_set ask e) in
     let addrs = S.filter (function AddrOf _ -> true | _ -> false) no_casts in
     S.diff st addrs

--- a/tests/regression/06-symbeq/26-symb_lockfuns.c
+++ b/tests/regression/06-symbeq/26-symb_lockfuns.c
@@ -1,0 +1,28 @@
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+#include <pthread.h>
+
+typedef struct { int myint; pthread_mutex_t mymutex; } mystruct;
+
+void lock(mystruct *s) { pthread_mutex_lock(&s->mymutex); }
+void unlock(mystruct *s) { pthread_mutex_unlock(&s->mymutex); }
+
+void *foo(void *arg) {
+  mystruct *s = (mystruct *) arg;
+
+  lock(s);
+  s->myint=s->myint+1;
+  unlock(s);
+
+  return NULL;
+}
+
+int main() {
+  mystruct *s = (mystruct *) malloc(sizeof(*s));
+  pthread_mutex_init(&s->mymutex, NULL);
+
+  pthread_t id1, id2;
+  pthread_create(&id1, NULL, foo, s);
+  pthread_create(&id2, NULL, foo, s);
+  pthread_join(id1, NULL);
+  pthread_join(id2, NULL);
+}

--- a/tests/regression/06-symbeq/26-symb_lockfuns.c
+++ b/tests/regression/06-symbeq/26-symb_lockfuns.c
@@ -1,4 +1,5 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+#include <stdlib.h>
 #include <pthread.h>
 
 typedef struct { int myint; pthread_mutex_t mymutex; } mystruct;

--- a/tests/regression/06-symbeq/26-symb_lockfuns.c
+++ b/tests/regression/06-symbeq/26-symb_lockfuns.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+// PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include <stdlib.h>
 #include <pthread.h>
 

--- a/tests/regression/06-symbeq/27-symb_no_lockfuns.c
+++ b/tests/regression/06-symbeq/27-symb_no_lockfuns.c
@@ -1,0 +1,25 @@
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+#include <pthread.h>
+
+typedef struct { int myint; pthread_mutex_t mymutex; } mystruct;
+
+void *foo(void *arg) {
+  mystruct *s = (mystruct *) arg;
+
+  pthread_mutex_lock(&s->mymutex);
+  s->myint=s->myint+1;
+  pthread_mutex_unlock(&s->mymutex);
+
+  return NULL;
+}
+
+int main() {
+  mystruct *s = (mystruct *) malloc(sizeof(*s));
+  pthread_mutex_init(&s->mymutex, NULL);
+
+  pthread_t id1, id2;
+  pthread_create(&id1, NULL, foo, s);
+  pthread_create(&id2, NULL, foo, s);
+  pthread_join(id1, NULL);
+  pthread_join(id2, NULL);
+}

--- a/tests/regression/06-symbeq/27-symb_no_lockfuns.c
+++ b/tests/regression/06-symbeq/27-symb_no_lockfuns.c
@@ -1,4 +1,5 @@
 // PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+#include <stdlib.h>
 #include <pthread.h>
 
 typedef struct { int myint; pthread_mutex_t mymutex; } mystruct;

--- a/tests/regression/06-symbeq/27-symb_no_lockfuns.c
+++ b/tests/regression/06-symbeq/27-symb_no_lockfuns.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+// PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include <stdlib.h>
 #include <pthread.h>
 

--- a/tests/regression/06-symbeq/28-symb_lockset_unsound.c
+++ b/tests/regression/06-symbeq/28-symb_lockset_unsound.c
@@ -11,7 +11,7 @@ void *foo(void *arg) {
 
   pthread_mutex_lock(&p1->mymutex);
   pthread_mutex_unlock(&p2->mymutex);
-  p1->myint++; // TODO RACE
+  p1->myint++; // RACE
 
   return NULL;
 }

--- a/tests/regression/06-symbeq/28-symb_lockset_unsound.c
+++ b/tests/regression/06-symbeq/28-symb_lockset_unsound.c
@@ -1,0 +1,28 @@
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+#include <stdlib.h>
+#include <pthread.h>
+
+typedef struct { int myint; pthread_mutex_t mymutex; } mystruct;
+
+
+void *foo(void *arg) {
+  mystruct *p1 = (mystruct *) arg;
+  mystruct *p2 = (mystruct *) arg;
+
+  pthread_mutex_lock(&p1->mymutex);
+  pthread_mutex_unlock(&p2->mymutex);
+  p1->myint++; // TODO RACE
+
+  return NULL;
+}
+
+int main() {
+  mystruct *s = (mystruct *) malloc(sizeof(*s));
+  pthread_mutex_init(&s->mymutex, NULL);
+
+  pthread_t id1, id2;
+  pthread_create(&id1, NULL, foo, s);
+  pthread_create(&id2, NULL, foo, s);
+  pthread_join(id1, NULL);
+  pthread_join(id2, NULL);
+}

--- a/tests/regression/06-symbeq/28-symb_lockset_unsound.c
+++ b/tests/regression/06-symbeq/28-symb_lockset_unsound.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+// PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include <stdlib.h>
 #include <pthread.h>
 

--- a/tests/regression/06-symbeq/29-symb_lockfun_unsound.c
+++ b/tests/regression/06-symbeq/29-symb_lockfun_unsound.c
@@ -1,0 +1,30 @@
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+#include <stdlib.h>
+#include <pthread.h>
+
+typedef struct { int myint; pthread_mutex_t mymutex; } mystruct;
+
+void unlock(mystruct *s) {
+  pthread_mutex_unlock(&s->mymutex); 
+}
+
+void *foo(void *arg) {
+  mystruct *s = (mystruct *) arg;
+
+  pthread_mutex_lock(&s->mymutex);
+  unlock(s);
+  s->myint=0; // RACE
+
+  return NULL;
+}
+
+int main() {
+  mystruct *s = (mystruct *) malloc(sizeof(*s));
+  pthread_mutex_init(&s->mymutex, NULL);
+
+  pthread_t id1, id2;
+  pthread_create(&id1, NULL, foo, s);
+  pthread_create(&id2, NULL, foo, s);
+  pthread_join(id1, NULL);
+  pthread_join(id2, NULL);
+}

--- a/tests/regression/06-symbeq/29-symb_lockfun_unsound.c
+++ b/tests/regression/06-symbeq/29-symb_lockfun_unsound.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+// PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include <stdlib.h>
 #include <pthread.h>
 
@@ -13,7 +13,7 @@ void *foo(void *arg) {
 
   pthread_mutex_lock(&s->mymutex);
   unlock(s);
-  s->myint=0; // RACE
+  s->myint=0; // TODO RACE
 
   return NULL;
 }

--- a/tests/regression/06-symbeq/29-symb_lockfun_unsound.c
+++ b/tests/regression/06-symbeq/29-symb_lockfun_unsound.c
@@ -13,7 +13,7 @@ void *foo(void *arg) {
 
   pthread_mutex_lock(&s->mymutex);
   unlock(s);
-  s->myint=0; // TODO RACE
+  s->myint=0; // RACE
 
   return NULL;
 }

--- a/tests/regression/06-symbeq/30-symb_lockset_mayunlock.c
+++ b/tests/regression/06-symbeq/30-symb_lockset_mayunlock.c
@@ -1,0 +1,30 @@
+// PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+#include <stdlib.h>
+#include <pthread.h>
+
+extern int __VERIFIER_nondet_int();
+typedef struct { int myint; pthread_mutex_t mymutex; } mystruct;
+
+
+void *foo(void *arg) {
+  mystruct *p1 = (mystruct *) arg;
+  mystruct *p2 = (mystruct *) arg;
+
+  pthread_mutex_lock(&p1->mymutex);
+  if (__VERIFIER_nondet_int()) p2 = NULL;
+  pthread_mutex_unlock(&p2->mymutex);
+  p1->myint++; // TODO RACE
+
+  return NULL;
+}
+
+int main() {
+  mystruct *s = (mystruct *) malloc(sizeof(*s));
+  pthread_mutex_init(&s->mymutex, NULL);
+
+  pthread_t id1, id2;
+  pthread_create(&id1, NULL, foo, s);
+  pthread_create(&id2, NULL, foo, s);
+  pthread_join(id1, NULL);
+  pthread_join(id2, NULL);
+}


### PR DESCRIPTION
Closes #430.

For some reason `combine` used the caller's local state instead of the callee's returned one. I don't know the internals of the symbolic locks analysis, so I don't know if this possibly causes some issues.