### PR TITLE
Fix protected/mutex_inits unsoundness in branched thread creation with protection/mutex-oplus/mutex-meet

### DIFF
--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -291,6 +291,10 @@ struct
   let sync ask getg sideg (st: BaseComponents (D).t) reason =
     match reason with
     | `Join -> (* required for branched thread creation *)
+      let global_cpa = CPA.filter (fun x _ -> is_global ask x && is_unprotected ask x) st.cpa in
+      sideg V.mutex_inits global_cpa; (* must be like enter_multithreaded *)
+      (* TODO: this makes mutex-oplus less precise in 28-race_reach/10-ptrmunge_racefree and 28-race_reach/trylock2_racefree, why? *)
+
       CPA.iter (fun x v ->
           (* TODO: is_unprotected - why breaks 02/11 init_mainfun? *)
           if is_global ask x && is_unprotected ask x then

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -545,17 +545,15 @@ struct
   let sync ask getg sideg (st: BaseComponents (D).t) reason =
     match reason with
     | `Join -> (* required for branched thread creation *)
-      let st' =
-        CPA.fold (fun x v (st: BaseComponents (D).t) ->
-            if is_global ask x && is_unprotected ask x then (
-              sideg (V.unprotected x) v;
-              {st with cpa = CPA.remove x st.cpa; priv = P.remove x st.priv}
-            )
-            else
-              st
-          ) st.cpa st
-      in
-      st'
+      CPA.fold (fun x v (st: BaseComponents (D).t) ->
+          if is_global ask x && is_unprotected ask x then (
+            sideg (V.unprotected x) v;
+            sideg (V.protected x) v; (* must be like enter_multithreaded *)
+            {st with cpa = CPA.remove x st.cpa; priv = P.remove x st.priv}
+          )
+          else
+            st
+        ) st.cpa st
     | `Return
     | `Normal
     | `Init

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -277,6 +277,13 @@ struct
 
   let lock ask getg (st: BaseComponents (D).t) m =
     let get_m = get_m_with_mutex_inits ask getg m in
+    (* Really we want is_unprotected, but pthread_cond_wait emits unlock-lock events,
+       where our (necessary) original context still has the mutex,
+       so the query would be on the wrong lockset.
+       TODO: Fixing the event contexts is hard: https://github.com/goblint/analyzer/pull/487#discussion_r765905029.
+       Therefore, just use _without to exclude the mutex we shouldn't have.
+       In non-cond locks we don't have it anyway, so there's no difference.
+       No other privatization uses is_unprotected, so this hack is only needed here. *)
     let is_in_V x _ = is_protected_by ask m x && is_unprotected_without ask x m in
     let cpa' = CPA.filter is_in_V get_m in
     if M.tracing then M.tracel "priv" "PerMutexOplusPriv.lock m=%a cpa'=%a\n" LockDomain.Addr.pretty m CPA.pretty cpa';

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -252,6 +252,7 @@ struct
   let threadenter = old_threadenter
 end
 
+(* Unsound for 13-privatized/67-pthread_cond_wait for unknown reason. *)
 module PerMutexOplusPriv: S =
 struct
   include PerMutexPrivBase

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -365,6 +365,9 @@ struct
   let sync ask getg sideg (st: BaseComponents (D).t) reason =
     match reason with
     | `Join -> (* required for branched thread creation *)
