### PR TITLE
Avoid back-and-forth cast between bigint and int64 for array domains

### DIFF
--- a/src/cdomains/arrayDomain.mli
+++ b/src/cdomains/arrayDomain.mli
@@ -1,3 +1,4 @@
+open IntOps
 
 (** Abstract domains representing arrays. *)
 module type S =
@@ -40,18 +41,18 @@ sig
   val fold_left2: ('a -> value -> value -> 'a) -> 'a -> t -> t -> 'a
   (** Left fold over the elements of two arrays (like List.fold_left2 *)
 
-  val smart_join: (Cil.exp -> int64 option) -> (Cil.exp -> int64 option) -> t -> t  -> t
-  val smart_widen: (Cil.exp -> int64 option) -> (Cil.exp -> int64 option) -> t -> t -> t
-  val smart_leq: (Cil.exp -> int64 option) -> (Cil.exp -> int64 option) -> t -> t  -> bool
+  val smart_join: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t  -> t
+  val smart_widen: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t -> t
+  val smart_leq: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t  -> bool
   val update_length: idx -> t -> t
 end
 
 module type LatticeWithSmartOps =
 sig
   include Lattice.S
-  val smart_join: (Cil.exp -> int64 option) -> (Cil.exp -> int64 option) -> t -> t ->  t
-  val smart_widen: (Cil.exp -> int64 option) -> (Cil.exp -> int64 option) -> t -> t -> t
-  val smart_leq: (Cil.exp -> int64 option) -> (Cil.exp -> int64 option) -> t -> t -> bool
+  val smart_join: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t ->  t
+  val smart_widen: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t -> t
+  val smart_leq: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t -> bool
 end
 
 module Trivial (Val: Lattice.S) (Idx: Lattice.S): S with type value = Val.t and type idx = Idx.t

--- a/src/cdomains/baseDomain.ml
+++ b/src/cdomains/baseDomain.ml
@@ -168,18 +168,16 @@ module DomFunctor (PrivD: Lattice.S) (ExpEval: ExpEvaluator with type t = BaseCo
 struct
   include BaseComponents (PrivD)
 
-  let (%) = Batteries.(%)
-  let eval_exp x = Option.map BI.to_int64 % (ExpEval.eval_exp x)
   let join (one:t) (two:t): t =
-    let cpa_join = CPA.join_with_fct (VD.smart_join (eval_exp one) (eval_exp two)) in
+    let cpa_join = CPA.join_with_fct (VD.smart_join (ExpEval.eval_exp one) (ExpEval.eval_exp two)) in
     op_scheme cpa_join PartDeps.join WeakUpdates.join PrivD.join one two
 
   let leq one two =
-    let cpa_leq = CPA.leq_with_fct (VD.smart_leq (eval_exp one) (eval_exp two)) in
+    let cpa_leq = CPA.leq_with_fct (VD.smart_leq (ExpEval.eval_exp one) (ExpEval.eval_exp two)) in
     cpa_leq one.cpa two.cpa && PartDeps.leq one.deps two.deps && WeakUpdates.leq one.weak two.weak && PrivD.leq one.priv two.priv
 
   let widen one two: t =
-    let cpa_widen = CPA.widen_with_fct (VD.smart_widen (eval_exp one) (eval_exp two)) in
+    let cpa_widen = CPA.widen_with_fct (VD.smart_widen (ExpEval.eval_exp one) (ExpEval.eval_exp two)) in
     op_scheme cpa_widen PartDeps.widen WeakUpdates.widen PrivD.widen one two
 end
 

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -25,9 +25,9 @@ sig
   val invalidate_value: Q.ask -> typ -> t -> t
   val is_safe_cast: typ -> typ -> bool
   val cast: ?torg:typ -> typ -> t -> t
-  val smart_join: (exp -> int64 option) -> (exp -> int64 option) -> t -> t ->  t
-  val smart_widen: (exp -> int64 option) -> (exp -> int64 option) ->  t -> t -> t
-  val smart_leq: (exp -> int64 option) -> (exp -> int64 option) -> t -> t -> bool
+  val smart_join: (exp -> BI.t option) -> (exp -> BI.t option) -> t -> t ->  t
+  val smart_widen: (exp -> BI.t option) -> (exp -> BI.t option) ->  t -> t -> t
+  val smart_leq: (exp -> BI.t option) -> (exp -> BI.t option) -> t -> t -> bool
   val is_immediate_type: typ -> bool
   val bot_value: typ -> t
   val is_bot_value: t -> bool


### PR DESCRIPTION
As a code artifact, the array domain contained some functions that expected `int64` values, instead of big integers, although big integers were used internally. This PR removes the use of `int64` within the array domain and the back-and-forth casts between big integers and `int64` in the array domain and the `ValueDomain` and `BaseDomain` using it.

Closes #505 