### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,3 +4,6 @@ FROM ocaml/opam:ubuntu-21.04-opam AS dev
 # TODO: use opam depext
 RUN sudo apt-get update \
     && sudo apt-get install -y libgmp-dev libmpfr-dev m4 autoconf pkg-config ruby gem curl
+
+# otherwise perl (not ruby!) complains during regression testing
+ENV LC_ALL=C.UTF-8

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+# just -opam tag because make setup will install ocaml compiler
+FROM ocaml/opam:ubuntu-21.04-opam AS dev
+
+# TODO: use opam depext
+RUN sudo apt-get update \
+    && sudo apt-get install -y libgmp-dev libmpfr-dev m4 autoconf pkg-config ruby gem curl

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,5 +5,9 @@ FROM ocaml/opam:ubuntu-21.04-opam AS dev
 RUN sudo apt-get update \
     && sudo apt-get install -y libgmp-dev libmpfr-dev m4 autoconf pkg-config ruby gem curl
 
+# remove default Docker <docker@example.com> git credentials added by opam base image: https://github.com/avsm/ocaml-dockerfile/blob/f184554282a3836bf3f1c34d20e77d0530f8349d/src-opam/dockerfile_linux.ml#L24-L28
+# this prevents devcontainer from using outside git credentials: https://code.visualstudio.com/docs/remote/containers#_sharing-git-credentials-with-your-container
+RUN rm ~/.gitconfig
+
 # otherwise perl (not ruby!) complains during regression testing
 ENV LC_ALL=C.UTF-8

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,9 @@
+# Goblint devcontainer
+This VS Code devcontainer provides a container-based development environment for Goblint.
+For introduction and prerequisites, see <https://code.visualstudio.com/docs/remote/containers>.
+
+There are two ways to activate the devcontainer:
+1. Select "Reopen in Container" in the notification after opening VS Code.
+2. Select "Remote-Containers: Reopen in Container" from the command palette.
+
+The devcontainer automatically sets up the environment for Goblint, including development tools and VS Code extensions.

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -1,0 +1,9 @@
+# no way to run `eval $(opam env)` in mounted workspace directory before vscode starts and have the environment remain
+# extracted manually from `opam env`
+
+OPAM_SWITCH_PREFIX=/workspaces/goblint-devcontainer/_opam
+CAML_LD_LIBRARY_PATH=/workspaces/goblint-devcontainer/_opam/lib/stublibs:/workspaces/goblint-devcontainer/_opam/lib/ocaml/stublibs:/workspaces/goblint-devcontainer/_opam/lib/ocaml
+OCAML_TOPLEVEL_PATH=/workspaces/goblint-devcontainer/_opam/lib/toplevel
+PKG_CONFIG_PATH=/workspaces/goblint-devcontainer/_opam/lib/pkgconfig
+MANPATH=:/workspaces/goblint-devcontainer/_opam/man
+PATH=/workspaces/goblint-devcontainer/_opam/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     "remoteUser": "opam",
     "postCreateCommand": "make setup; make dev",
 
-    "runArgs": ["--init"], // TODO: why added by default?
+    "runArgs": ["--init", "--env-file", ".devcontainer/devcontainer.env"], // TODO: why --init added by default?
 
     "extensions": [
 		"ocamllabs.ocaml-platform",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.202.5/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"runArgs": ["--init"],
+
+	"build": {
+		"dockerfile": "../Dockerfile",
+		"context": "..",
+		"target": "dev"
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "opam"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,21 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.202.5/containers/docker-existing-dockerfile
 {
-	"name": "Existing Dockerfile",
-	"runArgs": ["--init"],
+    "name": "Goblint",
 
-	"build": {
-		"dockerfile": "../Dockerfile",
-		"context": "..",
-		"target": "dev"
-	},
+    "build": {
+        "dockerfile": "./Dockerfile",
+        "context": ".."
+    },
+    "remoteUser": "opam",
+    "postCreateCommand": "make setup && make dev",
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+    "runArgs": ["--init"], // TODO: why added by default?
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [],
+    "extensions": [
+		"ocamllabs.ocaml-platform",
+		"hackwaly.ocamlearlybird"
+	],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "apt-get update && apt-get install -y curl",
-
-	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-
-	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
-	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-
-	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "opam"
+    "settings": {},
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
         "context": ".."
     },
     "remoteUser": "opam",
-    "postCreateCommand": "make setup && make dev",
+    "postCreateCommand": "make setup; make dev",
 
     "runArgs": ["--init"], // TODO: why added by default?
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 
 # just -opam tag because make setup will install ocaml compiler
 FROM ocaml/opam:ubuntu-21.04-opam AS dev
+
 # copy only files for make setup to cache docker layers without code changes
 COPY --chown=opam Makefile make.sh goblint.opam goblint.opam.locked /home/opam/analyzer/
 WORKDIR /home/opam/analyzer/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ _The [goblint package on opam](https://opam.ocaml.org/packages/goblint/) is very
 2. Continue using Linux instructions in WSL.
 
 ### Other
+* **[devcontainer](./.devcontainer/).** Select "Reopen in Container" in VS Code and continue with `make` using Linux instructions in devcontainer.
 * **[Docker (GitHub Container Registry)](https://github.com/goblint/analyzer/pkgs/container/analyzer)**. Run `docker pull ghcr.io/goblint/analyzer:latest`.
 * **Docker (repository).** Clone and run `docker build -t goblint .`.
 * **Vagrant.** Clone and run `vagrant up && vagrant ssh`.

--- a/make.sh
+++ b/make.sh
@@ -101,8 +101,9 @@ rule() {
       echo "For reference see ./Dockerfile or ./scripts/travis-ci.sh"
       opam_setup
     ;; dev)
+      eval $(opam env)
       echo "Installing opam packages for development..."
-      opam install utop ocaml-lsp-server ocp-indent ocamlformat ounit2 earlybird
+      opam install -y utop ocaml-lsp-server ocp-indent ocamlformat ounit2 earlybird
       # ocaml-lsp-server is needed for https://github.com/ocamllabs/vscode-ocaml-platform
       echo "Be sure to adjust your vim/emacs config!"
       echo "Installing Pre-commit hook..."


### PR DESCRIPTION
None of us probably need this, since we have working Goblint development environments already set up, but this VS Code devcontainer could be useful for any new Goblint developers (especially students).
This makes setting up the development environment a one-click process. It also automatically sets up the VS Code plugins for OCaml LSP and Earlybird, so everything should work out-of-the-box.

More information: https://code.visualstudio.com/docs/remote/containers.