### PR TITLE
Remove outdated and broken ocamlbuild

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,5 +1,0 @@
-<src> or <src/**>: include
-true: package(findlib), package(goblint-cil.all-features), package(batteries.unthreaded), package(ppx_deriving.std), package(ppx_deriving_yojson), package(ppx_distr_guards), package(qcheck-core.runner)
-<unittest/**>: include, package(oUnit)
-<src/extract/*.*>: package(ocaml-monadic)
-true: bin_annot, debug, optimize(3), thread

--- a/dune-project
+++ b/dune-project
@@ -37,9 +37,6 @@
     dune-site
     sha
     benchmark ; TODO: make this optional somehow, (optional) on bench executable doesn't work
-    ; TODO still need the following after switch to dune?
-    ocamlbuild
-    ocamlfind
   )
   (depopts
     apron

--- a/goblint.opam
+++ b/goblint.opam
@@ -34,8 +34,6 @@ depends: [
   "dune-site"
   "sha"
   "benchmark"
-  "ocamlbuild"
-  "ocamlfind"
 ]
 depopts: ["apron" "z3"]
 build: [

--- a/make.sh
+++ b/make.sh
@@ -19,14 +19,6 @@ opam_setup() {
   # opam install camlp4 mongo # camlp4 needed for mongo
 }
 
-# deprecated, use dune which is much faster
-OCBFLAGS="-cflag -annot -tag bin_annot -X webapp -no-links -use-ocamlfind -j 8 -no-log -ocamlopt opt -cflag -g"
-ocb() {
-  command -v opam >/dev/null 2>&1 && eval $(opam config env)
-  gen
-  ocamlbuild $OCBFLAGS $*
-}
-
 rule() {
   case $1 in
     # new rules using dune
@@ -67,34 +59,13 @@ rule() {
       dune build src/apronPrecCompare.exe &&
       cp _build/default/src/apronPrecCompare.exe apronPrecCompare
       chmod +w apronPrecCompare
-    # old rules using ocamlbuild
-    ;; ocbnat*)
-      ocb -no-plugin $TARGET.native &&
-      cp _build/$TARGET.native goblint
     ;; byte)
       eval $(opam config env)
       dune build goblint.byte &&
       cp _build/default/goblint.byte goblint.byte
       chmod +w goblint.byte
-    ;; profile)
-      # gprof (run only generates gmon.out). use: gprof goblint
-      ocb -tag profile $TARGET.p.native &&
-      cp _build/$TARGET.p.native goblint
-    ;; ocamlprof)
-      # gprof & ocamlprof (run also generates ocamlprof.dump). use: ocamlprof src/goblint.ml
-      ocb -ocamlopt ocamloptp $TARGET.p.native &&
-      cp _build/$TARGET.p.native goblint
-    # ;; docs)
-    #   rm -rf doc;
-    #   ls src/**/*.ml | egrep -v $EXCLUDE  | sed 's/.*\/\(.*\)\.ml/\1/' > doclist.odocl;
-    #   ocb -ocamldoc ocamldoc -docflags -charset,utf-8,-colorize-code,-keep-code doclist.docdir/index.html;
-    #   rm doclist.odocl;
-    #   ln -sf _build/doclist.docdir doc
     # ;; tag*)
     #   otags -vi `find src/ -iregex [^.]*\.mli?`
-    ;; arinc)
-      ocb src/mainarinc.native &&
-      cp _build/src/mainarinc.native arinc
 
     # setup, dependencies
     ;; deps)
@@ -167,8 +138,6 @@ rule() {
     # tests, CI
     ;; test)
       ./scripts/update_suite.rb # run regression tests
-    ;; unit)
-      ocamlbuild -use-ocamlfind unittest/mainTest.native && ./mainTest.native
     ;; testci)
       ruby scripts/update_suite.rb -s -d # -s: run tests sequentially instead of in parallel such that output is not scrambled, -d shows some stats?
     ;; travis) # run a travis docker container with the files tracked by git - intended to debug setup problems on travis-ci.com

--- a/src/dune
+++ b/src/dune
@@ -47,8 +47,8 @@
 (copy_files witness/z3/*.ml)
 
 (executables
-  (names goblint maindomaintest) ; TODO: separate domaintest executable?
-  (public_names goblint -)
+  (names goblint maindomaintest mainarinc mainspec) ; TODO: separate domaintest executable?
+  (public_names goblint - - -)
   (modes byte native) ; https://dune.readthedocs.io/en/stable/dune-files.html#linking-modes
   (modules goblint mainarinc maindomaintest mainspec)
   (libraries goblint.lib goblint.sites.dune)


### PR DESCRIPTION
AFAIK nobody is using these ocamlbuild rules for anything anymore. I tried to and they're utterly broken as well because our dune setup has evolved considerably to all sorts of advanced mechanisms: alternative dependencies for Apron and Z3; virtual libraries for dune-site (and Gobview). It's probably not worth the effort trying to make the inferior ocamlbuild work, so we can just drop the unnecessary dependency.

On a related note, we still have the `travis-ci.sh` script, which we don't use for CI anymore, but `Vagrantfile` does. It contains the following line:
https://github.com/goblint/analyzer/blob/0da0464dfd65c3d84566a71b55f9e5f19b218843/scripts/travis-ci.sh#L21
Now that the ocamlfind dependency is also dropped, do we not need `m4` anymore? I don't know what it would be needed for, but currently we still claim to require it in our README etc.

