### PR TITLE
Fix implementation of `equal` and `compare` in `IntDomTupleImpl` 

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2603,7 +2603,7 @@ module IntDomTupleImpl = struct
   module I4 = Congruence
 
   type t = I1.t option * I2.t option * I3.t option * I4.t option
-  [@@deriving to_yojson]
+  [@@deriving to_yojson, eq, ord]
 
   let name () = "intdomtuple"
 
@@ -2726,16 +2726,6 @@ module IntDomTupleImpl = struct
   let leq =
     for_all
     %% map2p {f2p= (fun (type a) (module I : S with type t = a) ?no_ov -> I.leq)}
-
-  let equal =
-    for_all
-    %% map2p {f2p= (fun (type a) (module I : S with type t = a) ?no_ov -> I.equal)}
-
-  let compare =
-    List.fold_left (fun a x -> if x <> 0 then x else a) 0
-    % to_list
-    %% map2p {f2p= (fun (type a) (module I : S with type t = a) ?no_ov -> I.compare)} (* idea? same impl. as above... *)
-
 
   let flat f x = match to_list_some x with [] -> None | xs -> Some (f xs)
 

--- a/tests/incremental/03-precision-annotation/01-change_precision.c
+++ b/tests/incremental/03-precision-annotation/01-change_precision.c
@@ -1,0 +1,30 @@
+//PARAM: --enable annotation.int.enabled
+#include <assert.h>
+#include <math.h>
+
+int main() __attribute__ ((goblint_precision("def_exc","interval")));
+
+int foo(int x){
+    if(x < 10){
+        return 0;
+    }
+    return 1;
+}
+
+int bar(int x){
+    if(x < 10){
+        return 0;
+    }
+    return 1;
+}
+
+int main(){
+    int x = rand() % 10;
+
+    int a = foo(x);
+    assert(a == 0); //UNKNOWN
+
+    int b = bar(x);
+    assert(b == 0); //UNKNOWN
+    return 0;
+}

--- a/tests/incremental/03-precision-annotation/01-change_precision.json
+++ b/tests/incremental/03-precision-annotation/01-change_precision.json
@@ -1,0 +1,7 @@
+{
+    "annotation": {
+        "int": {
+            "enabled": true
+        }
+    }
+}

--- a/tests/incremental/03-precision-annotation/01-change_precision.patch
+++ b/tests/incremental/03-precision-annotation/01-change_precision.patch
@@ -1,0 +1,21 @@
+diff --git tests/incremental/03-precision-annotation/01-change_precision.c tests/incremental/03-precision-annotation/01-change_precision2.c
+index 47170c52e..4e7a04f88 100644
+--- tests/incremental/03-precision-annotation/01-change_precision.c
++++ tests/incremental/03-precision-annotation/01-change_precision2.c
+@@ -3,6 +3,7 @@
+ #include <math.h>
+ 
+ int main() __attribute__ ((goblint_precision("def_exc","interval")));
++int foo(int in) __attribute__ ((goblint_precision("def_exc", "interval")));
+ 
+ int foo(int x){
+     if(x < 10){
+@@ -22,7 +23,7 @@ int main(){
+     int x = rand() % 10;
+ 
+     int a = foo(x);
+-    assert(a == 0); //UNKNOWN
++    assert(a == 0);
+ 
+     int b = bar(x);
+     assert(b == 0); //UNKNOWN


### PR DESCRIPTION
The `equal` and `compare` in `IntDomTupleImp` do not consider the entries corresponding to an domain, when one of the operands has  a `None` entry in the corresponding position. See #541

This PR fixes this by deriving `eq` and `ord`, i.e. the functions `equal` and `compare`. 