### PR TITLE
Reenable and fix some OCaml warnings

### DIFF
--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -129,7 +129,7 @@ struct
     assert (AD.varinfo_tracked x);
     let ik = Cilfacade.get_ikind x.vtype in
     if not (IntDomain.should_ignore_overflow ik) then ( (* don't add type bounds for signed when assume_none *)
-      let (type_min, type_max) = IntDomain.Size.range_big_int ik in
+      let (type_min, type_max) = IntDomain.Size.range ik in
       (* TODO: don't go through CIL exp? *)
       let apr = AD.assert_inv apr (BinOp (Le, Lval (Cil.var x), (Cil.kintegerCilint ik (Cilint.cilint_of_big_int type_max)), intType)) false in
       let apr = AD.assert_inv apr (BinOp (Ge, Lval (Cil.var x), (Cil.kintegerCilint ik (Cilint.cilint_of_big_int type_min)), intType)) false in

--- a/src/analyses/arinc.ml
+++ b/src/analyses/arinc.ml
@@ -45,6 +45,8 @@ end
 
 module Spec : Analyses.MCPSpec =
 struct
+  [@@@warning "-32"] (* disable unused-value-declaration warnings, some functions are only used by commented out code *)
+
   include Analyses.DefaultSpec
 
   let name () = "arinc"
@@ -68,7 +70,6 @@ struct
       v
   let get_by_id (id:id) : (resource*string) option =
     Hashtbl.filter ((=) id) resources |> Hashtbl.keys |> Enum.get
-  let get_name_by_id id = get_by_id id |> Option.get |> snd
 
   (* map process name to integer used in Pid domain *)
   let pnames = Hashtbl.create 13
@@ -82,7 +83,6 @@ struct
       let id = if Enum.is_empty ids then 1L else Int64.succ (Enum.arg_max identity ids) in
       Hashtbl.replace pnames pname id;
       id
-  let get_pid_by_id id = get_by_id id |> Option.get |> snd |> get_pid
 
 
   (* Domains *)
@@ -92,8 +92,6 @@ struct
   module G = Tasks
   module C = D
   module V = Printable.UnitConf (struct let name = "tasks" end)
-
-  let sprint_map f xs = String.concat ", " @@ List.map (sprint f) xs
 
   let context fd d = { d with pred = Pred.bot (); ctx = Ctx.bot () }
 
@@ -163,7 +161,6 @@ struct
       M.debug "mayPointTo: query result for %a is %a" d_exp exp Queries.LS.pretty v;
       (*failwith "mayPointTo"*)
       []
-  let mustPointTo ctx exp = let xs = mayPointTo ctx exp in if List.compare_length_with xs 1 = 0 then Some (List.hd xs) else None
   let iterMayPointTo ctx exp f = mayPointTo ctx exp |> List.iter f
   let debugMayPointTo ctx exp = M.debug "%a mayPointTo %a" d_exp exp (Pretty.d_list ", " Lval.CilLval.pretty) (mayPointTo ctx exp)
 
@@ -313,11 +310,6 @@ struct
         (* set current node as new predecessor, since something interesting happend during the call *)
         { d_callee with pred = Pred.of_node env.node; ctx = d_caller.ctx }
       )
-
-  (* ARINC utility functions *)
-  let mode_is_init  i = match Pmo.to_int i with Some 1L | Some 2L -> true | _ -> false
-  let mode_is_multi i = Pmo.to_int i = Some 3L
-  let pname_ErrorHandler = "ErrorHandler"
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     let open ArincUtil in let _ = 42 in (* sublime's syntax highlighter gets confused without the second let... *)

--- a/src/analyses/arinc.ml
+++ b/src/analyses/arinc.ml
@@ -45,7 +45,7 @@ end
 
 module Spec : Analyses.MCPSpec =
 struct
-  [@@@warning "-32"] (* disable unused-value-declaration warnings, some functions are only used by commented out code *)
+  [@@@warning "-unused-value-declaration"] (* some functions are only used by commented out code *)
 
   include Analyses.DefaultSpec
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -80,9 +80,6 @@ struct
    * Helpers
    **************************************************************************)
 
-  (* hack for char a[] = {"foo"} or {'f','o','o', '\000'} *)
-  let char_array : (lval, bytes) Hashtbl.t = Hashtbl.create 500
-
   let hash    (x,_)             = Hashtbl.hash x
   let leq     (x1,_) (y1,_) = CPA.leq   x1 y1
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -513,7 +513,7 @@ struct
       let toInt i =
         match IdxDom.to_int @@ ID.cast_to ik i with
         | Some x -> Const (CInt (x,ik, None))
-        | _ -> mkCast (Const (CStr "unknown")) intType
+        | _ -> mkCast ~e:(Const (CStr "unknown")) ~newt:intType
 
       in
       match o with
@@ -696,7 +696,7 @@ struct
       (* String literals *)
       | Const (CStr x) -> `Address (AD.from_string x) (* normal 8-bit strings, type: char* *)
       | Const (CWStr xs as c) -> (* wide character strings, type: wchar_t* *)
-        let x = Pretty.sprint 80 (d_const () c) in (* escapes, see impl. of d_const in cil.ml *)
+        let x = Pretty.sprint ~width:80 (d_const () c) in (* escapes, see impl. of d_const in cil.ml *)
         let x = String.sub x 2 (String.length x - 3) in (* remove surrounding quotes: L"foo" -> foo *)
         `Address (AD.from_string x) (* `Address (AD.str_ptr ()) *)
       (* Variables and address expressions *)
@@ -2047,7 +2047,7 @@ struct
             let result = if annot = None && (expected = Some ("NOWARN") || (expected = Some ("UNKNOWN") && not (String.exists line "UNKNOWN!"))) then "improved" else "failed" in
             (* Expressions with logical connectives like a && b are calculated in temporary variables by CIL. Instead of the original expression, we then see something like tmp___0. So we replace expr in msg by the original source if this is the case. *)
             let assert_expr = if string_match (regexp ".*assert(\\(.+\\));.*") line 0 then matched_group 1 line else expr in
-            let msg = if expr <> assert_expr then String.nreplace msg expr assert_expr else msg in
+            let msg = if expr <> assert_expr then String.nreplace ~str:msg ~sub:expr ~by:assert_expr else msg in
             warn_fn (msg ^ " Expected: " ^ (expected |? "SUCCESS") ^ " -> " ^ result)
           )
         ) else

--- a/src/analyses/extract_arinc.ml
+++ b/src/analyses/extract_arinc.ml
@@ -382,13 +382,13 @@ struct
     ignore @@ List.map (fun name -> Res.get ("process", name)) mainfuns;
     assert (List.compare_length_with mainfuns 1 = 0); (* TODO? *)
     List.iter (fun fname -> Pfuns.add "main" fname) mainfuns;
-    if GobConfig.get_bool "ana.arinc.export" then output_file (Goblintutil.create_dir "result/" ^ "arinc.os.pml") (snd (Pml_arinc.init ()))
+    if GobConfig.get_bool "ana.arinc.export" then output_file ~filename:(Goblintutil.create_dir "result/" ^ "arinc.os.pml") ~text:(snd (Pml_arinc.init ()))
 
   let finalize () = (* writes out collected cfg *)
     (* TODO call Pml_arinc.init again with the right number of resources to find out of bounds accesses? *)
     if GobConfig.get_bool "ana.arinc.export" then (
       let path = Goblintutil.create_dir "result" ^ "/arinc.pml" in (* returns abs. path *)
-      output_file path (codegen ());
+      output_file ~filename:path ~text:(codegen ());
       print_endline @@ "Model saved as " ^ path;
       print_endline "Run ./spin/check.sh to verify."
     )

--- a/src/analyses/extract_osek.ml
+++ b/src/analyses/extract_osek.ml
@@ -329,11 +329,11 @@ struct
     ignore @@ List.map (fun name -> Res.get ("process", name)) mainfuns;
     assert (List.compare_length_with mainfuns 1 = 0); (* TODO? *)
     List.iter (fun fname -> Pfuns.add "main" fname) mainfuns;
-    output_file (Goblintutil.create_dir "result/" ^ "osek.os.pml") (snd (Pml_osek.init ()))
+    output_file ~filename:(Goblintutil.create_dir "result/" ^ "osek.os.pml") ~text:(snd (Pml_osek.init ()))
 
   let finalize () = (* writes out collected cfg *)
     (* TODO call Pml_osek.init again with the right number of resources to find out of bounds accesses? *)
-    output_file "result/osek.pml" (codegen ())
+    output_file ~filename:"result/osek.pml" ~text:(codegen ())
 end
 
 let _ =

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -91,7 +91,7 @@ type action = [ `Write | `Read ]
 
 module Invalidate =
 struct
-  [@@@warning "-32"] (* disable unused-value-declaration warnings, some functions are not used below *)
+  [@@@warning "-unused-value-declaration"] (* some functions are not used below *)
 
   let drop = List.drop
   let keep ns = List.filteri (fun i _ -> List.mem i ns)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -154,7 +154,7 @@ let writesAll a x =
 (* Data races: which arguments are read/written?
  * We assume that no known functions that are reachable are executed/spawned. For that we use ThreadCreate above. *)
 (* WTF: why are argument numbers 1-indexed (in partition)? *)
-let invalidate_actions = ref [
+let invalidate_actions = [
     "GetResource", readsAll;
     "ReleaseResource", readsAll;
     "GetSpinlock", readsAll;
@@ -430,7 +430,6 @@ let invalidate_actions = ref [
     "LAP_Se_CreateProcess", writes [2; 3];
     "LAP_Se_CreateErrorHandler", writes [2; 3]
   ]
-let add_invalidate_actions xs = invalidate_actions := xs @ !invalidate_actions
 
 (* used by get_invalidate_action to make sure
  * that hash of invalidates is built only once
@@ -444,7 +443,7 @@ let get_invalidate_action name =
     | None -> begin
         let hash = Hashtbl.create 113 in
         let f (k, v) = Hashtbl.add hash k v in
-        List.iter f !invalidate_actions;
+        List.iter f invalidate_actions;
         processed_table := (Some hash);
         hash
       end

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -150,9 +150,6 @@ struct
     in
     f [] [] xs
 
-  let assoc_split k xs = assoc_split_eq (=) k xs
-
-
   (** [group_assoc_eq (=) [(1,a);(1,b);(2,x);(2,y)] = [(1,[a,b]),(2,[x,y])]] *)
   let group_assoc_eq eq (xs: ('a * 'b) list) : ('a * ('b list)) list  =
     let rec f a = function
@@ -161,9 +158,6 @@ struct
         let a', b = assoc_split_eq eq k xs in
         f ((k,v::a')::a) b
     in f [] xs
-
-  (** [group_assoc [(1,a);(1,b);(2,x);(2,y)] = [(1,[a,b]),(2,[x,y])]] *)
-  let group_assoc xs = group_assoc_eq (=) xs
 
   let filter_presubs n xs =
     let f n =

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -129,9 +129,6 @@ struct
       else fold_left (fun a (n,d) -> f a n d @@ assoc n y) a x
     with Not_found -> raise (DomListBroken "binop_fold : assoc failure")
 
-  let binop_map_rev (f: (module Printable.S) -> Obj.t -> Obj.t -> Obj.t) =
-    binop_fold (fun a n s d1 d2 -> (n, f s d1 d2) :: a) []
-
   let equal   x y = binop_fold (fun a n (module S : Printable.S) x y -> a && S.equal (obj x) (obj y)) true x y
   let compare x y = binop_fold (fun a n (module S : Printable.S) x y -> if a <> 0 then a else S.compare (obj x) (obj y)) 0 x y
 

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -156,7 +156,7 @@ struct
       (* ignore (printf "one_perelem (%a,%a,%a)\n" Exp.pretty e Exp.pretty a Exp.pretty l); *)
       match Exp.fold_offs (Exp.replace_base (dummyFunDec.svar,`NoOffset) e l) with
       | Some (v, o) ->
-        let l = Pretty.sprint 80 (d_offset (text "*") () o) in
+        let l = Pretty.sprint ~width:80 (d_offset (text "*") () o) in
         (* ignore (printf "adding lock %s\n" l); *)
         LSSet.add ("p-lock",l) xs
       | None -> xs

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -559,11 +559,11 @@ struct
     | StartOf (Var _,_)
     | Lval    (Var _,_) -> eq_set e s
     | AddrOf  (Mem e,ofs) ->
-      Queries.ES.map (fun e -> mkAddrOf (mkMem e ofs)) (eq_set_clos e s)
+      Queries.ES.map (fun e -> mkAddrOf (mkMem ~addr:e ~off:ofs)) (eq_set_clos e s)
     | StartOf (Mem e,ofs) ->
-      Queries.ES.map (fun e -> mkAddrOrStartOf (mkMem e ofs)) (eq_set_clos e s)
+      Queries.ES.map (fun e -> mkAddrOrStartOf (mkMem ~addr:e ~off:ofs)) (eq_set_clos e s)
     | Lval    (Mem e,ofs) ->
-      Queries.ES.map (fun e -> Lval (mkMem e ofs)) (eq_set_clos e s)
+      Queries.ES.map (fun e -> Lval (mkMem ~addr:e ~off:ofs)) (eq_set_clos e s)
     | CastE (t,e) ->
       Queries.ES.map (fun e -> CastE (t,e)) (eq_set_clos e s)
     | Question _ -> failwith "Logical operations should be compiled away by CIL."

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -738,6 +738,7 @@ struct
     A.meet_lincons_array Man.mgr d earray
 
   let strengthening j x y =
+    (* TODO: optimize strengthening *)
     if M.tracing then M.traceli "apron" "strengthening %a\n" pretty j;
     let x_env = A.env x in
     let y_env = A.env y in
@@ -803,6 +804,8 @@ struct
   let is_bot = equal (bot ())
   let is_top _ = false
 
+  let strengthening_enabled = GobConfig.get_bool "ana.apron.strengthening"
+
   let join x y =
     (* just to optimize joining folds, which start with bot *)
     if is_bot x then
@@ -813,8 +816,12 @@ struct
       if M.tracing then M.traceli "apron" "join %a %a\n" pretty x pretty y;
       let j = join x y in
       if M.tracing then M.trace "apron" "j = %a\n" pretty j;
-      (* TODO: optimize strengthening, currently disabled because relational traces doesn't join different environments *)
-      (* let j = strengthening j x y in *)
+      let j =
+        if strengthening_enabled then
+          strengthening j x y
+        else
+          j
+      in
       if M.tracing then M.traceu "apron" "-> %a\n" pretty j;
       j
     )

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -543,8 +543,6 @@ struct
     (* there is no A.compare, but polymorphic compare should delegate to Abstract0 and Environment compare's implemented in Apron's C *)
     Stdlib.compare x y
   let printXml f x = BatPrintf.fprintf f "<value>\n<map>\n<key>\nconstraints\n</key>\n<value>\n%s</value>\n<key>\nenv\n</key>\n<value>\n%s</value>\n</map>\n</value>\n" (XmlUtil.escape (Format.asprintf "%a" A.print x)) (XmlUtil.escape (Format.asprintf "%a" (Environment.print: Format.formatter -> Environment.t -> unit) (A.env x)))
-
-  let pretty_diff () (x,y) = text "pretty_diff"
 end
 
 

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -146,8 +146,8 @@ struct
 
   (* TODO: move this into some general place *)
   let is_cast_injective from_type to_type =
-    let (from_min, from_max) = IntDomain.Size.range_big_int (Cilfacade.get_ikind from_type) in
-    let (to_min, to_max) = IntDomain.Size.range_big_int (Cilfacade.get_ikind to_type) in
+    let (from_min, from_max) = IntDomain.Size.range (Cilfacade.get_ikind from_type) in
+    let (to_min, to_max) = IntDomain.Size.range (Cilfacade.get_ikind to_type) in
     BI.compare to_min from_min <= 0 && BI.compare from_max to_max <= 0
 
   let texpr1_expr_of_cil_exp d env =
@@ -186,7 +186,7 @@ struct
         in
         let ik = Cilfacade.get_ikind_exp exp in
         if not (IntDomain.should_ignore_overflow ik) then (
-          let (type_min, type_max) = IntDomain.Size.range_big_int ik in
+          let (type_min, type_max) = IntDomain.Size.range ik in
           let texpr1 = Texpr1.of_expr env expr in
           match Bounds.bound_texpr d texpr1 with
           | Some min, Some max when BI.compare type_min min <= 0 && BI.compare max type_max <= 0 -> ()

--- a/src/cdomains/arincDomain.ml
+++ b/src/cdomains/arincDomain.ml
@@ -37,7 +37,7 @@ struct
   let name () = "ARINC state"
 
   (* printing *)
-  let show x = Printf.sprintf "{ pid=%s; pri=%s; per=%s; cap=%s; pmo=%s; pre=%s; pred=%s; ctx=%s }" (Pid.show x.pid) (Pri.show x.pri) (Per.show x.per) (Cap.show x.cap) (Pmo.show x.pmo) (PrE.show x.pre) (Pretty.sprint 200 (Pred.pretty () x.pred)) (Ctx.show x.ctx)
+  let show x = Printf.sprintf "{ pid=%s; pri=%s; per=%s; cap=%s; pmo=%s; pre=%s; pred=%s; ctx=%s }" (Pid.show x.pid) (Pri.show x.pri) (Per.show x.per) (Cap.show x.cap) (Pmo.show x.pmo) (PrE.show x.pre) (Pretty.sprint ~width:200 (Pred.pretty () x.pred)) (Ctx.show x.ctx)
   include Printable.SimpleShow (struct
       type nonrec t = t
       let show = show

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -43,8 +43,8 @@ end
 
 module Trivial (Val: Lattice.S) (Idx: Lattice.S): S with type value = Val.t and type idx = Idx.t =
 struct
-  let name () = "trivial arrays"
   include Val
+  let name () = "trivial arrays"
   type idx = Idx.t
   type value = Val.t
 

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -63,7 +63,6 @@ struct
   let fold_left2 f a x y = f a x y
 
   let set_inplace = set
-  let copy a = a
   let printXml f x = BatPrintf.fprintf f "<value>\n<map>\n<key>Any</key>\n%a\n</map>\n</value>\n" Val.printXml x
   let smart_join _ _ = join
   let smart_widen _ _ = widen
@@ -443,7 +442,6 @@ struct
   let length _ = None
 
   let set_inplace = set
-  let copy a = a
 
   let smart_op (op: Val.t -> Val.t -> Val.t) length ((e1, (xl1,xm1,xr1)) as x1) ((e2, (xl2,xm2,xr2)) as x2) x1_eval_int x2_eval_int =
     normalize @@

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -62,7 +62,6 @@ struct
   let fold_left f a x = f a x
   let fold_left2 f a x y = f a x y
 
-  let set_inplace = set
   let printXml f x = BatPrintf.fprintf f "<value>\n<map>\n<key>Any</key>\n%a\n</map>\n</value>\n" Val.printXml x
   let smart_join _ _ = join
   let smart_widen _ _ = widen
@@ -440,8 +439,6 @@ struct
       (Expp.top(), (v, v, v))
 
   let length _ = None
-
-  let set_inplace = set
 
   let smart_op (op: Val.t -> Val.t -> Val.t) length ((e1, (xl1,xm1,xr1)) as x1) ((e2, (xl2,xm2,xr2)) as x2) x1_eval_int x2_eval_int =
     normalize @@

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -508,7 +508,6 @@ struct
     | _ ->
       failwith "ArrayDomain: Unallowed state (one of the partitioning expressions is bot)"
 
-  let (%) = Batteries.(%)
   let smart_join_with_length length x1_eval_int x2_eval_int x1 x2 =
     smart_op (Val.smart_join x1_eval_int x2_eval_int) length x1 x2 x1_eval_int x2_eval_int
 

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -23,7 +23,6 @@ struct
   include CilType.Varinfo
   let trace_enabled = true
   let is_global v = v.vglob
-  let copy x = x
   let show x =
     if RichVarinfo.BiVarinfoMap.Collection.mem_varinfo x then
       let description = RichVarinfo.BiVarinfoMap.Collection.describe_varinfo x in
@@ -86,7 +85,6 @@ module Bools: Lattice.S with type t = [`Bot | `Lifted of bool | `Top] =
 module CilExp =
 struct
   include CilType.Exp
-  let copy x = x
 
   let name () = "expressions"
 
@@ -155,7 +153,6 @@ end
 module CilStmt: Printable.S with type t = stmt =
 struct
   include CilType.Stmt
-  let copy x = x
   let show x = "<stmt>"
   let pretty = Cilfacade.stmt_pretty_short
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -401,8 +401,7 @@ struct
 end
 
 module Size = struct (* size in bits as int, range as int64 *)
-  exception Not_in_int64
-  open Cil open Int64 open Big_int_Z
+  open Cil open Big_int_Z
   let sign_big_int x = if BI.compare x BI.zero < 0 then `Signed else `Unsigned
 
   let max = function
@@ -420,13 +419,7 @@ module Size = struct (* size in bits as int, range as int64 *)
   let bits ik = (* highest bits for neg/pos values *)
     let s = bit ik in
     if isSigned ik then s-1, s-1 else 0, s
-  let bits_i64 ik = BatTuple.Tuple2.mapn of_int (bits ik)
-  let range ik = (* min/max values as int64 (signed), anything bigger is cropped! *)
-    let a,b = bits ik in
-    if a>63 || b>63 then raise Not_in_int64 else
-      let x = if isSigned ik then neg (shift_left 1L a) (* -2^a *) else 0L in
-      let y = sub (shift_left 1L b) 1L in (* 2^b - 1 *)
-      x,y
+  let bits_i64 ik = BatTuple.Tuple2.mapn Int64.of_int (bits ik)
   let range_big_int ik =
     let a,b = bits ik in
     let x = if isSigned ik then minus_big_int (shift_left_big_int unit_big_int a) (* -2^a *) else zero_big_int in
@@ -1310,8 +1303,7 @@ struct
   | `Excluded (s,r) -> if S.mem i s then `Neq else `Top
 
   let top_of ik = `Excluded (S.empty (), size ik)
-  let top_if_not_in_int64 ik f x = try f x with Size.Not_in_int64 -> top_of ik
-  let cast_to ?torg ?no_ov ik = top_if_not_in_int64 ik @@ function
+  let cast_to ?torg ?no_ov ik = function
     | `Excluded (s,r) ->
       let r' = size ik in
       `Excluded (

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1661,36 +1661,6 @@ struct
   let project ik p t = t
 end
 
-module OverflowInt64 = (* throws Overflow for add, sub, mul *)
-struct
-  exception Overflow of string
-
-  include Int64
-
-  let add (a:int64) (b:int64) =
-    if logor (logxor a b) (logxor a (lognot (add a b))) < 0L  (* no kidding! *)
-    then add a b
-    else raise (Overflow (Printf.sprintf "%Ld + %Ld" a b))
-
-  let sub (a:int64) (b:int64) =
-    if b = min_int
-    then
-      if a >= 0L
-      then raise (Overflow (Printf.sprintf "%Ld - %Ld" a b))
-      else sub a b
-    else
-      let oppb = neg b in
-      add a oppb
-
-  let mul (a:int64) (b:int64) =
-    if a = 0L then 0L
-    else
-      let x = mul a b in
-      if b = div x a
-      then x
-      else raise (Overflow (Printf.sprintf "%Ld * %Ld" a b))
-
-end
 (* BOOLEAN DOMAINS *)
 
 module type BooleansNames =

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1176,7 +1176,8 @@ module BigInt = struct
 
   let show x = BI.to_string x
   include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
-  let hash x = (BI.to_int x) * 2147483647
+  (* TODO: throws if x too big, used to be overridden with Hashtbl.hash by include Std anyway *)
+  (* let hash x = (BI.to_int x) * 2147483647 *)
   let arbitrary () = QCheck.map ~rev:to_int64 of_int64 QCheck.int64
 end
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -951,7 +951,6 @@ struct
   let show (x: Ints_t.t) = if (Ints_t.to_int64 x) = GU.inthack then "*" else Ints_t.to_string x
 
   include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
-  (* FIXME: poly compare *)
   let hash (x:t) = ((Ints_t.to_int x) - 787) * 17
   (* is_top and is_bot are never called, but if they were, the Std impl would raise their exception, so we overwrite them: *)
   let is_top _ = false
@@ -1279,7 +1278,6 @@ struct
     | `Excluded (s,l) -> "Not " ^ S.show s ^ short_size l
 
   include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
-  (* FIXME: poly compare? *)
   let hash (x:t) =
     match x with
     | `Excluded (s,r) -> S.hash s + R.hash r

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -529,10 +529,6 @@ struct
   let bot () = None
   let bot_of ik = bot () (* TODO: improve *)
 
-  let is_top x = failwith "is_top not implemented for intervals"
-
-  let is_bot x  = failwith "is_bot not implemented for intervals"
-
   let show = function None -> "bottom" | Some (x,y) -> "["^Ints_t.to_string x^","^Ints_t.to_string y^"]"
 
   include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
@@ -1178,11 +1174,9 @@ module BigInt = struct
   let cast_to ik x = Size.cast_big_int ik x
   let to_bool x = Some (not (BI.equal (BI.zero) x))
 
-  let hash x = (BI.to_int x) * 2147483647
   let show x = BI.to_string x
-  let pretty _ x = Pretty.text (BI.to_string x)
   include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
-
+  let hash x = (BI.to_int x) * 2147483647
   let arbitrary () = QCheck.map ~rev:to_int64 of_int64 QCheck.int64
 end
 
@@ -1282,14 +1276,14 @@ struct
     | `Excluded (s,l) when S.is_empty s -> "Unknown int" ^ short_size l
     (* Prepend the exclusion sets with something: *)
     | `Excluded (s,l) -> "Not " ^ S.show s ^ short_size l
+
+  include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
+  (* FIXME: poly compare? *)
   let hash (x:t) =
     match x with
     | `Excluded (s,r) -> S.hash s + R.hash r
     | `Definite i -> 83*BigInt.hash i
     | `Bot -> 61426164
-
-  include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
-  (* FIXME: poly compare? *)
 
   let maximal = function
     | `Definite x -> Some x
@@ -2120,8 +2114,6 @@ struct
   let bot () = None
   let bot_of ik = bot ()
 
-  let is_top x = x = top ()
-
   let show = function ik -> match ik with
     | None -> "⟂"
     | Some (c, m) when (c, m) = (Ints_t.zero, Ints_t.zero) -> Ints_t.to_string c
@@ -2132,6 +2124,8 @@ struct
       a^c^b
 
   include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
+
+  let is_top x = x = top ()
 
   let equal_to i = function
     | None -> failwith "unsupported: equal_to with bottom"

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -329,7 +329,7 @@ val of_const: Cilint.cilint * Cil.ikind * string option -> IntDomTuple.t
 module Size : sig
   (** The biggest type we support for integers. *)
   val top_typ         : Cil.typ
-  val range_big_int   : Cil.ikind -> Z.t * Z.t
+  val range           : Cil.ikind -> Z.t * Z.t
   val bits            : Cil.ikind -> int * int
 end
 

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -329,7 +329,6 @@ val of_const: Cilint.cilint * Cil.ikind * string option -> IntDomTuple.t
 module Size : sig
   (** The biggest type we support for integers. *)
   val top_typ         : Cil.typ
-  val range           : Cil.ikind -> int64 * int64
   val range_big_int   : Cil.ikind -> Z.t * Z.t
   val bits            : Cil.ikind -> int * int
 end

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -259,8 +259,6 @@ struct
     | NullPtr  -> voidType
     | UnknownPtr -> voidPtrType
 
-  let copy x = x
-
   let hash = function
     | Addr (v,o) -> v.vid + 2 * Offs.hash o
     | SafePtr | UnknownPtr -> Hashtbl.hash UnknownPtr (* SafePtr <= UnknownPtr ==> same hash *)

--- a/src/cdomains/lvalMapDomain.ml
+++ b/src/cdomains/lvalMapDomain.ml
@@ -258,7 +258,7 @@ struct
       in (if may then Messages.warn else Messages.error) ~loc:(List.last loc) ~category:warn_type "%a" (Pretty.docList ~sep:(Pretty.text " ") Pretty.text) t
 
   (* getting keys from Cil Lvals *)
-  let sprint f x = Pretty.sprint 80 (f () x)
+  let sprint f x = Pretty.sprint ~width:80 (f () x)
 
   let key_from_lval lval = match lval with (* TODO try to get a Lval.CilLval from Cil.Lval *)
     | Var v1, o1 -> v1, Lval.CilLval.of_ciloffs o1

--- a/src/cdomains/lvalMapDomain.ml
+++ b/src/cdomains/lvalMapDomain.ml
@@ -92,6 +92,7 @@ struct
   module Must = Lattice.Reverse (Must')
   module May  = SetDomain.ToppedSet (R) (struct let topname = "top" end)
   include Lattice.Prod (Must) (May)
+  let name () = Impl.name
 
   (* converts to polymorphic sets *)
   let split (x,y) = try Must'.elements x |> Set.of_list, May.elements y |> Set.of_list with SetDomain.Unsupported _ -> Set.empty, Set.empty

--- a/src/cdomains/lvalMapDomain.ml
+++ b/src/cdomains/lvalMapDomain.ml
@@ -135,8 +135,6 @@ struct
   let map' f = split %> Tuple2.mapn (Set.map f)
   let filter' f = split %> Tuple2.mapn (Set.filter f)
 
-  let locs ?p:(p=const true) v = filter p v |> map' (fun x -> x.loc) |> snd |> Set.elements
-
   (* predicates *)
   let must   p (x,y) = Must'.exists p x || May.for_all p y
   let may    p (x,y) = May.exists p y

--- a/src/cdomains/osektupel.ml
+++ b/src/cdomains/osektupel.ml
@@ -22,7 +22,6 @@ let hash (a,b,c,d) =
   let d' = match d with Bot -> -1 | Val d'' -> d'' in
   a' lxor b' lxor c' lxor d'
 
-let copy x = x
 let top () = (Val 0, Val 0, Val 0, Val 0)
 let is_top x = (x = top())
 let bot () = (Bot, Bot, Bot, Bot)

--- a/src/cdomains/threadIdDomain.ml
+++ b/src/cdomains/threadIdDomain.ml
@@ -188,9 +188,9 @@ struct
 
   let threadinit v ~multiple =
     if history_enabled () then
-      (Some (H.threadinit v multiple), None)
+      (Some (H.threadinit v ~multiple), None)
     else
-      (None, Some (P.threadinit v multiple))
+      (None, Some (P.threadinit v ~multiple))
 
   let is_main = unop H.is_main P.is_main
   let is_unique = unop H.is_unique P.is_unique

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -57,8 +57,8 @@ module ZeroInit = Lattice.Fake(Basetype.RawBools)
 
 module Blob (Value: S) (Size: IntDomain.Z)=
 struct
-  let name () = "blob"
   include Lattice.Prod3 (Value) (Size) (ZeroInit)
+  let name () = "blob"
   type value = Value.t
   type size = Size.t
   type origin = ZeroInit.t

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -95,7 +95,6 @@ struct
   let compare x y = if equal x y then 0 else M.compare Range.compare x y
   let merge = M.merge
   let for_all = M.for_all
-  let find_first = M.find_first
   let hash xs = fold (fun k v a -> a + (Domain.hash k * Range.hash v)) xs 0
 
   let cardinal = M.cardinal

--- a/src/dune
+++ b/src/dune
@@ -92,9 +92,9 @@
 
 (env
   (dev
-    (flags (:standard -warn-error -A -w -6-27-32)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
+    (flags (:standard -warn-error -A -w -27-32)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
   )
   (trace
-    (flags (:standard -warn-error -A -w -6-27-32)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
+    (flags (:standard -warn-error -A -w -27-32)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
   )
 )

--- a/src/dune
+++ b/src/dune
@@ -92,9 +92,9 @@
 
 (env
   (dev
-    (flags (:standard -warn-error -A -w -27-32)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
+    (flags (:standard -warn-error -A -w -27)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
   )
   (trace
-    (flags (:standard -warn-error -A -w -27-32)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
+    (flags (:standard -warn-error -A -w -27)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
   )
 )

--- a/src/dune
+++ b/src/dune
@@ -92,9 +92,9 @@
 
 (env
   (dev
-    (flags (:standard -warn-error -A -w -27)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
+    (flags (:standard -warn-error -A -w -unused-var-strict)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
   )
   (trace
-    (flags (:standard -warn-error -A -w -27)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
+    (flags (:standard -warn-error -A -w -unused-var-strict)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
   )
 )

--- a/src/extract/pml.ml
+++ b/src/extract/pml.ml
@@ -122,7 +122,7 @@ let bind x f = x >> f (fst x)
 let (>>=) = bind
 let return x = x (* ? *)
 
-let indent x = String.split_on_string "\n" x |> List.map (fun x -> "  "^x) |> String.concat "\n"
+let indent x = String.split_on_string ~by:"\n" x |> List.map (fun x -> "  "^x) |> String.concat "\n"
 
 let surround a b (v,s) = v, a^"\n"^indent s^"\n"^b
 let _match xs =

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -121,10 +121,10 @@ struct
     let f = Node.find_fundec a in
     CilType.Location.show x ^ "(" ^ f.svar.vname ^ ")"
 
-  include Printable.SimplePretty (
+  include Printable.SimpleShow (
     struct
       type nonrec t = t
-      let pretty = pretty
+      let show = show
     end
     )
 end

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -981,14 +981,6 @@ struct
     let d = D.fold h ctx.local (D.empty ()) in
     if D.is_bot d then raise Deadcode else d
 
-  let fold ctx f g h a =
-    let k x a =
-      try h a @@ g @@ f @@ conv ctx x
-      with Deadcode -> a
-    in
-    let d = D.fold k ctx.local a in
-    if D.is_bot d then raise Deadcode else d
-
   let fold' ctx f g h a =
     let k x a =
       try h a @@ g @@ f @@ conv ctx x

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -189,7 +189,6 @@ struct
   let name () = S.name ()^" level sliced"
 
   let start_level = ref (`Top)
-  let error_level = ref (`Lifted  0L)
 
   type marshal = S.marshal (* TODO: should hashcons table be in here to avoid relift altogether? *)
   let init marshal =

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -502,7 +502,7 @@ struct
             let should_save_run = false (* we already save main solver *)
           end
           in
-          let module S2' = (GlobSolverFromEqSolver (S2 (PostSolverArg))) (EQSys) (LHT) (GHT) in
+          let module S2' = (GlobSolverFromEqSolver (S2 (PostSolverArg2))) (EQSys) (LHT) (GHT) in
           let (r2, _) = S2'.solve entrystates entrystates_global startvars' in
           Comp.compare (get_string "solver", get_string "comparesolver") (lh,gh) (r2)
         in

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -30,7 +30,7 @@ let eqS (a: Cil.stmt) (b: Cil.stmt) =
   a.Cil.skind = b.Cil.skind
 
 let print (a: Pretty.doc)  =
-  print_endline @@ Pretty.sprint 100 a
+  print_endline @@ Pretty.sprint ~width:100 a
 
 (* hack: CIL generates new type names for anonymous types - we want to ignore these *)
 let compare_name a b =

--- a/src/prelude.ml
+++ b/src/prelude.ml
@@ -31,7 +31,7 @@ module Ana = struct
   include Cil
   let d_varinfo () x = d_lval () (Var x, NoOffset)
   include Pretty
-  let sprint f x = Pretty.sprint 80 (f () x)
+  let sprint f x = Pretty.sprint ~width:80 (f () x)
   (* Analyses.Spec etc. *)
   (* include Analyses (* circular build :( *) *)
   (* module M = Messages (* same, but this is in Analyses anyway *) *)

--- a/src/solvers/sLR.ml
+++ b/src/solvers/sLR.ml
@@ -272,7 +272,6 @@ module Make =
     module P =
     struct
       let single x = tap (fun s -> HM.add s x ()) (HM.create 10)
-      let rem_item = HM.remove
       let to_list s = HM.fold (fun x y z -> x :: z ) s []
       let has_item = HM.mem
       let rem_item = HM.remove

--- a/src/solvers/sLR.ml
+++ b/src/solvers/sLR.ml
@@ -482,7 +482,7 @@ module PrintInfluence =
       let r = S1.solve box x y in
       let f k _ =
         let q = if HM.mem S1.wpoint k then " shape=box style=rounded" else "" in
-        let s = Pretty.sprint 80 (S.Var.pretty_trace () k) ^ " " ^ string_of_int (try HM.find S1.X.keys k with Not_found -> 0) in
+        let s = Pretty.sprint ~width:80 (S.Var.pretty_trace () k) ^ " " ^ string_of_int (try HM.find S1.X.keys k with Not_found -> 0) in
         ignore (Pretty.fprintf ch "%d [label=\"%s\"%s];\n" (S.Var.hash k) (XmlUtil.escape s) q);
         let f y =
           if try HM.find S1.X.keys k > HM.find S1.X.keys y with Not_found -> false then

--- a/src/spec/specLexer.mll
+++ b/src/spec/specLexer.mll
@@ -62,6 +62,6 @@ rule token = parse
   | (w+ as n) s+ str
       { NODE(n, s) }
   | (w+ as a) s* "-" ((w+ ("," w+)*)? as ws) (">"? as fwd) ">" s* (w+ as b) s+
-      { EDGE(a, BatString.split_on_string "," ws, fwd=">", b) }
+      { EDGE(a, BatString.split_on_string ~by:"," ws, fwd=">", b) }
   | eof            { EOF }
   | _ as x         { raise(Token (Char.escaped x^": unknown token in line "^string_of_int !line)) }

--- a/src/spec/specUtil.ml
+++ b/src/spec/specUtil.ml
@@ -37,7 +37,7 @@ let parse ?repl:(repl=false) ?print:(print=false) ?dot:(dot=false) cin =
         (List.length !defs) (List.length nodes) (List.length edges);
     if save_dot && not dot then (
       let dotgraph = SpecCore.to_dot_graph !defs in
-      output_file "result/graph.dot" dotgraph;
+      output_file ~filename:"result/graph.dot" ~text:dotgraph;
       print_endline ("saved graph as "^Sys.getcwd ()^"/result/graph.dot");
     );
     if dot then (

--- a/src/util/arincUtil.ml
+++ b/src/util/arincUtil.ml
@@ -267,7 +267,7 @@ let print_actions () =
 let save_result desc ext content = (* output helper *)
   let dir = Goblintutil.create_dir "result" in (* returns abs. path *)
   let path = dir ^ "/arinc." ^ ext in
-  output_file path content;
+  output_file ~filename:path ~text:content;
   print_endline @@ "saved " ^ desc ^ " as " ^ path
 
 let save_dot_graph () =

--- a/src/util/gobConfig.ml
+++ b/src/util/gobConfig.ml
@@ -148,7 +148,7 @@ struct
         let fld, pth = split '.' '[' (String.lchop s) in
         Select (fld, parse_path' pth)
       | '[' ->
-        let idx, pth = String.split (String.lchop s) "]" in
+        let idx, pth = String.split (String.lchop s) ~by:"]" in
         Index (parse_index idx, parse_path' pth)
       | _ -> raise PathParseError
 

--- a/src/util/gobConfig.ml
+++ b/src/util/gobConfig.ml
@@ -323,15 +323,6 @@ struct
     drop_memo ();
     set_value (`List l) json_conf (parse_path st)
 
-  (** A convenience functions for writing values. *)
-  let set_auto' st v =
-    if v = "null" then set_null st else
-      try set_bool st (bool_of_string v)
-      with Invalid_argument _ ->
-      try set_int st (int_of_string v)
-      with Failure _ ->
-        set_string st v
-
   (** The ultimate convenience function for writing values. *)
   let one_quote = Str.regexp "\'"
   let set_auto st s =

--- a/src/util/oilParser.mly
+++ b/src/util/oilParser.mly
@@ -176,7 +176,3 @@ attribute_value:
   | OIL_STRING   {String $1}
   | AUTO         {Auto}
 ;
-
-%%
-
-let parse_error s = print_endline s

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -738,6 +738,12 @@
               "type": "boolean",
               "default": true
             },
+            "strengthening": {
+              "title": "ana.apron.strengthening",
+              "description": "Apply strengthening in join for extra precision with heterogeneous environments. Expensive!",
+              "type": "boolean",
+              "default": false
+            },
             "domain": {
               "title": "ana.apron.domain",
               "description":

--- a/src/util/richVarinfo.ml
+++ b/src/util/richVarinfo.ml
@@ -141,7 +141,7 @@ struct
   struct
     module BiVarinfoMap = PrivateMake(X)
     include BiVarinfoMap
-    let register =
+    let () =
       let m = (module BiVarinfoMap: S) in
       Collection.register_mapping m;
   end

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -31,7 +31,7 @@ end
 let registry = Registry.make ()
 
 let handle_exn id exn =
-  Response.Error.(make Code.InternalError (Printexc.to_string exn) () |> Response.error id)
+  Response.Error.(make ~code:Code.InternalError ~message:(Printexc.to_string exn) () |> Response.error id)
 
 module ParamParser (R : Request) = struct
   let parse params =
@@ -60,9 +60,9 @@ let handle_request (serv: t) (message: Message.either) (id: Id.t) =
               R.process params serv
               |> R.response_to_yojson
               |> Response.ok id
-            with Failure (code, msg) -> Response.Error.(make code msg () |> Response.error id))
-        | Error s -> Response.Error.(make Code.InvalidParams s () |> Response.error id))
-    | _ -> Response.Error.(make Code.MethodNotFound message.method_ () |> Response.error id)
+            with Failure (code, message) -> Response.Error.(make ~code ~message () |> Response.error id))
+        | Error message -> Response.Error.(make ~code:Code.InvalidParams ~message () |> Response.error id))
+    | _ -> Response.Error.(make ~code:Code.MethodNotFound ~message:message.method_ () |> Response.error id)
   in
   Response.yojson_of_t response |> Yojson.Safe.to_string |> IO.write_line serv.output;
   IO.flush serv.output

