### PR TITLE
Flag Helper for Binary Flag Configured `Printable`s, `Groupable`s, and `Lattice.PO`s

### DIFF
--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -689,19 +689,12 @@ struct
   type idx = Idx.t
   type value = Val.t
 
-  include FlagHelper(P)(T)(struct
+  include LatticeFlagHelper(P)(T)(struct
       let msg = "FlagConfiguredArrayDomain received a value where not exactly one component is set"
       let name = "FlagConfiguredArrayDomain"
     end)
 
   (* Simply call appropriate function for component that is not None *)
-  let leq = binop P.leq T.leq
-  let join = binop_to_t P.join T.join
-  let meet = binop_to_t P.meet T.meet
-  let widen = binop_to_t P.widen T.widen
-  let narrow = binop_to_t P.narrow T.narrow
-  let is_top = unop P.is_top T.is_top
-  let is_bot = unop P.is_bot T.is_bot
   let get a x (e,i) = unop (fun x ->
         if e = `Top then
           let e' = BatOption.map_default (fun x -> `Lifted (Cil.kinteger64 IInt x)) (`Top) (Option.map BI.to_int64 @@ Idx.to_int i) in
@@ -721,12 +714,7 @@ struct
   let smart_leq f g = binop (P.smart_leq f g) (T.smart_leq f g)
   let update_length newl x = unop_to_t (P.update_length newl) (T.update_length newl) x
 
-  let pretty_diff () ((p1,t1),(p2,t2)) = match (p1, t1),(p2, t2) with
-    | (Some p1, None), (Some p2, None) -> P.pretty_diff () (p1, p2)
-    | (None, Some t1), (None, Some t2) -> T.pretty_diff () (t1, t2)
-    | _ -> failwith "FlagConfiguredArrayDomain received a value where not exactly one component is set"
-
-  (* Functions that make us of the configuration flag *)
+  (* Functions that make use of the configuration flag *)
   let name () = "FlagConfiguredArrayDomain: " ^ if get_bool "exp.partition-arrays.enabled" then P.name () else T.name ()
 
   let partition_enabled () = get_bool "exp.partition-arrays.enabled"

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -1,6 +1,7 @@
 open Pretty
 open Cil
 open GobConfig
+open FlagHelper
 
 module M = Messages
 module A = Array
@@ -687,39 +688,13 @@ struct
 
   type idx = Idx.t
   type value = Val.t
-  type t = P.t option * T.t option
 
-  let invariant _ _ = Invariant.none
-  let tag _ = failwith "FlagConfiguredArrayDomain: no tag"
-  let arbitrary () = failwith "FlagConfiguredArrayDomain: no arbitrary"
-
-  (* Helpers *)
-  let binop opp opt (p1,t1) (p2,t2) = match (p1, t1),(p2, t2) with
-    | (Some p1, None), (Some p2, None) -> opp p1 p2
-    | (None, Some t1), (None, Some t2) -> opt t1 t2
-    | _ -> failwith "FlagConfiguredArrayDomain received a value where not exactly one component is set"
-
-  let binop_to_t opp opt (p1,t1) (p2,t2)= match (p1, t1),(p2, t2) with
-    | (Some p1, None), (Some p2, None) -> (Some (opp p1 p2), None)
-    | (None, Some t1), (None, Some t2) -> (None, Some(opt t1 t2))
-    | _ -> failwith "FlagConfiguredArrayDomain received a value where not exactly one component is set"
-
-  let unop opp opt (p,t) = match (p, t) with
-    | (Some p, None) -> opp p
-    | (None, Some t) -> opt t
-    | _ -> failwith "FlagConfiguredArrayDomain received a value where not exactly one component is set"
-
-  let unop_to_t opp opt (p,t) = match (p, t) with
-    | (Some p, None) -> (Some (opp p), None)
-    | (None, Some t) -> (None, Some(opt t))
-    | _ -> failwith "FlagConfiguredArrayDomain received a value where not exactly one component is set"
+  include FlagHelper(P)(T)(struct
+      let msg = "FlagConfiguredArrayDomain received a value where not exactly one component is set"
+      let name = "FlagConfiguredArrayDomain"
+    end)
 
   (* Simply call appropriate function for component that is not None *)
-  let equal = binop P.equal T.equal
-  let hash = unop P.hash T.hash
-  let compare = binop P.compare T.compare
-  let show = unop P.show T.show
-  let pretty () = unop (P.pretty ()) (T.pretty ())
   let leq = binop P.leq T.leq
   let join = binop_to_t P.join T.join
   let meet = binop_to_t P.meet T.meet
@@ -744,10 +719,6 @@ struct
   let smart_join f g = binop_to_t (P.smart_join f g) (T.smart_join f g)
   let smart_widen f g = binop_to_t (P.smart_widen f g) (T.smart_widen f g)
   let smart_leq f g = binop (P.smart_leq f g) (T.smart_leq f g)
-
-  let printXml f = unop (P.printXml f) (T.printXml f)
-  let to_yojson = unop (P.to_yojson) (T.to_yojson)
-
   let update_length newl x = unop_to_t (P.update_length newl) (T.update_length newl) x
 
   let pretty_diff () ((p1,t1),(p2,t2)) = match (p1, t1),(p2, t2) with
@@ -777,6 +748,4 @@ struct
       (Some (P.make i v), None)
     else
       (None, Some (T.make i v))
-
-  let relift = unop_to_t P.relift T.relift
 end

--- a/src/cdomains/structDomain.ml
+++ b/src/cdomains/structDomain.ml
@@ -465,8 +465,8 @@ struct
     | _ -> failwith "FlagConfiguredStructDomain received a value where not exactly one component is set"
 
 
-  module I = struct include FlagHelper (HS) (KS) (P) let name () = "" end
-  include FlagHelper (S) (I) (P)
+  module I = struct include LatticeFlagHelper (HS) (KS) (P) let name () = "" end
+  include LatticeFlagHelper (S) (I) (P)
 
   let invariant c = unop (S.invariant c) (I.unop (HS.invariant c) (KS.invariant c))
 
@@ -481,26 +481,14 @@ struct
   let binop_to_t' ops ophs opks = binop_to_t ops (I.binop_to_t ophs opks)
   let unop_to_t' ops ophs opks = unop_to_t ops (I.unop_to_t ophs opks)
 
-  let leq = binop' S.leq HS.leq KS.leq
   let leq_with_fct f = binop' (S.leq_with_fct f) (HS.leq_with_fct f) (KS.leq_with_fct f)
-  let join = binop_to_t' S.join HS.join KS.join
   let join_with_fct f = binop_to_t' (S.join_with_fct f) (HS.join_with_fct f) (KS.join_with_fct f)
-  let meet = binop_to_t' S.meet HS.meet KS.meet
-  let widen = binop_to_t' S.widen HS.widen KS.widen
   let widen_with_fct f = binop_to_t' (S.widen_with_fct f) (HS.widen_with_fct f) (KS.widen_with_fct f)
-  let narrow = binop_to_t' S.narrow HS.narrow KS.narrow
-  let is_top = unop' S.is_top HS.is_top KS.is_top
-  let is_bot = unop' S.is_bot HS.is_bot KS.is_bot
   let get = unop' S.get HS.get KS.get
   let replace = twoaccop_to_t S.replace HS.replace KS.replace
   let keys = unop' S.keys HS.keys KS.keys
   let map f = unop_to_t' (S.map f) (HS.map f) (KS.map f)
   let fold f = unop' (S.fold f) (HS.fold f) (KS.fold f)
-  let pretty_diff () ((s1,r1),(s2,r2)) = match (of_t (s1,r1), of_t ((s2, r2))) with
-    | (Some s1, None, None), (Some s2, None, None) -> S.pretty_diff () (s1, s2)
-    | (None, Some hs1, None), (None, Some hs2, None) -> HS.pretty_diff () (hs1, hs2)
-    | (None, None, Some ks1), (None, None, Some ks2) -> KS.pretty_diff () (ks1, ks2)
-    | _ -> failwith "FlagConfiguredStructDomain received a value where not exactly one component is set"
 
   (* Functions that make us of the configuration flag *)
   let chosen_domain () = get_string "exp.structs.domain"

--- a/src/cdomains/structDomain.ml
+++ b/src/cdomains/structDomain.ml
@@ -1,6 +1,7 @@
 open Cil
 open GobConfig
 open Pretty
+open FlagHelper
 
 (* Exception raised when the set domain can not support the requested operation.
  * This will be raised, when trying to iterate a set that has been set to Top *)
@@ -446,70 +447,56 @@ struct
 
   type field = fieldinfo
   type value = S.value
-  type t = S.t option * HS.t option * KS.t option [@@deriving to_yojson]
 
-  let tag _ = failwith "FlagConfiguredStructDomain: no tag"
-  let arbitrary () = failwith "FlagConfiguredStructDomain: no arbitrary"
+  module P = struct
+    let msg = "FlagConfiguredStructDomain received a value where not exactly one component is set"
+    let name = "FlagConfiguredStructDomain"
+  end
 
-  let unop ops ophs opks (s,hs,ks) = match (s, hs, ks) with
-    | (Some s, None, None) -> ops s
-    | (None, Some hs, None) -> ophs hs
-    | (None, None, Some ks) -> opks ks
+  let of_t = function
+    | (Some s, None) -> (Some s, None, None)
+    | (None, Some (hs,ks)) -> (None, hs, ks)
     | _ -> failwith "FlagConfiguredStructDomain received a value where not exactly one component is set"
 
-  let invariant c = unop (S.invariant c) (HS.invariant c) (KS.invariant c)
-
-  let pretty () = unop (S.pretty ()) (HS.pretty ()) (KS.pretty ())
-
-  (* Helpers *)
-  let binop ops ophs opks (s1,hs1,ks1) (s2,hs2,ks2) = match (s1, hs1, ks1), (s2, hs2, ks2) with
-    | (Some s1, None, None), (Some s2, None, None) -> ops s1 s2
-    | (None, Some hs1, None), (None, Some hs2, None) -> ophs hs1 hs2
-    | (None, None, Some ks1), (None, None, Some ks2) -> opks ks1 ks2
-    | _ -> failwith "FlagConfiguredStructDomain received a value where not exactly one component is set"
-
-  let binop_to_t ops ophs opks (s1,hs1,ks1) (s2,hs2,ks2)= match (s1, hs1, ks1),(s2, hs2, ks2) with
-    | (Some s1, None, None), (Some s2, None, None) -> (Some (ops s1 s2), None, None)
-    | (None, Some hs1, None), (None, Some hs2, None) -> (None, Some(ophs hs1 hs2), None)
-    | (None, None, Some ks1), (None, None, Some ks2) -> (None, None, Some(opks ks1 ks2))
+  let to_t = function
+    | (Some s, None, None) -> (Some s, None)
+    | (None, Some hs, None) -> (None, Some (Some hs, None))
+    | (None, None, Some ks) -> (None, Some (None, Some ks))
     | _ -> failwith "FlagConfiguredStructDomain received a value where not exactly one component is set"
 
 
-  let unop_to_t ops ophs opks (s,hs,ks) = match (s, hs, ks) with
-    | (Some s, None, None) -> (Some (ops s), None, None)
-    | (None, Some hs, None) -> (None, Some(ophs hs), None)
-    | (None, None, Some ks) -> (None, None, Some(opks ks))
-    | _ -> failwith "FlagConfiguredStructDomain received a value where not exactly one component is set"
+  module I = struct include FlagHelper (HS) (KS) (P) let name () = "" end
+  include FlagHelper (S) (I) (P)
 
-  let twoaccop_to_t ops ophs opks (s,hs,ks) a1 a2 = match (s, hs, ks) with
+  let invariant c = unop (S.invariant c) (I.unop (HS.invariant c) (KS.invariant c))
+
+  let twoaccop_to_t ops ophs opks (s,r) a1 a2 = to_t @@ match of_t (s,r) with
     | (Some s, None, None) -> (Some (ops s a1 a2), None, None)
     | (None, Some hs, None) -> (None, Some(ophs hs a1 a2), None)
     | (None, None, Some ks) -> (None, None, Some(opks ks a1 a2))
     | _ -> failwith "FlagConfiguredStructDomain received a value where not exactly one component is set"
 
-  (* Simply call appropriate function for component that is not None *)
-  let equal = binop S.equal HS.equal KS.equal
-  let hash = unop S.hash HS.hash KS.hash
-  let compare = binop S.compare HS.compare KS.compare
-  let show = unop S.show HS.show KS.show
-  let leq = binop S.leq HS.leq KS.leq
-  let leq_with_fct f = binop (S.leq_with_fct f) (HS.leq_with_fct f) (KS.leq_with_fct f)
-  let join = binop_to_t S.join HS.join KS.join
-  let join_with_fct f = binop_to_t (S.join_with_fct f) (HS.join_with_fct f) (KS.join_with_fct f)
-  let meet = binop_to_t S.meet HS.meet KS.meet
-  let widen = binop_to_t S.widen HS.widen KS.widen
-  let widen_with_fct f = binop_to_t (S.widen_with_fct f) (HS.widen_with_fct f) (KS.widen_with_fct f)
-  let narrow = binop_to_t S.narrow HS.narrow KS.narrow
-  let is_top = unop S.is_top HS.is_top KS.is_top
-  let is_bot = unop S.is_bot HS.is_bot KS.is_bot
-  let get = unop S.get HS.get KS.get
+  let binop' ops ophs opks = binop ops (I.binop ophs opks)
+  let unop' ops ophs opks = unop ops (I.unop ophs opks)
+  let binop_to_t' ops ophs opks = binop_to_t ops (I.binop_to_t ophs opks)
+  let unop_to_t' ops ophs opks = unop_to_t ops (I.unop_to_t ophs opks)
+
+  let leq = binop' S.leq HS.leq KS.leq
+  let leq_with_fct f = binop' (S.leq_with_fct f) (HS.leq_with_fct f) (KS.leq_with_fct f)
+  let join = binop_to_t' S.join HS.join KS.join
+  let join_with_fct f = binop_to_t' (S.join_with_fct f) (HS.join_with_fct f) (KS.join_with_fct f)
+  let meet = binop_to_t' S.meet HS.meet KS.meet
+  let widen = binop_to_t' S.widen HS.widen KS.widen
+  let widen_with_fct f = binop_to_t' (S.widen_with_fct f) (HS.widen_with_fct f) (KS.widen_with_fct f)
+  let narrow = binop_to_t' S.narrow HS.narrow KS.narrow
+  let is_top = unop' S.is_top HS.is_top KS.is_top
+  let is_bot = unop' S.is_bot HS.is_bot KS.is_bot
+  let get = unop' S.get HS.get KS.get
   let replace = twoaccop_to_t S.replace HS.replace KS.replace
-  let keys = unop S.keys HS.keys KS.keys
-  let map f = unop_to_t (S.map f) (HS.map f) (KS.map f)
-  let fold f = unop (S.fold f) (HS.fold f) (KS.fold f)
-  let printXml f = unop (S.printXml f) (HS.printXml f) (KS.printXml f)
-  let to_yojson = unop (S.to_yojson) (HS.to_yojson) (KS.to_yojson)
-  let pretty_diff () ((s1,hs1,ks1),(s2,hs2,ks2)) = match (s1, hs1, ks1),(s2, hs2, ks2) with
+  let keys = unop' S.keys HS.keys KS.keys
+  let map f = unop_to_t' (S.map f) (HS.map f) (KS.map f)
+  let fold f = unop' (S.fold f) (HS.fold f) (KS.fold f)
+  let pretty_diff () ((s1,r1),(s2,r2)) = match (of_t (s1,r1), of_t ((s2, r2))) with
     | (Some s1, None, None), (Some s2, None, None) -> S.pretty_diff () (s1, s2)
     | (None, Some hs1, None), (None, Some hs2, None) -> HS.pretty_diff () (hs1, hs2)
     | (None, None, Some ks1), (None, None, Some ks2) -> KS.pretty_diff () (ks1, ks2)
@@ -538,21 +525,21 @@ struct
     | _ -> failwith "FlagConfiguredStructDomain cannot name a struct from set option"
 
   let bot () =
-    match chosen_domain () with
+    to_t @@ match chosen_domain () with
     | "simple" -> (Some (S.bot ()), None, None)
     | "sets" -> (None, Some (HS.bot ()), None)
     | "keyed" -> (None, None, Some (KS.bot ()))
     | _ -> failwith "FlagConfiguredStructDomain cannot construct a bot struct from set option"
 
   let top () =
-    match chosen_domain () with
+    to_t @@ match chosen_domain () with
     | "simple" -> (Some (S.top ()), None, None)
     | "sets" -> (None, Some (HS.top ()), None)
     | "keyed" -> (None, None, Some (KS.top ()))
     | _ -> failwith "FlagConfiguredStructDomain cannot construct a top struct from set option"
 
   let create fn (comp: compinfo): t =
-    match pick_combined (chosen_domain ()) comp with
+    to_t @@ match pick_combined (chosen_domain ()) comp with
     | "simple" -> (Some (S.create fn comp), None, None)
     | "sets" -> (None, Some (HS.create fn comp), None)
     | "keyed" -> (None, None, Some (KS.create fn comp))

--- a/src/domains/flagHelper.ml
+++ b/src/domains/flagHelper.ml
@@ -1,0 +1,65 @@
+module type FlagError = sig
+  val msg: string
+  val name: string
+end
+
+
+module FlagHelper (L:Printable.S) (R:Printable.S) (Msg: FlagError) =
+struct
+  type t = L.t option * R.t option
+
+  let unop opl opr (h,r) = match (h, r) with
+    | (Some l, None) -> opl l
+    | (None, Some r) -> opr r
+    | _ -> failwith Msg.msg
+
+  let binop opl opr (l1,r1) (l2,r2) = match (l1, r1),(l2, r2) with
+    | (Some l1, None), (Some l2, None) -> opl l1 l2
+    | (None, Some r1), (None, Some r2) -> opr r1 r2
+    | _ -> failwith Msg.msg
+
+  let unop_to_t opl opr (l,t) = match (l, t) with
+    | (Some p, None) -> (Some (opl p), None)
+    | (None, Some t) -> (None, Some(opr t))
+    | _ -> failwith Msg.msg
+
+  let binop_to_t opl opr (l1,r1) (l2,r2)= match (l1, r1),(l2, r2) with
+    | (Some p1, None), (Some p2, None) -> (Some (opl p1 p2), None)
+    | (None, Some t1), (None, Some t2) -> (None, Some(opr t1 t2))
+    | _ -> failwith Msg.msg
+
+  let equal = binop L.equal R.equal
+  let hash = unop L.hash R.hash
+  let compare = binop L.compare R.compare
+  let show = unop L.show R.show
+  let pretty () = unop (L.pretty ()) (R.pretty ())
+  let printXml f = unop (L.printXml f) (R.printXml f)
+  let to_yojson = unop L.to_yojson R.to_yojson
+  let relift = unop_to_t L.relift R.relift
+
+  let invariant _ _ = Invariant.none
+  let tag _ = failwith (Msg.name ^ ": no tag")
+  let arbitrary () = failwith (Msg.name ^ ": no arbitrary")
+end
+
+module GroupableFlagHelper (L:MapDomain.Groupable) (R:MapDomain.Groupable) (Msg: FlagError) =
+struct
+  include FlagHelper (L) (R) (Msg)
+  type group = L.group option * R.group option
+
+  let trace_enabled = false
+
+  let show_group = unop L.show_group R.show_group
+  let to_group (h,p) = match (h, p) with
+    | (Some h, None) ->
+      (let r = L.to_group h in
+       match r with
+       | Some r -> Some (Some r, None)
+       | _ -> None)
+    | (None, Some p) ->
+      (let r = R.to_group p in
+       match r with
+       | Some r -> Some (None, Some r)
+       | _ -> None)
+    | _ -> failwith Msg.msg
+end

--- a/src/domains/flagHelper.ml
+++ b/src/domains/flagHelper.ml
@@ -63,3 +63,26 @@ struct
        | _ -> None)
     | _ -> failwith Msg.msg
 end
+
+module type LatticeFlagHelperArg = sig
+  include Lattice.PO
+  val is_top: t -> bool
+  val is_bot: t -> bool
+end
+
+module LatticeFlagHelper (L:LatticeFlagHelperArg) (R:LatticeFlagHelperArg) (Msg: FlagError) =
+struct
+  include FlagHelper (L) (R) (Msg)
+
+  let leq = binop L.leq R.leq
+  let join = binop_to_t L.join R.join
+  let meet = binop_to_t L.meet R.meet
+  let widen = binop_to_t L.widen R.widen
+  let narrow = binop_to_t L.narrow R.narrow
+  let is_top = unop L.is_top R.is_top
+  let is_bot = unop L.is_bot R.is_bot
+  let pretty_diff () ((l1,r1),(l2,r2)) = match (l1, r1),(l2, r2) with
+    | (Some p1, None), (Some p2, None) -> L.pretty_diff () (p1, p2)
+    | (None, Some t1), (None, Some t2) -> R.pretty_diff () (t1, t2)
+    | _ -> failwith Msg.msg
+end


### PR DESCRIPTION
This enables some more code reuse.
There is also `StructDomain.FlagConfiguredStructDomain`, but in this case there is three options and it is not immediately clear whether there can be meaningful reuse of code between this one and the other one which has two options.