### PR TITLE
Add option `ana.thread.include-node` to disable nodes in TIDs

### DIFF
--- a/src/cdomains/threadIdDomain.ml
+++ b/src/cdomains/threadIdDomain.ml
@@ -56,7 +56,7 @@ struct
 
   let threadinit v ~multiple: t = (v, None)
   let threadenter l v: t =
-    if GobConfig.get_bool "ana.thread.include-loc" then
+    if GobConfig.get_bool "ana.thread.include-node" then
       (v, Some l)
     else
       (v, None)

--- a/src/cdomains/threadIdDomain.ml
+++ b/src/cdomains/threadIdDomain.ml
@@ -55,7 +55,11 @@ struct
   )
 
   let threadinit v ~multiple: t = (v, None)
-  let threadenter l v: t = (v, Some l)
+  let threadenter l v: t =
+    if GobConfig.get_bool "ana.thread.include-loc" then
+      (v, Some l)
+    else
+      (v, None)
 
   let is_main = function
     | ({vname = "main"; _}, None) -> true

--- a/src/cdomains/threadIdDomain.ml
+++ b/src/cdomains/threadIdDomain.ml
@@ -41,7 +41,7 @@ end
 (** Type to represent an abstract thread ID. *)
 module FunNode: Stateless =
 struct
-  include Printable.Prod (CilType.Varinfo) (Printable.Option (Node) (struct let name = "no location" end))
+  include Printable.Prod (CilType.Varinfo) (Printable.Option (Node) (struct let name = "no node" end))
 
   let show = function
     | (f, Some n) -> f.vname ^ "@" ^ (CilType.Location.show (UpdateCil.getLoc n))

--- a/src/cdomains/threadIdDomain.ml
+++ b/src/cdomains/threadIdDomain.ml
@@ -39,7 +39,7 @@ end
 
 
 (** Type to represent an abstract thread ID. *)
-module FunLoc: Stateless =
+module FunNode: Stateless =
 struct
   include Printable.Prod (CilType.Varinfo) (Printable.Option (Node) (struct let name = "no location" end))
 
@@ -169,9 +169,9 @@ end
 module FlagConfiguredTID:Stateful =
 struct
   (* Thread IDs with prefix-set history *)
-  module H = History(FunLoc)
+  module H = History(FunNode)
   (* Plain thread IDs *)
-  module P = Unit(FunLoc)
+  module P = Unit(FunNode)
 
   include GroupableFlagHelper(H)(P)(struct
       let msg = "FlagConfiguredTID received a value where not exactly one component is set"

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -784,10 +784,10 @@
               "enum": ["history", "plain"],
               "default": "history"
             },
-            "include-loc" : {
-              "title": "ana.thread.include-loc",
+            "include-node" : {
+              "title": "ana.thread.include-node",
               "description":
-                "Whether the line at which a thread is created is part of its threadid",
+                "Whether the node at which a thread is created is part of its threadid",
               "type": "boolean",
               "default" : true
             }

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -783,6 +783,13 @@
               "type": "string",
               "enum": ["history", "plain"],
               "default": "history"
+            },
+            "include-loc" : {
+              "title": "ana.thread.include-loc",
+              "description":
+                "Whether the line at which a thread is created is part of its threadid",
+              "type": "boolean",
+              "default" : true
             }
           },
           "additionalProperties": false

--- a/tests/regression/36-apron/97-no-loc.c
+++ b/tests/regression/36-apron/97-no-loc.c
@@ -1,0 +1,39 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid --disable ana.thread.include-loc
+#include <pthread.h>
+#include <assert.h>
+
+int g = 10;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_benign(void *arg) {
+  pthread_mutex_lock(&A);
+  g = 20;
+  pthread_mutex_unlock(&A);
+  return NULL;
+}
+
+int main(void) {
+  int t;
+
+  // Force multi-threaded handling
+  pthread_t id2;
+
+  if(t) {
+    pthread_create(&id2, NULL, t_benign, NULL);
+  } else {
+    pthread_create(&id2, NULL, t_benign, NULL);
+  }
+
+  pthread_join(id2, NULL);
+
+
+  pthread_mutex_lock(&A);
+  g = 12;
+  pthread_mutex_unlock(&A);
+
+  pthread_mutex_lock(&A);
+  assert(g == 12);
+  pthread_mutex_unlock(&A);
+
+  return 0;
+}

--- a/tests/regression/36-apron/97-no-loc.c
+++ b/tests/regression/36-apron/97-no-loc.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid --disable ana.thread.include-loc
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid --disable ana.thread.include-node
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/98-loc.c
+++ b/tests/regression/36-apron/98-loc.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid --disable ana.thread.include-loc
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid --enable ana.thread.include-loc
 #include <pthread.h>
 #include <assert.h>
 
@@ -31,7 +31,7 @@ int main(void) {
     pthread_create(&id, NULL, t_benign, NULL);
   }
 
-  // As these two threads are not distinguished, we have a unique TID for id
+  // As these two threads are distinguished, we have a non-unique TID for id
   pthread_join(id, NULL);
 
 
@@ -40,7 +40,7 @@ int main(void) {
   pthread_mutex_unlock(&A);
 
   pthread_mutex_lock(&A);
-  assert(g == 12);
+  assert(g == 12); //TODO
   pthread_mutex_unlock(&A);
 
 // ---------------------------------------------------------------------------
@@ -54,7 +54,7 @@ int main(void) {
 
   pthread_join(id2, NULL);
 
-  // As these two threads are not distinguished, id3 is a not unique thread
+  // As these two threads are distinguished, id3 is a unique thread
   pthread_join(id3, NULL);
 
 
@@ -63,7 +63,7 @@ int main(void) {
   pthread_mutex_unlock(&A);
 
   pthread_mutex_lock(&A);
-  assert(h == 12); //TODO
+  assert(h == 12);
   pthread_mutex_unlock(&A);
 
   return 0;

--- a/tests/regression/36-apron/98-loc.c
+++ b/tests/regression/36-apron/98-loc.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid --enable ana.thread.include-loc
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid --enable ana.thread.include-node
 #include <pthread.h>
 #include <assert.h>
 


### PR DESCRIPTION
For the incremental analysis it is problematic if thread ids contain the node of the pthread_create(...) call as that leads to a complete reanalysis of the threads created in a changed function, even if these threads themselves are unchanged.

Add an option `ana.thread.include-node` to toggle this behavior.

Disabling it does (together with our must joined analysis) sometimes lead to less precision (not distinguishing threads started in sequence that start with the same function ). Interestingly, it can also lead to better precision when the same thread is created in different branches, as the variable holding the thread ids contains only this single unique thread.

See examples `36/97` and `36/98` for examples of this.

Closes #527 