### PR TITLE
Fix Address Domain calls to `widen x y` where `x \leq y` did not hold & Ensure `widen x x = x` in `def_exc` domain

### DIFF
--- a/src/cdomains/addressDomain.ml
+++ b/src/cdomains/addressDomain.ml
@@ -31,6 +31,7 @@ struct
   let widen x y =
     if M.tracing then M.traceli "ad" "widen %a %a\n" pretty x pretty y;
     let r = widen x y in
+    M.tracel "ad" "%s\n" (Printexc.raw_backtrace_to_string (Printexc.get_callstack 50));
     if M.tracing then M.traceu "ad" "-> %a\n" pretty r;
     r
 
@@ -133,7 +134,7 @@ struct
     | false, false -> cop x y
 
   let meet x y   = merge join meet x y
-  let narrow x y = merge widen narrow x y
+  let narrow x y = merge (fun x y -> (join x y) |> widen x) narrow x y
 
   let invariant c x =
     let c_exp = Cil.(Lval (BatOption.get c.Invariant.lval)) in

--- a/src/cdomains/addressDomain.ml
+++ b/src/cdomains/addressDomain.ml
@@ -31,7 +31,6 @@ struct
   let widen x y =
     if M.tracing then M.traceli "ad" "widen %a %a\n" pretty x pretty y;
     let r = widen x y in
-    M.tracel "ad" "%s\n" (Printexc.raw_backtrace_to_string (Printexc.get_callstack 50));
     if M.tracing then M.traceu "ad" "-> %a\n" pretty r;
     r
 

--- a/src/cdomains/addressDomain.ml
+++ b/src/cdomains/addressDomain.ml
@@ -134,7 +134,7 @@ struct
     | false, false -> cop x y
 
   let meet x y   = merge join meet x y
-  let narrow x y = merge (fun x y -> (join x y) |> widen x) narrow x y
+  let narrow x y = merge (fun x y -> widen x (join x y)) narrow x y
 
   let invariant c x =
     let c_exp = Cil.(Lval (BatOption.get c.Invariant.lval)) in

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1439,8 +1439,9 @@ struct
   let widen ik x y =
     if get_bool "ana.int.def_exc_widen_by_join" then
       join' ik x y
+    else if equal x y then
+      x
     else
-      (* if equal x y then x else *)
       join' ~range:(size ik) ik x y
 
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1436,11 +1436,13 @@ struct
 
   let join ik = join' ik
 
-  let widen ik =
+  let widen ik x y =
     if get_bool "ana.int.def_exc_widen_by_join" then
-      join' ik
+      join' ik x y
     else
-      join' ~range:(size ik) ik
+      (* if equal x y then x else *)
+      join' ~range:(size ik) ik x y
+
 
   let meet ik x y =
     match (x,y) with

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -394,9 +394,9 @@
             "def_exc_widen_by_join": {
               "title": "ana.int.def_exc_widen_by_join",
               "description":
-                "Perform def_exc widening by joins. Gives threshold-widening like behavior, with thresholds given by the ranges of different integer types. TODO: Value false has termination problems.",
+                "Perform def_exc widening by joins. Gives threshold-widening like behavior, with thresholds given by the ranges of different integer types.",
               "type": "boolean",
-              "default": true
+              "default": false
             },
             "interval_threshold_widening": {
               "title": "ana.int.interval_threshold_widening",

--- a/tests/regression/01-cpa/55-def_exc-widen.c
+++ b/tests/regression/01-cpa/55-def_exc-widen.c
@@ -1,0 +1,12 @@
+//PARAM: --disable ana.int.def_exc_widen_by_join
+int main(int argc , char **argv )
+{
+    char buf[512];
+    int top;
+    char *start ;
+
+    while (1) {
+        start = & buf[top];
+    }
+    return 0;
+}

--- a/tests/regression/03-practical/23-knot-timeout.c
+++ b/tests/regression/03-practical/23-knot-timeout.c
@@ -1,5 +1,5 @@
-// PARAM: --enable ana.int.def_exc_widen_by_join
-// time-out without def_exc_widen_by_join, see https://github.com/goblint/analyzer/pull/502)
+// PARAM: --disable ana.int.def_exc_widen_by_join
+// Used to timeout without ana.int.def_exc_widen_by_join
 #include<pthread.h>
 
 struct a {


### PR DESCRIPTION
With @jerhard  we discovered that the issue with `def_exc` not terminating seems to be that `widen` is somehow called from `narrow` in the addressDomain without ensuring that the second argument is greater than the first one.

Independently of that, the `widen` of `def_exc` should be fixed such that `widen x x = x`.