### PR TITLE
Set length of arrays during fast_global_inits

### DIFF
--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -300,6 +300,7 @@ struct
     if M.tracing then M.trace "update_offset" "part array set_with_length %a %a %a\n" pretty x LiftExp.pretty i Val.pretty a;
     if i = `Lifted MyCFG.all_array_index_exp then
       (assert !Goblintutil.global_initialization; (* just joining with xm here assumes that all values will be set, which is guaranteed during inits *)
+       (* the join is needed here! see e.g 30/04 *)
       let r =  Val.join xm a in
       (Expp.top(), (r, r, r)))
     else

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -993,12 +993,9 @@ struct
               let e = determine_offset ask l o exp (Some v) in
               let new_value_at_index = do_update_offset ask `Bot offs value exp l' o' v t in
               let new_array_value =  CArrays.set ask x' (e, idx) new_value_at_index in
-              let newl = match len with
-                | None -> ID.top_of (Cilfacade.ptrdiff_ikind ()) (* TODO: must be non-negative, top is overly cautious *)
-                | Some e ->
-                  let l = BatOption.map (fun x -> IndexDomain.of_int (Cilfacade.ptrdiff_ikind ()) @@ Cilint.big_int_of_cilint x) (Cil.getInteger @@ Cil.constFold true e) in
-                  BatOption.default (ID.top_of (Cilfacade.ptrdiff_ikind ())) l
-              in
+              let len_ci = BatOption.bind len (fun e -> Cil.getInteger @@ Cil.constFold true e) in
+              let len_id = BatOption.map (fun ci -> IndexDomain.of_int (Cilfacade.ptrdiff_ikind ()) @@ Cilint.big_int_of_cilint ci) len_ci in
+              let newl = BatOption.default (ID.top_of (Cilfacade.ptrdiff_ikind ())) len_id in
               let new_array_value = CArrays.update_length newl new_array_value in
               `Array new_array_value
             | `Top -> M.warn "Trying to update an index, but the array is unknown"; top ()

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -986,13 +986,20 @@ struct
               let new_array_value = CArrays.set ask x' (e, idx) new_value_at_index in
               `Array new_array_value
             | `Bot ->
-              let t = (match t with
-              | TArray(t1 ,_,_) -> t1
-              | _ -> t) in (* This is necessary because t is not a TArray in case of calloc *)
+              let t,len = (match t with
+                  | TArray(t1 ,len,_) -> t1, len
+                  | _ -> t, None) in (* This is necessary because t is not a TArray in case of calloc *)
               let x' = CArrays.bot () in
               let e = determine_offset ask l o exp (Some v) in
               let new_value_at_index = do_update_offset ask `Bot offs value exp l' o' v t in
               let new_array_value =  CArrays.set ask x' (e, idx) new_value_at_index in
+              let newl = match len with
+                | None -> ID.top_of (Cilfacade.ptrdiff_ikind ()) (* TODO: must be non-negative, top is overly cautious *)
+                | Some e ->
+                  let l = BatOption.map (fun x -> IndexDomain.of_int (Cilfacade.ptrdiff_ikind ()) @@ Cilint.big_int_of_cilint x) (Cil.getInteger @@ Cil.constFold true e) in
+                  BatOption.default (ID.top_of (Cilfacade.ptrdiff_ikind ())) l
+              in
+              let new_array_value = CArrays.update_length newl new_array_value in
               `Array new_array_value
             | `Top -> M.warn "Trying to update an index, but the array is unknown"; top ()
             | x when Goblintutil.opt_predicate (BI.equal BI.zero) (IndexDomain.to_int idx) -> do_update_offset ask x offs value exp l' o' v t

--- a/tests/regression/26-undefined_behavior/15-oob_init.c
+++ b/tests/regression/26-undefined_behavior/15-oob_init.c
@@ -1,8 +1,8 @@
-// SKIP PARAM: --enable ana.arrayoob
+// PARAM: --enable ana.arrayoob
 
 int a[1];
 
-int main() { 
+int main() {
   a[0] = 5; // NOWARN
   return 0;
 }


### PR DESCRIPTION
This fixes #451 by ensuring arrays have their length set, even when using `fast_global_inits`.
This is achieved by a change to `update_offset` to also set the array length whenever the old value is "superbot".

Closes #451.