### PR TITLE
Fix signed conversion overflow unsoundness with assume_none

### DIFF
--- a/tests/regression/39-signed-overflows/03-cast-return-void-ptr.c
+++ b/tests/regression/39-signed-overflows/03-cast-return-void-ptr.c
@@ -1,0 +1,15 @@
+// PARAM: --enable ana.int.interval --set sem.int.signed_overflow assume_none
+#include <assert.h>
+
+int empty() {
+  return -1; // return shouldn't cast to void* generally, but just for thread return
+}
+
+int main(void) {
+  if (!empty()==-1) { // if -1 is cast to void*, it makes both branches dead!
+    assert(1); // NOWARN (unreachable)
+  }
+
+  assert(1); // reachable
+  return 0;
+}

--- a/tests/regression/39-signed-overflows/04-cast-unsigned-to-signed.c
+++ b/tests/regression/39-signed-overflows/04-cast-unsigned-to-signed.c
@@ -1,0 +1,9 @@
+// PARAM: --enable ana.int.interval --set sem.int.signed_overflow assume_none
+#include <assert.h>
+
+int main(void) {
+  unsigned long x;
+  long y = x;
+  assert(y >= 0); // UNKNOWN!
+  return 0;
+}


### PR DESCRIPTION
After #438 I ran sv-benchmarks locally and noticed a handful of unsound cases where we haven't been unsound before. The more precise cast handling of intervals by just `norm` is problematic with `sem.int.signed_overflow` being `assume_none` (which is what we do for SV-COMP).

Namely, the conversion from `unsigned long` to `long` (which might not be entirely contained) is not signed overflow per se, but rather a conversion, where this is not undefined behavior, but implementation-defined behavior. So `assume_none` cannot soundly exclude that possibility. This is the case for some sv-benchmarks where GCC's implementation-defined behavior (wraparound) is still valid.

Also fixes a bug from #225, where all return values got cast to `void*`, not just the thread return ones.