### PR TITLE
Add files list to json-messages output

### DIFF
--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -274,13 +274,13 @@ struct
         (* TODO: change CIL to extract all include file names from line pragmas? *)
         (* TODO: or do extra preprocessing with -M? *)
         iterGlobals file (function
-            | GFun (fd, loc) -> SH.replace files loc.file ()
+            | GFun (fd, loc) -> SH.replace files loc.file (Hashtbl.find_option Preprocessor.dependencies loc.file)
             | _ -> () (* TODO: add locs from everything else, including all AST nodes *)
           );
-        files |> SH.keys |> List.of_enum
+        files |> SH.to_list
       in
       let json = `Assoc [
-        ("files", `List (List.map (fun s -> `String s) files));
+        ("files", `Assoc (List.map (Tuple2.map2 [%to_yojson: string list option]) files));
         ("messages", Messages.Table.to_yojson ());
       ]
       in

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -271,11 +271,11 @@ struct
       let files =
         let module SH = BatHashtbl.Make (Basetype.RawStrings) in
         let files = SH.create 100 in
-        (* TODO: change CIL to extract all include file names from line pragmas? *)
-        (* TODO: or do extra preprocessing with -M? *)
         iterGlobals file (function
-            | GFun (fd, loc) -> SH.replace files loc.file (Hashtbl.find_option Preprocessor.dependencies loc.file)
-            | _ -> () (* TODO: add locs from everything else, including all AST nodes *)
+            | GFun (_, loc)
+            | GVar (_, _, loc) ->
+              SH.replace files loc.file (Hashtbl.find_option Preprocessor.dependencies loc.file)
+            | _ -> () (* TODO: add locs from everything else? would also include system headers *)
           );
         files |> SH.to_list
       in

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -159,13 +159,16 @@ let basic_preprocess ~all_cppflags fname =
   else
     (* Preprocess using cpp. *)
     (* ?? what is __BLOCKS__? is it ok to just undef? this? http://en.wikipedia.org/wiki/Blocks_(C_language_extension) *)
-    let command = (Preprocessor.get_cpp ()) ^ " --undef __BLOCKS__ " ^ String.join " " (List.map Filename.quote all_cppflags) ^ " \"" ^ fname ^ "\" -o \"" ^ nname ^ "\"" in
+    let deps_file = Filename.chop_extension nname ^ ".d" in
+    let command = (Preprocessor.get_cpp ()) ^ " --undef __BLOCKS__ " ^ String.join " " (List.map Filename.quote all_cppflags) ^ " -MMD -MT " ^ fname ^ " \"" ^ fname ^ "\" -o \"" ^ nname ^ "\"" in
     if get_bool "dbg.verbose" then print_endline command;
 
     (* if something goes wrong, we need to clean up and exit *)
     let rm_and_exit () = remove_temp_dir (); raise Exit in
     try match Unix.system command with
-      | Unix.WEXITED 0 -> nname
+      | Unix.WEXITED 0 ->
+        Preprocessor.parse_makefile_deps deps_file;
+        nname
       | _ -> eprintf "Goblint: Preprocessing failed."; rm_and_exit ()
     with Unix.Unix_error (e, f, a) ->
       eprintf "%s at syscall %s with argument \"%s\".\n" (Unix.error_message e) f a; rm_and_exit ()

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -175,6 +175,8 @@ let basic_preprocess ~all_cppflags fname =
 
 (** Preprocess all files. Return list of preprocessed files and the temp directory name. *)
 let preprocess_files () =
+  Hashtbl.clear Preprocessor.dependencies; (* clear for server mode *)
+
   (* Preprocessor flags *)
   let cppflags = ref (get_string_list "cppflags") in
 

--- a/src/util/compilationDatabase.ml
+++ b/src/util/compilationDatabase.ml
@@ -55,11 +55,12 @@ let load_and_preprocess ~all_cppflags filename =
     else
       let preprocessed_file = Filename.concat preprocessed_dir (Filename.chop_extension (GobFilename.chop_common_prefix database_dir file) ^ ".i") in
       GobSys.mkdir_parents preprocessed_file;
+      let deps_file = Filename.chop_extension preprocessed_file ^ ".d" in
       let preprocess_command = match obj.command, obj.arguments with
         | Some command, None ->
           (* TODO: extract o_file *)
           let command = reroot command in
-          let preprocess_command = Str.replace_first command_program_regexp ("\\1 " ^ String.join " " (List.map Filename.quote all_cppflags) ^ " -E") command in
+          let preprocess_command = Str.replace_first command_program_regexp ("\\1 " ^ String.join " " (List.map Filename.quote all_cppflags) ^ " -E -MMD -MT " ^ file) command in
           let preprocess_command = Str.replace_first command_o_regexp ("-o " ^ preprocessed_file) preprocess_command in
           if preprocess_command = command then (* easier way to check if match was found (and replaced) *)
             failwith "CompilationDatabase.preprocess: no -o argument found for " ^ file
@@ -71,7 +72,7 @@ let load_and_preprocess ~all_cppflags filename =
             | (o_i, _) ->
               begin match List.split_at o_i arguments with
                 | (arguments_program :: arguments_init, _ :: o_file :: arguments_tl) ->
-                  let preprocess_arguments = all_cppflags @ "-E" :: arguments_init @ "-o" :: preprocessed_file :: arguments_tl in
+                  let preprocess_arguments = all_cppflags @ "-E" :: "-MMD" :: "-MT" :: file :: arguments_init @ "-o" :: preprocessed_file :: arguments_tl in
                   Filename.quote_command arguments_program preprocess_arguments
                 | _ ->
                   failwith "CompilationDatabase.preprocess: no -o argument value found for " ^ file
@@ -88,6 +89,7 @@ let load_and_preprocess ~all_cppflags filename =
       if GobConfig.get_bool "dbg.verbose" then
         Printf.printf "Preprocessing %s\n  to %s\n  using %s\n  in %s\n" file preprocessed_file preprocess_command cwd;
       system ~cwd preprocess_command; (* command/arguments might have paths relative to directory *)
+      Preprocessor.parse_makefile_deps deps_file;
       Some preprocessed_file
     in
   parse_file filename

--- a/src/util/dune
+++ b/src/util/dune
@@ -1,2 +1,2 @@
-(ocamllex oilLexer)
-(ocamlyacc oilParser)
+(ocamllex oilLexer makefileLexer)
+(ocamlyacc oilParser makefileParser)

--- a/src/util/makefileLexer.mll
+++ b/src/util/makefileLexer.mll
@@ -1,0 +1,11 @@
+{
+  open MakefileParser
+}
+
+rule token = parse
+  | ' ' { token lexbuf }
+  | "\\\n" { token lexbuf }
+  | '\n' { NEWLINE }
+  | eof { EOF }
+  | ':' { COLON }
+  | [^':'' ''\n']+ { IDENTIFIER (Lexing.lexeme lexbuf) }

--- a/src/util/makefileParser.mly
+++ b/src/util/makefileParser.mly
@@ -1,0 +1,24 @@
+%token <string> IDENTIFIER
+%token COLON
+%token NEWLINE
+%token EOF
+
+%type <string * string list> deps
+
+%start deps
+
+%%
+
+deps:
+  | IDENTIFIER COLON identifier_list NEWLINE EOF { ($1, $3) }
+  ;
+
+identifier_list:
+  | { [] }
+  | identifier_nonempty_list { $1 }
+  ;
+
+identifier_nonempty_list:
+  | IDENTIFIER { [$1] }
+  | IDENTIFIER identifier_nonempty_list { $1 :: $2 }
+  ;

--- a/src/util/preprocessor.ml
+++ b/src/util/preprocessor.ml
@@ -35,3 +35,14 @@ let cpp =
   )
 
 let get_cpp () = Lazy.force cpp
