### PR TITLE
Optimize short-circuitable folds in `MCP`

### DIFF
--- a/src/analyses/mCPAccess.ml
+++ b/src/analyses/mCPAccess.ml
@@ -14,12 +14,12 @@ struct
   let unop_fold f a (x:t) =
     fold_left2 (fun a (n,d) (n',s) -> assert (n = n'); f a n s d) a x (domain_list ())
 
-  let binop_fold f a (x:t) (y:t) =
-    GobList.fold_left3 (fun a (n,d) (n',d') (n'',s) -> assert (n = n' && n = n''); f a n s d d') a x y (domain_list ())
+  let binop_for_all f (x:t) (y:t) =
+    GobList.for_all3 (fun (n,d) (n',d') (n'',s) -> assert (n = n' && n = n''); f n s d d') x y (domain_list ())
 
-  let may_race x y = binop_fold (fun a n (module S: Analyses.MCPA) x y ->
-      a && S.may_race (obj x) (obj y)
-    ) true x y
+  let may_race x y = binop_for_all (fun n (module S: Analyses.MCPA) x y ->
+      S.may_race (obj x) (obj y)
+    ) x y
 
   let pretty () a =
     (* filter with should_print *)

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -119,9 +119,6 @@ struct
       (name, S.to_yojson (obj x)) :: a
     in `Assoc (unop_fold f [] xs)
 
-  let binop_fold f a (x:t) (y:t) =
-    GobList.fold_left3 (fun a (n,d) (n',d') (n'',s) -> assert (n = n' && n = n''); f a n s d d') a x y (domain_list ())
-
   let binop_for_all f (x:t) (y:t) =
     GobList.for_all3 (fun (n,d) (n',d') (n'',s) -> assert (n = n' && n = n''); f n s d d') x y (domain_list ())
 
@@ -260,9 +257,6 @@ struct
 
   let binop_for_all f (x:t) (y:t) =
     GobList.for_all3 (fun (n,d) (n',d') (n'',s) -> assert (n = n' && n = n''); f n s d d') x y (domain_list ())
-
-  let unop_fold f a (x:t) =
-    fold_left2 (fun a (n,d) (n',s) -> assert (n = n'); f a n s d) a x (domain_list ())
 
   let unop_for_all f (x:t) =
     List.for_all2 (fun (n,d) (n',s) -> assert (n = n'); f n s d) x (domain_list ())

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -125,9 +125,22 @@ struct
   let binop_for_all f (x:t) (y:t) =
     GobList.for_all3 (fun (n,d) (n',d') (n'',s) -> assert (n = n' && n = n''); f n s d d') x y (domain_list ())
 
+  (* too specific for GobList *)
+  let rec compare3 f l1 l2 l3 = match l1, l2, l3 with
+    | [], [], [] -> 0
+    | x1 :: l1, x2 :: l2, x3 :: l3 ->
+      let c = f x1 x2 x3 in
+      if c <> 0 then
+        c
+      else
+        (compare3 [@tailcall]) f l1 l2 l3
+    | _, _, _ -> invalid_arg "DomListPrintable.compare3"
+
+  let binop_compare f (x:t) (y:t) =
+    compare3 (fun (n,d) (n',d') (n'',s) -> assert (n = n' && n = n''); f n s d d') x y (domain_list ())
+
   let equal   x y = binop_for_all (fun n (module S : Printable.S) x y -> S.equal (obj x) (obj y)) x y
-  (* TODO: something for compare? *)
-  let compare x y = binop_fold (fun a n (module S : Printable.S) x y -> if a <> 0 then a else S.compare (obj x) (obj y)) 0 x y
+  let compare x y = binop_compare (fun n (module S : Printable.S) x y -> S.compare (obj x) (obj y)) x y
 
   let hashmul x y = if x=0 then y else if y=0 then x else x*y
 

--- a/src/util/gobList.ml
+++ b/src/util/gobList.ml
@@ -12,3 +12,8 @@ let rec fold_left3 f acc l1 l2 l3 = match l1, l2, l3 with
   | [], [], [] -> acc
   | x1 :: l1, x2 :: l2, x3 :: l3 -> fold_left3 f (f acc x1 x2 x3) l1 l2 l3
   | _, _, _ -> invalid_arg "GobList.fold_left3"
+
+let rec for_all3 f l1 l2 l3 = match l1, l2, l3 with
+  | [], [], [] -> true
+  | x1 :: l1, x2 :: l2, x3 :: l3 -> f x1 x2 x3 && (for_all3 [@tailcall]) f l1 l2 l3
+  | _, _, _ -> invalid_arg "GobList.for_all3"


### PR DESCRIPTION
This PR is an attempt to optimize the following `MCP` domain/context/access functions:
* `equal`
* `compare`
* `leq`
* `is_top`
* `is_bot`
* `may_race`

The previous implementations used folds, which inevitably had to iterate over the entire list each time. Even though the folding functions themselves used the short-circuiting binary operators, this didn't short-circuit much. Moreover, all the inefficient `List.assoc` calls were still happening just to pass the corresponding arguments to the folding function (which in the short-circuiting case didn't even use them).
These `assoc`s are a pain because as the fold goes down the list, each corresponding `assoc` needs to go through more of the other list. Overall, this means O(n²) complexity.

This PR implements alternative short-circuitable folds for `MCP`, which abort the list iteration via local exception to short-circuit. It not only avoids the unnecessary list tail iteration, but also all the `assoc` calls that would unnecessarily happen there.

This is quite relevant because while profiling slow race warning performance that @vesalvojdani noticed, it turns out that 30% of race warning time is just spent on `MCPAccess.A.compare` while manipulating sets of accesses.
I'm speculating that this might even have general performance improvement since path-sensitivity also uses sets of `MCP.D` values.


### TODO
- [x] Benchmark.