### PR TITLE
Add shorthand for `--set`

### DIFF
--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -84,6 +84,11 @@ let option_spec_list =
     set_bool "dbg.print_dead_code" true;
     set_string "result" "sarif"
   in
+  let defaults_spec_list = List.map (fun (_, (name, (_, _))) ->
+      (* allow "--option value" as shorthand for "--set option value" *)
+      ("--" ^ name, Arg.String (set_auto name), "")
+    ) !Defaults.registrar
+  in
   let tmp_arg = ref "" in
   [ "-o"                   , Arg.String (set_string "outfile"), ""
   ; "-v"                   , Arg.Unit (fun () -> set_bool "dbg.verbose" true; set_bool "printstats" true), ""
@@ -115,7 +120,7 @@ let option_spec_list =
   ; "--osekcheck"          , Arg.Unit (fun () -> set_bool "ana.osek.check" true), ""
   ; "--oseknames"          , Arg.Set_string OilUtil.osek_renames, ""
   ; "--osekids"            , Arg.Set_string OilUtil.osek_ids, ""
-  ]
+  ] @ defaults_spec_list (* lowest priority *)
 
 
 (** Parse arguments and fill [arg_files]. Print help if needed. *)


### PR DESCRIPTION
This allows `--option value` as shorthand for `--set option value`, which saves a bit of typing on the command line. It doesn't mean that we should completely get rid of `--set` everywhere, but this is just a small convenience.

It's a tiny change code-wise, but I wanted to have a PR for visibility instead of secretly slipping it straight into master without anyone else being aware of this.

I thought about even allowing just `--option` (no argument) for boolean options, but that only goes one way: it could make something true, which is false by default, but not vice versa (without being super confusing). I think there's no need to go that far, because `--enable`/`--disable` are much clearer and not too different. Also one can still do `--option true`/`--option false` this way.