### PR TITLE
Bump goblint-cil to add C11 generic support

### DIFF
--- a/goblint.opam
+++ b/goblint.opam
@@ -58,7 +58,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 pin-depends: [
-  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#568dc23716a2a5f308fc8e332c7a0ef1302823c4" ]
+  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#a6aa225b362e7bdd140810041901e5e2e85a436e" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # quoter workaround reverted for release, so no pin needed

--- a/goblint.opam
+++ b/goblint.opam
@@ -58,7 +58,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 pin-depends: [
-  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#f3a075d0dab06c3b05ff31a34c02c3a4ec8ff8f9" ]
+  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#568dc23716a2a5f308fc8e332c7a0ef1302823c4" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # quoter workaround reverted for release, so no pin needed

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -94,7 +94,7 @@ version: "dev"
 pin-depends: [
   [
     "goblint-cil.1.8.2"
-    "git+https://github.com/goblint/cil.git#f3a075d0dab06c3b05ff31a34c02c3a4ec8ff8f9"
+    "git+https://github.com/goblint/cil.git#568dc23716a2a5f308fc8e332c7a0ef1302823c4"
   ]
   [
     "apron.v0.9.13"

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -94,7 +94,7 @@ version: "dev"
 pin-depends: [
   [
     "goblint-cil.1.8.2"
-    "git+https://github.com/goblint/cil.git#568dc23716a2a5f308fc8e332c7a0ef1302823c4"
+    "git+https://github.com/goblint/cil.git#a6aa225b362e7bdd140810041901e5e2e85a436e"
   ]
   [
     "apron.v0.9.13"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -1,7 +1,7 @@
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 pin-depends: [
-  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#568dc23716a2a5f308fc8e332c7a0ef1302823c4" ]
+  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#a6aa225b362e7bdd140810041901e5e2e85a436e" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # quoter workaround reverted for release, so no pin needed

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -1,7 +1,7 @@
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 pin-depends: [
-  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#f3a075d0dab06c3b05ff31a34c02c3a4ec8ff8f9" ]
+  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#568dc23716a2a5f308fc8e332c7a0ef1302823c4" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # quoter workaround reverted for release, so no pin needed

--- a/includes/stdlib.c
+++ b/includes/stdlib.c
@@ -30,8 +30,8 @@ void qsort(void *ptr, size_t count, size_t size, int (*comp)(const void*, const 
 }
 
 
-void* bsearch(const void *key, void *ptr, size_t count, size_t size, int (*comp)(const void*, const void*))  __attribute__((goblint_stub));
-void* bsearch(const void *key, void *ptr, size_t count, size_t size, int (*comp)(const void*, const void*)) {
+void* bsearch(const void *key, const void *ptr, size_t count, size_t size, int (*comp)(const void*, const void*))  __attribute__((goblint_stub));
+void* bsearch(const void *key, const void *ptr, size_t count, size_t size, int (*comp)(const void*, const void*)) {
   // linear search for simplicity
   for (size_t i = 0; i < count; i++) {
     const void *a = ptr + i * size;


### PR DESCRIPTION
Bump goblint-cil so changes from https://github.com/goblint/cil/pull/48 become available. Currently still fails for the following tests:

`12 test(s) failed: ["00/14 startstate", "04/33 kernel_rc", "04/34 kernel_nr", "04/39 rw_lock_nr", "04/40 rw_lock_rc", "04/48 assign_spawn", "04/53 kernel-spinlock", "09/07 kernel_list_rc", "09/08 kernel_list_nr", "09/14 kernel_foreach_rc", "09/15 kernel_foreach_nr", "41/02 bsearch"]`