### PR TITLE
Fix meet of arrays with different partitioning expressions

### DIFF
--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -567,7 +567,14 @@ struct
   let smart_widen = smart_widen_with_length None
   let smart_leq = smart_leq_with_length None
 
-  let meet a b = normalize @@ meet a b
+  let meet (e1,v1) (e2,v2) = normalize @@
+    match e1,e2 with
+    | `Lifted e1e, `Lifted e2e when not (Basetype.CilExp.equal e1e e2e) ->
+      (* partitioned according to two different expressions -> meet can not be element-wise *)
+      (* TODO: do smart things if the relationship between e1e and e2e is known *)
+      (e1,v1)
+    | _ -> meet (e1,v1) (e2,v2)
+
   let narrow a b = normalize @@ narrow a b
 
   let update_length _ x = x

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -571,6 +571,7 @@ struct
     match e1,e2 with
     | `Lifted e1e, `Lifted e2e when not (Basetype.CilExp.equal e1e e2e) ->
       (* partitioned according to two different expressions -> meet can not be element-wise *)
+      (* arrays can not be partitioned according to multiple expressions, arbitrary prefer the first one here *)
       (* TODO: do smart things if the relationship between e1e and e2e is known *)
       (e1,v1)
     | _ -> meet (e1,v1) (e2,v2)
@@ -579,6 +580,7 @@ struct
     match e1,e2 with
     | `Lifted e1e, `Lifted e2e when not (Basetype.CilExp.equal e1e e2e) ->
       (* partitioned according to two different expressions -> narrow can not be element-wise *)
+      (* arrays can not be partitioned according to multiple expressions, arbitrary prefer the first one here *)
       (* TODO: do smart things if the relationship between e1e and e2e is known *)
       (e1,v1)
     | _ -> narrow (e1,v1) (e2,v2)

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -575,7 +575,13 @@ struct
       (e1,v1)
     | _ -> meet (e1,v1) (e2,v2)
 
-  let narrow a b = normalize @@ narrow a b
+  let narrow (e1,v1) (e2,v2) = normalize @@
+    match e1,e2 with
+    | `Lifted e1e, `Lifted e2e when not (Basetype.CilExp.equal e1e e2e) ->
+      (* partitioned according to two different expressions -> narrow can not be element-wise *)
+      (* TODO: do smart things if the relationship between e1e and e2e is known *)
+      (e1,v1)
+    | _ -> narrow (e1,v1) (e2,v2)
 
   let update_length _ x = x
 end

--- a/tests/regression/22-partitioned_arrays/16-refine-meet.c
+++ b/tests/regression/22-partitioned_arrays/16-refine-meet.c
@@ -1,0 +1,19 @@
+// PARAM: --enable exp.partition-arrays.enabled
+int garr[7];
+
+int main(int argc, char **argv)
+{
+	unsigned char *arr[3];
+    unsigned char * top;
+
+	// Call to a function with a missing fundef causes invalidation of garr
+	fundef_missing();
+
+	garr[0] = 8;
+
+
+	if (garr[1] == 1) {
+		// Statement so CIL doesn't optimize the if out
+		int ret = 12;
+	}
+}

--- a/tests/regression/22-partitioned_arrays/16-refine-meet.c
+++ b/tests/regression/22-partitioned_arrays/16-refine-meet.c
@@ -3,9 +3,6 @@ int garr[7];
 
 int main(int argc, char **argv)
 {
-	unsigned char *arr[3];
-    unsigned char * top;
-
 	// Call to a function with a missing fundef causes invalidation of garr
 	fundef_missing();
 


### PR DESCRIPTION
In the course of #419, I modified the `invariant` function to work on the entire variable instead of only on an offset. The offset is updated and after this the meet between the old and the new value happens.
This is beneficial e.g. with our new struct domains.

However, it uncovered an issue with the `meet` in the partitioned array domain: If two partitioned values are met and they are partitioned according to different expressions, the resulting component-wise `meet` is partitioned according to a bottom expression, which is an invalid value that we never create. (same goes for `narrow`).

This fixes the immediate problem. In the long run, I will later clean up this mess in #485.

TODO:
- [x] Check if this fixes all instances of #482 on SV-Comp

Closes #482.