### PR TITLE
Filter non-racing accesses of racing variable

### DIFF
--- a/tests/regression/04-mutex/27-base_rc.c
+++ b/tests/regression/04-mutex/27-base_rc.c
@@ -9,7 +9,7 @@ void bad() {
 }
 void good() {
   pthread_mutex_lock(&gm);
-  global++; // RACE
+  global++; // NORACE (MHP)
   pthread_mutex_unlock(&gm);
 }
 

--- a/tests/regression/04-mutex/35-trylock_rc.c
+++ b/tests/regression/04-mutex/35-trylock_rc.c
@@ -49,7 +49,7 @@ void *monitor_thread (void *arg) {
     if (status != EBUSY) {
       if (status != 0)
         err_abort (status, "Trylock mutex");
-      printf ("Counter is %ld\n", counter/SPIN); // RACE
+      printf ("Counter is %ld\n", counter/SPIN); // NORACE (MHP)
       status = pthread_mutex_unlock (&mutex);
       if (status != 0)
         err_abort (status, "Unlock mutex");

--- a/tests/regression/10-synch/12-join_rc.c
+++ b/tests/regression/10-synch/12-join_rc.c
@@ -18,7 +18,7 @@ int main(void) {
   for (i=0; i<10; i++)
     pthread_create(&id[i], NULL, t_fun, NULL);
   pthread_mutex_lock(&mutex);
-  myglobal=myglobal+1; // RACE
+  myglobal=myglobal+1; // NORACE (MHP)
   pthread_mutex_unlock(&mutex);
   for (i=0; i<9; i++)
     pthread_join(id[i], NULL);

--- a/tests/regression/53-races-mhp/03-not-created_rc.c
+++ b/tests/regression/53-races-mhp/03-not-created_rc.c
@@ -1,0 +1,29 @@
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+void *t_fun2(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  myglobal=myglobal+1; // RACE!
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id, id2;
+  pthread_create(&id, NULL, t_fun, NULL); // enter multithreaded
+  myglobal = 5; // NORACE
+
+  pthread_create(&id2, NULL, t_fun2, NULL);
+  pthread_mutex_lock(&mutex2);
+  myglobal=myglobal+1; // RACE!
+  pthread_mutex_unlock(&mutex2);
+  return 0;
+}


### PR DESCRIPTION
Previously, if we determined a variable to have racing accesses, then we printed all of its accesses. This is excessive since there might be accesses that don't race with any other.

This PR filters the accesses of a racing variable to only contain those that actually race with another access to it. This is now possible due to the pairwise may-race checking and avoids some spurious warnings.