### PR TITLE
Improve interval overflow detection

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -533,7 +533,7 @@ struct
 
   let set_overflow_flag ik =
     if Cil.isSigned ik && !GU.postsolving then (
-      Goblintutil.did_overflow := true;
+      Goblintutil.svcomp_may_overflow := true;
       M.warn ~category:M.Category.Integer.overflow ~tags:[CWE 190] "Integer overflow"
     )
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -615,15 +615,7 @@ struct
   let maximal = function None -> None | Some (x,y) -> Some y
   let minimal = function None -> None | Some (x,y) -> Some x
 
-  let cast_to ?torg ?no_ov t = function
-    | None -> None
-    | Some (x,y) ->
-      try
-        let a = Ints_t.of_bigint @@ Size.cast_big_int t (Ints_t.to_bigint x) in
-        let b = Ints_t.of_bigint @@ Size.cast_big_int t (Ints_t.to_bigint y) in
-        let a,b = if Ints_t.compare x a <> 0 || Ints_t.compare y b <> 0 then Size.range_big_int t |> (fun (a, b) -> (Ints_t.of_bigint a, Ints_t.of_bigint b)) else a,b in
-        norm t @@ Some (a, b)
-      with Size.Not_in_int64 -> top_of t
+  let cast_to ?torg ?no_ov t = norm t (* norm does all overflow handling *)
 
   let widen ik x y =
     match x, y with

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -14,7 +14,8 @@ let jsonFiles : string list ref = ref []
     This is set to true in control.ml before we verify the result (or already before solving if warn = 'early') *)
 let should_warn = ref false
 
-let did_overflow = ref false
+(** Whether signed overflow or underflow happened *)
+let svcomp_may_overflow = ref false
 
 (** hack to use a special integer to denote synchronized array-based locking *)
 let inthack = Int64.of_int (-19012009) (* TODO do we still need this? *)

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -567,7 +567,7 @@ struct
         let next _ = []
       end
       in
-      if not !Goblintutil.did_overflow then
+      if not !Goblintutil.svcomp_may_overflow then
         let module TaskResult =
         struct
           module Arg = Arg

--- a/tests/regression/50-juliet/01-CWE190_Integer_Overflow__01.c
+++ b/tests/regression/50-juliet/01-CWE190_Integer_Overflow__01.c
@@ -6,7 +6,7 @@ void main()
     char data;
     fscanf(stdin, "%c", &data);
     {
-        char result = data + 1;  // TODO WARN: potential overflow
+        char result = data + 1;  // WARN: potential overflow
         printf("%hhd\n", result);
     }
 }

--- a/tests/regression/50-juliet/02-CWE190_Integer_Overflow__02.c
+++ b/tests/regression/50-juliet/02-CWE190_Integer_Overflow__02.c
@@ -12,7 +12,7 @@ void main()
 
     if(data > 0 && multiply > 0) // avoid potential underflow
     {
-        char result = data * multiply;  // TODO WARN: potential overflow
+        char result = data * multiply;  // WARN: potential overflow
         printf("%hhd\n", result);
     }
 }

--- a/tests/regression/50-juliet/03-CWE190_Integer_Overflow__03.c
+++ b/tests/regression/50-juliet/03-CWE190_Integer_Overflow__03.c
@@ -8,7 +8,7 @@ static void badSink(unsigned int data)
     if (badStatic)
     {
         {
-            int result = data * data; // TODO WARN: potential overflow
+            int result = data * data; // WARN: potential overflow
             printf("%hhd\n", result);
         }
     }

--- a/tests/regression/50-juliet/04-CWE191_Integer_Underflow__01.c
+++ b/tests/regression/50-juliet/04-CWE191_Integer_Underflow__01.c
@@ -6,7 +6,7 @@ void main()
     char data;
     fscanf(stdin, "%c", &data);
     {
-        data--; // TODO WARN: potential underflow
+        data--; // WARN: potential underflow
         char result = data;
         printf("%hhd\n", result);
     }

--- a/tests/regression/50-juliet/05-CWE191_Integer_Underflow__02.c
+++ b/tests/regression/50-juliet/05-CWE191_Integer_Underflow__02.c
@@ -7,7 +7,7 @@ void main()
     fscanf(stdin, "%c", &data);
     if(-data < 0) // avoid potential overflow
     {
-        char result = -data * 2; // TODO WARN: potential underflow
+        char result = -data * 2; // WARN: potential underflow
         printf("%hhd\n", result);
     }
 }

--- a/tests/regression/50-juliet/06-CWE191_Integer_Underflow__03.c
+++ b/tests/regression/50-juliet/06-CWE191_Integer_Underflow__03.c
@@ -11,7 +11,7 @@ void main()
         data = rand();
         if(data < 0) // avoid potential overflow
         {
-            char result = data * 2; // TODO WARN: potential underflow
+            char result = data * 2; // WARN: potential underflow
             printf("%hhd\n", result);
         }
     }


### PR DESCRIPTION
This fixes some more points in #346:

1. Simplify `cast_to` to just `norm`, which already does all overflow handling. This means we also warn about overflows in casts. Not sure why it was so involved before.
2. Distinguish overflow warnings from underflow warnings. This is just to better match the CWEs, internally we call them all still overflows.