### PR TITLE
Add ikind argument to IntDomain arbitraries, fix some bugs

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1358,7 +1358,7 @@ struct
     let norm ik v =
       match v with
       | `Excluded (s, r) ->
-        let possibly_overflowed = not (R.leq r (size ik)) in
+        let possibly_overflowed = not (R.leq r (size ik)) || not (S.for_all (in_range (size ik)) s) in
         (* If no overflow occurred, just return x *)
         if not possibly_overflowed then (
           v

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2551,15 +2551,10 @@ struct
   let arbitrary ik =
     let open QCheck in
     let int_arb = map ~rev:Ints_t.to_int64 Ints_t.of_int64 MyCheck.Arbitrary.int64 in
-    let top_arb = make ~print:show (Gen.return (top ())) in
-    let bot_arb = make ~print:show (Gen.return (bot ())) in
-    let int_cong_arb = pair int_arb (make (Gen.return Ints_t.zero)) in
     let cong_arb = pair int_arb int_arb in
     let of_pair ik p = normalize ik (Some p) in
-    oneof
-      ((set_print show @@ map (of_pair ik) cong_arb)::
-         (set_print show @@ map (of_pair ik) int_cong_arb)::
-           top_arb::bot_arb::[])
+    let to_pair = Option.get in
+    set_print show (map ~rev:to_pair (of_pair ik) cong_arb)
 
   let relift x = x
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2231,7 +2231,7 @@ struct
     let congruence_series a c m =
       let rec next a1 c1 a2 c2 =
         if a2 |: a1 then (a2, c2)
-        else next a2 c2 (a1 %: a2) ((c1 -: c2) *: (a1 /: a2))
+        else next a2 c2 (a1 %: a2) (c1 -: (c2 *: (a1 /: a2)))
       in next m Ints_t.zero a c
     in
     let simple_case i c m =

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -231,6 +231,7 @@ sig
   val of_interval: Cil.ikind -> int_t * int_t -> t
 
   val of_congruence: Cil.ikind -> int_t * int_t -> t
+  val arbitrary: unit -> t QCheck.arbitrary
 end
 (** Interface of IntDomain implementations that do not take ikinds for arithmetic operations yet.
    TODO: Should be ported to S in the future. *)
@@ -272,6 +273,7 @@ sig
   val refine_with_incl_list: Cil.ikind -> t -> int_t list option -> t
 
   val project: Cil.ikind -> PrecisionUtil.precision -> t -> t
+  val arbitrary: Cil.ikind -> t QCheck.arbitrary
 end
 (** Interface of IntDomain implementations taking an ikind for arithmetic operations *)
 

--- a/src/domains/intDomainProperties.ml
+++ b/src/domains/intDomainProperties.ml
@@ -57,7 +57,7 @@ struct
 
   let name () = Pretty.(sprint ~width:80 (dprintf "%s (%a)" (name ()) Cil.d_ikind (Ik.ikind ())))
 
-  let arbitrary () = QCheck.map ~rev:(fun x -> x) (cast_to (Ik.ikind ())) (arbitrary ())
+  let arbitrary () = arbitrary (Ik.ikind ())
 end
 
 module IntegerSet =

--- a/src/domains/intDomainProperties.ml
+++ b/src/domains/intDomainProperties.ml
@@ -62,8 +62,7 @@ end
 
 module IntegerSet =
 struct
-  (* TODO: base this on BI instead *)
-  module Base = IntDomain.Integers(IntOps.Int64Ops)
+  module Base = IntDomain.Integers(IntOps.BigIntOps)
 
   include SetDomain.Make(Base)
 
@@ -101,9 +100,8 @@ end
 module CD = IntegerSet
 module AF (AD: OldS) =
 struct
-  (* TODO: don't do this through int64, make CD use BI instead *)
-  let abstract s = CD.fold (fun c a -> AD.join (AD.of_int (BI.of_int64 c)) a) s (AD.bot ())
-  let check_leq s x  = CD.for_all (fun c -> AD.leq (AD.of_int (BI.of_int64 c)) x) s
+  let abstract s = CD.fold (fun c a -> AD.join (AD.of_int c) a) s (AD.bot ())
+  let check_leq s x  = CD.for_all (fun c -> AD.leq (AD.of_int c) x) s
 end
 
 module Valid (AD: OldS): DomainProperties.S =
@@ -118,7 +116,7 @@ struct
   let valid_sub = make_valid2 ~name:"sub" ~cond:none_bot CD.sub AD.sub
   let valid_mul = make_valid2 ~name:"mul" ~cond:none_bot CD.mul AD.mul
 
-  let snd_not_0 (a, b) = none_bot (a,b) && not (CD.mem 0L b) (* CD (IntegerSet) can't handle because no top *)
+  let snd_not_0 (a, b) = none_bot (a,b) && not (CD.mem Z.zero b) (* CD (IntegerSet) can't handle because no top *)
   let valid_div = make_valid2 ~name:"div" ~cond:snd_not_0 CD.div AD.div
   let valid_rem = make_valid2 ~name:"rem" ~cond:snd_not_0 CD.rem AD.rem
 

--- a/unittest/maindomaintest.ml
+++ b/unittest/maindomaintest.ml
@@ -69,7 +69,7 @@ let nonAssocDomains: (module Lattice.S) list = []
 let intDomains: (module IntDomainProperties.S) list = [
   (module IntDomain.Interval);
   (module IntDomain.Enums);
-  (* (module IntDomain.Congruence); *)
+  (module IntDomain.Congruence);
   (* (module IntDomain.Flattened); *)
   (* (module IntDomain.Interval32); *)
   (* (module IntDomain.Booleans); *)

--- a/unittest/maindomaintest.ml
+++ b/unittest/maindomaintest.ml
@@ -117,19 +117,19 @@ let old_intdomains intDomains =
   |> List.map (fun (d, ik) ->
       let module D = (val d: IntDomainProperties.S) in
       let module Ikind = struct let ikind () = ik end in
-      (module IntDomainProperties.WithIkind (D) (Ikind): IntDomainProperties.OldS)
+      (module IntDomainProperties.WithIkind (D) (Ikind): IntDomainProperties.OldSWithIkind)
     )
 let intTestsuite =
   old_intdomains intDomains
   |> List.concat_map (fun d ->
-      let module D = (val d: IntDomainProperties.OldS) in
+      let module D = (val d: IntDomainProperties.OldSWithIkind) in
       let module DP = IntDomainProperties.All (D) in
       DP.tests
     )
 let nonAssocIntTestsuite =
   old_intdomains nonAssocIntDomains
   |> List.concat_map (fun d ->
-      let module D = (val d: IntDomainProperties.OldS) in
+      let module D = (val d: IntDomainProperties.OldSWithIkind) in
       let module DP = IntDomainProperties.AllNonAssoc (D) in
       DP.tests
     )

--- a/unittest/maindomaintest.ml
+++ b/unittest/maindomaintest.ml
@@ -69,7 +69,7 @@ let nonAssocDomains: (module Lattice.S) list = []
 let intDomains: (module IntDomainProperties.S) list = [
   (module IntDomain.Interval);
   (module IntDomain.Enums);
-  (module IntDomain.Congruence);
+  (* (module IntDomain.Congruence); *)
   (* (module IntDomain.Flattened); *)
   (* (module IntDomain.Interval32); *)
   (* (module IntDomain.Booleans); *)


### PR DESCRIPTION
### TODO
Enabling `ILong` ikind for IntDomain property tests still fails one test for intervals:
```
test `integerset -> intervals (long): valid rem` failed on ≥ 1 cases:
([-1L], [-1L]) (after 124 shrink steps)
```