### PR TITLE
DefExc.widen Excluded range to static size instead of join

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1390,7 +1390,7 @@ struct
     | `Excluded (xs,xr), `Excluded (ys,yr) ->
       Exclusion.(leq (Exc (xs,xr)) (Exc (ys, yr)))
 
-  let join ik x y =
+  let join' ?range ik x y =
     match (x,y) with
     (* The least upper bound with the bottom element: *)
     | `Bot, x -> x
@@ -1414,9 +1414,10 @@ struct
       else
         `Excluded (S.remove x s, r)
     (* For two exclusion sets, only their intersection can be excluded: *)
-    | `Excluded (x,wx), `Excluded (y,wy) -> `Excluded (S.inter x y, R.join wx wy)
+    | `Excluded (x,wx), `Excluded (y,wy) -> `Excluded (S.inter x y, range |? R.join wx wy)
 
-  let widen = join
+  let join ik = join' ik
+  let widen ik = join' ~range:(size ik) ik
 
   let meet ik x y =
     match (x,y) with


### PR DESCRIPTION
In `DefExc` we currently have `let widen = join`.
As I see it, this causes extra iterations for little to no gain.

Consider this loop:
```c
int main() {
  int i = 0;
  while (i < 10)
    i++;
  return i;
}
```

The excluded range via `join` already does something like a threshold widening by going through the intermediate int sizes (`i++` overflows range) before reaching the static type:
```
i -> (0,[0,0])
i -> (Unknown int([0,7]),[0,9])
i -> (Unknown int([0,8]),[0,9])
i -> (Unknown int([0,16]),[0,9])
i -> (Unknown int([-31,31]),[0,9])
i -> (Unknown int([-31,31]),[0,9])
```
 
Instead of doing this, one can jump to the static type directly for `widen` and only keep this stepwise behavior for `join`.

```console
$ ./goblint wp.c --html --enable ana.int.interval --trace sol2 2>&1 | grep ' solve node 79' | wc -l
11
```
from 15 calls to `solve` without this change.

I tried to find an example where you would get a less precise exclusion range.
But here for `i` we already have `[-31,31]` with `widen = join`:
```c
int main () {
  for (int i = 0; i < 10; i++) {
    char j = 0;
    for (; j < 10; j++) ;
    i = j;
    j = 0;
  }
}
```
I guess you can construct some example where you widen some value in a loop that is not changed each iteration but only joined from some branches.
However, the saved iterations for every int loop probably outweigh this loss.