### PR TITLE
Optimize `eval_rv` for addresses in base `query`

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1305,7 +1305,7 @@ struct
             end
           | `Address n -> begin
               if M.tracing then M.tracec "invariant" "Yes, %a is not %a\n" d_lval x AD.pretty n;
-              match eval_rv a gs st (Lval x) with
+              match eval_rv_address a gs st (Lval x) with
               | `Address a when AD.is_definite n ->
                 Some (x, `Address (AD.diff a n))
               | `Top when AD.is_null n ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -886,6 +886,17 @@ struct
       M.warn "Unknown call to function %a." d_exp fval;
       [dummyFunDec.svar]
 
+  (** Evaluate expression as address.
+      Avoids expensive Apron EvalInt if the `Int result would be useless to us anyway. *)
+  let eval_rv_address ask gs st e =
+    (* no way to do eval_rv with expected type, so filter expression beforehand *)
+    match Cilfacade.typeOf e with
+    | t when Cil.isArithmeticType t -> (* definitely not address *)
+      VD.top_value t
+    | exception Cilfacade.TypeOfError _ (* something weird, might be address *)
+    | _ ->
+      eval_rv ask gs st e
+
   (* interpreter end *)
 
   let query ctx (type a) (q: a Q.t): a Q.result =
@@ -899,7 +910,7 @@ struct
     | Q.EvalInt e ->
       query_evalint (Analyses.ask_of_ctx ctx) ctx.global ctx.local e
     | Q.EvalLength e -> begin
-        match eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e with
+        match eval_rv_address (Analyses.ask_of_ctx ctx) ctx.global ctx.local e with
         | `Address a ->
           let slen = List.map String.length (AD.to_string a) in
           let lenOf = function
@@ -914,7 +925,7 @@ struct
         | _ -> Queries.Result.top q
       end
     | Q.BlobSize e -> begin
-        let p = eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e in
+        let p = eval_rv_address (Analyses.ask_of_ctx ctx) ctx.global ctx.local e in
         (* ignore @@ printf "BlobSize %a MayPointTo %a\n" d_plainexp e VD.pretty p; *)
         match p with
         | `Address a ->
@@ -926,7 +937,7 @@ struct
         | _ -> Queries.Result.top q
       end
     | Q.MayPointTo e -> begin
-        match eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e with
+        match eval_rv_address (Analyses.ask_of_ctx ctx) ctx.global ctx.local e with
         | `Address a ->
           let s = addrToLvalSet a in
           if AD.mem Addr.UnknownPtr a
@@ -944,7 +955,7 @@ struct
         | _ -> Queries.Result.top q
       end
     | Q.ReachableFrom e -> begin
-        match eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e with
+        match eval_rv_address (Analyses.ask_of_ctx ctx) ctx.global ctx.local e with
         | `Top -> Queries.Result.top q
         | `Bot -> Queries.Result.bot q (* TODO: remove *)
         | `Address a when AD.is_top a || AD.mem Addr.UnknownPtr a ->
@@ -956,7 +967,7 @@ struct
         | _ -> Q.LS.empty ()
       end
     | Q.ReachableUkTypes e -> begin
-        match eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e with
+        match eval_rv_address (Analyses.ask_of_ctx ctx) ctx.global ctx.local e with
         | `Top -> Queries.Result.top q
         | `Bot -> Queries.Result.bot q (* TODO: remove *)
         | `Address a when AD.is_top a || AD.mem Addr.UnknownPtr a ->
@@ -966,7 +977,7 @@ struct
         | _ -> Q.TS.empty ()
       end
     | Q.EvalStr e -> begin
-        match eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e with
+        match eval_rv_address (Analyses.ask_of_ctx ctx) ctx.global ctx.local e with
         (* exactly one string in the set (works for assignments of string constants) *)
         | `Address a when List.compare_length_with (AD.to_string a) 1 = 0 -> (* exactly one string *)
           `Lifted (List.hd (AD.to_string a))


### PR DESCRIPTION
In https://github.com/goblint/analyzer/pull/379#issuecomment-963173203 I did some `perf` profiling and noticed a notable amount of unnecessary Apron calculations happening through the following steps:
1. Mutex analysis runs `do_access` on every subexpression to record their accesses for race detection.
2. To do that, it performs a `MayPointTo`/`ReachableFrom` query on the expression.
3. Base analysis answers those querying by doing `eval_rv` on them first.
4. If the expression has integer type, base will perform `EvalInt` queries.
5. Apron analysis answers those `EvalInt` queries.
6. Once control-flow gets back to base's `query`, the result is pattern matched for `Address` and any `Int` result is ignored.

So the key problem is that base implementation for `MayPointTo`, etc will first spend a lot of effort (via Apron) evaluating the integer expression and then just throws all that work away because it was unnecessary as it was just looking for address sets.

Ideally `eval_rv` would have some argument to tell it that we only care about certain result variants to prevent it from doing work which we will want to ignore anyway. That would be a big change to `eval_rv`, so instead here's a relatively simple optimization: a `eval_rv_address` wrapper is added which will not call `eval_rv` at all for arithmetic types, thus avoiding the above problem.

As a side note, we don't actually want to prevent `eval_rv_address` from completely doing queries to Apron because integers might still appear in array offsets, where we want to evaluate them as precisely as possible, even if the array itself contains pointers (and thus the result type is not arithmetic).

On top of the current optimizations I did to #379, this brings the analysis time for 52/16 from 3.7s down to 3.1s.