### PR TITLE
Ignore `.s` files (assembly) in compilation database

### DIFF
--- a/src/util/compilationDatabase.ml
+++ b/src/util/compilationDatabase.ml
@@ -49,42 +49,46 @@ let load_and_preprocess ~all_cppflags filename =
   let preprocessed_dir = Goblintutil.create_dir (Filename.concat ".goblint" "preprocessed") in
   let preprocess obj =
     let file = obj.file in
-    let preprocessed_file = Filename.concat preprocessed_dir (Filename.chop_extension (GobFilename.chop_common_prefix database_dir file) ^ ".i") in
-    GobSys.mkdir_parents preprocessed_file;
-    let preprocess_command = match obj.command, obj.arguments with
-      | Some command, None ->
-        (* TODO: extract o_file *)
-        let command = reroot command in
-        let preprocess_command = Str.replace_first command_program_regexp ("\\1 " ^ String.join " " (List.map Filename.quote all_cppflags) ^ " -E") command in
-        let preprocess_command = Str.replace_first command_o_regexp ("-o " ^ preprocessed_file) preprocess_command in
-        if preprocess_command = command then (* easier way to check if match was found (and replaced) *)
-          failwith "CompilationDatabase.preprocess: no -o argument found for " ^ file
-        else
-          preprocess_command
-      | None, Some arguments ->
-        let arguments = List.map reroot arguments in
-        begin match List.findi (fun i e -> e = "-o") arguments with
-          | (o_i, _) ->
-            begin match List.split_at o_i arguments with
-              | (arguments_program :: arguments_init, _ :: o_file :: arguments_tl) ->
-                let preprocess_arguments = all_cppflags @ "-E" :: arguments_init @ "-o" :: preprocessed_file :: arguments_tl in
-                Filename.quote_command arguments_program preprocess_arguments
-              | _ ->
-                failwith "CompilationDatabase.preprocess: no -o argument value found for " ^ file
-            end
-          | exception Not_found ->
+    let extension = Filename.extension file in
+    if extension = ".s" || extension = ".S" then
+      None
+    else
+      let preprocessed_file = Filename.concat preprocessed_dir (Filename.chop_extension (GobFilename.chop_common_prefix database_dir file) ^ ".i") in
+      GobSys.mkdir_parents preprocessed_file;
+      let preprocess_command = match obj.command, obj.arguments with
+        | Some command, None ->
+          (* TODO: extract o_file *)
+          let command = reroot command in
+          let preprocess_command = Str.replace_first command_program_regexp ("\\1 " ^ String.join " " (List.map Filename.quote all_cppflags) ^ " -E") command in
+          let preprocess_command = Str.replace_first command_o_regexp ("-o " ^ preprocessed_file) preprocess_command in
+          if preprocess_command = command then (* easier way to check if match was found (and replaced) *)
             failwith "CompilationDatabase.preprocess: no -o argument found for " ^ file
-        end
-      | Some _, Some _ ->
-        failwith "CompilationDatabase.preprocess: both command and arguments specified for " ^ file
-      | None, None ->
-        failwith "CompilationDatabase.preprocess: neither command nor arguments specified for " ^ file
+          else
+            preprocess_command
+        | None, Some arguments ->
+          let arguments = List.map reroot arguments in
+          begin match List.findi (fun i e -> e = "-o") arguments with
+            | (o_i, _) ->
+              begin match List.split_at o_i arguments with
+                | (arguments_program :: arguments_init, _ :: o_file :: arguments_tl) ->
+                  let preprocess_arguments = all_cppflags @ "-E" :: arguments_init @ "-o" :: preprocessed_file :: arguments_tl in
+                  Filename.quote_command arguments_program preprocess_arguments
+                | _ ->
+                  failwith "CompilationDatabase.preprocess: no -o argument value found for " ^ file
+              end
+            | exception Not_found ->
+              failwith "CompilationDatabase.preprocess: no -o argument found for " ^ file
+          end
+        | Some _, Some _ ->
+          failwith "CompilationDatabase.preprocess: both command and arguments specified for " ^ file
+        | None, None ->
+          failwith "CompilationDatabase.preprocess: neither command nor arguments specified for " ^ file
+      in
+      let cwd = reroot obj.directory in
+      if GobConfig.get_bool "dbg.verbose" then
+        Printf.printf "Preprocessing %s\n  to %s\n  using %s\n  in %s\n" file preprocessed_file preprocess_command cwd;
+      system ~cwd preprocess_command; (* command/arguments might have paths relative to directory *)
+      Some preprocessed_file
     in
-    let cwd = reroot obj.directory in
-    if GobConfig.get_bool "dbg.verbose" then
-      Printf.printf "Preprocessing %s\n  to %s\n  using %s\n  in %s\n" file preprocessed_file preprocess_command cwd;
-    system ~cwd preprocess_command; (* command/arguments might have paths relative to directory *)
-    preprocessed_file
-  in
   parse_file filename
-  |> List.map preprocess
+  |> BatList.filter_map preprocess


### PR DESCRIPTION
`cpp` does not generate `.i` files from them, but Goblint later goes looking for them, failing because it can't find them.
Needed for https://github.com/goblint/bench/issues/7