### PR TITLE
Add option `incremental.force-reanalyze.funs`

### DIFF
--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -35,7 +35,7 @@ let eqF (a: Cil.fundec) (b: Cil.fundec) (cfgs : (cfg * cfg) option) =
       List.for_all2 eq_varinfo a.sformals b.sformals
     with Invalid_argument _ -> false in
   let identical, diffOpt =
-    if List.mem a.svar.vname (GobConfig.get_string_list "incremental.extra-changed") then
+    if List.mem a.svar.vname (GobConfig.get_string_list "incremental.force-reanalyze.funs") then
       false, None
     else
       try

--- a/src/incremental/serialize.ml
+++ b/src/incremental/serialize.ml
@@ -26,7 +26,7 @@ let unmarshal fileName =
   Marshal.input (open_in_bin fileName)
 
 let results_exist () =
-  (* If Goblint did not crash irregularly, the existance of the result directory indicates that there are results *)
+  (* If Goblint did not crash irregularly, the existence of the result directory indicates that there are results *)
   let r = gob_results_dir () in
   Sys.file_exists r && Sys.is_directory r
 
@@ -38,7 +38,7 @@ let type_to_file_name = function
   | CilFile -> cil_file_name
   | VersionData -> version_map_filename
 
-(** Loads data for incremntal runs from the appropriate file *)
+(** Loads data for incremental runs from the appropriate file *)
 let load_data (data_type: incremental_data_kind) =
   let p = Filename.concat (gob_results_dir ()) (type_to_file_name data_type) in
   unmarshal p

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -161,7 +161,7 @@ let _ = ()
       ; reg Incremental "incremental.reluctant.on" "true" "Destabilize nodes in changed functions reluctantly"
       ; reg Incremental "incremental.reluctant.compare" "'leq'" "In order to reuse the function's old abstract value the new abstract value must be leq (focus on efficiency) or equal (focus on precision) compared to the old."
       ; reg Incremental "incremental.compare" "'ast'" "Which comparison should be used for functions? 'ast'/'cfg' (cfg comparison also differentiates which nodes of a function have changed)"
-      ; reg Incremental "incremental.extra-changed" "[]" "List of functions that are to be considered as changed regardless of result of comparing ASTs or CFGs"
+      ; reg Incremental "incremental.force-reanalyze.funs" "[]" "List of functions that are to be re-analayzed from scratch"
 
 (* {4 category [Semantics]} *)
 let _ = ()

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -161,6 +161,7 @@ let _ = ()
       ; reg Incremental "incremental.reluctant.on" "true" "Destabilize nodes in changed functions reluctantly"
       ; reg Incremental "incremental.reluctant.compare" "'leq'" "In order to reuse the function's old abstract value the new abstract value must be leq (focus on efficiency) or equal (focus on precision) compared to the old."
       ; reg Incremental "incremental.compare" "'ast'" "Which comparison should be used for functions? 'ast'/'cfg' (cfg comparison also differentiates which nodes of a function have changed)"
+      ; reg Incremental "incremental.extra-changed" "[]" "List of functions that are to be considered as changed regardless of result of comparing ASTs or CFGs"
 
 (* {4 category [Semantics]} *)
 let _ = ()


### PR DESCRIPTION
This adds an option such that a user can specify a list of function names that are to be considered as changed regardless of the result of the AST/CFG comparison.
This is need such that certain functions can be marked as "changed" when different configuration options have been enabled for them.