### PR TITLE
Incremental: fix cfg comparison

### DIFF
--- a/src/incremental/compareCFG.ml
+++ b/src/incremental/compareCFG.ml
@@ -102,31 +102,29 @@ let compareCfgs (module CfgOld : CfgForward) (module CfgNew : CfgForward) fun1 f
 let reexamine f1 f2 (same : unit NTH.t) (diffNodes1 : unit NH.t) (module CfgOld : CfgForward) (module CfgNew : CfgForward) =
   NTH.filter_map_inplace (fun (n1,n2) _ -> if NH.mem diffNodes1 n1 then None else Some ()) same;
   NTH.add same (FunctionEntry f1, FunctionEntry f2) ();
-  let vis = NH.create 103 in
+  let module NS = Set.Make(Node) in
   let diffNodes2 = NH.create 103 in
 
   let asSndInSame k = NTH.fold (fun (n1,n2) _ acc -> acc || Node.equal n2 k) same false in
   (* remove all nodes that are affected by a primary new node from same, add the first reached tuple to the primary differing node sets *)
-  let rec refine_same firstReached k =
-    if NH.mem vis k then ()
-    else begin
-      NH.add vis k ();
-      if asSndInSame k then begin
-        NTH.filter_map_inplace (fun (n1,n2) _ -> if Node.equal n2 k then (if not firstReached then (NH.replace diffNodes1 n1 (); NH.replace diffNodes2 n2 ()); None) else Some ()) same;
-        dfs2 k (refine_same true) end
-      else if firstReached || NH.mem diffNodes2 k then ()
-      else dfs2 k (refine_same firstReached) end
+  let rec refine_same firstReached vis k =
+    if asSndInSame k then begin
+      NTH.filter_map_inplace (fun (n1,n2) _ -> if Node.equal n2 k then (if not firstReached then (NH.replace diffNodes1 n1 (); NH.replace diffNodes2 n2 ()); None) else Some ()) same;
+      dfs2 vis k (refine_same true) end
+    else if firstReached || NH.mem diffNodes2 k then ()
+    else dfs2 vis k (refine_same firstReached)
   (* find the primary new nodes, the first non-classified nodes in the new cfg (correspond to the primary obsolete nodes) *)
-  and classify_prim_new k =
-    if NH.mem vis k then ()
+  and classify_prim_new vis k =
+    if asSndInSame k then dfs2 vis k classify_prim_new
+    else (NH.add diffNodes2 k (); dfs2 NS.empty k (refine_same false))
+  and dfs2 vis node f =
+    if NS.mem node vis then ()
     else begin
-      NH.replace vis k ();
-      if asSndInSame k then dfs2 k classify_prim_new
-      else (NH.add diffNodes2 k (); NH.clear vis; dfs2 k (refine_same false)) end
-  and dfs2 node f =
-    let succ = List.map snd (CfgNew.next node) in
-    List.iter f succ in
-  dfs2 (FunctionEntry f2) classify_prim_new;
+      let vis' = NS.add node vis in
+      let succ = List.map snd (CfgNew.next node) in
+      List.iter (f vis') succ
+    end in
+  dfs2 NS.empty (FunctionEntry f2) classify_prim_new;
   (NTH.to_seq_keys same, NH.to_seq_keys diffNodes1, NH.to_seq_keys diffNodes2)
 
 let compareFun (module CfgOld : CfgForward) (module CfgNew : CfgForward) fun1 fun2 =

--- a/tests/incremental/02-cfg-comparison/00-infinite-loop.c
+++ b/tests/incremental/02-cfg-comparison/00-infinite-loop.c
@@ -1,0 +1,14 @@
+void main()
+{ int x;
+  int y = 0;
+
+  assert(y==0);
+
+  while (1) {
+    if (x) {
+      y++;
+    } else {
+      y--;
+    }
+  }
+}

--- a/tests/incremental/02-cfg-comparison/00-infinite-loop.json
+++ b/tests/incremental/02-cfg-comparison/00-infinite-loop.json
@@ -1,0 +1,5 @@
+{
+  "incremental": {
+    "compare": "cfg"
+  }
+}

--- a/tests/incremental/02-cfg-comparison/00-infinite-loop.patch
+++ b/tests/incremental/02-cfg-comparison/00-infinite-loop.patch
@@ -1,0 +1,8 @@
+--- tests/incremental/02-cfg-comparison/00-infinite-loop.c
++++ tests/incremental/02-cfg-comparison/00-infinite-loop.c
+@@ -11,4 +11,5 @@ void main()
+       y--;
+     }
+   }
++  return;
+ }


### PR DESCRIPTION
Closes #523

In the second (reexamine) phase of the CFG comparison, one common set of visited nodes `vis` was used to detect cycles. This is however problematic, since it is emptied at the transition from phase 2.1 (detection of primary new nodes in CFG 2) to phase 2.2 (remove nodes from the unchanged node set, that are influenced by a change through a back-edge in CFG 2). When emptying the `vis` set while descending into one branch of the DFS, this might lead to a cyclic descend not being detected in another branch. This can cause a Stack Overflow. Keeping separate `vis` sets in each branch of the DFS should fix this issue. 

The added test is a minimal example extracted from `pthread/knot_comb.c` in the bench repository where the problematic and fixed behavior can be observed.