### PR TITLE
Add option `include_stdlib` to toggle inclusion of Goblint's `stdlib.c`

### DIFF
--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -280,7 +280,10 @@ let preprocess_files () =
 
   let extra_arg_files = ref [] in
 
-  extra_arg_files := find_custom_include "stdlib.c" :: find_custom_include "pthread.c" :: !extra_arg_files;
+  if get_bool "include_stdlib" then
+    extra_arg_files := find_custom_include "stdlib.c" :: !extra_arg_files;
+
+  extra_arg_files :=  find_custom_include "pthread.c" :: !extra_arg_files;
 
   if get_bool "ana.sv-comp.functions" then
     extra_arg_files := find_custom_include "sv-comp.c" :: !extra_arg_files;

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -29,6 +29,12 @@
       "items": { "type": "string" },
       "default": []
     },
+    "include_stdlib" : {
+      "title": "include_stdlib",
+      "description": "Include Goblint's stdlib.c (containing defintions of bsearch and qsort).",
+      "type": "boolean",
+      "default": true
+    },
     "kernel-root": {
       "title": "kernel-root",
       "description": "Root directory for Linux kernel (linux-headers)",


### PR DESCRIPTION
Always including Goblint's `stdlib.c` leads to merge conflicts for any projects that do define those functions themselves (e.g. in  https://github.com/goblint/bench/issues/16).
Add an option to disable this inclusion which produces much cleaner CIL merges for such projects.