### PR TITLE
Switch Apron oct and box to double

### DIFF
--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -97,7 +97,15 @@ let int_of_scalar ?round (scalar: Scalar.t) =
     None
   else
     match scalar with
-    | Mpqf scalar ->
+    | Float f -> (* octD, boxD *)
+      (* bound_texpr on bottom also gives Float even with MPQ *)
+      let f_opt = match round with
+        | Some `Floor -> Some (Float.floor f)
+        | Some `Ceil -> Some (Float.ceil f)
+        | None -> None
+      in
+      Option.map (fun f -> BI.of_bigint (Z.of_float f)) f_opt
+    | Mpqf scalar -> (* octMPQ, boxMPQ, polkaMPQ *)
       let n = Mpqf.get_num scalar in
       let d = Mpqf.get_den scalar in
       let z_opt =
@@ -112,7 +120,7 @@ let int_of_scalar ?round (scalar: Scalar.t) =
       in
       Option.map (fun z -> BI.of_string (Mpzf.to_string z)) z_opt
     | _ ->
-      failwith ("int_of_scalar: not rational: " ^ Scalar.to_string scalar)
+      failwith ("int_of_scalar: unsupported: " ^ Scalar.to_string scalar)
 
 module Bounds (Man: Manager) =
 struct

--- a/src/dune
+++ b/src/dune
@@ -18,7 +18,7 @@
     ; Alternative dependencies seem like the only way to optionally depend on optional dependencies.
     ; See: https://dune.readthedocs.io/en/stable/concepts.html#alternative-dependencies.
     (select apronDomain.ml from
-      (apron apron.octMPQ apron.boxMPQ apron.polkaMPQ -> apronDomain.apron.ml)
+      (apron apron.octD apron.boxD apron.polkaMPQ -> apronDomain.apron.ml)
       (-> apronDomain.no-apron.ml)
     )
     (select apronPrecCompareUtil.ml from

--- a/tests/regression/36-apron/33-large-int64.c
+++ b/tests/regression/36-apron/33-large-int64.c
@@ -10,9 +10,9 @@ void main() {
     assert(x < z);
 
     if (9223372036854775805 <= x && z <= 9223372036854775807) {
-      assert(x == 9223372036854775805);
-      assert(y == 9223372036854775806);
-      assert(z == 9223372036854775807);
+      assert(x == 9223372036854775805); // TODO (unknown with D, success with MPQ)
+      assert(y == 9223372036854775806); // TODO (unknown with D, success with MPQ)
+      assert(z == 9223372036854775807); // TODO (unknown with D, success with MPQ)
 
       assert(x != -3);
       assert(y != -2);

--- a/tests/regression/36-apron/34-large-bigint.c
+++ b/tests/regression/36-apron/34-large-bigint.c
@@ -10,12 +10,12 @@ void main() {
     assert(x < z);
 
     if (18446744073709551612ull <= x && z <= 18446744073709551615ull) {
-      assert(18446744073709551612ull <= x);
-      assert(x <= 18446744073709551613ull);
-      assert(18446744073709551613ull <= y);
-      assert(y <= 18446744073709551614ull);
-      assert(18446744073709551614ull <= z);
-      assert(z <= 18446744073709551615ull);
+      assert(18446744073709551612ull <= x); // TODO (unknown with D, success with MPQ)
+      assert(x <= 18446744073709551613ull); // TODO (unknown with D, success with MPQ)
+      assert(18446744073709551613ull <= y); // TODO (unknown with D, success with MPQ)
+      assert(y <= 18446744073709551614ull); // TODO (unknown with D, success with MPQ)
+      assert(18446744073709551614ull <= z); // TODO (unknown with D, success with MPQ)
+      assert(z <= 18446744073709551615ull); // TODO (unknown with D, success with MPQ)
 
       assert(x >= x - x); // avoid base from answering to check if apron doesn't say x == -3
       assert(y >= y - y); // avoid base from answering to check if apron doesn't say y == -3


### PR DESCRIPTION
In #379 on top of #439, on 52/16 this further improves the analysis time from 3.1s to 1.1s. Almost 3 times faster!

According to https://antoinemine.github.io/Apron/doc/api/c/oct_doc.html#numeric this should still be sound. All we lose is the ability to handle very large integer constants.
Unfortunately the choice of `octMPQ` vs `octD` must be compile-time, so there's no easy way to make it configurable.

The polyhedra option still uses `polkaMPQ` because there's no `polkaD` in the apron package.