### PR TITLE
Generalize handling of `.d` files: Accept `.d` files with multiple targets, eat `-MF` arguments to preprocessor

### DIFF
--- a/src/util/compilationDatabase.ml
+++ b/src/util/compilationDatabase.ml
@@ -72,6 +72,10 @@ let load_and_preprocess ~all_cppflags filename =
             | (o_i, _) ->
               begin match List.split_at o_i arguments with
                 | (arguments_program :: arguments_init, _ :: o_file :: arguments_tl) ->
+                  let arguments_init = match List.findi (fun i e -> e = "-MF") arguments_init with
+                    | (mf_i,_) -> List.remove_at mf_i (List.remove_at mf_i arguments_init)
+                    | exception Not_found -> arguments_init
+                  in
                   let preprocess_arguments = all_cppflags @ "-E" :: "-MMD" :: "-MT" :: file :: arguments_init @ "-o" :: preprocessed_file :: arguments_tl in
                   Filename.quote_command arguments_program preprocess_arguments
                 | _ ->

--- a/src/util/makefileParser.mly
+++ b/src/util/makefileParser.mly
@@ -3,14 +3,16 @@
 %token NEWLINE
 %token EOF
 
-%type <string * string list> deps
+%type <(string list * string list) list> deps
 
 %start deps
 
 %%
 
 deps:
-  | IDENTIFIER COLON identifier_list NEWLINE EOF { ($1, $3) }
+  | identifier_nonempty_list COLON identifier_list NEWLINE deps { ($1, $3) :: $5 }
+  | NEWLINE identifier_nonempty_list COLON identifier_list NEWLINE deps { ($2, $4) :: $6 }
+  | EOF { [] }
   ;
 
 identifier_list:

--- a/src/util/preprocessor.ml
+++ b/src/util/preprocessor.ml
@@ -40,11 +40,13 @@ let get_cpp () = Lazy.force cpp
 let dependencies: (string, string list) Hashtbl.t = Hashtbl.create 3
 
 let parse_makefile_deps makefile =
-  try
-    BatFile.with_file_in makefile (fun input ->
+  BatFile.with_file_in makefile (fun input ->
       let lexbuf = Lexing.from_channel input in
-      let (rule, deps) = MakefileParser.deps MakefileLexer.token lexbuf in
-      let deps = List.remove deps rule in
-      Hashtbl.replace dependencies rule deps
+      let rules = MakefileParser.deps MakefileLexer.token lexbuf in
+      List.iter (fun (rule, deps) ->
+          List.iter (fun r ->
+              let deps = List.remove deps r in
+              Hashtbl.replace dependencies r deps
+            ) rule
+        ) rules
     )
-  with Sys_error _ -> ();

--- a/src/util/preprocessor.ml
+++ b/src/util/preprocessor.ml
@@ -40,9 +40,11 @@ let get_cpp () = Lazy.force cpp
 let dependencies: (string, string list) Hashtbl.t = Hashtbl.create 3
 
 let parse_makefile_deps makefile =
-  BatFile.with_file_in makefile (fun input ->
+  try
+    BatFile.with_file_in makefile (fun input ->
       let lexbuf = Lexing.from_channel input in
       let (rule, deps) = MakefileParser.deps MakefileLexer.token lexbuf in
       let deps = List.remove deps rule in
       Hashtbl.replace dependencies rule deps
     )
+  with Sys_error _ -> ();


### PR DESCRIPTION
Skip instead of failing if there is no `.d` file for some entry in the compilation database.
Needed for https://github.com/goblint/bench/issues/9 after https://github.com/goblint/analyzer/pull/535