### PR TITLE
Annotations via options

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1100,8 +1100,8 @@ struct
     | `Struct _
     | `Union _ ->
       begin
-        let vars_in_paritioning = VD.affecting_vars value in
-        let dep_new = List.fold_left (fun dep var -> add_one_dep x var dep) st.deps vars_in_paritioning in
+        let vars_in_partitioning = VD.affecting_vars value in
+        let dep_new = List.fold_left (fun dep var -> add_one_dep x var dep) st.deps vars_in_partitioning in
         { st with deps = dep_new }
       end
     (* `List and `Blob cannot contain arrays *)
@@ -1282,7 +1282,7 @@ struct
     { st with cpa = List.fold_left f st.cpa v_list; deps = List.fold_left g st.deps v_list }
 
   (* Removes all partitionings done according to this variable *)
-  let rem_many_paritioning a (st:store) (v_list: varinfo list):store =
+  let rem_many_partitioning a (st:store) (v_list: varinfo list):store =
     (* Removes the partitioning information from all affected arrays, call before removing locals *)
     let rem_partitioning a (st:store) (x:varinfo):store =
       let affected_arrays =
@@ -1849,7 +1849,7 @@ struct
       Priv.enter_multithreaded (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st
     | _ ->
       let locals = List.filter (fun v -> not (WeakUpdates.mem v st.weak)) (fundec.sformals @ fundec.slocals) in
-      let nst_part = rem_many_paritioning (Analyses.ask_of_ctx ctx) ctx.local locals in
+      let nst_part = rem_many_partitioning (Analyses.ask_of_ctx ctx) ctx.local locals in
       let nst: store = rem_many (Analyses.ask_of_ctx ctx) nst_part locals in
       match exp with
       | None -> nst

--- a/src/util/contextUtil.ml
+++ b/src/util/contextUtil.ml
@@ -1,6 +1,6 @@
 open Cil
 
-(** Definition of Goblint specific user defined C attributes **)
+(** Definition of Goblint specific user defined C attributes and their alternatives via options **)
 
 type attribute =
   | GobContext
@@ -19,10 +19,14 @@ let has_attribute s1 s2 al =
       | _ -> false
     ) al
 
+let has_option s1 s2 fd =
+  List.mem fd.svar.vname (GobConfig.get_string_list ("annotation." ^ s1 ^ "." ^ s2))
+
 let should_keep ~isAttr ~keepOption ~removeAttr ~keepAttr fd =
   let al = fd.svar.vattr in
   let s = attribute_to_string isAttr in
-  match GobConfig.get_bool keepOption, has_attribute s removeAttr al, has_attribute s keepAttr al with
+  let has_annot a = has_option s a fd || has_attribute s a al in
+  match GobConfig.get_bool keepOption, has_annot removeAttr, has_annot keepAttr with
   | _, true, true ->
     failwith (Printf.sprintf "ContextUtil.should_remove: conflicting context attributes %s and %s on %s" removeAttr keepAttr (CilType.Fundec.show fd))
   | _, false, true

