### PR TITLE
Group racing accesses into disjoint components

### DIFF
--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -422,8 +422,13 @@ let group_may_race accs =
 
 let race_conf accs =
   assert (not (AS.is_empty accs)); (* group_may_race should only construct non-empty components *)
-  if AS.cardinal accs = 1 then (* singleton component has no race *) (* TODO: what about self-races? *)
-    None
+  if AS.cardinal accs = 1 then ( (* singleton component *)
+    let acc = AS.choose accs in
+    if may_race acc acc then (* self-race *)
+      Some (A.conf acc)
+    else
+      None
+  )
   else
     Some (AS.max_conf accs)
 

--- a/tests/regression/10-synch/05-two_unique_two_lock.c
+++ b/tests/regression/10-synch/05-two_unique_two_lock.c
@@ -1,0 +1,34 @@
+// PARAM: --set ana.activated[+] thread
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t B = PTHREAD_MUTEX_INITIALIZER;
+
+void *f1(void *arg) {
+  pthread_mutex_lock(&A);
+  myglobal=1; // RACE! (with just 4)
+  pthread_mutex_unlock(&A);
+  pthread_mutex_lock(&B);
+  myglobal=2; // RACE! (with just 3)
+  pthread_mutex_unlock(&B);
+  return NULL;
+}
+
+void *f2(void *arg) {
+  pthread_mutex_lock(&A);
+  myglobal=3; // RACE! (with just 2)
+  pthread_mutex_unlock(&A);
+  pthread_mutex_lock(&B);
+  myglobal=4; // RACE! (with just 1)
+  pthread_mutex_unlock(&B);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t t1, t2;
+  pthread_create(&t1, NULL, f1, NULL);
+  pthread_create(&t2, NULL, f2, NULL);
+  return 0;
+}

--- a/tests/regression/10-synch/06-thread_nonunique_plain.c
+++ b/tests/regression/10-synch/06-thread_nonunique_plain.c
@@ -1,0 +1,20 @@
+// PARAM: --set ana.activated[+] thread --set ana.thread.domain plain
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+
+void *t_fun(void *arg) {
+  myglobal=42; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id[10];
+  int i;
+  for (i=0; i<10; i++)
+    pthread_create(&id[i], NULL, t_fun, NULL);
+  for (i=0; i<10; i++)
+    pthread_join (id[i], NULL);
+  return 0;
+}


### PR DESCRIPTION
Accesses of a single location are grouped into disjoint components, i.e. connected components in the graph of accesses with `may_race` edges).
This doesn't strictly improve precision, because all the same accesses are still printed, but it improves the precision and usability of the output by making it clearer, which accesses cannot race with which.
It makes sense to expose this information because the pairwise race checking internally knows (only previously only implicitly).

### Example
In the added test `tests/regression/10-synch/05-two_unique_two_lock.c`.

#### Before
All accesses are printed under one warning.
```
[Warning][Race] Memory location myglobal@05-two_unique_two_lock.c:5:5-5:13 (race with conf. 110):
  write with [lock:{A}, thread * mhp:(([f1@tests/regression/10-synch/05-two_unique_two_lock.c:31:3-31:37, main], {}), ...)] (conf. 110)  (exp: & myglobal) (tests/regression/10-synch/05-two_unique_two_lock.c:11:3-11:13)
  write with [lock:{B}, thread * mhp:(([f1@tests/regression/10-synch/05-two_unique_two_lock.c:31:3-31:37, main], {}), ...)] (conf. 110)  (exp: & myglobal) (tests/regression/10-synch/05-two_unique_two_lock.c:14:3-14:13)
  write with [lock:{A}, thread * mhp:(([f2@tests/regression/10-synch/05-two_unique_two_lock.c:32:3-32:37, main], {}), ...)] (conf. 110)  (exp: & myglobal) (tests/regression/10-synch/05-two_unique_two_lock.c:21:3-21:13)
  write with [lock:{B}, thread * mhp:(([f2@tests/regression/10-synch/05-two_unique_two_lock.c:32:3-32:37, main], {}), ...)] (conf. 110)  (exp: & myglobal) (tests/regression/10-synch/05-two_unique_two_lock.c:24:3-24:13)
```

#### After
Accesses are printed under two different warnings for the same location such that the two racing components have no races between each other, only internally:
```
[Warning][Race] Memory location myglobal@05-two_unique_two_lock.c:5:5-5:13 (race with conf. 110):
  write with [lock:{B}, thread * mhp:(([f1@tests/regression/10-synch/05-two_unique_two_lock.c:31:3-31:37, main], {}), ...)] (conf. 110)  (exp: & myglobal) (tests/regression/10-synch/05-two_unique_two_lock.c:14:3-14:13)
  write with [lock:{A}, thread * mhp:(([f2@tests/regression/10-synch/05-two_unique_two_lock.c:32:3-32:37, main], {}), ...)] (conf. 110)  (exp: & myglobal) (tests/regression/10-synch/05-two_unique_two_lock.c:21:3-21:13)

[Warning][Race] Memory location myglobal@05-two_unique_two_lock.c:5:5-5:13 (race with conf. 110):
  write with [lock:{A}, thread * mhp:(([f1@tests/regression/10-synch/05-two_unique_two_lock.c:31:3-31:37, main], {}), ...)] (conf. 110)  (exp: & myglobal) (tests/regression/10-synch/05-two_unique_two_lock.c:11:3-11:13)
  write with [lock:{B}, thread * mhp:(([f2@tests/regression/10-synch/05-two_unique_two_lock.c:32:3-32:37, main], {}), ...)] (conf. 110)  (exp: & myglobal) (tests/regression/10-synch/05-two_unique_two_lock.c:24:3-24:13)
```