### PR TITLE
Remove unnecessary export of AD by Apron privatizations.

### DIFF
--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -43,7 +43,6 @@ module type S =
 
 module Dummy: S = functor (AD: ApronDomain.S2) ->
 struct
-  module AD = AD
   module D = Lattice.Unit
   module G = Lattice.Unit
 
@@ -93,7 +92,6 @@ struct
     let name () = "W"
   end
 
-  module AD = AD
   module D = Lattice.Prod (P) (W)
   module G = AD
 
@@ -313,7 +311,6 @@ struct
   open Protection
   open ExplicitMutexGlobals
 
-  module AD = AD
   module D = Lattice.Unit
   module G = AD
 
@@ -479,7 +476,6 @@ struct
   open Locksets
   open WriteCenteredD
 
-  module AD = AD
   module D = Lattice.Prod (W) (P)
   module G = AD
 


### PR DESCRIPTION
Remove unnecessarily exported `AD` in apron privatizations.