### PR TITLE
LvalDomain: Print offset of rich varinfo as well

### DIFF
--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -215,7 +215,7 @@ struct
   let short_addr (x, o) =
     if RichVarinfo.BiVarinfoMap.Collection.mem_varinfo x then
       let description = RichVarinfo.BiVarinfoMap.Collection.describe_varinfo x in
-      "(" ^ x.vname ^ ", " ^ description ^ ")"
+      "(" ^ x.vname ^ ", " ^ description ^ ")" ^ short_offs o
     else x.vname ^ short_offs o
 
   let show = function


### PR DESCRIPTION
Currently, we only print the offset of non-rich varinfos. This can be confusing.