### PR TITLE
Better interactive tests

### DIFF
--- a/scripts/test-incremental.sh
+++ b/scripts/test-incremental.sh
@@ -15,11 +15,11 @@ args="--enable dbg.debug --enable printstats -v"
 
 ./goblint --conf $conf $args --enable incremental.save $source &> $base/$test.before.log
 
-patch -b $source $patch
+patch -p0 -b <$patch
 
 ./goblint --conf $conf $args --enable incremental.load --set save_run $base/$test-incrementalrun $source &> $base/$test.after.incr.log
 ./goblint --conf $conf $args --enable incremental.only-rename --set save_run $base/$test-originalrun $source &> $base/$test.after.scratch.log
 ./goblint --conf $conf --enable solverdiffs --compare_runs $base/$test-originalrun $base/$test-incrementalrun $source
 
-patch -b -R $source $patch
+patch -p0 -b -R <$patch
 rm -r $base/$test-originalrun $base/$test-incrementalrun

--- a/scripts/update_suite.rb
+++ b/scripts/update_suite.rb
@@ -405,9 +405,9 @@ class ProjectIncr < Project
   def create_test_set(lines)
     super(lines)
     @testset.p = self
-    `patch -b #{path} #{patch_path}`
+    `patch -p0 -b <#{patch_path}`
     lines_incr = IO.readlines(path)
-    `patch -b -R #{path} #{patch_path}`
+    `patch -p0 -b -R <#{patch_path}`
     @testset_incr = parse_tests(lines_incr)
     @testset_incr.p = self
     @testset_incr.warnfile = File.join($testresults, group, name + ".incr.warn.txt")
@@ -423,19 +423,19 @@ class ProjectIncr < Project
     starttime = Time.now
     run_testset(@testset_incr, cmd, starttime)
     # apply patch
-    `patch -b #{@path} #{@patch_path}`
+    `patch -p3 -b <#{@patch_path}`
     starttime = Time.now
     run_testset(@testset_incr, cmd_incr, starttime)
     # revert patch
-    `patch -b -R #{@path} #{@patch_path}`
+    `patch -p3 -b -R <#{@patch_path}`
     FileUtils.rm_rf('incremental_data')
   end
 
   def report
     testset.report
-    `patch -b #{path} #{patch_path}`
+    `patch -p0 -b <#{patch_path}`
     testset_incr.report
-    `patch -b -R #{path} #{patch_path}`
+    `patch -p0 -b -R <#{patch_path}`
   end
 
   def collect_warnings

--- a/tests/incremental/00-basic/00-local.patch
+++ b/tests/incremental/00-basic/00-local.patch
@@ -1,8 +1,8 @@
---- tests/incremental/00-local.c	2021-09-30 13:12:18.381946503 +0300
-+++ "tests/incremental/00-local copy.c"	2021-09-30 13:12:32.697729338 +0300
+--- tests/incremental/00-basic/00-local.c	2021-09-30 13:12:18.381946503 +0300
++++ tests/incremental/00-basic/00-local.c	2021-09-30 13:12:32.697729338 +0300
 @@ -1,7 +1,7 @@
  #include <assert.h>