+
+
+let dependencies: (string, string list) Hashtbl.t = Hashtbl.create 3
+
+let parse_makefile_deps makefile =
+  BatFile.with_file_in makefile (fun input ->
+    let lexbuf = Lexing.from_channel input in
+    let (rule, deps) = MakefileParser.deps MakefileLexer.token lexbuf in
+    let deps = List.remove deps rule in
+    Hashtbl.replace dependencies rule deps
+  )


### PR DESCRIPTION
Adds a list of analyzed (and dependency) files to the json-messages output used by GobPie.
It would be very useful for the latter when using compilation databases to know the list of files that Goblint read from the compilation database and analyzed. Otherwise GobPie would have to unnecessarily duplicate compilation database logic.

Moreover, what this list should also contain is all the dependency files, i.e. included headers (transitively!), because any change to those would also require reanalysis. This however is nontrivial and I currently see two possible ways to go about it:
1. Extend CIL's `#line` etc pragma parser to not only change the current location inside its lexer, but record each filename encountered and expose that to Goblint. Just iterating over all locations inside the AST might be insufficient if the header file contains no definitions!
2. Use the preprocessor with `-M` to ask it for all dependencies in Makefile format and parse that in Goblint.

@michael-schwarz Do you have a preference or any other idea?


### TODO
- [x] Add included header files.