### PR TITLE
Store and load data of analyses in incremental runs. (Cherry-picking #498 onto master)

### DIFF
--- a/src/incremental/serialize.ml
+++ b/src/incremental/serialize.ml
@@ -5,6 +5,7 @@ let goblint_dirname = "incremental_data"
 let version_map_filename = "version.data"
 let cil_file_name = "ast.data"
 let solver_data_file_name = "solver.data"
+let analysis_data_file_name = "analysis.data"
 let results_dir = "results"
 let results_tmp_dir = "results_tmp"
 let gob_directory () = let src_dir = !base_directory in
@@ -31,12 +32,13 @@ let results_exist () =
   Sys.file_exists r && Sys.is_directory r
 
 (* Convenience enumeration of the different data types we store for incremental analysis, so file-name logic is concentrated in one place *)
-type incremental_data_kind = SolverData | CilFile | VersionData
+type incremental_data_kind = SolverData | CilFile | VersionData | AnalysisData
 
 let type_to_file_name = function
   | SolverData -> solver_data_file_name
   | CilFile -> cil_file_name
   | VersionData -> version_map_filename
+  | AnalysisData -> analysis_data_file_name
 
 (** Loads data for incremental runs from the appropriate file *)
 let load_data (data_type: incremental_data_kind) =

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -431,7 +431,7 @@ let check_arguments () =
   if get_bool "ana.base.context.int" && not (get_bool "ana.base.context.non-ptr") then (set_bool "ana.base.context.int" false; warn "ana.base.context.int implicitly disabled by ana.base.context.non-ptr");
   (* order matters: non-ptr=false, int=true -> int=false cascades to interval=false with warning *)
   if get_bool "ana.base.context.interval" && not (get_bool "ana.base.context.int") then (set_bool "ana.base.context.interval" false; warn "ana.base.context.interval implicitly disabled by ana.base.context.int");
-  if get_bool "incremental.only-rename" then (set_bool "incremental.load" true; warn "incremental.only-rename implicitly activates incremental.rename-load. Previous AST is loaded for diff and rename, but analyis results are not reused.")
+  if get_bool "incremental.only-rename" then (set_bool "incremental.load" true; warn "incremental.only-rename implicitly activates incremental.load. Previous AST is loaded for diff and rename, but analyis results are not reused.")
 
 let handle_extraspecials () =
   let funs = get_string_list "exp.extraspecials" in


### PR DESCRIPTION
In particular, this is needed for reloading the hashtables where varinfos describing dynamically allocated memory are stored. The
analyses rely on this data for correctness.

Needed for #522 