- 
+
  int main() {
 -    int x = 1;
 -    assert(x == 1); // success before, success after

--- a/tests/incremental/00-basic/01-global.patch
+++ b/tests/incremental/00-basic/01-global.patch
@@ -1,5 +1,5 @@
---- a/tests/incremental/00-basic/01-global.c
-+++ b/tests/incremental/00-basic/01-global.c
+--- tests/incremental/00-basic/01-global.c
++++ tests/incremental/00-basic/01-global.c
 @@ -1,6 +1,6 @@
  // Previosuly, the function was erroneously not reanalyzed when the global initializer/the start state changed
  // when hash-consing is activated.

--- a/tests/incremental/00-basic/01-global.patch
+++ b/tests/incremental/00-basic/01-global.patch
@@ -1,4 +1,10 @@
-3c3
-< int g = 0;
----
-> int g = 53;
+--- a/tests/incremental/00-basic/01-global.c
++++ b/tests/incremental/00-basic/01-global.c
+@@ -1,6 +1,6 @@
+ // Previosuly, the function was erroneously not reanalyzed when the global initializer/the start state changed
+ // when hash-consing is activated.
+-int g = 0;
++int g = 35;
+
+ int main(){
+     int x = g;

--- a/tests/incremental/00-basic/02-changed_start_state1.patch
+++ b/tests/incremental/00-basic/02-changed_start_state1.patch
@@ -1,5 +1,5 @@
---- a/tests/incremental/00-basic/02-changed_start_state1.c
-+++ b/tests/incremental/00-basic/02-changed_start_state1.c
+--- tests/incremental/00-basic/02-changed_start_state1.c
++++ tests/incremental/00-basic/02-changed_start_state1.c
 @@ -1,13 +1,13 @@
  #include <assert.h>
 

--- a/tests/incremental/00-basic/03-changed_start_state2.patch
+++ b/tests/incremental/00-basic/03-changed_start_state2.patch
@@ -1,5 +1,5 @@
---- a/tests/incremental/00-basic/03-changed_start_state2.c
-+++ b/tests/incremental/00-basic/03-changed_start_state2.c
+--- tests/incremental/00-basic/03-changed_start_state2.c
++++ tests/incremental/00-basic/03-changed_start_state2.c
 @@ -1,13 +1,13 @@
  #include <assert.h>
 

--- a/tests/incremental/00-basic/04-rename_ids.patch
+++ b/tests/incremental/00-basic/04-rename_ids.patch
@@ -1,2 +1,10 @@
-8a9
->   case 3:
+--- tests/incremental/00-basic/04-rename_ids.c
++++ tests/incremental/00-basic/04-rename_ids.c
+@@ -6,6 +6,7 @@ void d();
+ void c() {
+   switch (a) {
+   case 2:
++  case 3:
+     d();
+   }
+   b();

--- a/tests/incremental/00-basic/06-threadid.patch
+++ b/tests/incremental/00-basic/06-threadid.patch
@@ -1,4 +1,12 @@
-20a21,23
-> 
-> 
-> 
+--- tests/incremental/00-basic/06-threadid.c
++++ tests/incremental/00-basic/06-threadid.c
+@@ -18,6 +18,9 @@ pthread_t create_thread(){
+   x = f();
+   // Shifting the lines below down in the incremental run should not require a re-evalatuion,
+   // but the threadid in the HTML-Output should contain the new location.
++
++
++
+   pthread_create(&id, NULL, t_fun, NULL);
+   pthread_join (id, NULL);
+   x = 0;

--- a/tests/incremental/01-force-reanalyze/00-int.c
+++ b/tests/incremental/01-force-reanalyze/00-int.c
@@ -1,0 +1,17 @@
+#include<assert.h>
+
+int f(int in){
+  while(in < 17) {
+    in++;
+  }
+  assert(in == 17); //UNKNOWN
+  return in;
+}
+
+int main() {
+  int a = 0;
+  assert(a); // FAIL!
+  a = f(a);
+  assert(a == 17); //UNKNOWN
+  return 0;
+}

--- a/tests/incremental/01-force-reanalyze/00-int.json
+++ b/tests/incremental/01-force-reanalyze/00-int.json
@@ -12,6 +12,9 @@
     "incremental" : {
         "force-reanalyze" : {
             "funs": ["f"]
+        },
+        "reluctant" : {
+          "on" : false
         }
     }
 }

--- a/tests/incremental/01-force-reanalyze/00-int.json
+++ b/tests/incremental/01-force-reanalyze/00-int.json
@@ -1,0 +1,17 @@
+{
+    "annotation" : {
+        "int" : {
+            "enabled" : true
+        }
+    },
+    "ana" : {
+        "int" : {
+            "refinement" : "fixpoint"
+        }
+    },
+    "incremental" : {
+        "force_reanalysis" : {
+            "funs": ["f"]
+        }
+    }
+}

--- a/tests/incremental/01-force-reanalyze/00-int.json
+++ b/tests/incremental/01-force-reanalyze/00-int.json
@@ -10,7 +10,7 @@
         }
     },
     "incremental" : {
-        "force_reanalysis" : {
+        "force-reanalyze" : {
             "funs": ["f"]
         }
     }

--- a/tests/incremental/01-force-reanalyze/00-int.patch
+++ b/tests/incremental/01-force-reanalyze/00-int.patch
@@ -1,0 +1,31 @@
+--- tests/incremental/01-force-reanalyze/00-int.c
++++ tests/incremental/01-force-reanalyze/00-int.c
+@@ -4,7 +4,7 @@ int f(int in){
+   while(in < 17) {
+     in++;
+   }
+-  assert(in == 17); //UNKNOWN
++  assert(in == 17);
+   return in;
+ }
+
+@@ -12,6 +12,6 @@ int main() {
+   int a = 0;
+   assert(a); // FAIL!
+   a = f(a);
+-  assert(a == 17); //UNKNOWN
++  assert(a == 17);
+   return 0;
+ }
+--- tests/incremental/01-force-reanalyze/00-int.json
++++ tests/incremental/01-force-reanalyze/00-int.json
+@@ -2,6 +2,9 @@
+     "annotation" : {
+         "int" : {
+             "enabled" : true
++        },
++        "goblint_precision": {
++            "interval" : ["f"]
+         }
+     },
+     "ana" : {


### PR DESCRIPTION
This PR extends the regression test script for incremental tests to also handle patch files that contain changes in multiple files. This can be used to encode changes in the configuration for the incremental run. An instance for which this is needed is the implemented test case that targets the forceful re-evaluation of functions with an increased precision.

Due to the mentioned test case we noticed that the precision refinement is not compatible with the reluctant destabilization yet. Therefore I deactivated this option in the test case and created a new issue for this (#508).