### PR TITLE
Find non-Clang, non-Apple `cpp` at runtime

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -84,19 +84,6 @@
   (action (write-file %{target} "(* Automatically regenerated, changes do not persist! *)\nlet profile = \"%{profile}\"")))
 
 (rule
-  (target configCpp.ml)
-  (mode (promote (until-clean) (only configCpp.ml))) ; replace existing file in source tree, even if releasing (only overrides)
-  (enabled_if (<> %{system} "macosx"))
-  (action (write-file %{target} "(* Automatically regenerated, changes do not persist! *)\nlet cpp = \"cpp\"")))
-
-(rule
-  (target configCpp.ml)
-  (mode (promote (until-clean) (only configCpp.ml))) ; replace existing file in source tree, even if releasing (only overrides)
-  (deps (universe))
-  (enabled_if (= %{system} "macosx")) ; if we are on OS X and cpp is the Apple LLVM version, we should look for some Homebrew cpp-8 (or other version)
-  (action (pipe-stdout (with-accepted-exit-codes 0 (bash "compgen -c cpp- | head -n1")) (with-stdout-to %{target} (bash "xargs printf '(* Automatically regenerated, changes do not persist! *)\nlet cpp = \"%s\"'")))))
-
-(rule
   (alias runtest)
   (deps ../goblint ../scripts/update_suite.rb ../Makefile ../make.sh (source_tree ../tests/regression) (source_tree ../includes) (source_tree ../linux-headers))
   (action (chdir .. (run ./make.sh test)))

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -288,6 +288,9 @@ let preprocess_files () =
   if get_bool "ana.sv-comp.functions" then
     extra_arg_files := find_custom_include "sv-comp.c" :: !extra_arg_files;
 
+  (* TODO: remove *)
+  ignore (Preprocessor.get_cpp ());
+
   List.flatten (List.map preprocess_arg_file (!extra_arg_files @ !arg_files))
 
 (** Possibly merge all postprocessed files *)

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -161,7 +161,7 @@ let basic_preprocess ~all_cppflags fname =
   else
     (* Preprocess using cpp. *)
     (* ?? what is __BLOCKS__? is it ok to just undef? this? http://en.wikipedia.org/wiki/Blocks_(C_language_extension) *)
-    let command = ConfigCpp.cpp ^ " --undef __BLOCKS__ " ^ String.join " " (List.map Filename.quote all_cppflags) ^ " \"" ^ fname ^ "\" -o \"" ^ nname ^ "\"" in
+    let command = (Preprocessor.get_cpp ()) ^ " --undef __BLOCKS__ " ^ String.join " " (List.map Filename.quote all_cppflags) ^ " \"" ^ fname ^ "\" -o \"" ^ nname ^ "\"" in
     if get_bool "dbg.verbose" then print_endline command;
 
     (* if something goes wrong, we need to clean up and exit *)
@@ -287,9 +287,6 @@ let preprocess_files () =
 
   if get_bool "ana.sv-comp.functions" then
     extra_arg_files := find_custom_include "sv-comp.c" :: !extra_arg_files;
-
-  (* TODO: remove *)
-  ignore (Preprocessor.get_cpp ());
 
   List.flatten (List.map preprocess_arg_file (!extra_arg_files @ !arg_files))
 

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -237,6 +237,7 @@ let _ = ()
       ; reg Experimental "exp.structs.key.prefer-ptrs" "true"     "Whether pointers should be preferred for key."
       ; reg Experimental "exp.gcc_path"           "'/usr/bin/gcc'" "Location of gcc. Used to combine source files with cilly. Change to gcc-9 or another version on OS X (with gcc being clang by default cilly will fail otherwise)."
       ; reg Experimental "exp.compdb.original-path" "" "Original absolute path of Compilation Database. Used to reroot all absolute paths in there if moved, e.g. in container mounts."
+      ; reg Experimental "exp.cpp-path" "" "Path to C preprocessor (cpp) to use. If empty, then automatically searched."
 
 (* {4 category [Debugging]} *)
 let _ = ()

--- a/src/util/preprocessor.ml
+++ b/src/util/preprocessor.ml
@@ -1,6 +1,6 @@
 open Prelude
 
-let bad_cpp_version_regexp = Str.regexp_case_fold "ubuntu" (* TODO: change *)
+let bad_cpp_version_regexp = Str.regexp_case_fold "clang\\|apple\\|darwin"
 
 let is_bad name =
   let cpp_in = Unix.open_process_in (name ^ " --version") in

--- a/src/util/preprocessor.ml
+++ b/src/util/preprocessor.ml
@@ -1,0 +1,34 @@
+open Prelude
+
+let bad_cpp_version_regexp = Str.regexp_case_fold "ubuntu" (* TODO: change *)
+
+let is_bad name =
+  let cpp_in = Unix.open_process_in (name ^ " --version") in
+  let cpp_version = IO.read_all cpp_in in
+  let r = match Str.search_forward bad_cpp_version_regexp cpp_version 0 with
+    | exception Not_found -> false
+    | _ -> true
+  in
+  if GobConfig.get_bool "dbg.verbose" then
+    Printf.printf "Preprocessor %s: is_bad=%B\n" name r;
+  r
+
+let compgen prefix =
+  let bash_command = Filename.quote ("compgen -c " ^ prefix) in
+  let compgen = Unix.open_process_in ("bash -c " ^ bash_command) in
+  IO.lines_of compgen
+  |> List.of_enum
+
+let cpp =
+  let is_good name = not (is_bad name) in
+  let default = "cpp" in
+  lazy (
+    if is_good default then
+      default
+    else (
+      compgen "cpp-" (* only run compgen if default was bad *)
+      |> List.find_exn is_good (Failure "No good preprocessor (cpp) found")
+    )
+  )
+
+let get_cpp () = Lazy.force cpp

--- a/src/util/preprocessor.ml
+++ b/src/util/preprocessor.ml
@@ -23,7 +23,10 @@ let cpp =
   let is_good name = not (is_bad name) in
   let default = "cpp" in
   lazy (
-    if is_good default then
+    let cpp_path = GobConfig.get_string "exp.cpp-path" in
+    if cpp_path <> "" then
+      cpp_path (* explicit option overrides is_good check *)
+    else if is_good default then
       default
     else (
       compgen "cpp-" (* only run compgen if default was bad *)


### PR DESCRIPTION
Closes #470.

Adds the option `exp.cpp-path` which overrides the automatic search procedure, in case it is ever needed.