### PR TITLE
Avoid calling `context` with top of context insensitive analyses

### DIFF
--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -766,7 +766,7 @@ struct
         ; assign = (fun ?name v e -> assigns := (v,e,name, repr ctx')::!assigns)
         }
       in
-      n, repr @@ S.combine ctx' r fe f a (obj (assoc n fc)) (obj (assoc n fd))
+      n, repr @@ S.combine ctx' r fe f a (Option.map obj (Option.bind fc (assoc_opt n))) (obj (assoc n fd))
     in
     let d, q = map_deadcode f @@ spec_list ctx.local in
     do_sideg ctx !sides;

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -108,9 +108,11 @@ struct
 
   let context fd x =
     let x = spec_list x in
-    map (fun (n,(module S:MCPSpec),d) ->
-        let d' = if mem n !cont_inse then S.D.top () else obj d in
-        n, repr @@ S.context fd d'
+    filter_map (fun (n,(module S:MCPSpec),d) ->
+        if mem n !cont_inse then
+          None
+        else
+          Some (n, repr @@ S.context fd (obj d))
       ) x
 
   let should_join x y =

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -383,7 +383,7 @@ sig
 
   val special : (D.t, G.t, C.t, V.t) ctx -> lval option -> varinfo -> exp list -> D.t
   val enter   : (D.t, G.t, C.t, V.t) ctx -> lval option -> fundec -> exp list -> (D.t * D.t) list
-  val combine : (D.t, G.t, C.t, V.t) ctx -> lval option -> exp -> fundec -> exp list -> C.t -> D.t -> D.t
+  val combine : (D.t, G.t, C.t, V.t) ctx -> lval option -> exp -> fundec -> exp list -> C.t option -> D.t -> D.t
 
   (** Returns initial state for created thread. *)
   val threadenter : (D.t, G.t, C.t, V.t) ctx -> lval option -> varinfo -> exp list -> D.t list

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -157,7 +157,7 @@ struct
     S.special (conv ctx) r f args
 
   let combine ctx r fe f args fc es =
-    S.combine (conv ctx) r fe f args (C.unlift fc) es
+    S.combine (conv ctx) r fe f args (Option.map C.unlift fc) es
 
   let threadenter ctx lval f args =
     S.threadenter (conv ctx) lval f args
@@ -623,6 +623,7 @@ struct
     List.iter (fun (c,fc,v) -> if not (S.D.is_bot v) then sidel (FunctionEntry f, fc) v) paths;
     let paths = List.map (fun (c,fc,v) -> (c, fc, if S.D.is_bot v then v else getl (Function f, fc))) paths in
     let paths = List.filter (fun (c,fc,v) -> not (D.is_bot v)) paths in
+    let paths = List.map (Tuple3.map2 Option.some) paths in
     if M.tracing then M.traceli "combine" "combining\n";
     let paths = List.map combine paths in
     let r = List.fold_left D.join (D.bot ()) paths in

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -315,7 +315,7 @@ struct
         if should_inline f then
           let nosync = (Sync.singleton x (SyncSet.singleton x)) in
           (* returns already post-sync in FromSpec *)
-          step (Function f) fc x (InlineReturn l) nosync
+          step (Function f) (Option.get fc) x (InlineReturn l) nosync (* fc should be Some outside of MCP *)
         else
           step_ctx_edge ctx cd
       in

--- a/tests/regression/00-sanity/29-earlyglobs-insens.c
+++ b/tests/regression/00-sanity/29-earlyglobs-insens.c
@@ -1,0 +1,2 @@
+// PARAM: --set ana.ctx_insens[+] base --enable exp.earlyglobs
+int main() {}


### PR DESCRIPTION
Closes #555.

Implements the idea from https://github.com/goblint/analyzer/issues/555#issuecomment-1018256466:
> I wonder if instead of trying to fix the base analysis, one could just avoid that top altogether and simply not even create the component corresponding to a context insensitive analysis there. Not sure if that maybe violates some assumption the rest of `MCP` makes to have all activated analyses always present in the combined context list.

Turns out it broke `MCP.combine` which wants to look up contexts of the called function as well. I just made that optional for insensitive analyses. That argument is only used by the witness lifter anyway.