### PR TITLE
Switch to OUnit2, move domain property tests into unit tests

### DIFF
--- a/.github/workflows/locked.yml
+++ b/.github/workflows/locked.yml
@@ -52,12 +52,6 @@ jobs:
       - name: Test unit
         run: opam exec -- dune runtest unittest
 
-      - name: Build domaintest
-        run: ./make.sh domaintest
-
-      - name: Test domains
-        run: ./goblint.domaintest
-
       - name: Test incremental regression
         run: ruby scripts/update_suite.rb -i
 

--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -70,12 +70,6 @@ jobs:
       - name: Test unit
         run: opam exec -- dune runtest unittest
 
-      - name: Build domaintest
-        run: ./make.sh domaintest
-
-      - name: Test domains
-        run: ./goblint.domaintest # could be made long
-
       - name: Test marshal regression
         run: ruby scripts/update_suite.rb -m
 
@@ -149,12 +143,6 @@ jobs:
 
       - name: Test unit
         run: opam exec -- dune runtest unittest
-
-      - name: Build domaintest
-        run: ./make.sh domaintest
-
-      - name: Test domains
-        run: ./goblint.domaintest # could be made long
 
       - name: Test marshal regression
         run: ruby scripts/update_suite.rb -m

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -49,15 +49,18 @@ git diff --no-prefix relative/path/to/test.c relative/path/to/test.json > relati
 
 The comparison input and the metadata in the patch headers are not necessary and can be removed.
 
+## Unit tests
+
+### Running
+The unit tests can be run with `dune runtest unittest`.
+Use `--watch` for automatic rebuilding and retesting.
+
 ## Domain tests
 Property-based testing (a la QuickCheck) is used to test some domains (`Lattice.S` implementations) for their lattice properties.
 On integer domains the integer operations are also tested for being a valid abstraction of sets of integers.
 
 ### Running
