### PR TITLE
Fix: max vid computation in incremental analysis

### DIFF
--- a/scripts/incremental.sh
+++ b/scripts/incremental.sh
@@ -53,8 +53,8 @@ trap finish EXIT
 
 outp=$out/$(basename $repo_path)
 
-rm -r "$outp"
-rm -r "incremental_data"
+rm -rf "$outp"
+rm -rf "incremental_data"
 function log {
   echo "$*" | tee -a $outp/incremental.log
 }

--- a/src/incremental/versionLookup.ml
+++ b/src/incremental/versionLookup.ml
@@ -21,7 +21,8 @@ let create_map (new_file: Cil.file) =
   let add_to_hashtbl tbl (global: Cil.global) =
     match global with
     | GFun (fund, _) as f -> (match fund.smaxstmtid with
-        | Some i -> update_vid fund.svar.vid; update_sid i; Hashtbl.replace tbl (identifier_of_global f) f
+        | Some i -> update_vid fund.svar.vid; List.iter (fun v -> update_vid v.vid) fund.slocals;
+          List.iter (fun v -> update_vid v.vid) fund.sformals; update_sid i; Hashtbl.replace tbl (identifier_of_global f) f
         | None -> failwith "smaxstmtid should have been computed when calling Cil.computeCFGInfo")
     | GVar (var, _, _) as v -> update_vid var.vid; Hashtbl.replace tbl (identifier_of_global v) v
     | GVarDecl (var, _) as v -> update_vid var.vid; Hashtbl.replace tbl (identifier_of_global v) v

--- a/src/incremental/versionLookup.ml
+++ b/src/incremental/versionLookup.ml
@@ -37,7 +37,7 @@ let create_map (new_file: Cil.file) =
     | GFun _
     | GVar _
     | GVarDecl _ -> Hashtbl.replace tbl (identifier_of_global global) global
-    | other -> () in
+    | _ -> () in
   let tbl : (global_identifier, Cil.global) Hashtbl.t = Hashtbl.create 1000 in
   Cil.iterGlobals new_file (fun g -> add_to_hashtbl tbl g; update_max_ids max_vid max_sid g);
   tbl, {max_sid = !max_sid; max_vid = !max_vid}

--- a/src/incremental/versionLookup.ml
+++ b/src/incremental/versionLookup.ml
@@ -6,6 +6,22 @@ type max_ids = {
   max_vid: int;
 }
 
+let update_id_max (id_max : int ref) id =
+  if id > !id_max then id_max := id
+
+let update_sids sid_max (glob: global) = match glob with
+  | GFun (fn, loc) -> List.iter (fun s -> update_id_max sid_max s.sid) fn.sallstmts
+  | _ -> ()
+
+let update_vids vid_max (glob: global) = match glob with
+  | GFun (fn, loc) -> update_id_max vid_max fn.svar.vid; List.iter (List.iter (fun v -> update_id_max vid_max v.vid)) [fn.slocals; fn.sformals]
+  | GVar (v,_,_) -> update_id_max vid_max v.vid
+  | GVarDecl (v,_) -> update_id_max vid_max v.vid
+  | _ -> ()
+
+let update_max_ids vid_max sid_max (glob: global) =
+  update_vids vid_max glob; update_sids sid_max glob
+
 let updateMap (oldFile: Cil.file) (newFile: Cil.file) (ht: (global_identifier, Cil.global) Hashtbl.t) =
   let changes = Stats.time "compareCilFiles" (fun () -> compareCilFiles oldFile newFile) () in
   (* TODO: For updateCIL, we have to show whether the new data is from an changed or added functiong  *)
@@ -16,20 +32,14 @@ let updateMap (oldFile: Cil.file) (newFile: Cil.file) (ht: (global_identifier, C
 let create_map (new_file: Cil.file) =
   let max_sid = ref 0 in
   let max_vid = ref 0 in
-  let update_sid sid = if sid > !max_sid then max_sid := sid in
-  let update_vid vid = if vid > !max_vid then max_vid := vid in
   let add_to_hashtbl tbl (global: Cil.global) =
     match global with
-    | GFun (fund, _) as f -> (match fund.smaxstmtid with
-        | Some i -> update_vid fund.svar.vid; List.iter (fun v -> update_vid v.vid) fund.slocals;
-          List.iter (fun v -> update_vid v.vid) fund.sformals; update_sid i; Hashtbl.replace tbl (identifier_of_global f) f
-        | None -> failwith "smaxstmtid should have been computed when calling Cil.computeCFGInfo")
-    | GVar (var, _, _) as v -> update_vid var.vid; Hashtbl.replace tbl (identifier_of_global v) v
-    | GVarDecl (var, _) as v -> update_vid var.vid; Hashtbl.replace tbl (identifier_of_global v) v
-    | other -> ()
-  in
+    | GFun _
+    | GVar _
+    | GVarDecl _ -> Hashtbl.replace tbl (identifier_of_global global) global
+    | other -> () in
   let tbl : (global_identifier, Cil.global) Hashtbl.t = Hashtbl.create 1000 in
-  Cil.iterGlobals new_file (add_to_hashtbl tbl);
+  Cil.iterGlobals new_file (fun g -> add_to_hashtbl tbl g; update_max_ids max_vid max_sid g);
   tbl, {max_sid = !max_sid; max_vid = !max_vid}
 
 (* Load and update the version map *)


### PR DESCRIPTION
Closes #427 

This PR introduces the following changes:
- the computation of the maximum `vid` (when running in incremental mode but without loading any previous results) of a function is fixed such that it not only considers the functions `vid` but also includes the `vids` of local variables and formal parameters. 
- The code is refactored to remove the then duplicate computation of the maximum ids in `UpdateCil.ml`.
- Additionally, the incremental.sh script for running the incremental analysis on a repository is changed such that the removing of the possibly not existing output and incremental data directories will not cause it to fail. 