+      let global_cpa = CPA.filter (fun x _ -> is_global ask x && is_unprotected ask x) st.cpa in
+      sideg V.mutex_inits global_cpa; (* must be like enter_multithreaded *)
+
       let cpa' = CPA.fold (fun x v cpa ->
           if is_global ask x && is_unprotected ask x (* && not (VD.is_top v) *) then (
             if M.tracing then M.tracel "priv" "SYNC SIDE %a = %a\n" d_varinfo x VD.pretty v;

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -252,7 +252,6 @@ struct
   let threadenter = old_threadenter
 end
 
-(* Unsound for 13-privatized/67-pthread_cond_wait for unknown reason. *)
 module PerMutexOplusPriv: S =
 struct
   include PerMutexPrivBase
@@ -278,7 +277,7 @@ struct
 
   let lock ask getg (st: BaseComponents (D).t) m =
     let get_m = get_m_with_mutex_inits ask getg m in
-    let is_in_V x _ = is_protected_by ask m x && is_unprotected ask x in
+    let is_in_V x _ = is_protected_by ask m x && is_unprotected_without ask x m in
     let cpa' = CPA.filter is_in_V get_m in
     if M.tracing then M.tracel "priv" "PerMutexOplusPriv.lock m=%a cpa'=%a\n" LockDomain.Addr.pretty m CPA.pretty cpa';
     {st with cpa = CPA.fold CPA.add cpa' st.cpa}

--- a/tests/regression/13-privatized/67-pthread_cond_wait.c
+++ b/tests/regression/13-privatized/67-pthread_cond_wait.c
@@ -12,6 +12,7 @@ void* f1(void* ptr) {
     pthread_mutex_lock(&mut);
     g = 1;
     pthread_cond_wait(&cond,&mut);
+    // TODO: mutex-oplus is unsound here!
     assert(g == 0); //UNKNOWN!
     assert(g != 1); //UNKNOWN!
     printf("g is %i", g);

--- a/tests/regression/13-privatized/71-branched-thread-creation-priv.c
+++ b/tests/regression/13-privatized/71-branched-thread-creation-priv.c
@@ -1,0 +1,30 @@
+extern int __VERIFIER_nondet_int();
+
+#include <pthread.h>
+#include <assert.h>
+
+int global = 5;
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+int main() {
+  int r = __VERIFIER_nondet_int();
+  pthread_t id;
+
+  if (r) {
+    pthread_create(&id, NULL, t_fun, NULL);
+  }
+  else {
+    global = 10;
+  }
+  // sync join needs to publish global also to protected/mutex_inits like enter_multithreaded
+
+  pthread_mutex_lock(&m);
+  assert(global == 5); // UNKNOWN!
+  pthread_mutex_unlock(&m);
+
+  return 0;
+}

--- a/tests/regression/13-privatized/72-pthread_cond_wait_mutexoplus.c
+++ b/tests/regression/13-privatized/72-pthread_cond_wait_mutexoplus.c
@@ -1,3 +1,4 @@
+// PARAM: --sets exp.privatization mutex-oplus
 #include<pthread.h>
 #include<stdio.h>
 #include<unistd.h>

--- a/tests/regression/36-apron/96-branched-thread-creation-apron-priv.c
+++ b/tests/regression/36-apron/96-branched-thread-creation-apron-priv.c
@@ -1,0 +1,33 @@
+// SKIP PARAM: --set ana.activated[+] apron
+extern int __VERIFIER_nondet_int();
+
+#include <pthread.h>
+#include <assert.h>
+
+int g = 5;
+int h = 5;
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+int main() {
+  int r = __VERIFIER_nondet_int();
+  pthread_t id;
+
+  if (r) {
+    pthread_create(&id, NULL, t_fun, NULL);
+  }
+  else {
+    h = 10;
+  }
+  // sync join needs to publish globals also to protected/mutex_inits like enter_multithreaded
+  // might need join strengthening to reveal unsoundness instead of going to top directly
+
+  pthread_mutex_lock(&m);
+  assert(g == h); // UNKNOWN!
+  pthread_mutex_unlock(&m);
+
+  return 0;
+}


### PR DESCRIPTION
The interactive benchmark precision comparisons revealed that the protected global invariant for a variable could be unsound in the presence of branched thread creation.
Namely, when doing `enter_multithreaded` we initialize both the unprotected and the protected invariant with the initial value, but in `sync Join` (which is for branched thread creation), we previously did not. This lead to the privatized value being unsound. Our previous branched thread creation test only checks the unprotected values.

The same problem happened with mutex_inits in mutex-oplus and mutex-meet.

### TODO
- [x] Is a similar fix needed for Apron privatizations? @michael-schwarz 
- [x] Fixes the interactive bench comparison? @vesalvojdani 