### PR TITLE
Use global invariant for dead branch detection

### DIFF
--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -83,6 +83,7 @@ module Bools: Lattice.S with type t = [`Bot | `Lifted of bool | `Top] =
 
 module CilExp =
 struct
+  include Printable.Std (* for Groupable *)
   include CilType.Exp
   let copy x = x
 

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1127,22 +1127,16 @@ struct
   let threadenter ctx = S.threadenter (conv ctx)
   let threadspawn ctx lv f args fctx = S.threadspawn (conv ctx) lv f args (conv fctx)
 
-  module Locmap = Deadcode.Locmap
-
-  let dead_branches = function true -> Deadcode.dead_branches_then | false -> Deadcode.dead_branches_else
 
   let branch ctx exp tv =
     if !GU.postsolving then (
-      Locmap.replace Deadcode.dead_branches_cond !Tracing.current_loc exp;
       try
         let r = branch ctx exp tv in
         (* branch is live *)
-        Locmap.replace (dead_branches tv) !Tracing.current_loc false; (* set to live (false) *)
         ctx.sideg (V.node ctx.prev_node) (G.create_node (EM.singleton exp (`Lifted tv)));
         r
       with Deadcode ->
         (* branch is dead *)
-        Locmap.modify_def true !Tracing.current_loc Fun.id (dead_branches tv); (* set to dead (true) if not mem, otherwise keep existing (Fun.id) since it may be live (false) in another context *)
         ctx.sideg (V.node ctx.prev_node) (G.create_node (EM.singleton exp `Bot));
         raise Deadcode
     )

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1085,6 +1085,11 @@ struct
       | _ -> failwith "DeadBranchLifter.node"
     let create_s s = `Lifted1 s
     let create_node node = `Lifted2 node
+
+    let printXml f = function
+      | `Lifted1 x -> S.G.printXml f x
+      | `Lifted2 x -> BatPrintf.fprintf f "<analysis name=\"dead-branch\">%a</analysis>" EM.printXml x
+      | x -> BatPrintf.fprintf f "<analysis name=\"dead-branch-lifter\">%a</analysis>" printXml x
   end
 
   let conv (ctx: (_, G.t, _, V.t) ctx): (_, S.G.t, _, S.V.t) ctx =

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -70,7 +70,8 @@ struct
 
   (* print out information about dead code *)
   let print_dead_code (xs:Result.t) uncalled_fn_loc =
-    let dead_locations : unit Deadcode.Locmap.t = Deadcode.Locmap.create 10 in
+    let module Locmap = BatHashtbl.Make (CilType.Location) in
+    let dead_locations : unit Locmap.t = Locmap.create 10 in
     let module NH = Hashtbl.Make (Node) in
     let live_nodes : unit NH.t = NH.create 10 in
     let count = ref 0 in (* Is only populated if "dbg.print_dead_code" is true *)
@@ -88,7 +89,7 @@ struct
       let is_dead = LT.for_all (fun (_,x,f) -> Spec.D.is_bot x) v in
       if is_dead then (
         dead_lines := StringMap.modify_def StringMap.empty l.file add_file !dead_lines;
-        Deadcode.Locmap.add dead_locations l ();
+        Locmap.add dead_locations l ();
       ) else (
         live_lines := StringMap.modify_def StringMap.empty l.file add_file !live_lines;
         NH.add live_nodes n ()

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -148,20 +148,6 @@ struct
       );
       printf "Total lines (logical LoC): %d\n" (live_count + !count + uncalled_fn_loc); (* We can only give total LoC if we counted dead code *)
     );
-    let str = function true -> "then" | false -> "else" in
-    let report tv (loc, dead) =
-      match dead, Deadcode.Locmap.find_option Deadcode.dead_branches_cond loc with
-      | true, Some exp -> M.warn ~loc ~category:Deadcode ~tags:[CWE (if tv then 570 else 571)] "the %s branch over expression '%a' is dead" (str tv) d_exp exp
-      | true, None     -> M.warn ~loc ~category:Deadcode ~tags:[CWE (if tv then 570 else 571)] "an %s branch is dead" (str tv)
-      | _ -> ()
-    in
-    if get_bool "dbg.print_dead_code" then (
-      let by_fst (a,_) (b,_) = Stdlib.compare a b in
-      Deadcode.Locmap.to_list Deadcode.dead_branches_then |> List.sort by_fst |> List.iter (report true) ;
-      Deadcode.Locmap.to_list Deadcode.dead_branches_else |> List.sort by_fst |> List.iter (report false) ;
-      Deadcode.Locmap.clear Deadcode.dead_branches_then;
-      Deadcode.Locmap.clear Deadcode.dead_branches_else
-    );
     NH.mem live_nodes
 
   (* convert result that can be out-put *)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -70,8 +70,6 @@ struct
 
   (* print out information about dead code *)
   let print_dead_code (xs:Result.t) uncalled_fn_loc =
-    let module Locmap = BatHashtbl.Make (CilType.Location) in
-    let dead_locations : unit Locmap.t = Locmap.create 10 in
     let module NH = Hashtbl.Make (Node) in
     let live_nodes : unit NH.t = NH.create 10 in
     let count = ref 0 in (* Is only populated if "dbg.print_dead_code" is true *)
@@ -88,8 +86,7 @@ struct
       let add_file = StringMap.modify_def BatISet.empty f.svar.vname add_fun in
       let is_dead = LT.for_all (fun (_,x,f) -> Spec.D.is_bot x) v in
       if is_dead then (
-        dead_lines := StringMap.modify_def StringMap.empty l.file add_file !dead_lines;
-        Locmap.add dead_locations l ();
+        dead_lines := StringMap.modify_def StringMap.empty l.file add_file !dead_lines
       ) else (
         live_lines := StringMap.modify_def StringMap.empty l.file add_file !live_lines;
         NH.add live_nodes n ()

--- a/src/util/deadcode.ml
+++ b/src/util/deadcode.ml
@@ -1,5 +1,1 @@
 module Locmap = BatHashtbl.Make (CilType.Location)
-
-let dead_branches_then : bool Locmap.t = Locmap.create 10
-let dead_branches_else : bool Locmap.t = Locmap.create 10
-let dead_branches_cond : Cil.exp Locmap.t = Locmap.create 10

--- a/src/util/deadcode.ml
+++ b/src/util/deadcode.ml
@@ -1,1 +1,0 @@
-module Locmap = BatHashtbl.Make (CilType.Location)

--- a/tests/incremental/00-basic/07-dead-branch.c
+++ b/tests/incremental/00-basic/07-dead-branch.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+void foo() {
+
+}
+
+int main() {
+  int a = 1;
+
+  if (a) // WARN
+    assert(a);
+
+  foo();
+
+  return 0;
+}

--- a/tests/incremental/00-basic/07-dead-branch.json
+++ b/tests/incremental/00-basic/07-dead-branch.json
@@ -1,0 +1,5 @@
+{
+    "dbg": {
+        "print_dead_code": true
+    }
+}

--- a/tests/incremental/00-basic/07-dead-branch.patch
+++ b/tests/incremental/00-basic/07-dead-branch.patch
@@ -1,0 +1,11 @@
+--- tests/incremental/00-basic/07-dead-branch.c
++++ tests/incremental/00-basic/07-dead-branch.c
+@@ -1,7 +1,7 @@
+ #include <assert.h>
+
+ void foo() {
+-
++  assert(1);
+ }
+
+ int main() {

--- a/tests/regression/01-cpa/55-dead-branch-multiple.c
+++ b/tests/regression/01-cpa/55-dead-branch-multiple.c
@@ -4,7 +4,7 @@ int main() {
   int a = 1;
   int b = 0;
 
-  if (a && b) { // TODO WARN
+  if (a && b) { // WARN
     assert(0); // NOWARN (unreachable)
   }
 

--- a/tests/regression/01-cpa/55-dead-branch-multiple.c
+++ b/tests/regression/01-cpa/55-dead-branch-multiple.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+int main() {
+  int a = 1;
+  int b = 0;
+
+  if (a && b) { // TODO WARN
+    assert(0); // NOWARN (unreachable)
+  }
+
+  return 0;
+}


### PR DESCRIPTION
While debugging other incremental issues, I realized that some dead branch warnings go missing. This was because dead branch detection used global hashtables in the `Deadcode` module to accomplish its job.

This PR replaces that with the general global invariant mechanism. While doing so, it switches from using locations to nodes, making it even more robust for the incremental case.
A useful side effect of the latter is that now dead branch warnings are also given for subexpressions of short-circuting conditions (e.g. `a && b`). Previously this was broken since both branching nodes had the same location, which quietly broke the location-based hashtable.

This PR is on top of #391. On master the incremental problem doesn't appear because postsolving isn't done incrementally, so all the dead branch warnings get recreated anyway.

### TODO
- [x] Fix global view in HTML.