### PR TITLE
Threshold widening for Interval & Configurable DefExc widen

### DIFF
--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -16,7 +16,7 @@ module M = Messages
     - heterogeneous environments: https://link.springer.com/chapter/10.1007%2F978-3-030-17184-1_26 (Section 4.1) *)
 
 let widening_thresholds_apron = lazy (
-  let t = WideningThresholds.thresholds () in
+  let t = WideningThresholds.thresholds_incl_mul2 () in
   let r = List.map (fun x -> Apron.Scalar.of_mpqf @@ Mpqf.of_string @@ Z.to_string x) t in
   Array.of_list r
 )

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -648,12 +648,14 @@ struct
     let threshold = get_bool "ana.int.interval_threshold_widening" in
     let upper_threshold u =
       let ts = Lazy.force widening_thresholds in
-      let t = List.find_opt (fun x -> Z.compare (Ints_t.to_bigint u) x <= 0) ts in
+      let u = Ints_t.to_bigint u in
+      let t = List.find_opt (fun x -> Z.compare u x <= 0) ts in
       BatOption.map_default Ints_t.of_bigint (max_int ik) t
     in
     let lower_threshold l =
       let ts = Lazy.force widening_thresholds_desc in
-      let t = List.find_opt (fun x -> Z.compare (Ints_t.to_bigint l) x >= 0) ts in
+      let l = Ints_t.to_bigint l in
+      let t = List.find_opt (fun x -> Z.compare l x >= 0) ts in
       BatOption.map_default Ints_t.of_bigint (min_int ik) t
     in
     match x, y with

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1417,7 +1417,12 @@ struct
     | `Excluded (x,wx), `Excluded (y,wy) -> `Excluded (S.inter x y, range |? R.join wx wy)
 
   let join ik = join' ik
-  let widen ik = join' ~range:(size ik) ik
+
+  let widen ik =
+    if get_bool "ana.int.def_exc_widen_by_join" then
+      join' ik
+    else
+      join' ~range:(size ik) ik
 
   let meet ik x y =
     match (x,y) with

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -648,12 +648,12 @@ struct
     let threshold = get_bool "ana.int.interval_threshold_widening" in
     let upper_threshold u =
       let ts = Lazy.force widening_thresholds in
-      let t = List.find_opt (fun x -> Ints_t.compare u (Ints_t.of_bigint x) <= 0) ts in
+      let t = List.find_opt (fun x -> Z.compare (Ints_t.to_bigint u) x <= 0) ts in
       BatOption.map_default Ints_t.of_bigint (max_int ik) t
     in
     let lower_threshold l =
       let ts = Lazy.force widening_thresholds_desc in
-      let t = List.find_opt (fun x -> Ints_t.compare l (Ints_t.of_bigint x) >= 0) ts in
+      let t = List.find_opt (fun x -> Z.compare (Ints_t.to_bigint l) x >= 0) ts in
       BatOption.map_default Ints_t.of_bigint (min_int ik) t
     in
     match x, y with

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -415,6 +415,13 @@
               "type": "string",
               "enum": ["never", "once", "fixpoint"],
               "default": "never"
+            },
+            "def_exc_widen_by_join": {
+              "title": "ana.int.def_exc_widen_by_join",
+              "description":
+                "Perform def_exc widening by joins. Gives threshold-widening like behavior, with thresholds given by the ranges of different integer types.",
+              "type": "boolean",
+              "default": false
             }
           },
           "additionalProperties": false

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -422,6 +422,13 @@
                 "Perform def_exc widening by joins. Gives threshold-widening like behavior, with thresholds given by the ranges of different integer types.",
               "type": "boolean",
               "default": false
+            },
+            "interval_threshold_widening": {
+              "title": "ana.int.interval_threshold_widening",
+              "description":
+                "Use constants appearing in program as threshold for widening",
+              "type": "boolean",
+              "default": false
             }
           },
           "additionalProperties": false

--- a/src/util/wideningThresholds.ml
+++ b/src/util/wideningThresholds.ml
@@ -2,25 +2,31 @@ open Cil
 module Thresholds = Set.Make(Z)
 
 
-class extractConstantsVisitor(widening_thresholds) = object
+class extractConstantsVisitor(widening_thresholds,widening_thresholds_incl_mul2) = object
   inherit nopCilVisitor
 
   method! vexpr e =
     match e with
     | Const (CInt(i,ik,_)) ->
       widening_thresholds := Thresholds.add i !widening_thresholds;
-      (* Adding double value of all constants so that we can establish for single variables that they are <= const*)
-      (* This is only needed for Apron, one might want to remove it later *)
-      widening_thresholds := Thresholds.add (Z.mul (Z.of_int 2) i) !widening_thresholds;
+      widening_thresholds_incl_mul2 := Thresholds.add i !widening_thresholds_incl_mul2;
+      (* Adding double value of all constants so that we can establish for single variables that they are <= const *)
+      (* This is e.g. needed for Apron. Done here where we still have the set representation to avoid expensive    *)
+      (* deduplication and sorting on a list later *)
+      widening_thresholds_incl_mul2 := Thresholds.add (Z.mul (Z.of_int 2) i) !widening_thresholds_incl_mul2;
       DoChildren
     | _ -> DoChildren
 end
 
 let widening_thresholds = lazy (
   let set = ref Thresholds.empty in
-  let thisVisitor = new extractConstantsVisitor(set) in
+  let set_incl_mul2 = ref Thresholds.empty in
+  let thisVisitor = new extractConstantsVisitor(set,set_incl_mul2) in
   visitCilFileSameGlobals thisVisitor (!Cilfacade.current_file);
-  Thresholds.elements !set)
+  Thresholds.elements !set, Thresholds.elements !set_incl_mul2)
 
 let thresholds () =
-  Lazy.force widening_thresholds
+  fst @@ Lazy.force widening_thresholds
+
+let thresholds_incl_mul2 () =
+  snd @@ Lazy.force widening_thresholds

--- a/src/util/wideningThresholds.mli
+++ b/src/util/wideningThresholds.mli
@@ -1,1 +1,2 @@
 val thresholds : unit -> Z.t list
+val thresholds_incl_mul2 : unit -> Z.t list

--- a/tests/regression/03-practical/23-knot-timeout.c
+++ b/tests/regression/03-practical/23-knot-timeout.c
@@ -1,4 +1,5 @@
-// SKIP (time-out with cb439e0, see https://github.com/goblint/analyzer/pull/502)
+// PARAM: --enable ana.int.def_exc_widen_by_join
+// time-out without def_exc_widen_by_join, see https://github.com/goblint/analyzer/pull/502)
 #include<pthread.h>
 
 struct a {

--- a/tests/regression/03-practical/24-threshold.c
+++ b/tests/regression/03-practical/24-threshold.c
@@ -1,0 +1,34 @@
+// PARAM: --enable ana.int.interval --enable ana.int.interval_threshold_widening
+
+#include <pthread.h>
+#include <assert.h>
+
+int g;
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void* fun(void* arg) {
+    pthread_mutex_lock(&m);
+    if(g < 100) {
+        g++;
+    };
+    pthread_mutex_unlock(&m);
+}
+
+
+int main() {
+    pthread_t t1;
+    pthread_create(&t1, 0, fun, 0);
+
+    pthread_mutex_lock(&m);
+    if(g < 100) {
+        g++;
+    };
+    pthread_mutex_unlock(&m);
+
+    pthread_join(t1, 0);
+
+    assert(g <= 100);
+
+	return 0;
+}

--- a/tests/regression/34-localization/02-hybrid.c
+++ b/tests/regression/34-localization/02-hybrid.c
@@ -9,7 +9,7 @@ void main()
    while (1) {
       i++;
       for (int j=0; j < 10; j++) {
-         assert(0 >= i); // UNKNOWN
+         assert(0 <= i); // UNKNOWN
          assert(i <= 10);
       }
       if (i>9) i=0;

--- a/tests/regression/42-annotated-precision/26-34_02-hybrid.c
+++ b/tests/regression/42-annotated-precision/26-34_02-hybrid.c
@@ -10,7 +10,7 @@ void main()
    while (1) {
       i++;
       for (int j=0; j < 10; j++) {
-         assert(0 >= i); // UNKNOWN
+         assert(0 <= i); // UNKNOWN
          assert(i <= 10);
       }
       if (i>9) i=0;


### PR DESCRIPTION
We do have threshold widening for our apron-based analyses where the thresholds come from the constants appearing in the program.

This adds an option `ana.int.interval_threshold_widening` to also have this behavior for intervals in our base analysis. This is especially relevant for globals since we never narrow for them.

With this new option, the assert in the following program succeeds, while this would not be the case without it.

~~~C
// PARAM: --enable ana.int.interval --enable ana.int.interval_threshold_widening

#include <pthread.h>
#include <assert.h>

int g;

pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;

void* fun(void* arg) {
    pthread_mutex_lock(&m);
    if(g < 100) {
        g++;
    };
    pthread_mutex_unlock(&m);
}


int main() {
    pthread_t t1;
    pthread_create(&t1, 0, fun, 0);

    pthread_mutex_lock(&m);
    if(g < 100) {
        g++;
    };
    pthread_mutex_unlock(&m);

    pthread_join(t1, 0);

    assert(g <= 100);

	return 0;
}
~~~

It also adds an option `ana.int.def_exc_widen_by_join` to get the pre #502 behavior for DefExc, i.e., `widen = join`.

The threshold widening for intervals should remain disabled by default (using all constants in the program is prohibitively expensive for larger programs, we would need a smart heuristics there). 
However, we should discuss what we want to do for `ana.int.def_exc_widen_by_join`, in the light of 3a6491aa0fac5a7d136f13febd17ebe8e1d54643.

Closes #459 