--- a/src/util/defaults.ml
+++ b/src/util/defaults.ml
@@ -12,7 +12,7 @@ type category = Std             (** Parsing input, includes, standard stuff, etc
               | Incremental     (** Incremental features                          *)
               | Semantics       (** Semantics                                     *)
               | Transformations (** Transformations                               *)
-              | Annotation      (** Features for annotations                       *)
+              | Annotation      (** Features for annotations                      *)
               | Experimental    (** Experimental features of analyses             *)
               | Debugging       (** Debugging, tracing, etc.                      *)
               | Warnings        (** Filtering warnings                            *)
@@ -181,6 +181,24 @@ let _ = ()
 let _ = ()
       ; reg Annotation "annotation.int.enabled"   "false" "Enable manual annotation of functions with desired precision, i.e. the activated IntDomains."
       ; reg Annotation "annotation.int.privglobs" "true"  "Enables handling of privatized globals, by setting the precision to the heighest value, when annotation.int.enabled is true."
+      ; reg Annotation "annotation.goblint_context.base.no-non-ptr" "[]" ""
+      ; reg Annotation "annotation.goblint_context.base.non-ptr" "[]" ""
+      ; reg Annotation "annotation.goblint_context.base.no-int" "[]" ""
+      ; reg Annotation "annotation.goblint_context.base.int" "[]" ""
+      ; reg Annotation "annotation.goblint_context.base.no-interval" "[]" ""
+      ; reg Annotation "annotation.goblint_context.base.interval" "[]" ""
+      ; reg Annotation "annotation.goblint_context.apron.no-context" "[]" ""
+      ; reg Annotation "annotation.goblint_context.apron.context" "[]" ""
+      ; reg Annotation "annotation.goblint_context.no-widen" "[]" ""
+      ; reg Annotation "annotation.goblint_context.widen" "[]" ""
+      ; reg Annotation "annotation.goblint_precision.no-def_exc" "[]" ""
+      ; reg Annotation "annotation.goblint_precision.def_exc" "[]" ""
+      ; reg Annotation "annotation.goblint_precision.no-interval" "[]" ""
+      ; reg Annotation "annotation.goblint_precision.interval" "[]" ""
+      ; reg Annotation "annotation.goblint_precision.no-enums" "[]" ""
+      ; reg Annotation "annotation.goblint_precision.enums" "[]" ""
+      ; reg Annotation "annotation.goblint_precision.no-congruence" "[]" ""
+      ; reg Annotation "annotation.goblint_precision.congruence" "[]" ""
 
 (* {4 category [Experimental]} *)
 let _ = ()

--- a/tests/regression/02-base/67-no-int-context-option.c
+++ b/tests/regression/02-base/67-no-int-context-option.c
@@ -1,0 +1,15 @@
+// PARAM: --enable ana.int.interval --disable ana.context.widen --enable ana.base.context.int --set annotation.goblint_context.base.no-int[+] f
+#include <assert.h>
+
+int f(int x) {
+  if (x)
+    return f(x+1);
+  else
+    return x;
+}
+
+int main () {
+  int a = f(1);
+  assert(!a);
+  return 0;
+}

--- a/tests/regression/02-base/68-int-context-option.c
+++ b/tests/regression/02-base/68-int-context-option.c
@@ -1,0 +1,15 @@
+// PARAM: --enable ana.int.interval --disable ana.context.widen --disable ana.base.context.int --set annotation.goblint_context.base.int[+] f
+#include <assert.h>
+
+int f(int x) {
+  if (x)
+    return x * f(x - 1);
+  else
+    return 1;
+}
+
+int main () {
+  int a = f(10);
+  assert(a == 3628800);
+  return 0;
+}

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -156,7 +156,7 @@ void example7(void) {
     assert(a[top] == 0); // UNKNOWN
 }
 
-// Check that the global variable is not used for paritioning
+// Check that the global variable is not used for partitioning
 void example8() {
     int a[10];
 

--- a/tests/regression/42-annotated-precision/01-def_exc.c
+++ b/tests/regression/42-annotated-precision/01-def_exc.c
@@ -1,12 +1,15 @@
 // PARAM: --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include<assert.h>
 
-int f(int in) __attribute__ ((goblint_precision("def_exc", "interval"))) {
+int f(int in) __attribute__ ((goblint_precision("def_exc", "interval")));
+int main() __attribute__ ((goblint_precision("def_exc")));
+
+int f(int in) {
   in++;
   return in;
 }
 
-int main() __attribute__ ((goblint_precision("def_exc"))) {
+int main() {
   int a = 0;
   assert(a); // FAIL!
   a = f(a);

--- a/tests/regression/42-annotated-precision/02-interval.c
+++ b/tests/regression/42-annotated-precision/02-interval.c
@@ -1,12 +1,15 @@
 // PARAM: --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include<assert.h>
 
-int f(int in) __attribute__ ((goblint_precision("no-def_exc","interval"))) {
+int f(int in) __attribute__ ((goblint_precision("no-def_exc","interval")));
+int main() __attribute__ ((goblint_precision("def_exc", "interval"))) ;
+
+int f(int in) {
   in++;
   return in;
 }
 
-int main() __attribute__ ((goblint_precision("def_exc", "interval"))) {
+int main() {
   int a = 0;
   assert(a); // FAIL!
   a = f(a);

--- a/tests/regression/42-annotated-precision/03-congruence.c
+++ b/tests/regression/42-annotated-precision/03-congruence.c
@@ -1,12 +1,15 @@
 // PARAM: --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include<assert.h>
 
-int f(int in) __attribute__ ((goblint_precision("no-def_exc","interval"))) {
+int f(int in) __attribute__ ((goblint_precision("no-def_exc","interval")));
+int main() __attribute__ ((goblint_precision("no-def_exc","congruence")));
+
+int f(int in) {
   in++;
   return in;
 }
 
-int main() __attribute__ ((goblint_precision("no-def_exc","congruence"))) {
+int main() {
   int a = 0;
   int b = f(a);
   assert(b);

--- a/tests/regression/42-annotated-precision/04-struct.c
+++ b/tests/regression/42-annotated-precision/04-struct.c
@@ -6,12 +6,15 @@ struct a {
   int i;
 };
 
-void f(struct a *in) __attribute__ ((goblint_precision("no-def_exc","interval", "congruence"))) {
+void f(struct a *in) __attribute__ ((goblint_precision("no-def_exc","interval", "congruence")));
+int main() __attribute__ ((goblint_precision("congruence")));
+
+void f(struct a *in) {
   in->i += 4;
   return;
 }
 
-int main() __attribute__ ((goblint_precision("congruence"))) {
+int main() {
   struct a a1, b1 = {"Jane", 3};
 
   a1.name = "John";

--- a/tests/regression/42-annotated-precision/05-array.c
+++ b/tests/regression/42-annotated-precision/05-array.c
@@ -3,7 +3,12 @@
 #include<stdbool.h>
 #include<assert.h>
 
-void f(int in[], int len) __attribute__ ((goblint_precision("no-def_exc","interval", "congruence"))) {
+void f(int in[], int len) __attribute__ ((goblint_precision("no-def_exc","interval", "congruence")));
+void g(bool in[], int len) __attribute__ ((goblint_precision("interval", "enums", "congruence")));
+int main() __attribute__ ((goblint_precision("interval")));
+
+
+void f(int in[], int len) {
   assert(in[0]); // FAIL!
   int c[len];
   for (int i = 0; i < len; i++) {
@@ -13,14 +18,14 @@ void f(int in[], int len) __attribute__ ((goblint_precision("no-def_exc","interv
   return;
 }
 
-void g(bool in[], int len) __attribute__ ((goblint_precision("interval", "enums", "congruence"))) {
+void g(bool in[], int len) {
   for (int i = 0; i < len; i++) {
     in[i] ^= true;
   }
   return;
 }
 
-int main() __attribute__ ((goblint_precision("interval"))) {
+int main() {
   int a[] = {0,0,0};
   bool b[] = {true, false};
   char s[][] = {"Edward","Tom","Julia"};

--- a/tests/regression/42-annotated-precision/06-global.c
+++ b/tests/regression/42-annotated-precision/06-global.c
@@ -1,17 +1,20 @@
 // PARAM: --enable annotation.int.enabled --enable exp.earlyglobs --set ana.int.refinement fixpoint
 #include<assert.h>
 
+int inc(int in) __attribute__ ((goblint_precision("no-def_exc", "interval")));
+int main() __attribute__ ((goblint_precision("def_exc")));
+
 int g1 = 0;
 int g2 = 0;
 
-int inc(int in) __attribute__ ((goblint_precision("no-def_exc", "interval"))) {
+int inc(int in) {
     int b = in + 1;
     assert(b);
     g2 = 1;
     return b;
 }
 
-int main() __attribute__ ((goblint_precision("def_exc"))) {
+int main() {
   int a = 0;
   assert(g1); // FAIL!
   a = inc(g1);

--- a/tests/regression/42-annotated-precision/07-missing_annotation.c
+++ b/tests/regression/42-annotated-precision/07-missing_annotation.c
@@ -1,10 +1,14 @@
 // PARAM: --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
-int f(int in) __attribute__((goblint_precision("def_exc"))) {
+int f(int in) __attribute__((goblint_precision("def_exc")));
+int main() __attribute__((goblint_precision("no-def_exc")));
+
+
+int f(int in) {
   return in + 1;
 }
 
-int main() __attribute__((goblint_precision("no-def_exc"))) {
+int main() {
   int a = 1;
   assert(a); // UNKNOWN!
   a = f(a);

--- a/tests/regression/42-annotated-precision/08-22_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/08-22_01-simple_array.c
@@ -1,7 +1,20 @@
 // PARAM: --set solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int global;
 
-int main(void) __attribute__((goblint_precision("no-interval")))
+int main(void) __attribute__((goblint_precision("no-interval")));
+void example1(void) __attribute__((goblint_precision("no-def_exc")));
+void example2(void) __attribute__((goblint_precision("no-def_exc")));
+void example3(void) __attribute__((goblint_precision("no-def_exc")));
+void example4(void) __attribute__((goblint_precision("no-def_exc")));
+void example5(void) __attribute__((goblint_precision("no-def_exc")));
+void example6(void) __attribute__((goblint_precision("no-def_exc")));
+void example7(void) __attribute__((goblint_precision("no-def_exc")));
+void example8() __attribute__((goblint_precision("no-def_exc")));
+void example9() __attribute__((goblint_precision("no-def_exc")));
+void example10() __attribute__((goblint_precision("no-def_exc")));
+
+
+int main(void)
 {
     example1();
     example2();
@@ -17,7 +30,7 @@ int main(void) __attribute__((goblint_precision("no-interval")))
 }
 
 // Simple example
-void example1(void) __attribute__((goblint_precision("no-def_exc")))
+void example1(void)
 {
     int a[42];
     int i = 0;
@@ -37,7 +50,7 @@ void example1(void) __attribute__((goblint_precision("no-def_exc")))
 }
 
 // More complicated expression to index rather than just a variable
-void example2(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example2(void) {
     int a[42];
     int i = 1;
 
@@ -54,7 +67,7 @@ void example2(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Two values initialized in one loop
-void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example3(void) {
     int a[42];
     int i = 0;
 
@@ -72,7 +85,7 @@ void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Example where initialization proceeds backwards
-void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4(void) {
     int a[42];
     int i = 41;
 
@@ -88,7 +101,7 @@ void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Example having two arrays partitioned according to one expression
-void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example5(void) {
     int a[42];
     int b[42];
     int i = 0;
@@ -109,7 +122,7 @@ void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Example showing array becoming partitioned according to different expressions
-void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example6(void) {
     int a[42];
     int i = 0;
     int j = 0;
@@ -139,7 +152,7 @@ void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // This was the case where we thought we needed path-splitting
-void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example7(void) {
     int a[42];
     int i = 0;
     int top;
@@ -159,7 +172,7 @@ void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Check that the global variable is not used for partitioning
-void example8() __attribute__((goblint_precision("no-def_exc"))) {
+void example8() {
     int a[10];
 
     a[global] = 4;
@@ -177,7 +190,7 @@ void example8() __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Check that arrays of types different from int are handeled correctly
-void example9() __attribute__((goblint_precision("no-def_exc"))) {
+void example9() {
     char a[10];
     int n;
     assert(a[3] == 800); // FAIL
@@ -196,7 +209,7 @@ void example9() __attribute__((goblint_precision("no-def_exc"))) {
     assert(a[3] == -129); //FAIL
 }
 
-void example10() __attribute__((goblint_precision("no-def_exc"))) {
+void example10() {
     int a[20];
     a[5] = 3;
 

--- a/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
@@ -1,5 +1,27 @@
 // PARAM: --set solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
-int main(void) __attribute__((goblint_precision("no-interval"))) {
+
+int main(void) __attribute__((goblint_precision("no-interval")));
+void example1(void) __attribute__((goblint_precision("no-def_exc")));
+void example2() __attribute__((goblint_precision("no-def_exc")));
+void example3(void) __attribute__((goblint_precision("no-def_exc")));
+void example4(void) __attribute__((goblint_precision("no-def_exc")));
+void example5(void) __attribute__((goblint_precision("no-def_exc")));
+void example6(void) __attribute__((goblint_precision("no-def_exc")));
+void example7(void) __attribute__((goblint_precision("no-def_exc")));
+void example8(void) __attribute__((goblint_precision("no-def_exc")));
+
+struct a {
+  int x[42];
+  int y;
+};
+
+void example9() __attribute__((goblint_precision("no-def_exc")));
+int example10() __attribute__((goblint_precision("no-def_exc")));
+void foo(int (*a)[40]) __attribute__((goblint_precision("no-def_exc")));
+void example11() __attribute__((goblint_precision("no-def_exc")));
+
+
+int main(void) {
     example1();
     example2();
     example3();
@@ -15,7 +37,7 @@ int main(void) __attribute__((goblint_precision("no-interval"))) {
 }
 
 // Initializing an array with pointers
-void example1(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example1(void) {
     int top;
 
     int a[42];
@@ -53,7 +75,7 @@ void example1(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Tests correct handling when pointers may point to several different things
-void example2() __attribute__((goblint_precision("no-def_exc"))) {
+void example2() {
   int array1[10000000];
   int array2[10000000];
 
@@ -78,7 +100,7 @@ void example2() __attribute__((goblint_precision("no-def_exc"))) {
   assert(*ptr == 6); // UNKNOWN
 }
 
-void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example3(void) {
   int array1[5];
   int *ptr = &array1;
 
@@ -89,7 +111,7 @@ void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 
-void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4(void) {
   int array1[5];
   int *ptr = &array1;
   int *end = &(array1[5]);
@@ -103,7 +125,7 @@ void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
   // In an ideal world, I would like to have information about array1[0] and so on. For this the <= would need to improve, so that ptr is known to point to {array1[5,5]}
 }
 
-void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example5(void) {
   int array1[5];
   int *ptr = &(array1[4]);
 
@@ -120,7 +142,7 @@ void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
   assert(array1[0] == 42); // UNKNOWN
 }
 
-void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example6(void) {
   int array1[100];
   int* ptr = &array1;
 
@@ -146,7 +168,7 @@ void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
   assert(x==7);
 }
 
-void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example7(void) {
   int top;
 
   int arr1[42];
@@ -184,7 +206,7 @@ void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
   assert(x == 10); // FAIL
 }
 
-void example8(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example8(void) {
   int a[42][42];
 
   for(int i = 0; i < 42; i++) {
@@ -211,7 +233,7 @@ struct a {
   int y;
 };
 
-void example9() __attribute__((goblint_precision("no-def_exc"))) {
+void example9() {
   int a[42][42];
   int (*ptr2)[42];
   int *y;
@@ -229,7 +251,7 @@ void example9() __attribute__((goblint_precision("no-def_exc"))) {
   assert(*y == 3);
 }
 
-int example10() __attribute__((goblint_precision("no-def_exc"))) {
+int example10() {
   struct a x[42];
   int i, j, y, *ptr;
 
@@ -246,12 +268,12 @@ int example10() __attribute__((goblint_precision("no-def_exc"))) {
   printf("y is %d", y);
 }
 
-void foo(int (*a)[40]) __attribute__((goblint_precision("no-def_exc"))){
+void foo(int (*a)[40]) {
   int x = (*(a + 29))[7];
   assert(x == 23); //UNKNOWN
 }
 
-void example11() __attribute__((goblint_precision("no-def_exc")))
+void example11()
 {
   int b[40][40];
   b[7][7] = 23;

--- a/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
@@ -1,4 +1,7 @@
 // PARAM: --set solver td3 --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+void example1(void) __attribute__((goblint_precision("no-def_exc","interval")));
+void example2(void) __attribute__((goblint_precision("no-def_exc","interval")));
+
 int main(void) {
     example1();
     example2();
@@ -6,7 +9,7 @@ int main(void) {
 }
 
 // Two-dimensional array
-void example1(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void example1(void) {
     int a[10][10];
     int i=0;
     int j=0;
@@ -36,7 +39,7 @@ void example1(void) __attribute__((goblint_precision("no-def_exc","interval"))) 
 }
 
 // Combines backwards- and forwards-iteration
-void example2(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void example2(void) {
     int array[10][10];
     int i = 9;
 

--- a/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
@@ -22,7 +22,18 @@ union uStruct {
   struct kala k;
 };
 
-int main(void) __attribute__((goblint_precision("no-interval"))) {
+int main(void) __attribute__((goblint_precision("no-interval")));
+void example1() __attribute__((goblint_precision("no-def_exc")));
+void example2() __attribute__((goblint_precision("no-def_exc")));
+void example3() __attribute__((goblint_precision("no-def_exc")));
+void example4() __attribute__((goblint_precision("no-def_exc")));
+void example5() __attribute__((goblint_precision("no-def_exc")));
+void example6() __attribute__((goblint_precision("no-def_exc")));
+void example7() __attribute__((goblint_precision("no-def_exc")));
+void example8() __attribute__((goblint_precision("no-def_exc")));
+
+
+int main(void) {
   example1();
   example2();
   example3();
@@ -34,7 +45,7 @@ int main(void) __attribute__((goblint_precision("no-interval"))) {
   return 0;
 }
 
-void example1() __attribute__((goblint_precision("no-def_exc"))) {
+void example1() {
   struct kala l;
   int i = 0;
   int top;
@@ -63,7 +74,7 @@ void example1() __attribute__((goblint_precision("no-def_exc"))) {
   assert(l.a[4] == 42);
 }
 
-void example2() __attribute__((goblint_precision("no-def_exc"))) {
+void example2() {
   struct kala kalas[5];
 
   int i2 = 0;
@@ -82,7 +93,7 @@ void example2() __attribute__((goblint_precision("no-def_exc"))) {
   assert(kalas[0].a[0] == 8);
 }
 
-void example3() __attribute__((goblint_precision("no-def_exc"))) {
+void example3() {
   struct kala xnn;
   for(int l=0; l < 5; l++) {
       xnn.a[l] = 42;
@@ -91,7 +102,7 @@ void example3() __attribute__((goblint_precision("no-def_exc"))) {
   assert(xnn.a[3] == 42);
 }
 
-void example4() __attribute__((goblint_precision("no-def_exc"))) {
+void example4() {
   struct kala xn;
 
   struct kala xs[5];
@@ -106,7 +117,7 @@ void example4() __attribute__((goblint_precision("no-def_exc"))) {
   assert(xs[3].a[0] == 7);
 }
 
-void example5() __attribute__((goblint_precision("no-def_exc"))) {
+void example5() {
   // This example is a bit contrived to show that splitting and moving works for
   // unions
   union uArray ua;
@@ -145,7 +156,7 @@ void example5() __attribute__((goblint_precision("no-def_exc"))) {
   assert(us.k.a[0] == 0); // FAIL
 }
 
-void example6() __attribute__((goblint_precision("no-def_exc"))) {
+void example6() {
   int a[42];
   int i = 0;
 
@@ -165,7 +176,7 @@ void example6() __attribute__((goblint_precision("no-def_exc"))) {
   assert(a[k.v] != 3);
 }
 
-void example7() __attribute__((goblint_precision("no-def_exc"))) {
+void example7() {
   // Has no asserts, just checks this doesn't cause an infinite loop
   int a[42];
   int i = 0;
@@ -179,7 +190,7 @@ void example7() __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Test correct behavior with more involved expression in subscript operator
-void example8() __attribute__((goblint_precision("no-def_exc"))) {
+void example8() {
   int a[42];
   union uArray ua;
 

--- a/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
@@ -1,11 +1,17 @@
 // PARAM: --set solver td3 --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+
+void example1() __attribute__((goblint_precision("no-def_exc","interval")));
+void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval")));
+void example2(void) __attribute__((goblint_precision("no-def_exc","interval")));
+void callee(int* arr) __attribute__((goblint_precision("no-def_exc","interval"))) ;
+
 int main(void) {
   example1();
   example2();
 }
 
 // ----------------------------------- Example 1 ------------------------------------------------------------------------------
-void example1() __attribute__((goblint_precision("no-def_exc","interval"))) {
+void example1() {
   int a[20];
   int b[20];
 
@@ -27,7 +33,7 @@ void do_first(int* arr) {
   arr[0] = 3;
 }
 
-void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void init_array(int* arr, int val) {
   for(int i = 0; i < 20; i++) {
       arr[i] = val;
   }
@@ -39,7 +45,7 @@ void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc"
 
 // ----------------------------------- Example 2 ------------------------------------------------------------------------------
 
-void example2(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void example2(void) {
   int arr[20];
 
   for(int i = 0; i < 20; i++)
@@ -62,6 +68,6 @@ void example2(void) __attribute__((goblint_precision("no-def_exc","interval"))) 
   assert(arr[20] == 42); //UNKNOWN
 }
 
-void callee(int* arr) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void callee(int* arr) {
   arr[0] = 7;
 }

--- a/tests/regression/42-annotated-precision/13-22_07-global_array.c
+++ b/tests/regression/42-annotated-precision/13-22_07-global_array.c
@@ -1,7 +1,10 @@
 // PARAM: --set solver td3 --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int global_array[50];
 
-int main(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
+int main(void) __attribute__((goblint_precision("no-def_exc","interval")));
+void some_func(void) __attribute__((goblint_precision("no-def_exc","interval")));
+
+int main(void) {
   some_func();
 
   int x = global_array[5];
@@ -10,7 +13,7 @@ int main(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
 }
 
 
-void some_func(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void some_func(void) {
   global_array[0] = 5;
 
   for(int i=1; i < 50; i++) {

--- a/tests/regression/42-annotated-precision/14-22_10-array_octagon.c
+++ b/tests/regression/42-annotated-precision/14-22_10-array_octagon.c
@@ -1,5 +1,21 @@
 // PARAM: --set solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','octagon','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
-void main(void) __attribute__((goblint_precision("no-interval"))) {
+
+void main(void) __attribute__((goblint_precision("no-interval")));
+void example1(void) __attribute__((goblint_precision("no-def_exc")));
+void example2(void) __attribute__((goblint_precision("no-def_exc")));
+void example3(void) __attribute__((goblint_precision("no-def_exc")));
+void example4(void) __attribute__((goblint_precision("no-def_exc")));
+void example4a(void) __attribute__((goblint_precision("no-def_exc")));
+void example4b(void) __attribute__((goblint_precision("no-def_exc")));
+void example4c(void) __attribute__((goblint_precision("no-def_exc")));
+void example5(void) __attribute__((goblint_precision("no-def_exc")));
+void example6(void) __attribute__((goblint_precision("no-def_exc")));
+void example7(void) __attribute__((goblint_precision("no-def_exc")));
+void example8(void) __attribute__((goblint_precision("no-def_exc")));
+void mineEx1(void) __attribute__((goblint_precision("no-def_exc")));
+
+
+void main(void) {
   example1();
   example2();
   example3();
@@ -14,7 +30,7 @@ void main(void) __attribute__((goblint_precision("no-interval"))) {
   mineEx1();
 }
 
-void example1(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example1(void) {
   int a[20];
   int i = 0;
   int j = 0;
@@ -56,7 +72,7 @@ void example1(void) __attribute__((goblint_precision("no-def_exc"))) {
   assert(a[z] == 0); //FAIL
 }
 
-void example2(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example2(void) {
   int a[20];
   int i = 0;
   int j = 0;
@@ -99,7 +115,7 @@ void example2(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Simple example (employing MustBeEqual)
-void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example3(void) {
   int a[42];
   int i = 0;
   int x;
@@ -114,7 +130,7 @@ void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Simple example (employing MayBeEqual / MayBeSmaller)
-void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4(void) {
   int a[42];
   int i = 0;
 
@@ -139,7 +155,7 @@ void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 // Just like the example before except that it tests correct behavior when variable order is reversed
-void example4a(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4a(void) {
   int a[42];
   int j;
   int i = 0;
@@ -162,7 +178,7 @@ void example4a(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Just like the example before except that it tests correct behavior when operands for + are reversed
-void example4b(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4b(void) {
   int a[42];
   int j;
   int i = 0;
@@ -185,7 +201,7 @@ void example4b(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Like example before but iterating backwards
-void example4c(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4c(void) {
   int a[42];
   int j;
   int i = 41;
@@ -202,7 +218,7 @@ void example4c(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 
-void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example5(void) {
   int a[40];
   int i = 0;
 
@@ -228,7 +244,7 @@ void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 
-void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example6(void) {
   int a[42];
   int i = 0;
   int top;
@@ -247,7 +263,7 @@ void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 
-void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example7(void) {
   int top;
 
   int a[42];
@@ -271,7 +287,7 @@ void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 
-void example8(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example8(void) {
   int a[42];
   int i = 0;
   int j = i;
@@ -307,7 +323,7 @@ void example8(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
-void mineEx1(void) __attribute__((goblint_precision("no-def_exc"))) {
+void mineEx1(void) {
   int X = 0;
   int N = rand();
   if(N < 0) { N = 0; }

--- a/tests/regression/42-annotated-precision/15-23_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/15-23_01-simple_array.c
@@ -1,7 +1,17 @@
 // PARAM: --set solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int global;
 
-int main(void) __attribute__((goblint_precision("no-interval")))
+int main(void) __attribute__((goblint_precision("no-interval")));
+void example1(void) __attribute__((goblint_precision("no-def_exc")));
+void example2(void) __attribute__((goblint_precision("no-def_exc")));
+void example3(void) __attribute__((goblint_precision("no-def_exc")));
+void example4(void) __attribute__((goblint_precision("no-def_exc")));
+void example5(void) __attribute__((goblint_precision("no-def_exc")));
+void example6(void) __attribute__((goblint_precision("no-def_exc")));
+void example7(void) __attribute__((goblint_precision("no-def_exc")));
+void example8() __attribute__((goblint_precision("no-def_exc")));
+
+int main(void)
 {
     example1();
     example2();
@@ -15,7 +25,7 @@ int main(void) __attribute__((goblint_precision("no-interval")))
 }
 
 // Simple example
-void example1(void) __attribute__((goblint_precision("no-def_exc")))
+void example1(void)
 {
     int a[42];
     int i = 0;
@@ -35,7 +45,7 @@ void example1(void) __attribute__((goblint_precision("no-def_exc")))
 }
 
 // More complicated expression to index rather than just a variable
-void example2(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example2(void) {
     int a[42];
     int i = 1;
 
@@ -52,7 +62,7 @@ void example2(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Two values initialized in one loop
-void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example3(void) {
     int a[42];
     int i = 0;
 
@@ -70,7 +80,7 @@ void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Example where initialization proceeds backwards
-void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4(void) {
     int a[42];
     int i = 41;
 
@@ -86,7 +96,7 @@ void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Example having two arrays partitioned according to one expression
-void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example5(void) {
     int a[42];
     int b[42];
     int i = 0;
@@ -107,7 +117,7 @@ void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Example showing array becoming partitioned according to different expressions
-void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example6(void) {
     int a[42];
     int i = 0;
     int j = 0;
@@ -137,7 +147,7 @@ void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // This was the case where we thought we needed path-splitting
-void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example7(void) {
     int a[42];
     int i = 0;
     int top;
@@ -156,8 +166,8 @@ void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
     assert(a[top] == 0); // UNKNOWN
 }
 
-// Check that the global variable is not used for paritioning
-void example8() __attribute__((goblint_precision("no-def_exc"))) {
+// Check that the global variable is not used for partitioning
+void example8() {
     int a[10];
 
     a[global] = 4;

--- a/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
@@ -1,5 +1,16 @@
 // PARAM: --set solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
-int main(void) __attribute__((goblint_precision("no-interval"))) {
+
+int main(void) __attribute__((goblint_precision("no-interval")));
+void example1(void) __attribute__((goblint_precision("no-def_exc")));
+void example2() __attribute__((goblint_precision("no-def_exc")));
+void example3(void) __attribute__((goblint_precision("no-def_exc")));
+void example4(void) __attribute__((goblint_precision("no-def_exc")));
+void example5(void) __attribute__((goblint_precision("no-def_exc")));
+void example6(void) __attribute__((goblint_precision("no-def_exc")));
+void example7(void) __attribute__((goblint_precision("no-def_exc")));
+
+
+int main(void) {
     example1();
     example2();
     example3();
@@ -11,7 +22,7 @@ int main(void) __attribute__((goblint_precision("no-interval"))) {
 }
 
 // Initializing an array with pointers
-void example1(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example1(void) {
     int top;
 
     int a[42];
@@ -49,7 +60,7 @@ void example1(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Tests correct handling when pointers may point to several different things
-void example2() __attribute__((goblint_precision("no-def_exc"))) {
+void example2() {
   int array1[10000000];
   int array2[10000000];
 
@@ -74,7 +85,7 @@ void example2() __attribute__((goblint_precision("no-def_exc"))) {
   assert(*ptr == 6); // UNKNOWN
 }
 
-void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example3(void) {
   int array1[5];
   int *ptr = &array1;
 
@@ -85,7 +96,7 @@ void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 
-void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4(void) {
   int array1[5];
   int *ptr = &array1;
   int *end = &(array1[5]);
@@ -99,7 +110,7 @@ void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
   // In an ideal world, I would like to have information about array1[0] and so on. For this the <= would need yo improve
 }
 
-void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example5(void) {
   int array1[5];
   int *ptr = &(array1[4]);
 
@@ -116,7 +127,7 @@ void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
   assert(array1[0] == 42); // UNKNOWN
 }
 
-void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example6(void) {
   int array1[100];
   int* ptr = &array1;
 
@@ -142,7 +153,7 @@ void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
   assert(x==7);
 }
 
-void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example7(void) {
   int top;
 
   int arr1[42];

--- a/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
@@ -5,8 +5,12 @@ int main(void) {
     return 0;
 }
 
+void example1(void) __attribute__((goblint_precision("no-def_exc","interval")));
+void example2(void) __attribute__((goblint_precision("no-def_exc","interval")));
+
+
 // Two-dimensional array
-void example1(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void example1(void) {
     int a[10][10];
     int i=0;
     int j=0;
@@ -36,7 +40,7 @@ void example1(void) __attribute__((goblint_precision("no-def_exc","interval"))) 
 }
 
 // Combines backwards- and forwards-iteration
-void example2(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void example2(void) {
     int array[10][10];
     int i = 9;
 

--- a/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
@@ -22,7 +22,18 @@ union uStruct {
   struct kala k;
 };
 
-int main(void) __attribute__((goblint_precision("no-interval"))) {
+int main(void) __attribute__((goblint_precision("no-interval")));
+void example1() __attribute__((goblint_precision("no-def_exc")));
+void example2() __attribute__((goblint_precision("no-def_exc")));
+void example3() __attribute__((goblint_precision("no-def_exc")));
+void example4() __attribute__((goblint_precision("no-def_exc")));
+void example5() __attribute__((goblint_precision("no-def_exc")));
+void example6() __attribute__((goblint_precision("no-def_exc")));
+void example7() __attribute__((goblint_precision("no-def_exc")));
+void example8() __attribute__((goblint_precision("no-def_exc")));
+
+
+int main(void) {
   example1();
   example2();
   example3();
@@ -34,7 +45,7 @@ int main(void) __attribute__((goblint_precision("no-interval"))) {
   return 0;
 }
 
-void example1() __attribute__((goblint_precision("no-def_exc"))) {
+void example1() {
   struct kala l;
   int i = 0;
   int top;
@@ -56,14 +67,14 @@ void example1() __attribute__((goblint_precision("no-def_exc"))) {
   // Destructively assign to i
   i = top;
 
-  // Check the array is still known to be completly initialized
+  // Check the array is still known to be completely initialized
   assert(l.a[1] == 42);
   assert(l.a[2] == 42);
   assert(l.a[3] == 42);
   assert(l.a[4] == 42);
 }
 
-void example2() __attribute__((goblint_precision("no-def_exc"))) {
+void example2() {
   struct kala kalas[5];
 
   int i2 = 0;
@@ -82,7 +93,7 @@ void example2() __attribute__((goblint_precision("no-def_exc"))) {
   assert(kalas[0].a[0] == 8);
 }
 
-void example3() __attribute__((goblint_precision("no-def_exc"))) {
+void example3() {
   struct kala xnn;
   for(int l=0; l < 5; l++) {
       xnn.a[l] = 42;
@@ -91,7 +102,7 @@ void example3() __attribute__((goblint_precision("no-def_exc"))) {
   assert(xnn.a[3] == 42);
 }
 
-void example4() __attribute__((goblint_precision("no-def_exc"))) {
+void example4() {
   struct kala xn;
 
   struct kala xs[5];
@@ -106,7 +117,7 @@ void example4() __attribute__((goblint_precision("no-def_exc"))) {
   assert(xs[3].a[0] == 7);
 }
 
-void example5() __attribute__((goblint_precision("no-def_exc"))) {
+void example5() {
   // This example is a bit contrived to show that splitting and moving works for
   // unions
   union uArray ua;
@@ -145,7 +156,7 @@ void example5() __attribute__((goblint_precision("no-def_exc"))) {
   assert(us.k.a[0] == 0); // FAIL
 }
 
-void example6() __attribute__((goblint_precision("no-def_exc"))) {
+void example6() {
   int a[42];
   int i = 0;
 
@@ -165,7 +176,7 @@ void example6() __attribute__((goblint_precision("no-def_exc"))) {
   assert(a[k.v] != 3);
 }
 
-void example7() __attribute__((goblint_precision("no-def_exc"))) {
+void example7() {
   // Has no asserts, just checks this doesn't cause an infinite loop
   int a[42];
   int i = 0;
@@ -179,7 +190,7 @@ void example7() __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Test correct behavior with more involved expression in subscript operator
-void example8() __attribute__((goblint_precision("no-def_exc"))) {
+void example8() {
   int a[42];
   union uArray ua;
 

--- a/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
@@ -1,11 +1,16 @@
 // PARAM: --set solver td3 --enable exp.partition-arrays.enabled  --set exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+
+void example1() __attribute__((goblint_precision("no-def_exc","interval")));
+void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval")));
+void example2(void) __attribute__((goblint_precision("no-def_exc","interval")));
+
 int main(void) {
   example1();
   example2();
 }
 
 // ----------------------------------- Example 1 ------------------------------------------------------------------------------
-void example1() __attribute__((goblint_precision("no-def_exc","interval"))) {
+void example1() {
   int a[20];
   int b[20];
 
@@ -27,7 +32,7 @@ void do_first(int* arr) {
   arr[0] = 3;
 }
 
-void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void init_array(int* arr, int val) {
   for(int i = 0; i < 20; i++) {
       arr[i] = val;
   }
@@ -39,7 +44,7 @@ void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc"
 
 // ----------------------------------- Example 2 ------------------------------------------------------------------------------
 
-void example2(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void example2(void) {
   int arr[20];
 
   for(int i = 0; i < 20; i++)

--- a/tests/regression/42-annotated-precision/20-23_10-array_octagon.c
+++ b/tests/regression/42-annotated-precision/20-23_10-array_octagon.c
@@ -1,5 +1,20 @@
 // PARAM: --set solver td3 --enable ana.int.interval --enable exp.partition-arrays.enabled  --set exp.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','octagon','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
-void main(void) __attribute__((goblint_precision("no-interval"))) {
+
+void main(void) __attribute__((goblint_precision("no-interval")));
+void example1(void) __attribute__((goblint_precision("no-def_exc")));
+void example2(void) __attribute__((goblint_precision("no-def_exc")));
+void example3(void) __attribute__((goblint_precision("no-def_exc")));
+void example4(void) __attribute__((goblint_precision("no-def_exc")));
+void example4a(void) __attribute__((goblint_precision("no-def_exc")));
+void example4b(void) __attribute__((goblint_precision("no-def_exc")));
+void example4c(void) __attribute__((goblint_precision("no-def_exc")));
+void example5(void) __attribute__((goblint_precision("no-def_exc")));
+void example6(void) __attribute__((goblint_precision("no-def_exc")));
+void example8(void) __attribute__((goblint_precision("no-def_exc")));
+void mineEx1(void) __attribute__((goblint_precision("no-def_exc")));
+
+
+void main(void) {
   example1();
   example2();
   example3();
@@ -14,7 +29,7 @@ void main(void) __attribute__((goblint_precision("no-interval"))) {
   mineEx1();
 }
 
-void example1(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example1(void) {
   int a[20];
   int i = 0;
   int j = 0;
@@ -56,7 +71,7 @@ void example1(void) __attribute__((goblint_precision("no-def_exc"))) {
   assert(a[z] == 0); //FAIL
 }
 
-void example2(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example2(void) {
   int a[20];
   int i = 0;
   int j = 0;
@@ -99,7 +114,7 @@ void example2(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Simple example (employing MustBeEqual)
-void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example3(void) {
   int a[42];
   int i = 0;
   int x;
@@ -114,7 +129,7 @@ void example3(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Simple example (employing MayBeEqual / MayBeSmaller)
-void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4(void) {
   int a[42];
   int i = 0;
 
@@ -139,7 +154,7 @@ void example4(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 // Just like the example before except that it tests correct behavior when variable order is reversed
-void example4a(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4a(void) {
   int a[42];
   int j;
   int i = 0;
@@ -162,7 +177,7 @@ void example4a(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Just like the example before except that it tests correct behavior when operands for + are reversed
-void example4b(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4b(void) {
   int a[42];
   int j;
   int i = 0;
@@ -185,7 +200,7 @@ void example4b(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Like example before but iterating backwards
-void example4c(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example4c(void) {
   int a[42];
   int j;
   int i = 41;
@@ -202,7 +217,7 @@ void example4c(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 
-void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example5(void) {
   int a[40];
   int i = 0;
 
@@ -228,7 +243,7 @@ void example5(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 
-void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example6(void) {
   int a[42];
   int i = 0;
   int top;
@@ -247,7 +262,7 @@ void example6(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 
-void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example7(void) {
   int top;
 
   int a[42];
@@ -271,7 +286,7 @@ void example7(void) __attribute__((goblint_precision("no-def_exc"))) {
   }
 }
 
-void example8(void) __attribute__((goblint_precision("no-def_exc"))) {
+void example8(void) {
   int a[42];
   int i = 0;
   int j = i;
@@ -307,7 +322,7 @@ void example8(void) __attribute__((goblint_precision("no-def_exc"))) {
 }
 
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
-void mineEx1(void) __attribute__((goblint_precision("no-def_exc"))) {
+void mineEx1(void) {
   int X = 0;
   int N = rand();
   if(N < 0) { N = 0; }

--- a/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
+++ b/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
@@ -1,10 +1,14 @@
 // PARAM: --set solver td3 --enable exp.partition-arrays.enabled --set exp.partition-arrays.keep-expr "last" --enable exp.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set exp.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+
+void example1() __attribute__((goblint_precision("no-def_exc","interval")));
+void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval")));
+
 int main(void) {
   example1();
 }
 
 // ----------------------------------- Example 1 ------------------------------------------------------------------------------
-void example1() __attribute__((goblint_precision("no-def_exc","interval"))) {
+void example1() {
   int a[20];
   int b[20];
 
@@ -26,7 +30,7 @@ void do_first(int* arr) {
   arr[0] = 3;
 }
 
-void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void init_array(int* arr, int val) {
   for(int i = 0; i < 15; i++) {
       arr[i] = val;
   }

--- a/tests/regression/42-annotated-precision/22-26_05-dynamically-sized-array-oob-access.c
+++ b/tests/regression/42-annotated-precision/22-26_05-dynamically-sized-array-oob-access.c
@@ -2,9 +2,11 @@
 
 // Variable sized array: oob access
 
+int main() __attribute__((goblint_precision("no-def_exc","interval")));
+
 #include <stdio.h>
 #include <stdlib.h>
-int main() __attribute__((goblint_precision("no-def_exc","interval"))) {
+int main() {
   int top;
   int N;
 // The if statement is needed, so the size is actually dynamic

--- a/tests/regression/42-annotated-precision/23-26_07-arrays-within-structures.c
+++ b/tests/regression/42-annotated-precision/23-26_07-arrays-within-structures.c
@@ -2,7 +2,10 @@
 // Arrays within structures. Source of sample struct:
 // https://codeforwin.org/2018/07/how-to-declare-initialize-and-access-array-of-structure.html
 #include <stdio.h>
-int main() __attribute__((goblint_precision("no-def_exc","interval"))) {
+
+int main() __attribute__((goblint_precision("no-def_exc","interval")));
+
+int main() {
   struct student {
     char name[100];
     int roll;

--- a/tests/regression/42-annotated-precision/24-30_02-off.c
+++ b/tests/regression/42-annotated-precision/24-30_02-off.c
@@ -3,7 +3,9 @@
 int global_array[50];
 int global_array_multi[50][2][2];
 
-int main(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
+int main(void) __attribute__((goblint_precision("no-def_exc","interval")));
+
+int main(void) {
   for(int i =0; i < 50; i++) {
       assert(global_array[i] == 0);
       assert(global_array_multi[i][1][1] == 0);

--- a/tests/regression/42-annotated-precision/25-34_01-nested.c
+++ b/tests/regression/42-annotated-precision/25-34_01-nested.c
@@ -3,7 +3,9 @@
 // Localized widening should be able to prove that i=10 at the end
 // of the nested loops.
 
-void main() __attribute__((goblint_precision("no-def_exc","interval")))
+void main() __attribute__((goblint_precision("no-def_exc","interval")));
+
+void main()
 {
    int i = 0;
 

--- a/tests/regression/42-annotated-precision/26-34_02-hybrid.c
+++ b/tests/regression/42-annotated-precision/26-34_02-hybrid.c
@@ -2,8 +2,9 @@
 // Example from Amato-Scozzari, SAS 2013
 // Localized narrowing with restart policy should be able to prove that
 // 0 <= i <= 10 inside the inner loop.
+void main() __attribute__((goblint_precision("no-def_exc","interval")));
 
-void main() __attribute__((goblint_precision("no-def_exc","interval")))
+void main()
 {
    int i = 0;
    while (1) {

--- a/tests/regression/42-annotated-precision/27-01_03-loops.c
+++ b/tests/regression/42-annotated-precision/27-01_03-loops.c
@@ -1,8 +1,9 @@
 // PARAM: --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include<stdio.h>
 #include<assert.h>
+int main () __attribute__((goblint_precision("def_exc")));
 
-int main () __attribute__((goblint_precision("def_exc"))) {
+int main () {
   int i,j,k;
 
   i = k = 0; j = 7;

--- a/tests/regression/42-annotated-precision/28-02_36-calloc_struct.c
+++ b/tests/regression/42-annotated-precision/28-02_36-calloc_struct.c
@@ -10,7 +10,9 @@ typedef struct {
 
 data *d;
 
-int main(void) __attribute__((goblint_precision("no-def_exc","interval"))) {
+int main(void) __attribute__((goblint_precision("no-def_exc","interval")));
+
+int main(void) {
     d = calloc(1,sizeof(data));
     d -> x = 0;
     d -> y = 0;

--- a/tests/regression/42-annotated-precision/29-07_14-struct_in_struct.c
+++ b/tests/regression/42-annotated-precision/29-07_14-struct_in_struct.c
@@ -8,33 +8,42 @@ typedef struct {
 	int i;
 } T;
 
-void init_S(S *x) __attribute__((goblint_precision("def_exc"))) {
+void init_S(S *x) __attribute__((goblint_precision("def_exc")));
+S ret_S() __attribute__((goblint_precision("def_exc")));
+void mod_S1(S *z) __attribute__((goblint_precision("def_exc")));
+void mod_S2(S *z) __attribute__((goblint_precision("def_exc")));
+void mod_S31(S *z) __attribute__((goblint_precision("def_exc")));
+void mod_S32(S *z) __attribute__((goblint_precision("def_exc")));
+int main() __attribute__((goblint_precision("def_exc")));
+
+
+void init_S(S *x) {
 	x->i = 0;
 }
 
-S ret_S() __attribute__((goblint_precision("def_exc"))) {
+S ret_S() {
 	S y;
 	y.i = 0;
 	return y;
 }
 
-void mod_S1(S *z) __attribute__((goblint_precision("def_exc"))) {
+void mod_S1(S *z) {
 	z->i = z->i + 1; //NOWARN
 }
 
-void mod_S2(S *z) __attribute__((goblint_precision("def_exc"))) {
+void mod_S2(S *z) {
 	z->i = z->i + 1; //NOWARN
 }
 
-void mod_S31(S *z) __attribute__((goblint_precision("def_exc"))) {
+void mod_S31(S *z) {
 	z->i = z->i + 1; //WARN
 }
 
-void mod_S32(S *z) __attribute__((goblint_precision("def_exc"))) {
+void mod_S32(S *z) {
 	z->i = z->i + 1; //NOWARN
 }
 
-int main() __attribute__((goblint_precision("def_exc"))) {
+int main() {
 	T tt1,tt2,tt3;
 	int q = 0;
 

--- a/tests/regression/42-annotated-precision/30-31_12-log-bitwise-enums.c
+++ b/tests/regression/42-annotated-precision/30-31_12-log-bitwise-enums.c
@@ -3,7 +3,9 @@
 #include<assert.h>
 #include<stdio.h>
 
-int main() __attribute__((goblint_precision("no-def_exc","enums"))) {
+int main() __attribute__((goblint_precision("no-def_exc","enums")));
+
+int main() {
     int x = 2;
     int y = 3;
     int n = 0;

--- a/tests/regression/42-annotated-precision/31-37_04-branching.c
+++ b/tests/regression/42-annotated-precision/31-37_04-branching.c
@@ -1,5 +1,7 @@
 // PARAM: --set sem.int.signed_overflow assume_none --enable annotation.int.enabled --set ana.int.refinement fixpoint
-int main() __attribute__((goblint_precision("no-def_exc","congruence"))) {
+int main() __attribute__((goblint_precision("no-def_exc","congruence")));
+
+int main() {
     // A refinement of a congruence class should only take place for the == and != operator.
     int i;
     if (i==0){

--- a/tests/regression/42-annotated-precision/32-01_03-loops_i.c
+++ b/tests/regression/42-annotated-precision/32-01_03-loops_i.c
@@ -1,8 +1,9 @@
 // PARAM: --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include<stdio.h>
 #include<assert.h>
+int main () __attribute__((goblint_precision("no-def_exc","interval")));
 
-int main () __attribute__((goblint_precision("no-def_exc","interval"))) {
+int main () {
   int i,j,k;
 
   i = k = 0; j = 7;

--- a/tests/regression/42-annotated-precision/33-02_36-calloc_struct_i.c
+++ b/tests/regression/42-annotated-precision/33-02_36-calloc_struct_i.c
@@ -9,8 +9,9 @@ typedef struct {
 } data;
 
 data *d;
+int main(void) __attribute__((goblint_precision("no-def_exc","interval","enums")));
 
-int main(void) __attribute__((goblint_precision("no-def_exc","interval","enums"))) {
+int main(void) {
     d = calloc(1,sizeof(data));
     d -> x = 0;
     d -> y = 0;

--- a/tests/regression/42-annotated-precision/34-07_14-struct_in_struct_i.c
+++ b/tests/regression/42-annotated-precision/34-07_14-struct_in_struct_i.c
@@ -8,33 +8,41 @@ typedef struct {
 	int i;
 } T;
 
-void init_S(S *x) __attribute__((goblint_precision("def_exc"))) {
+void init_S(S *x) __attribute__((goblint_precision("def_exc")));
+S ret_S() __attribute__((goblint_precision("def_exc")));
+void mod_S1(S *z) __attribute__((goblint_precision("def_exc")));
+void mod_S2(S *z) __attribute__((goblint_precision("def_exc")));
+void mod_S31(S *z) __attribute__((goblint_precision("def_exc")));
+void mod_S32(S *z) __attribute__((goblint_precision("no-def_exc","interval")));
+int main() __attribute__((goblint_precision("def_exc")));
+
+void init_S(S *x) {
 	x->i = 0;
 }
 
-S ret_S() __attribute__((goblint_precision("def_exc"))) {
+S ret_S() {
 	S y;
 	y.i = 0;
 	return y;
 }
 
-void mod_S1(S *z) __attribute__((goblint_precision("def_exc"))) {
+void mod_S1(S *z) {
 	z->i = z->i + 1; //NOWARN
 }
 
-void mod_S2(S *z) __attribute__((goblint_precision("def_exc"))) {
+void mod_S2(S *z) {
 	z->i = z->i + 1; //NOWARN
 }
 
-void mod_S31(S *z) __attribute__((goblint_precision("def_exc"))) {
+void mod_S31(S *z) {
 	z->i = z->i + 1; //WARN
 }
 
-void mod_S32(S *z) __attribute__((goblint_precision("no-def_exc","interval"))) {
+void mod_S32(S *z) {
 	z->i = z->i + 1; //WARN
 }
 
-int main() __attribute__((goblint_precision("def_exc"))) {
+int main() {
 	T tt1,tt2,tt3;
 	int q = 0;
 

--- a/tests/regression/42-annotated-precision/35-31_12-log-bitwise-enums_i.c
+++ b/tests/regression/42-annotated-precision/35-31_12-log-bitwise-enums_i.c
@@ -2,8 +2,9 @@
 
 #include<assert.h>
 #include<stdio.h>
+int main() __attribute__((goblint_precision("no-def_exc","interval")));
 
-int main() __attribute__((goblint_precision("no-def_exc","interval"))) {
+int main() {
     int x = 2;
     int y = 3;
     int n = 0;

--- a/tests/regression/42-annotated-precision/36-37_04-branching_i.c
+++ b/tests/regression/42-annotated-precision/36-37_04-branching_i.c
@@ -1,5 +1,7 @@
 // PARAM: --set sem.int.signed_overflow assume_none --enable annotation.int.enabled --set ana.int.refinement fixpoint
-int main() __attribute__((goblint_precision("no-def_exc","interval","congruence"))) {
+int main() __attribute__((goblint_precision("no-def_exc","interval","congruence")));
+
+int main() {
     // A refinement of a congruence class should only take place for the == and != operator.
     int i;
     if (i==0){

--- a/tests/regression/42-annotated-precision/37-def_exc-via-option.c
+++ b/tests/regression/42-annotated-precision/37-def_exc-via-option.c
@@ -1,0 +1,15 @@
+// PARAM: --enable annotation.int.enabled --set ana.int.refinement fixpoint --set annotation.goblint_precision.def_exc[+] f --set annotation.goblint_precision.interval[+] f  --set annotation.goblint_precision.def_exc[+] main
+#include<assert.h>
+
+int f(int in) {
+  in++;
+  return in;
+}
+
+int main() {
+  int a = 0;
+  assert(a); // FAIL!
+  a = f(a);
+  assert(a);
+  return 0;
+}


### PR DESCRIPTION
This adds the option to configure per-function options not just via annotations in the source code but also via dedicated options.

On a side note, it also fixes the placement of these attributes such that the programs inf folder `42` are not rejected by GCC.
Closes #491, #492 