--- a/src/util/tracing.ml
+++ b/src/util/tracing.ml
@@ -86,7 +86,7 @@ let traceTag (sys : string) : Pretty.doc =
   (text ((ind !indent_level) ^ "%%% " ^ sys ^ ": "))
 
 let printtrace sys d: unit =
-  fprint stderr 80 ((traceTag sys) ++ d);
+  fprint stderr ~width:80 ((traceTag sys) ++ d);
   flush stderr
 
 let gtrace always f sys var ?loc do_subsys fmt =

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -27,7 +27,7 @@ struct
 
   let embed e = e
   let cfgedge e = Some e
-  let to_string e = Pretty.sprint 80 (Edge.pretty_plain () e)
+  let to_string e = Pretty.sprint ~width:80 (Edge.pretty_plain () e)
 end
 
 type inline_edge =
@@ -52,7 +52,7 @@ struct
     | CFGEdge e -> Some e
     | _ -> None
 
-  let to_string e = Pretty.sprint 80 (pretty_inline_edge () e)
+  let to_string e = Pretty.sprint ~width:80 (pretty_inline_edge () e)
 end
 
 (* Abstract Reachability Graph *)

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -202,14 +202,6 @@ struct
     let d = Dom.fold h (fst ctx.local) (Dom.empty ()) |> Dom.reduce in
     if Dom.is_bot d then raise Deadcode else (d, Sync.bot ())
 