-1. Compile: `make domaintest`.
-2. Run: `./goblint.domaintest`.
-
-    See `--help` for other useful flags provided by qcheck, e.g. `-v` or `--long`.
+Domain tests are now run as part of [unit tests](#unit-tests).
 
 ### Writing
 To test a domain, you need to do the following:

--- a/dune-project
+++ b/dune-project
@@ -35,6 +35,7 @@
     (ppx_blob (>= 0.6.0))
     (ocaml-monadic (>= 0.5))
     (ounit2 :with-test)
+    (qcheck-ounit :with-test)
     (odoc :with-doc)
     dune-site
     json-data-encoding

--- a/goblint.opam
+++ b/goblint.opam
@@ -31,6 +31,7 @@ depends: [
   "ppx_blob" {>= "0.6.0"}
   "ocaml-monadic" {>= "0.5"}
   "ounit2" {with-test}
+  "qcheck-ounit" {with-test}
   "odoc" {with-doc}
   "dune-site"
   "json-data-encoding"

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -70,6 +70,7 @@ depends: [
   "ppx_distr_guards" {= "0.3"}
   "ppxlib" {= "0.23.0"}
   "qcheck-core" {= "0.17"}
+  "qcheck-ounit" {= "0.17" & with-test}
   "re" {= "1.9.0" & with-doc}
   "result" {= "1.5"}
   "seq" {= "base" & with-doc}

--- a/make.sh
+++ b/make.sh
@@ -36,11 +36,6 @@ rule() {
       eval $(opam config env)
       # dune build -w $TARGET.exe
       dune runtest --no-buffer --watch
-    ;; domaintest)
-      eval $(opam config env)
-      dune build src/maindomaintest.exe &&
-      rm -f goblint.domaintest &&
-      cp _build/default/src/maindomaintest.exe goblint.domaintest
     ;; privPrecCompare)
       eval $(opam config env)
       dune build src/privPrecCompare.exe &&

--- a/src/dune
+++ b/src/dune
@@ -7,7 +7,7 @@
   (name goblint_lib)
   (public_name goblint.lib)
   (wrapped false)
-  (modules :standard \ goblint mainarinc maindomaintest mainspec privPrecCompare apronPrecCompare)
+  (modules :standard \ goblint mainarinc mainspec privPrecCompare apronPrecCompare)
   (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc
     ; Conditionally compile based on whether apron optional dependency is installed or not.
     ; Alternative dependencies seem like the only way to optionally depend on optional dependencies.
@@ -48,10 +48,10 @@
 (copy_files# witness/z3/*.ml)
 
 (executables
-  (names goblint maindomaintest mainarinc mainspec) ; TODO: separate domaintest executable?
-  (public_names goblint - - -)
+  (names goblint mainarinc mainspec)
+  (public_names goblint - -)
   (modes byte native) ; https://dune.readthedocs.io/en/stable/dune-files.html#linking-modes
-  (modules goblint mainarinc maindomaintest mainspec)
+  (modules goblint mainarinc mainspec)
   (libraries goblint.lib goblint.sites.dune)
   (preprocess (staged_pps ppx_deriving.std ppx_deriving_yojson ppx_distr_guards ocaml-monadic))
   (flags :standard -linkall)

--- a/unittest/cdomains/intDomainTest.ml
+++ b/unittest/cdomains/intDomainTest.ml
@@ -1,4 +1,4 @@
-open OUnit
+open OUnit2
 open Z
 
 module IntTest (I:IntDomainProperties.OldS) =
@@ -16,7 +16,7 @@ struct
   let ifalse     = I.of_bool false
 
 
-  let test_int_comp () =
+  let test_int_comp _ =
     assert_equal ~printer:I.show izero (I.of_int zero);
     assert_equal ~printer:I.show ione  (I.of_int one);
     assert_equal ~printer:I.show itrue (I.of_bool true);
@@ -28,7 +28,7 @@ struct
     assert_equal (Some zero) (I.to_int ifalse)
 
 
-  let test_bool () =
+  let test_bool _ =
     assert_equal (Some true ) (I.to_bool ione);
     assert_equal (Some false) (I.to_bool izero);
     assert_bool "0 isn't bool" (I.is_bool izero);
@@ -43,32 +43,32 @@ struct
     assert_equal ~printer:I.show ifalse (I.ne ione  ione)
 
 
-  let test_neg () =
+  let test_neg _ =
     assert_equal ~printer:I.show in5 (I.neg i5);
     assert_equal ~printer:I.show i5 (I.neg (I.neg i5));
     assert_equal ~printer:I.show izero (I.neg izero)
 
 
-  let test_add () =
+  let test_add _ =
     assert_equal ~printer:I.show ione (I.add izero ione);
     assert_equal ~printer:I.show ione (I.add ione  izero);
     assert_equal ~printer:I.show izero(I.add izero izero)
 
 
-  let test_sub () =
+  let test_sub _ =
     assert_equal ~printer:I.show ione (I.sub izero iminus_one);
     assert_equal ~printer:I.show ione (I.sub ione  izero);
     assert_equal ~printer:I.show izero(I.sub izero izero)
 
 
-  let test_mul () =
+  let test_mul _ =
     assert_equal ~printer:I.show izero(I.mul izero iminus_one);
     assert_equal ~printer:I.show izero(I.mul izero izero);
     assert_equal ~printer:I.show ione (I.mul ione  ione);
     assert_equal ~printer:I.show i42  (I.mul ione  i42)
 
 
-  let test_div () =
+  let test_div _ =
     assert_equal ~printer:I.show ione (I.div ione ione);
     assert_equal ~printer:I.show ione (I.div i5 i5);
     assert_equal ~printer:I.show i5   (I.div i5 ione);
@@ -76,14 +76,14 @@ struct
     assert_bool "div_by_0" (try I.is_top (I.div i5 izero) with Division_by_zero -> true)
 
 
-  let test_rem () =
+  let test_rem _ =
     assert_equal ~printer:I.show ione (I.rem ione  i5);
     assert_equal ~printer:I.show izero(I.rem izero i5);
     assert_equal ~printer:I.show itwo (I.rem i42   i5);
     assert_equal ~printer:I.show itwo (I.rem i42   in5)
 
 
-  let test_bit () =
+  let test_bit _ =
     assert_equal ~printer:I.show iminus_one (I.bitnot izero);
     assert_equal ~printer:I.show iminus_two (I.bitnot ione);
     assert_equal ~printer:I.show i5   (I.bitand i5 i5);
@@ -137,7 +137,7 @@ let tex1       = T.of_excl_list [one ]
 let tex10      = T.of_excl_list [zero; one]
 let tex01      = T.of_excl_list [one; zero]
 
-let test_bot () =
+let test_bot _ =
   assert_bool "bot != bot" (T.is_bot tbot);
   assert_bool "top != top" (T.is_top ttop);
   assert_bool "top == bot" (not (T.is_bot ttop));
@@ -145,7 +145,7 @@ let test_bot () =
   assert_bool "0 == top" (not (T.is_top tzero));
   assert_bool "1 == top" (not (T.is_top tone))
 
-let test_join () =
+let test_join _ =
   assert_equal ~printer:T.show tone (T.join tbot  tone);
   assert_equal ~printer:T.show tzero(T.join tbot  tzero);
   assert_equal ~printer:T.show tone (T.join tone  tbot);
@@ -168,7 +168,7 @@ let test_join () =
   assert_equal ~printer:T.show tex1 (T.join tex1  tzero);
   assert_equal ~printer:T.show tex0 (T.join tex0  tone )
 
-let test_meet () =
+let test_meet _ =
   assert_equal ~printer:T.show tbot (T.meet tbot  tone);
   assert_equal ~printer:T.show tbot (T.meet tbot  tzero);
   assert_equal ~printer:T.show tbot (T.meet tone  tbot);
@@ -190,7 +190,7 @@ let test_meet () =
   assert_equal ~printer:T.show tzero(T.meet tex1  tzero);
   assert_equal ~printer:T.show tone (T.meet tex0  tone )
 
-let test_ex_set () =
+let test_ex_set _ =
   assert_equal (Some [zero; one]) (T.to_excl_list tex10);
   assert_equal (Some [zero; one]) (T.to_excl_list tex01);
   assert_bool  "Not [1;0] is not excl set" (T.is_excl_list tex10);

--- a/unittest/domains/mapDomainTest.ml
+++ b/unittest/domains/mapDomainTest.ml
@@ -1,4 +1,4 @@
-open OUnit
+open OUnit2
 
 module GroupableDriver : MapDomain.Groupable with type t = string  =
 struct
@@ -24,7 +24,7 @@ struct
       | false -> M.is_bot x
 
 
-  let test_add_remove_find () =
+  let test_add_remove_find _ =
     let map = ref (get_empty ()) in
       begin
 	assert_bool "can't get empty map" (is_empty !map);
@@ -46,7 +46,7 @@ struct
 
       end
 
-  let test_iter () =
+  let test_iter _ =
     let map = ref (get_empty ()) in
     let values = ["1","1";"2","2";"3","3";"4","4"]  in
     let fun1 k v =
@@ -59,7 +59,7 @@ struct
 	assert_bool "iter does not work" (is_empty !map)
       end
 
-  let test_fold () =
+  let test_fold _ =
     let map = ref (get_empty ()) in
     let values = ["1","2";"2","3";"3","4";"4","5"]  in
     let result = "45342312" in
@@ -69,7 +69,7 @@ struct
 	assert_equal result (M.fold fun1 !map "")
       end
 
-  let test_add_list () =
+  let test_add_list _ =
     let map = ref (get_empty ()) in
     let values = ["1","2";"2","3";"3","4";"4","5"]  in
       map := M.add_list values !map;
@@ -78,7 +78,7 @@ struct
       assert_equal "4" (M.find "3" !map);
       assert_equal "5" (M.find "4" !map)
 
-  let test_map () =
+  let test_map _ =
     let map = ref (get_empty ()) in
     let values = ["1","2";"2","3";"3","4";"4","5"]  in
     let fun1 n = n^"1" in
@@ -89,7 +89,7 @@ struct
       assert_equal "41" (M.find "3" !map);
       assert_equal "51" (M.find "4" !map)
 
-  let test_add_list_set () =
+  let test_add_list_set _ =
     let map = ref (get_empty ()) in
     let keys = ["1";"2";"3"] in
       map := M.add_list_set keys "v" !map;
@@ -97,7 +97,7 @@ struct
       assert_equal "v" (M.find "2" !map);
       assert_equal "v" (M.find "3" !map)
 
-  let test_add_list_fun () =
+  let test_add_list_fun _ =
     let map = ref (get_empty ()) in
     let fun1 k = k^"1" in
     let keys = ["1";"2";"3";"4"] in
@@ -108,7 +108,7 @@ struct
       assert_equal "41" (M.find "4" !map)
 
 
-  let test_for_all () =
+  let test_for_all _ =
     let map = ref (get_empty ()) in
     let values = ["1","1";"2","2";"3","3";"4","4"] in
     let fun1 k v = k = v in
@@ -116,7 +116,7 @@ struct
       assert_bool "for_all broken" (M.for_all fun1 !map)
 
 
-  let test_map2 () =
+  let test_map2 _ =
     let map1 = ref (get_empty ()) in
     let map2 = ref (get_empty ()) in
     let values1 = ["1","a";"2","b";"3","c";"4","d"] in
@@ -129,7 +129,7 @@ struct
       assert_equal "111" (M.fold fun2 (M.map2 fun1 !map2 !map1) "")
 
 
-  let test_long_map2 () =
+  let test_long_map2 _ =
     let map1 = ref (get_empty ()) in
     let map2 = ref (get_empty ()) in
     let values1 = ["1","a";"2","b";"3","c";"4","d"] in
@@ -166,7 +166,7 @@ module Tbot = TestMap (Mbot)
 module Ttop = TestMap (Mtop)
 
 
-let test_Mbot_join_meet () =
+let test_Mbot_join_meet _ =
   let assert_eq =
     let printer a = Pretty.sprint ~width:80 (Mbot.pretty () a) in
     let cmp = Mbot.equal in
@@ -202,7 +202,7 @@ let test_Mbot_join_meet () =
     assert_eq mtwo  (Mbot.meet m21   mtwo);
     ()
 
-let test_Mtop_join_meet () =
+let test_Mtop_join_meet _ =
   let assert_eq =
     let printer a = Pretty.sprint ~width:80 (Mtop.pretty () a) in
     let cmp = Mtop.equal in

--- a/unittest/dune
+++ b/unittest/dune
@@ -2,7 +2,8 @@
 
 (test
   (name mainTest)
-  (libraries ounit2 goblint.lib goblint.sites.dune)
+  (libraries ounit2 qcheck-ounit goblint.lib goblint.sites.dune)
+  (preprocess (staged_pps ppx_deriving.std ppx_deriving_yojson))
   (flags :standard -linkall))
 
 (env

--- a/unittest/mainTest.ml
+++ b/unittest/mainTest.ml
@@ -1,22 +1,10 @@
-open OUnit
+open OUnit2
 
-module U = Testutils
-
-let all_tests _ = ("" >:::
+let all_tests = ("" >:::
   [ IntDomainTest.test ();
     MapDomainTest.test ();
     SolverTest.test ();
     (* etc *)
   ])
 
-let _ =
-  (* first we need to load the default config which is done at the toplevel in Defaults *)
-  (* let module Ignore = Defaults in *)
-  let verbose = ref false in
-  let set_verbose _ = verbose := true in
-  Arg.parse
-    [("-verbose", Arg.Unit set_verbose, "Run the test in verbose mode.");]
-    (fun x -> raise (Arg.Bad ("Bad argument : " ^ x)))
-    ("usage: " ^ Sys.argv.(0) ^ " [-verbose]");
-  if not (U.was_successful (run_test_tt ~verbose:!verbose (all_tests ()))) then
-    exit 1
+let () = run_test_tt_main all_tests

--- a/unittest/mainTest.ml
+++ b/unittest/mainTest.ml
@@ -5,6 +5,7 @@ let all_tests = ("" >:::
     MapDomainTest.test ();
     SolverTest.test ();
     (* etc *)
+    "domaintest" >::: QCheck_ounit.to_ounit2_test_list Maindomaintest.all_testsuite
   ])
 
 let () = run_test_tt_main all_tests

--- a/unittest/maindomaintest.ml
+++ b/unittest/maindomaintest.ml
@@ -133,5 +133,6 @@ let nonAssocIntTestsuite =
       let module DP = IntDomainProperties.AllNonAssoc (D) in
       DP.tests
     )
-let () =
-  QCheck_base_runner.run_tests_main ~argv:Sys.argv (testsuite @ nonAssocTestsuite @ intTestsuite @ nonAssocIntTestsuite)
+(* let () =
+  QCheck_base_runner.run_tests_main ~argv:Sys.argv (testsuite @ nonAssocTestsuite @ intTestsuite @ nonAssocIntTestsuite) *)
+let all_testsuite = testsuite @ nonAssocTestsuite @ intTestsuite @ nonAssocIntTestsuite

--- a/unittest/solver/solverTest.ml
+++ b/unittest/solver/solverTest.ml
@@ -1,4 +1,4 @@
-open OUnit
+open OUnit2
 open Pretty
 
 (* variables are strings *)
@@ -56,7 +56,7 @@ struct
 end
 module Solver = Constraints.GlobSolverFromEqSolver (Constraints.EqIncrSolverFromEqSolver (EffectWConEq.Make) (PostSolverArg)) (ConstrSys) (LH) (GH)
 
-let test1 () =
+let test1 _ =
   let id x = x in
   let ((sol, gsol), _) = Solver.solve [] [] ["w"] in
   assert_equal ~printer:id "42" (Int.show (GH.find gsol "g"));

--- a/unittest/testutils.ml
+++ b/unittest/testutils.ml
@@ -1,9 +1,0 @@
-open OUnit
-
-let was_test_successful x =
-  match x with
-      RSuccess y -> true
-    | _ -> false
-
-let was_successful x =
-  List.fold_left (&&) true (List.map was_test_successful x)


### PR DESCRIPTION
Instead of having a special `goblint.domaintest` binary for the domain tests, this moves them into the unit test suite. In order to use qcheck property tests in a OUnit suite, we must switch to the OUnit2 API.