### PR TITLE
Fix known addresses not escaping when address set contains unknown

### DIFF
--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -108,7 +108,7 @@ struct
         match ask.f (Queries.ReachableFrom e) with
         | a when not (Queries.LS.is_top a)  ->
           let to_extra (v,o) xs = AD.from_var_offset (v,(conv_offset o)) :: xs  in
-          Queries.LS.fold to_extra a []
+          Queries.LS.fold to_extra (Queries.LS.remove (dummyFunDec.svar, `NoOffset) a) []
         (* Ignore soundness warnings, as invalidation proper will raise them. *)
         | _ -> []
       in

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -62,7 +62,9 @@ struct
       let to_extra (v,o) set = D.add v set in
       Queries.LS.fold to_extra a (D.empty ())
     (* Ignore soundness warnings, as invalidation proper will raise them. *)
-    | _ -> D.empty ()
+    | a ->
+      if M.tracing then M.tracel "escape" "reachable %a: %a\n" d_exp e Queries.LS.pretty a;
+      D.empty ()
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     ctx.local
@@ -84,6 +86,7 @@ struct
       match args with
       | [ptc_arg] ->
         let escaped = fctx.local in (* reuse reachable computation from threadenter *)
+        if M.tracing then M.tracel "escape" "%a: %a\n" d_exp ptc_arg D.pretty escaped;
         if not (D.is_empty escaped) then (* avoid emitting unnecessary event *)
           ctx.emit (Events.Escape escaped);
         escaped

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -60,7 +60,7 @@ struct
     | a when not (Queries.LS.is_top a) ->
       (* let to_extra (v,o) set = D.add (Addr.from_var_offset (v, cut_offset o)) set in *)
       let to_extra (v,o) set = D.add v set in
-      Queries.LS.fold to_extra a (D.empty ())
+      Queries.LS.fold to_extra (Queries.LS.remove (dummyFunDec.svar, `NoOffset) a) (D.empty ())
     (* Ignore soundness warnings, as invalidation proper will raise them. *)
     | a ->
       if M.tracing then M.tracel "escape" "reachable %a: %a\n" d_exp e Queries.LS.pretty a;

--- a/src/analyses/uninit.ml
+++ b/src/analyses/uninit.ml
@@ -89,7 +89,7 @@ struct
       match ask (Queries.ReachableFrom e) with
       | a when not (Queries.LS.is_top a) ->
         let to_extra (v,o) xs = (v, Base.Offs.from_offset (conv_offset o), true) :: xs  in
-        Queries.LS.fold to_extra a []
+        Queries.LS.fold to_extra (Queries.LS.remove (dummyFunDec.svar, `NoOffset) a) []
       (* Ignore soundness warnings, as invalidation proper will raise them. *)
       | _ -> []
     in
@@ -227,7 +227,7 @@ struct
         match ask.f (Queries.ReachableFrom e) with
         | a when not (Queries.LS.is_top a) ->
           let to_extra (v,o) xs = AD.from_var_offset (v,(conv_offset o)) :: xs  in
-          Queries.LS.fold to_extra a []
+          Queries.LS.fold to_extra (Queries.LS.remove (dummyFunDec.svar, `NoOffset) a) []
         (* Ignore soundness warnings, as invalidation proper will raise them. *)
         | _ -> []
       in

--- a/tests/regression/02-base/70-escape-unknown.c
+++ b/tests/regression/02-base/70-escape-unknown.c
@@ -1,0 +1,28 @@
+#include <pthread.h>
+#include <assert.h>
+
+int *p;
+
+void *t_fun(void *arg) {
+  if (arg != NULL) {
+    *((int*)arg) = 42;
+  }
+  return NULL;
+}
+
+int main() {
+  pthread_t id, id2;
+  int *r; // unknown
+  int i = 5;
+
+  pthread_create(&id, NULL, t_fun, NULL); // enter multithreaded
+
+  p = r;
+  p = &i;
+
+  pthread_create(&id2, NULL, t_fun, p); // i should escape, even if p contains unknown
+
+  assert(i == 5); // UNKNOWN!
+
+  return 0;
+}


### PR DESCRIPTION
Previously any address set containing the unknown pointer returned top from the reachable query. The thread escape analysis completely ignores such escaping (it has no information, even about the addresses that were known).

This PR changes the reachable query to still return a non-top lvalue set, which contains the usual dummy as a representative for the unknown pointer, along all the known ones. This is similar to the points-to query.
Other analyses still ignore the dummy, but at least they can be a bit more sound w.r.t. to the known addresses.

This fixes the incomparability of `aget_comb01.patch` with RestartBothOnce in the interactive benchmarks.