-  let fold ctx f g h a =
-    let k x a =
-      try h a @@ g @@ f @@ conv ctx x
-      with Deadcode -> a
-    in
-    let d = Dom.fold k (fst ctx.local) a in
-    if Dom.is_bot d then raise Deadcode else (d, Sync.bot ())
-
   let fold' ctx f g h a =
     let k x a =
       try h a x @@ g @@ f @@ conv ctx x

--- a/tests/regression/36-apron/99-mine14-strengthening.c
+++ b/tests/regression/36-apron/99-mine14-strengthening.c
@@ -1,0 +1,35 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --enable ana.apron.threshold_widening --set ana.apron.privatization protection --enable ana.apron.strengthening
+// Fig 5a from Miné 2014
+// Example for join strengthening
+#include <pthread.h>
+#include <stdio.h>
+
+int x;
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  int top;
+  while(top) {
+    pthread_mutex_lock(&mutex);
+    if(x<100) {
+      x++;
+    }
+    pthread_mutex_unlock(&mutex);
+  }
+  return NULL;
+}
+
+
+int main(void) {
+  int top, top2;
+
+
+  pthread_t id;
+  pthread_t id2;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_create(&id2, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex);
+  assert(x <= 100);
+  pthread_mutex_unlock(&mutex);
+  return 0;
+}

--- a/unittest/dune
+++ b/unittest/dune
@@ -8,6 +8,6 @@
 
 (env
   (dev
-    (flags (:standard -warn-error -A -w -6-27-32)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
+    (flags (:standard -warn-error -A -w -unused-var-strict)) ; https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal
   )
 )

--- a/unittest/maindomaintest.ml
+++ b/unittest/maindomaintest.ml
@@ -21,6 +21,7 @@ end
 
 module PrintableChar =
 struct
+  include Printable.Std
   type t = char [@@deriving eq, ord, to_yojson]
   let name () = "char"
   let show x = String.make 1 x
@@ -30,7 +31,6 @@ struct
     type nonrec t = t
     let show = show
   end
-  include Printable.Std
   include Printable.SimpleShow (P)
 
   let hash = Char.code


### PR DESCRIPTION
This reenables two OCaml warnings and fixes the code such that they aren't emitted:
1. `labels-omitted`. Using labels for calling functions with labelled arguments makes code more readable, especially when the labelled arguments are there for good reason, e.g. to distinguish two arguments of the same type (some string functions).
2. `unused-value-declaration`. I have no idea why this would be disabled because it immediately found loads of unused code and _numerous bugs_ where an `include` was accidentally overridding a definition.