### PR TITLE
Invalidate variables that are assigned return values of `pthread_create(...)` and `pthread_join(...)`

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2179,18 +2179,17 @@ struct
     (* handling thread joins... sort of *)
     | `ThreadJoin (id,ret_var) ->
       let st' =
-        begin match (eval_rv (Analyses.ask_of_ctx ctx) gs st ret_var) with
-          | `Int n when GU.opt_predicate (BI.equal BI.zero) (ID.to_int n) -> st
-          | `Address ret_a ->
-            begin match eval_rv (Analyses.ask_of_ctx ctx) gs st id with
-              | `Thread a ->
-                let a = List.fold AD.join (AD.bot ()) (List.map (fun x -> AD.from_var (ThreadIdDomain.Thread.to_varinfo x)) (ValueDomain.Threads.elements a)) in
-                (* TODO: is this type right? *)
-                set ~ctx:(Some ctx) (Analyses.ask_of_ctx ctx) gs st ret_a (Cilfacade.typeOf ret_var) (get (Analyses.ask_of_ctx ctx) gs st a None)
-              | _      -> invalidate ~ctx (Analyses.ask_of_ctx ctx) gs st [ret_var]
-            end
-          | _      -> invalidate ~ctx (Analyses.ask_of_ctx ctx) gs st [ret_var]
-        end
+        match (eval_rv (Analyses.ask_of_ctx ctx) gs st ret_var) with
+        | `Int n when GU.opt_predicate (BI.equal BI.zero) (ID.to_int n) -> st
+        | `Address ret_a ->
+          begin match eval_rv (Analyses.ask_of_ctx ctx) gs st id with
+            | `Thread a ->
+              let a = List.fold AD.join (AD.bot ()) (List.map (fun x -> AD.from_var (ThreadIdDomain.Thread.to_varinfo x)) (ValueDomain.Threads.elements a)) in
+              (* TODO: is this type right? *)
+              set ~ctx:(Some ctx) (Analyses.ask_of_ctx ctx) gs st ret_a (Cilfacade.typeOf ret_var) (get (Analyses.ask_of_ctx ctx) gs st a None)
+            | _      -> invalidate ~ctx (Analyses.ask_of_ctx ctx) gs st [ret_var]
+          end
+        | _      -> invalidate ~ctx (Analyses.ask_of_ctx ctx) gs st [ret_var]
       in
       invalidate_ret_lv st'
     | `Malloc size -> begin

--- a/tests/regression/01-cpa/54-tid-invalidate.c
+++ b/tests/regression/01-cpa/54-tid-invalidate.c
@@ -1,0 +1,16 @@
+#include <pthread.h>
+#include <assert.h>
+
+void *t_benign(void *arg) {
+  return NULL;
+}
+
+int main() {
+    int ret = 17;
+    pthread_t id2;
+    pthread_create(&id2, NULL, t_benign, NULL);
+    ret = pthread_join(id2,NULL);
+
+    assert(ret == 17); //UNKNOWN!
+    return 0;
+}

--- a/tests/regression/01-cpa/54-tid-invalidate.c
+++ b/tests/regression/01-cpa/54-tid-invalidate.c
@@ -8,7 +8,11 @@ void *t_benign(void *arg) {
 int main() {
     int ret = 17;
     pthread_t id2;
-    pthread_create(&id2, NULL, t_benign, NULL);
+    ret = pthread_create(&id2, NULL, t_benign, NULL);
+
+    assert(ret == 17); //UNKNOWN!
+
+    ret = 17;
     ret = pthread_join(id2,NULL);
 
     assert(ret == 17); //UNKNOWN!


### PR DESCRIPTION
Previously the invalidation in these two cases was missing.

For most library functions the invalidation is done by default as `special` falls through to the default case.
https://github.com/goblint/analyzer/blob/2e8aa66c46643d6774f3c60e70f988004aa121a9/src/analyses/base.ml#L2250

For these two, however, the call needs to be made explicit.

Closes #387