### PR TITLE
Array unrolling abstract domain

### DIFF
--- a/conf/svcomp.json
+++ b/conf/svcomp.json
@@ -1,5 +1,10 @@
 {
   "ana": {
+    "base": {
+      "arrays": {
+        "domain": "partitioned"
+      }
+    },
     "sv-comp": {
       "enabled": true,
       "functions": true
@@ -49,8 +54,7 @@
     }
   },
   "exp": {
-    "region-offsets": true,
-    "arrays-domain": "partitioned"
+    "region-offsets": true
   },
   "witness": {
     "id": "enumerate",

--- a/conf/svcomp.json
+++ b/conf/svcomp.json
@@ -1,10 +1,5 @@
 {
   "ana": {
-    "base": {
-      "partition-arrays": {
-        "enabled": true
-      }
-    },
     "sv-comp": {
       "enabled": true,
       "functions": true
@@ -54,7 +49,8 @@
     }
   },
   "exp": {
-    "region-offsets": true
+    "region-offsets": true,
+    "arrays-domain": "partitioned"
   },
   "witness": {
     "id": "enumerate",

--- a/conf/svcomp21.json
+++ b/conf/svcomp21.json
@@ -41,11 +41,15 @@
         "kmalloc_array",
         "kcalloc"
       ]
+    },
+    "base": {
+      "arrays": {
+        "domain": "partitioned"
+      }
     }
   },
   "exp": {
-    "region-offsets": true,
-    "arrays-domain": "partitioned"
+    "region-offsets": true
   },
   "solver": "td3",
   "sem": {

--- a/conf/svcomp21.json
+++ b/conf/svcomp21.json
@@ -1,10 +1,5 @@
 {
   "ana": {
-    "base": {
-      "partition-arrays": {
-        "enabled": true
-      }
-    },
     "sv-comp": {
       "enabled": true,
       "functions": true
@@ -49,7 +44,8 @@
     }
   },
   "exp": {
-    "region-offsets": true
+    "region-offsets": true,
+    "arrays-domain": "partitioned"
   },
   "solver": "td3",
   "sem": {

--- a/conf/svcomp22.json
+++ b/conf/svcomp22.json
@@ -41,11 +41,15 @@
         "kmalloc_array",
         "kcalloc"
       ]
+    },
+    "base": {
+      "arrays": {
+        "domain": "partitioned"
+      }
     }
   },
   "exp": {
-    "region-offsets": true,
-    "arrays-domain": "partitioned"
+    "region-offsets": true
   },
   "solver": "td3",
   "sem": {

--- a/conf/svcomp22.json
+++ b/conf/svcomp22.json
@@ -1,10 +1,5 @@
 {
   "ana": {
-    "base": {
-      "partition-arrays": {
-        "enabled": true
-      }
-    },
     "sv-comp": {
       "enabled": true,
       "functions": true
@@ -49,7 +44,8 @@
     }
   },
   "exp": {
-    "region-offsets": true
+    "region-offsets": true,
+    "arrays-domain": "partitioned"
   },
   "solver": "td3",
   "sem": {

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -74,7 +74,7 @@ end
 module Unroll (Val: Lattice.S) (Idx:IntDomain.Z): S with type value = Val.t and type idx = Idx.t =
 struct
   module Factor = struct let x () = (get_int "exp.array-unrolling-factor") end
-  module Base = Lattice.ProdArray (Val) (Factor)
+  module Base = Lattice.ProdList (Val) (Factor)
   include Lattice.ProdSimple(Base) (Val)
 
   let name () = "unrolled arrays"

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -93,7 +93,7 @@ struct
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let extract x = match x with
       | Some c -> c
-      | None -> Z.zero
+      | None -> failwith "arrarDomain: that sould not happen"
   let get (ask: Q.ask) (xl, xr) (_,i) =
     let search_unrolled_values min_i max_i =
       let mi = Z.to_int min_i in

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -865,7 +865,7 @@ struct
   let smart_leq f g = binop' (P.smart_leq f g) (T.smart_leq f g) (U.smart_leq f g)
   let update_length newl x = unop_to_t' (P.update_length newl) (T.update_length newl) (U.update_length newl) x
 
-  (* Functions that make us of the configuration flag *)
+  (* Functions that make use of the configuration flag *)
   let chosen_domain () = get_string "ana.base.arrays.domain"
 
   let name () = "FlagConfiguredArrayDomain: " ^ match chosen_domain () with

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -139,7 +139,7 @@ struct
     else ((update_unrolled_values min_i (Z.of_int ((factor ())-1))), (Val.join xr v))
   let make _ v =
     let xl = BatList.make (factor ()) v in
-    (xl,v)
+    (xl,Val.bot ())
   let length _ = None
   let move_if_affected ?(replace_with_const=false) _ x _ _ = x
   let get_vars_in_e _ = []

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -137,8 +137,8 @@ struct
     if Z.geq min_i f then (xl, (Val.join xr v))
     else if Z.lt max_i f then ((update_unrolled_values min_i max_i), xr)
     else ((update_unrolled_values min_i (Z.of_int ((factor ())-1))), (Val.join xr v))
-  let make i v =
-    let xl = Array.to_list (Array.make (factor ()) v) in
+  let make _ v =
+    let xl = BatList.make (factor ()) v in
     (xl,v)
   let length _ = None
   let move_if_affected ?(replace_with_const=false) _ x _ _ = x

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -808,7 +808,7 @@ struct
   (* Simply call appropriate function for component that is not None *)
   let get a x (e,i) = unop' (fun x ->
     if e = `Top then
-      let e' = BatOption.map_default (fun x -> `Lifted (Cil.kinteger64 IInt x)) (`Top) (Option.map BI.to_int64 @@ Idx.to_int i) in
+      let e' = BatOption.map_default (fun x -> `Lifted (Cil.kintegerCilint (Cilfacade.ptrdiff_ikind ()) x)) (`Top) (Idx.to_int i) in
       P.get a x (e', i)
     else
       P.get a x (e, i)

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -146,8 +146,6 @@ struct
   let map f (xl, xr) = ((List.map f xl), f xr)
   let fold_left f a x = f a (join_of_all_parts x)
   let fold_left2 f a x y = f a (join_of_all_parts x) (join_of_all_parts y)
-  let set_inplace = set
-  let copy a = a
   let printXml f (xl,xr) = BatPrintf.fprintf f "<value>\n<map>\n
   <key>unrolled array</key>\n
   <key>xl</key>\n%a\n\n
@@ -792,11 +790,6 @@ struct
     let msg = "FlagConfiguredArrayDomain received a value where not exactly one component is set"
     let name = "FlagConfiguredArrayDomain"
   end
-
-  let of_t = function
-  | (Some p, None) -> (Some p, None, None)
-  | (None, Some (t,u)) -> (None, t, u)
-  | _ -> failwith "FlagConfiguredArrayDomain received a value where not exactly one component is set"
 
   let to_t = function
   | (Some p, None, None) -> (Some p, None)

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -71,7 +71,7 @@ end
 
 module Unroll (Val: Lattice.S) (Idx:IntDomain.Z): S with type value = Val.t and type idx = Idx.t =
 struct
-  module Factor = struct let x () = (get_int "exp.array-unrolling-factor") end
+  module Factor = struct let x () = (get_int "ana.base.arrays.unrolling-factor") end
   module Base = Lattice.ProdList (Val) (Factor)
   include Lattice.ProdSimple(Base) (Val)
 
@@ -79,8 +79,8 @@ struct
   type idx = Idx.t
   type value = Val.t
   let factor () = 
-    match get_int "exp.array-unrolling-factor" with
-    | 0 -> failwith "ArrayDomain: exp.array-unrolling-factor needs to be set when using the unroll domain"
+    match get_int "ana.base.arrays.unrolling-factor" with
+    | 0 -> failwith "ArrayDomain: ana.base.arrays.unrolling-factor needs to be set when using the unroll domain"
     | x -> x
   let join_of_all_parts (xl, xr) = List.fold_left Val.join xr xl
   let show (xl, xr) =
@@ -828,7 +828,7 @@ struct
   let update_length newl x = unop_to_t' (P.update_length newl) (T.update_length newl) (U.update_length newl) x
 
   (* Functions that make us of the configuration flag *)
-  let chosen_domain () = get_string "exp.arrays-domain"
+  let chosen_domain () = get_string "ana.base.arrays.domain"
 
   let name () = "FlagConfiguredArrayDomain: " ^ match chosen_domain () with
     | "trivial" -> T.name ()

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -800,10 +800,10 @@ struct
   module I = struct include LatticeFlagHelper (T) (U) (K) let name () = "" end
   include LatticeFlagHelper (P) (I) (K)
 
-  let binop' ops ophs opks = binop ops (I.binop ophs opks)
-  let unop' ops ophs opks = unop ops (I.unop ophs opks)
-  let binop_to_t' ops ophs opks = binop_to_t ops (I.binop_to_t ophs opks)
-  let unop_to_t' ops ophs opks = unop_to_t ops (I.unop_to_t ophs opks)
+  let binop' opp opt opu = binop opp (I.binop opt opu)
+  let unop' opp opt opu = unop opp (I.unop opt opu)
+  let binop_to_t' opp opt opu = binop_to_t opp (I.binop_to_t opt opu)
+  let unop_to_t' opp opt opu = unop_to_t opp (I.unop_to_t opt opu)
 
   (* Simply call appropriate function for component that is not None *)
   let get a x (e,i) = unop' (fun x ->

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -80,7 +80,10 @@ struct
   let name () = "unrolled arrays"
   type idx = Idx.t
   type value = Val.t
-  let factor () = get_int "exp.array-unrolling-factor"
+  let factor () = 
+    match get_int "exp.array-unrolling-factor" with
+    | 0 -> failwith "ArrayDomain: exp.array-unrolling-factor needs to be set when using the unroll domain"
+    | x -> x
   let join_of_all_parts (xl, xr) = List.fold_left Val.join xr xl
   let show (xl, xr) =
     let rec show_list xlist = match xlist with

--- a/src/cdomains/arrayDomain.mli
+++ b/src/cdomains/arrayDomain.mli
@@ -76,4 +76,4 @@ module PartitionedWithLength (Val: LatticeWithSmartOps) (Idx:IntDomain.Z): S wit
 (** Like partitioned but additionally manages the length of the array. *)
 
 module FlagConfiguredArrayDomain(Val: LatticeWithSmartOps) (Idx:IntDomain.Z):S with type value = Val.t and type idx = Idx.t
-(** Switches between PartitionedWithLength, TrivialWithLength and Unroll based on the value of exp.arrays-domain. *)
+(** Switches between PartitionedWithLength, TrivialWithLength and Unroll based on the value of ana.base.arrays.domain. *)

--- a/src/cdomains/arrayDomain.mli
+++ b/src/cdomains/arrayDomain.mli
@@ -76,4 +76,4 @@ module PartitionedWithLength (Val: LatticeWithSmartOps) (Idx:IntDomain.Z): S wit
 (** Like partitioned but additionally manages the length of the array. *)
 
 module FlagConfiguredArrayDomain(Val: LatticeWithSmartOps) (Idx:IntDomain.Z):S with type value = Val.t and type idx = Idx.t
-(** Switches between PartitionedWithLength and TrivialWithLength based on the value of ana.base.partition-arrays. *)
+(** Switches between PartitionedWithLength, TrivialWithLength and Unroll based on the value of exp.arrays-domain. *)

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -148,10 +148,10 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> init_value fd.ftype) ci)
     | TComp ({cstruct=false; _},_) -> `Union (Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (CArrays.make (IndexDomain.bot ())  (if (get_string "exp.arrays-domain"="partitioned" || get_string "exp.arrays-domain"="unroll") then (init_value ai) else (bot_value ai)))
+      `Array (CArrays.make (IndexDomain.bot ())  (if (get_string "ana.base.arrays.domain"="partitioned" || get_string "ana.base.arrays.domain"="unroll") then (init_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = BatOption.map Cilint.big_int_of_cilint (Cil.getInteger (Cil.constFold true exp)) in
-      `Array (CArrays.make (BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) (IndexDomain.bot ()) l) (if (get_string "exp.arrays-domain"="partitioned" || get_string "exp.arrays-domain"="unroll") then (init_value ai) else (bot_value ai)))
+      `Array (CArrays.make (BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) (IndexDomain.bot ()) l) (if (get_string "ana.base.arrays.domain"="partitioned" || get_string "ana.base.arrays.domain"="unroll") then (init_value ai) else (bot_value ai)))
     (* | t when is_thread_type t -> `Thread (ConcDomain.ThreadSet.empty ()) *)
     | TNamed ({ttype=t; _}, _) -> init_value t
     | _ -> `Top
@@ -163,10 +163,10 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> top_value fd.ftype) ci)
     | TComp ({cstruct=false; _},_) -> `Union (Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (CArrays.make (IndexDomain.top ()) (if (get_string "exp.arrays-domain"="partitioned" || get_string "exp.arrays-domain"="unroll") then (top_value ai) else (bot_value ai)))
+      `Array (CArrays.make (IndexDomain.top ()) (if (get_string "ana.base.arrays.domain"="partitioned" || get_string "ana.base.arrays.domain"="unroll") then (top_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = BatOption.map Cilint.big_int_of_cilint (Cil.getInteger (Cil.constFold true exp)) in
-      `Array (CArrays.make (BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) (IndexDomain.top_of (Cilfacade.ptrdiff_ikind ())) l) (if (get_string "exp.arrays-domain"="partitioned" || get_string "exp.arrays-domain"="unroll") then (top_value ai) else (bot_value ai)))
+      `Array (CArrays.make (BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) (IndexDomain.top_of (Cilfacade.ptrdiff_ikind ())) l) (if (get_string "ana.base.arrays.domain"="partitioned" || get_string "ana.base.arrays.domain"="unroll") then (top_value ai) else (bot_value ai)))
     | TNamed ({ttype=t; _}, _) -> top_value t
     | _ -> `Top
 

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -148,10 +148,10 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> init_value fd.ftype) ci)
     | TComp ({cstruct=false; _},_) -> `Union (Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (CArrays.make (IndexDomain.bot ())  (if (get_string "exp.arrays-domain")="partitioned" || (get_string "exp.arrays-domain")="unroll" then (init_value ai) else (bot_value ai)))
+      `Array (CArrays.make (IndexDomain.bot ())  (if (get_string "exp.arrays-domain"="partitioned" || get_string "exp.arrays-domain"="unroll") then (init_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = BatOption.map Cilint.big_int_of_cilint (Cil.getInteger (Cil.constFold true exp)) in
-      `Array (CArrays.make (BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) (IndexDomain.bot ()) l) (if (get_string "exp.arrays-domain")="partitioned" || (get_string "exp.arrays-domain")="unroll" then (init_value ai) else (bot_value ai)))
+      `Array (CArrays.make (BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) (IndexDomain.bot ()) l) (if (get_string "exp.arrays-domain"="partitioned" || get_string "exp.arrays-domain"="unroll") then (init_value ai) else (bot_value ai)))
     (* | t when is_thread_type t -> `Thread (ConcDomain.ThreadSet.empty ()) *)
     | TNamed ({ttype=t; _}, _) -> init_value t
     | _ -> `Top
@@ -163,10 +163,10 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> top_value fd.ftype) ci)
     | TComp ({cstruct=false; _},_) -> `Union (Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (CArrays.make (IndexDomain.top ()) (if get_bool "ana.base.partition-arrays.enabled" then (top_value ai) else (bot_value ai)))
+      `Array (CArrays.make (IndexDomain.top ()) (if (get_string "exp.arrays-domain"="partitioned" || get_string "exp.arrays-domain"="unroll") then (top_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = BatOption.map Cilint.big_int_of_cilint (Cil.getInteger (Cil.constFold true exp)) in
-      `Array (CArrays.make (BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) (IndexDomain.top_of (Cilfacade.ptrdiff_ikind ())) l) (if get_bool "ana.base.partition-arrays.enabled" then (top_value ai) else (bot_value ai)))
+      `Array (CArrays.make (BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) (IndexDomain.top_of (Cilfacade.ptrdiff_ikind ())) l) (if (get_string "exp.arrays-domain"="partitioned" || get_string "exp.arrays-domain"="unroll") then (top_value ai) else (bot_value ai)))
     | TNamed ({ttype=t; _}, _) -> top_value t
     | _ -> `Top
 

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -148,10 +148,10 @@ struct
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> init_value fd.ftype) ci)
     | TComp ({cstruct=false; _},_) -> `Union (Unions.top ())
     | TArray (ai, None, _) ->
-      `Array (CArrays.make (IndexDomain.bot ())  (if get_bool "ana.base.partition-arrays.enabled" then (init_value ai) else (bot_value ai)))
+      `Array (CArrays.make (IndexDomain.bot ())  (if (get_string "exp.arrays-domain")="partitioned" || (get_string "exp.arrays-domain")="unroll" then (init_value ai) else (bot_value ai)))
     | TArray (ai, Some exp, _) ->
       let l = BatOption.map Cilint.big_int_of_cilint (Cil.getInteger (Cil.constFold true exp)) in
-      `Array (CArrays.make (BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) (IndexDomain.bot ()) l) (if get_bool "ana.base.partition-arrays.enabled" then (init_value ai) else (bot_value ai)))
+      `Array (CArrays.make (BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) (IndexDomain.bot ()) l) (if (get_string "exp.arrays-domain")="partitioned" || (get_string "exp.arrays-domain")="unroll" then (init_value ai) else (bot_value ai)))
     (* | t when is_thread_type t -> `Thread (ConcDomain.ThreadSet.empty ()) *)
     | TNamed ({ttype=t; _}, _) -> init_value t
     | _ -> `Top

--- a/src/domains/lattice.ml
+++ b/src/domains/lattice.ml
@@ -582,7 +582,7 @@ struct
 end
 
 module type Num = sig val x : unit -> int end
-module ProdArray (Base: S) (N: Num) =
+module ProdList (Base: S) (N: Num) =
 struct
   include Printable.Liszt (Base)
 

--- a/src/domains/lattice.ml
+++ b/src/domains/lattice.ml
@@ -587,13 +587,9 @@ struct
   include Printable.Liszt (Base)
 
   let bot () = Array.to_list (Array.make (N.x ()) (Base.bot ()))
-  let is_bot =
-    let f acc x = Base.is_bot x && acc in
-    List.fold_left f true
+  let is_bot = List.for_all Base.is_bot
   let top () = Array.to_list (Array.make (N.x ()) (Base.top ()))
-  let is_top =
-    let f acc x = Base.is_top x && acc in
-    List.fold_left f true
+  let is_top = List.for_all Base.is_top
 
   let leq =
     let f acc x y = Base.leq x y && acc in

--- a/src/domains/lattice.ml
+++ b/src/domains/lattice.ml
@@ -586,9 +586,9 @@ module ProdList (Base: S) (N: Num) =
 struct
   include Printable.Liszt (Base)
 
-  let bot () = Array.to_list (Array.make (N.x ()) (Base.bot ()))
+  let bot () = BatList.make (N.x ()) (Base.bot ())
   let is_bot = List.for_all Base.is_bot
-  let top () = Array.to_list (Array.make (N.x ()) (Base.top ()))
+  let top () = BatList.make (N.x ()) (Base.top ())
   let is_top = List.for_all Base.is_top
 
   let leq =

--- a/src/domains/lattice.ml
+++ b/src/domains/lattice.ml
@@ -581,6 +581,33 @@ struct
     Pretty.dprintf "%a not leq %a" pretty x pretty y
 end
 
+module type Num = sig val x : unit -> int end
+module ProdArray (Base: S) (N: Num) =
+struct
+  include Printable.Liszt (Base)
+
+  let bot () = Array.to_list (Array.make (N.x ()) (Base.bot ()))
+  let is_bot =
+    let f acc x = Base.is_bot x && acc in
+    List.fold_left f true
+  let top () = Array.to_list (Array.make (N.x ()) (Base.top ()))
+  let is_top =
+    let f acc x = Base.is_top x && acc in
+    List.fold_left f true
+
+  let leq =
+    let f acc x y = Base.leq x y && acc in
+    List.fold_left2 f true
+
+  let join = List.map2 Base.join
+  let widen = List.map2 Base.widen
+  let meet = List.map2 Base.meet
+  let narrow = List.map2 Base.narrow
+
+  let pretty_diff () ((x:t),(y:t)): Pretty.doc =
+    Pretty.dprintf "%a not leq %a" pretty x pretty y
+end
+
 module Chain (P: Printable.ChainParams) =
 struct
   include Printable.Std

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1401,6 +1401,20 @@
             "Path to C preprocessor (cpp) to use. If empty, then automatically searched.",
           "type": "string",
           "default": ""
+        },
+        "arrays-domain": {
+          "title": "exp.arrays-domain",
+          "description":
+            "The domain that should be used for arrays. trivial/partitioned/unroll. When employing the partition array domain, make sure to enable the expRelation analysis as well. When employing the unrolling array domain, make sure to set the exp.array-unrolling-factor >0.",
+          "type": "string",
+          "default": "trivial"
+        },
+        "array-unrolling-factor": {
+          "title": "exp.array-unrolling-factor",
+          "description":
+            "Indicates how many values will the unrolled part of the unrolled array domain contain.",
+          "type": "integer",
+          "default": 0
         }
       },
       "additionalProperties": false

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -649,6 +649,27 @@
               },
               "additionalProperties": false
             },
+            "arrays":{
+              "title": "ana.base.arrays",
+              "type": "object",
+              "properties": {
+                "domain": {
+                  "title": "ana.base.arrays.domain",
+                  "description":
+                    "The domain that should be used for arrays. When employing the partition array domain, make sure to enable the expRelation analysis as well. When employing the unrolling array domain, make sure to set the ana.base.arrays.unrolling-factor >0.",
+                  "type": "string",
+                  "enum": ["trivial", "partitioned", "unroll"],
+                  "default": "trivial"
+                },
+                "unrolling-factor": {
+                  "title": "ana.base.arrays.unrolling-factor",
+                  "description": "Indicates how many values will the unrolled part of the unrolled array domain contain.",
+                  "type": "integer",
+                  "default": 0
+                }
+              },
+              "additionalProperties": false
+            },
             "structs": {
               "title": "ana.base.structs",
               "type": "object",
@@ -1400,21 +1421,6 @@
             "Path to C preprocessor (cpp) to use. If empty, then automatically searched.",
           "type": "string",
           "default": ""
-        },
-        "arrays-domain": {
-          "title": "exp.arrays-domain",
-          "description":
-            "The domain that should be used for arrays. When employing the partition array domain, make sure to enable the expRelation analysis as well. When employing the unrolling array domain, make sure to set the exp.array-unrolling-factor >0.",
-          "type": "string",
-          "enum": ["trivial", "partitioned", "unroll"],
-          "default": "trivial"
-        },
-        "array-unrolling-factor": {
-          "title": "exp.array-unrolling-factor",
-          "description":
-            "Indicates how many values will the unrolled part of the unrolled array domain contain.",
-          "type": "integer",
-          "default": 0
         }
       },
       "additionalProperties": false

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -624,13 +624,6 @@
               "title": "ana.base.partition-arrays",
               "type": "object",
               "properties": {
-                "enabled": {
-                  "title": "ana.base.partition-arrays.enabled",
-                  "description":
-                    "Employ the partitioning array domain. When this is on, make sure to enable the expRelation analysis as well.",
-                  "type": "boolean",
-                  "default": false
-                },
                 "keep-expr": {
                   "title": "ana.base.partition-arrays.keep-expr",
                   "description":

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1404,8 +1404,9 @@
         "arrays-domain": {
           "title": "exp.arrays-domain",
           "description":
-            "The domain that should be used for arrays. trivial/partitioned/unroll. When employing the partition array domain, make sure to enable the expRelation analysis as well. When employing the unrolling array domain, make sure to set the exp.array-unrolling-factor >0.",
+            "The domain that should be used for arrays. When employing the partition array domain, make sure to enable the expRelation analysis as well. When employing the unrolling array domain, make sure to set the exp.array-unrolling-factor >0.",
           "type": "string",
+          "enum": ["trivial", "partitioned", "unroll"],
           "default": "trivial"
         },
         "array-unrolling-factor": {

--- a/sv-comp/benchexec/my-bench/goblint.xml
+++ b/sv-comp/benchexec/my-bench/goblint.xml
@@ -11,7 +11,7 @@
   <option name="--enable">ana.int.interval</option>
   <!-- <option name="-sets solver td3"/> -->
   <option name="--enable">ana.context.widen</option>
-  <option name="-sets exp.arrays-domain partitioned"/>
+  <option name="--enable">ana.base.partition-arrays.enabled</option>
 
 <rundefinition name="sv-comp20_prop-reachsafety">
   <tasks name="Goblint-Tests-Basic-ReachSafety">

--- a/sv-comp/benchexec/my-bench/goblint.xml
+++ b/sv-comp/benchexec/my-bench/goblint.xml
@@ -11,7 +11,7 @@
   <option name="--enable">ana.int.interval</option>
   <!-- <option name="-sets solver td3"/> -->
   <option name="--enable">ana.context.widen</option>
-  <option name="--enable">ana.base.partition-arrays.enabled</option>
+  <option name="-sets exp.arrays-domain partitioned"/>
 
 <rundefinition name="sv-comp20_prop-reachsafety">
   <tasks name="Goblint-Tests-Basic-ReachSafety">

--- a/tests/regression/01-cpa/51-marshal.c
+++ b/tests/regression/01-cpa/51-marshal.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']" --set ana.base.privatization none
 void callee(int j) {
   j++;
 }

--- a/tests/regression/01-cpa/51-marshal.c
+++ b/tests/regression/01-cpa/51-marshal.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper']" --set ana.base.privatization none
 void callee(int j) {
   j++;
 }

--- a/tests/regression/02-base/35-calloc_array.c
+++ b/tests/regression/02-base/35-calloc_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/35-calloc_array.c
+++ b/tests/regression/02-base/35-calloc_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
+// PARAM: --set ana.int.interval true --set ana.base.arrays.domain partitioned
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/36-calloc_struct.c
+++ b/tests/regression/02-base/36-calloc_struct.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/36-calloc_struct.c
+++ b/tests/regression/02-base/36-calloc_struct.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
+// PARAM: --set ana.int.interval true --set ana.base.arrays.domain partitioned
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/37-calloc_glob.c
+++ b/tests/regression/02-base/37-calloc_glob.c
@@ -1,6 +1,6 @@
 // Made after 02 22
 
-// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
+// PARAM: --set ana.int.interval true --set ana.base.arrays.domain partitioned
 
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/regression/02-base/37-calloc_glob.c
+++ b/tests/regression/02-base/37-calloc_glob.c
@@ -1,6 +1,6 @@
 // Made after 02 22
 
-// PARAM: --set ana.int.interval true --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
 
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/regression/02-base/38-calloc_int.c
+++ b/tests/regression/02-base/38-calloc_int.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
 #include<stdlib.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/38-calloc_int.c
+++ b/tests/regression/02-base/38-calloc_int.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
+// PARAM: --set ana.int.interval true --set ana.base.arrays.domain partitioned
 #include<stdlib.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/39-calloc_matrix.c
+++ b/tests/regression/02-base/39-calloc_matrix.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/39-calloc_matrix.c
+++ b/tests/regression/02-base/39-calloc_matrix.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
+// PARAM: --set ana.int.interval true --set ana.base.arrays.domain partitioned
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/40-calloc_loop.c
+++ b/tests/regression/02-base/40-calloc_loop.c
@@ -1,5 +1,5 @@
 // Made after 02 21
-// PARAM: --set ana.int.interval true --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
 
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/regression/02-base/40-calloc_loop.c
+++ b/tests/regression/02-base/40-calloc_loop.c
@@ -1,5 +1,5 @@
 // Made after 02 21
-// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
+// PARAM: --set ana.int.interval true --set ana.base.arrays.domain partitioned
 
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/regression/02-base/41-calloc_globmt.c
+++ b/tests/regression/02-base/41-calloc_globmt.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']" --set ana.int.interval true --set exp.arrays-domain partitioned
+// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']" --set ana.int.interval true --set ana.base.arrays.domain partitioned
 #include <stdlib.h>
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/02-base/41-calloc_globmt.c
+++ b/tests/regression/02-base/41-calloc_globmt.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']" --set ana.int.interval true --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']" --set ana.int.interval true --set exp.arrays-domain partitioned
 #include <stdlib.h>
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/02-base/42-calloc_zero_init.c
+++ b/tests/regression/02-base/42-calloc_zero_init.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/42-calloc_zero_init.c
+++ b/tests/regression/02-base/42-calloc_zero_init.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
+// PARAM: --set ana.int.interval true --set ana.base.arrays.domain partitioned
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/43-calloc_struct_array.c
+++ b/tests/regression/02-base/43-calloc_struct_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/43-calloc_struct_array.c
+++ b/tests/regression/02-base/43-calloc_struct_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
+// PARAM: --set ana.int.interval true --set ana.base.arrays.domain partitioned
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/02-base/44-malloc_array.c
+++ b/tests/regression/02-base/44-malloc_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
 #include<stdlib.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/44-malloc_array.c
+++ b/tests/regression/02-base/44-malloc_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set exp.arrays-domain partitioned
+// PARAM: --set ana.int.interval true --set ana.base.arrays.domain partitioned
 #include<stdlib.h>
 #include<assert.h>
 

--- a/tests/regression/10-synch/23-tid-partitioned-array.c
+++ b/tests/regression/10-synch/23-tid-partitioned-array.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] thread --set exp.arrays-domain partitioned
+// PARAM: --set ana.activated[+] thread --set ana.base.arrays.domain partitioned
 #include <pthread.h>
 
 void *t_fun(void *arg) {

--- a/tests/regression/10-synch/23-tid-partitioned-array.c
+++ b/tests/regression/10-synch/23-tid-partitioned-array.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] thread --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.activated[+] thread --set exp.arrays-domain partitioned
 #include <pthread.h>
 
 void *t_fun(void *arg) {

--- a/tests/regression/10-synch/24-tid-partitioned-array-global.c
+++ b/tests/regression/10-synch/24-tid-partitioned-array-global.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] thread --set exp.arrays-domain partitioned
+// PARAM: --set ana.activated[+] thread --set ana.base.arrays.domain partitioned
 #include <pthread.h>
 
 pthread_t t_ids[10000];

--- a/tests/regression/10-synch/24-tid-partitioned-array-global.c
+++ b/tests/regression/10-synch/24-tid-partitioned-array-global.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] thread --enable ana.base.partition-arrays.enabled
+// PARAM: --set ana.activated[+] thread --set exp.arrays-domain partitioned
 #include <pthread.h>
 
 pthread_t t_ids[10000];

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int global;
 
 int main(void)

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int global;
 
 int main(void)

--- a/tests/regression/22-partitioned_arrays/02-pointers_array.c
+++ b/tests/regression/22-partitioned_arrays/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/02-pointers_array.c
+++ b/tests/regression/22-partitioned_arrays/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
+++ b/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
+++ b/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     example1();
     example2();

--- a/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
+++ b/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
+++ b/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
+++ b/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
+++ b/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/22-partitioned_arrays/06-interprocedural.c
+++ b/tests/regression/22-partitioned_arrays/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/06-interprocedural.c
+++ b/tests/regression/22-partitioned_arrays/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
   example1();
   example2();

--- a/tests/regression/22-partitioned_arrays/07-global_array.c
+++ b/tests/regression/22-partitioned_arrays/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/07-global_array.c
+++ b/tests/regression/22-partitioned_arrays/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/08-unsupported.c
+++ b/tests/regression/22-partitioned_arrays/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/08-unsupported.c
+++ b/tests/regression/22-partitioned_arrays/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/09-one_by_one.c
+++ b/tests/regression/22-partitioned_arrays/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/22-partitioned_arrays/09-one_by_one.c
+++ b/tests/regression/22-partitioned_arrays/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/22-partitioned_arrays/11-was_problematic.c
+++ b/tests/regression/22-partitioned_arrays/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/22-partitioned_arrays/11-was_problematic.c
+++ b/tests/regression/22-partitioned_arrays/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
+++ b/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void)
 {
   int arr[260];

--- a/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
+++ b/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void)
 {
   int arr[260];

--- a/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
+++ b/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 struct some_struct
 {
     int dir[7];

--- a/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
+++ b/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 struct some_struct
 {
     int dir[7];

--- a/tests/regression/22-partitioned_arrays/14-with_def_exc.c
+++ b/tests/regression/22-partitioned_arrays/14-with_def_exc.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.def_exc  --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.def_exc  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     // Minimal and maximal in def_exc were broken. They are not directly used, but used in the MayBeLess and MayBeEqual queries, that
     // are in turn used by the partitioning arrays. This is why we run the arrays in combination with def_exc.

--- a/tests/regression/22-partitioned_arrays/14-with_def_exc.c
+++ b/tests/regression/22-partitioned_arrays/14-with_def_exc.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.def_exc  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.def_exc  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     // Minimal and maximal in def_exc were broken. They are not directly used, but used in the MayBeLess and MayBeEqual queries, that
     // are in turn used by the partitioning arrays. This is why we run the arrays in combination with def_exc.

--- a/tests/regression/22-partitioned_arrays/15-var_eq.c
+++ b/tests/regression/22-partitioned_arrays/15-var_eq.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','var_eq']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','var_eq']" --set ana.base.privatization none
 int global;
 
 int main(void)

--- a/tests/regression/22-partitioned_arrays/15-var_eq.c
+++ b/tests/regression/22-partitioned_arrays/15-var_eq.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','var_eq']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','var_eq']" --set ana.base.privatization none
 int global;
 
 int main(void)

--- a/tests/regression/22-partitioned_arrays/16-refine-meet.c
+++ b/tests/regression/22-partitioned_arrays/16-refine-meet.c
@@ -1,4 +1,4 @@
-// PARAM: --set exp.arrays-domain partitioned
+// PARAM: --set ana.base.arrays.domain partitioned
 int garr[7];
 
 int main(int argc, char **argv)

--- a/tests/regression/22-partitioned_arrays/16-refine-meet.c
+++ b/tests/regression/22-partitioned_arrays/16-refine-meet.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.base.partition-arrays.enabled
+// PARAM: --set exp.arrays-domain partitioned
 int garr[7];
 
 int main(int argc, char **argv)

--- a/tests/regression/22-partitioned_arrays/17-large_arrays.c
+++ b/tests/regression/22-partitioned_arrays/17-large_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set exp.arrays-domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 #include <stdlib.h>
 #include <limits.h>

--- a/tests/regression/22-partitioned_arrays/17-large_arrays.c
+++ b/tests/regression/22-partitioned_arrays/17-large_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --enable ana.base.partition-arrays.enabled
+// PARAM: --enable ana.int.interval --set exp.arrays-domain partitioned
 #include <assert.h>
 #include <stdlib.h>
 #include <limits.h>

--- a/tests/regression/22-partitioned_arrays/18-large_arrays-nocalloc.c
+++ b/tests/regression/22-partitioned_arrays/18-large_arrays-nocalloc.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set exp.arrays-domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 #include <stdlib.h>
 #include <limits.h>

--- a/tests/regression/22-partitioned_arrays/18-large_arrays-nocalloc.c
+++ b/tests/regression/22-partitioned_arrays/18-large_arrays-nocalloc.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --enable ana.base.partition-arrays.enabled
+// PARAM: --enable ana.int.interval --set exp.arrays-domain partitioned
 #include <assert.h>
 #include <stdlib.h>
 #include <limits.h>

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int global;
 
 int main(void)

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int global;
 
 int main(void)

--- a/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
+++ b/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
+++ b/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     example1();
     example2();

--- a/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
+++ b/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
+++ b/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
+++ b/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
+++ b/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
   example1();
   example2();

--- a/tests/regression/23-partitioned_arrays_last/07-global_array.c
+++ b/tests/regression/23-partitioned_arrays_last/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/07-global_array.c
+++ b/tests/regression/23-partitioned_arrays_last/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int global_array[50];
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/08-unsupported.c
+++ b/tests/regression/23-partitioned_arrays_last/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/08-unsupported.c
+++ b/tests/regression/23-partitioned_arrays_last/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
+++ b/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
+++ b/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     int a[4];
     int b[4];

--- a/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
+++ b/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last"  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
+++ b/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last"  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last"  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(int argc, char **argv)
 {
   int unLo;

--- a/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
+++ b/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --enable ana.base.partition-arrays.enabled --set ana.base.partition-arrays.keep-expr "last"  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned --set ana.base.partition-arrays.keep-expr "last"  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void)
 {
   int arr[260];

--- a/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
+++ b/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned --set ana.base.partition-arrays.keep-expr "last"  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last"  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void)
 {
   int arr[260];

--- a/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
+++ b/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.partition-arrays.keep-expr last --enable ana.base.partition-arrays.enabled --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.partition-arrays.keep-expr last --set exp.arrays-domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 void main(void) {
   example1();
 }

--- a/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
+++ b/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.partition-arrays.keep-expr last --set exp.arrays-domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.partition-arrays.keep-expr last --set ana.base.arrays.domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 void main(void) {
   example1();
 }

--- a/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
+++ b/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
   example1();
 }

--- a/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
+++ b/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
   example1();
 }

--- a/tests/regression/24-octagon/01-octagon_simple.c
+++ b/tests/regression/24-octagon/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 void main(void) {
   int X = 0;

--- a/tests/regression/24-octagon/01-octagon_simple.c
+++ b/tests/regression/24-octagon/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 void main(void) {
   int X = 0;

--- a/tests/regression/24-octagon/02-octagon_interprocedural.c
+++ b/tests/regression/24-octagon/02-octagon_interprocedural.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     f1();
 }

--- a/tests/regression/24-octagon/02-octagon_interprocedural.c
+++ b/tests/regression/24-octagon/02-octagon_interprocedural.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     f1();
 }

--- a/tests/regression/24-octagon/03-previously_problematic_a.c
+++ b/tests/regression/24-octagon/03-previously_problematic_a.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/03-previously_problematic_a.c
+++ b/tests/regression/24-octagon/03-previously_problematic_a.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/04-previously_problematic_b.c
+++ b/tests/regression/24-octagon/04-previously_problematic_b.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 typedef int wchar_t;

--- a/tests/regression/24-octagon/04-previously_problematic_b.c
+++ b/tests/regression/24-octagon/04-previously_problematic_b.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 typedef int wchar_t;

--- a/tests/regression/24-octagon/05-previously_problematic_c.c
+++ b/tests/regression/24-octagon/05-previously_problematic_c.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/05-previously_problematic_c.c
+++ b/tests/regression/24-octagon/05-previously_problematic_c.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/06-previously_problematic_d.c
+++ b/tests/regression/24-octagon/06-previously_problematic_d.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/06-previously_problematic_d.c
+++ b/tests/regression/24-octagon/06-previously_problematic_d.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/07-previously_problematic_e.c
+++ b/tests/regression/24-octagon/07-previously_problematic_e.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/07-previously_problematic_e.c
+++ b/tests/regression/24-octagon/07-previously_problematic_e.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/08-previously_problematic_f.c
+++ b/tests/regression/24-octagon/08-previously_problematic_f.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/08-previously_problematic_f.c
+++ b/tests/regression/24-octagon/08-previously_problematic_f.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/09-previously_problematic_g.c
+++ b/tests/regression/24-octagon/09-previously_problematic_g.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/09-previously_problematic_g.c
+++ b/tests/regression/24-octagon/09-previously_problematic_g.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/10-previously_problematic_h.c
+++ b/tests/regression/24-octagon/10-previously_problematic_h.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/10-previously_problematic_h.c
+++ b/tests/regression/24-octagon/10-previously_problematic_h.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/11-previously_problematic_i.c
+++ b/tests/regression/24-octagon/11-previously_problematic_i.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 char buf2[67];

--- a/tests/regression/24-octagon/11-previously_problematic_i.c
+++ b/tests/regression/24-octagon/11-previously_problematic_i.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 char buf2[67];

--- a/tests/regression/24-octagon/13-array_octagon.c
+++ b/tests/regression/24-octagon/13-array_octagon.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set sem.int.signed_overflow assume_none
 void main(void) {
   example0();
   example1();

--- a/tests/regression/24-octagon/13-array_octagon.c
+++ b/tests/regression/24-octagon/13-array_octagon.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set sem.int.signed_overflow assume_none
 void main(void) {
   example0();
   example1();

--- a/tests/regression/24-octagon/14-array_octagon_keep_last.c
+++ b/tests/regression/24-octagon/14-array_octagon_keep_last.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set sem.int.signed_overflow assume_none
 void main(void) {
   example1();
   example2();

--- a/tests/regression/24-octagon/14-array_octagon_keep_last.c
+++ b/tests/regression/24-octagon/14-array_octagon_keep_last.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set sem.int.signed_overflow assume_none
 void main(void) {
   example1();
   example2();

--- a/tests/regression/24-octagon/15-array_octagon_prec.c
+++ b/tests/regression/24-octagon/15-array_octagon_prec.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
 
 void main(void) __attribute__((goblint_precision("no-interval")));
 void example1(void) __attribute__((goblint_precision("no-def_exc")));

--- a/tests/regression/24-octagon/15-array_octagon_prec.c
+++ b/tests/regression/24-octagon/15-array_octagon_prec.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
 
 void main(void) __attribute__((goblint_precision("no-interval")));
 void example1(void) __attribute__((goblint_precision("no-def_exc")));

--- a/tests/regression/24-octagon/16-array_octagon_keep_last_prec.c
+++ b/tests/regression/24-octagon/16-array_octagon_keep_last_prec.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
 
 void main(void) __attribute__((goblint_precision("no-interval")));
 void example1(void) __attribute__((goblint_precision("no-def_exc")));

--- a/tests/regression/24-octagon/16-array_octagon_keep_last_prec.c
+++ b/tests/regression/24-octagon/16-array_octagon_keep_last_prec.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
 
 void main(void) __attribute__((goblint_precision("no-interval")));
 void example1(void) __attribute__((goblint_precision("no-def_exc")));

--- a/tests/regression/25-vla/01-simple.c
+++ b/tests/regression/25-vla/01-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void)
 {
   int a[40];

--- a/tests/regression/25-vla/01-simple.c
+++ b/tests/regression/25-vla/01-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void)
 {
   int a[40];

--- a/tests/regression/25-vla/02-loop.c
+++ b/tests/regression/25-vla/02-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void)
 {
   example1();

--- a/tests/regression/25-vla/02-loop.c
+++ b/tests/regression/25-vla/02-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 int main(void)
 {
   example1();

--- a/tests/regression/25-vla/03-calls.c
+++ b/tests/regression/25-vla/03-calls.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 // Variable-sized arrays
 void foo(int n, int a[n]);
 void foo2(int n, int a[30][n]);

--- a/tests/regression/25-vla/03-calls.c
+++ b/tests/regression/25-vla/03-calls.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 // Variable-sized arrays
 void foo(int n, int a[n]);
 void foo2(int n, int a[30][n]);

--- a/tests/regression/25-vla/04-passing_ptr_to_array.c
+++ b/tests/regression/25-vla/04-passing_ptr_to_array.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 
 void foo(int (*a)[40]){
     int x = (*(a + 29))[7];

--- a/tests/regression/25-vla/04-passing_ptr_to_array.c
+++ b/tests/regression/25-vla/04-passing_ptr_to_array.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 
 void foo(int (*a)[40]){
     int x = (*(a + 29))[7];

--- a/tests/regression/25-vla/05-more_passing.c
+++ b/tests/regression/25-vla/05-more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 # include<stdio.h>
 
 void foo(int n, int a[n]) {

--- a/tests/regression/25-vla/05-more_passing.c
+++ b/tests/regression/25-vla/05-more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 # include<stdio.h>
 
 void foo(int n, int a[n]) {

--- a/tests/regression/25-vla/06-even_more_passing.c
+++ b/tests/regression/25-vla/06-even_more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 
 void foo2(int n , int (*a)[n] )
 {

--- a/tests/regression/25-vla/06-even_more_passing.c
+++ b/tests/regression/25-vla/06-even_more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 
 void foo2(int n , int (*a)[n] )
 {

--- a/tests/regression/30-fast_global_inits/01-on.c
+++ b/tests/regression/30-fast_global_inits/01-on.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 int global_array[50];
 int global_array_multi[50][2][2];

--- a/tests/regression/30-fast_global_inits/01-on.c
+++ b/tests/regression/30-fast_global_inits/01-on.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 int global_array[50];
 int global_array_multi[50][2][2];

--- a/tests/regression/30-fast_global_inits/02-off.c
+++ b/tests/regression/30-fast_global_inits/02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --disable exp.fast_global_inits
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --disable exp.fast_global_inits
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 int global_array[50];
 int global_array_multi[50][2][2];

--- a/tests/regression/30-fast_global_inits/02-off.c
+++ b/tests/regression/30-fast_global_inits/02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --disable exp.fast_global_inits
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --disable exp.fast_global_inits
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 int global_array[50];
 int global_array_multi[50][2][2];

--- a/tests/regression/30-fast_global_inits/03-performance.c
+++ b/tests/regression/30-fast_global_inits/03-performance.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --enable exp.fast_global_inits  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --enable exp.fast_global_inits  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 // Without fast_global_inits this takes >150s, when it is enabled < 0.1s
 int global_array[50][500][20];
 

--- a/tests/regression/30-fast_global_inits/03-performance.c
+++ b/tests/regression/30-fast_global_inits/03-performance.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --enable exp.fast_global_inits  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --enable exp.fast_global_inits  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none
 // Without fast_global_inits this takes >150s, when it is enabled < 0.1s
 int global_array[50][500][20];
 

--- a/tests/regression/30-fast_global_inits/04-non-zero.c
+++ b/tests/regression/30-fast_global_inits/04-non-zero.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled --enable exp.fast_global_inits
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned --enable exp.fast_global_inits
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 int global_array[5] = {9, 0, 3, 42, 11};
 int global_array_multi[2][5] =  {{9, 0, 3, 42, 11}, {9, 0, 3, 42, 11}};

--- a/tests/regression/30-fast_global_inits/04-non-zero.c
+++ b/tests/regression/30-fast_global_inits/04-non-zero.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned --enable exp.fast_global_inits
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable exp.fast_global_inits
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 int global_array[5] = {9, 0, 3, 42, 11};
 int global_array_multi[2][5] =  {{9, 0, 3, 42, 11}, {9, 0, 3, 42, 11}};

--- a/tests/regression/30-fast_global_inits/05-non-zero-performance.c
+++ b/tests/regression/30-fast_global_inits/05-non-zero-performance.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned --enable exp.fast_global_inits
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable exp.fast_global_inits
 int global_array[10000] = {9, 0, 3, 42, 11 }; // All non-specified ones will be zero
 int global_array_multi[2][10000] =  {{9, 0, 3, 42, 11}, {9, 0, 3, 42, 11}};  // All non-specified ones will be zero
 

--- a/tests/regression/30-fast_global_inits/05-non-zero-performance.c
+++ b/tests/regression/30-fast_global_inits/05-non-zero-performance.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled --enable exp.fast_global_inits
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned --enable exp.fast_global_inits
 int global_array[10000] = {9, 0, 3, 42, 11 }; // All non-specified ones will be zero
 int global_array_multi[2][10000] =  {{9, 0, 3, 42, 11}, {9, 0, 3, 42, 11}};  // All non-specified ones will be zero
 

--- a/tests/regression/31-ikind-aware-ints/04-ptrdiff.c
+++ b/tests/regression/31-ikind-aware-ints/04-ptrdiff.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --enable ana.base.partition-arrays.enabled --set ana.activated "['base', 'mallocWrapper', 'escape', 'expRelation', 'var_eq']" --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.activated "['base', 'mallocWrapper', 'escape', 'expRelation', 'var_eq']" --set ana.base.privatization none
 int *tmp;
 
 int main ()

--- a/tests/regression/31-ikind-aware-ints/04-ptrdiff.c
+++ b/tests/regression/31-ikind-aware-ints/04-ptrdiff.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.activated "['base', 'mallocWrapper', 'escape', 'expRelation', 'var_eq']" --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated "['base', 'mallocWrapper', 'escape', 'expRelation', 'var_eq']" --set ana.base.privatization none
 int *tmp;
 
 int main ()

--- a/tests/regression/31-ikind-aware-ints/05-shift.c
+++ b/tests/regression/31-ikind-aware-ints/05-shift.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.activated "['base', 'mallocWrapper']" --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated "['base', 'mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     // Shifting by a negative number is UB, but we should still not crash on it, but go to top instead
     int v = -1;

--- a/tests/regression/31-ikind-aware-ints/05-shift.c
+++ b/tests/regression/31-ikind-aware-ints/05-shift.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --enable ana.base.partition-arrays.enabled --set ana.activated "['base', 'mallocWrapper']" --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.activated "['base', 'mallocWrapper']" --set ana.base.privatization none
 int main(void) {
     // Shifting by a negative number is UB, but we should still not crash on it, but go to top instead
     int v = -1;

--- a/tests/regression/31-ikind-aware-ints/06-structs.c
+++ b/tests/regression/31-ikind-aware-ints/06-structs.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.activated "['base', 'threadflag', 'mallocWrapper']" --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated "['base', 'threadflag', 'mallocWrapper']" --set ana.base.privatization none
 struct rtl8169_private {
    unsigned int features ;
 };

--- a/tests/regression/31-ikind-aware-ints/06-structs.c
+++ b/tests/regression/31-ikind-aware-ints/06-structs.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --enable ana.base.partition-arrays.enabled --set ana.activated "['base', 'threadflag', 'mallocWrapper']" --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set exp.arrays-domain partitioned --set ana.activated "['base', 'threadflag', 'mallocWrapper']" --set ana.base.privatization none
 struct rtl8169_private {
    unsigned int features ;
 };

--- a/tests/regression/36-apron/01-octagon_simple.c
+++ b/tests/regression/36-apron/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 void main(void) {
   int X = 0;

--- a/tests/regression/36-apron/01-octagon_simple.c
+++ b/tests/regression/36-apron/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 void main(void) {
   int X = 0;

--- a/tests/regression/36-apron/02-octagon_interprocudral.c
+++ b/tests/regression/36-apron/02-octagon_interprocudral.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set ana.apron.privatization dummy
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set ana.apron.privatization dummy
 extern int __VERIFIER_nondet_int();
 
 int main(void) {

--- a/tests/regression/36-apron/02-octagon_interprocudral.c
+++ b/tests/regression/36-apron/02-octagon_interprocudral.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set ana.apron.privatization dummy
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper']" --set ana.base.privatization none --set ana.apron.privatization dummy
 extern int __VERIFIER_nondet_int();
 
 int main(void) {

--- a/tests/regression/36-apron/94-simple-apron-interval.c
+++ b/tests/regression/36-apron/94-simple-apron-interval.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy --set ana.apron.domain "interval"
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy --set ana.apron.domain "interval"
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf, adapted
 void main(void) {
   int X = 0;

--- a/tests/regression/36-apron/94-simple-apron-interval.c
+++ b/tests/regression/36-apron/94-simple-apron-interval.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy --set ana.apron.domain "interval"
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy --set ana.apron.domain "interval"
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf, adapted
 void main(void) {
   int X = 0;

--- a/tests/regression/36-apron/95-simple-polyhedra.c
+++ b/tests/regression/36-apron/95-simple-polyhedra.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy --set ana.apron.domain "polyhedra"
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy --set ana.apron.domain "polyhedra"
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf, adapted
 void main(void) {
   int X = 0;

--- a/tests/regression/36-apron/95-simple-polyhedra.c
+++ b/tests/regression/36-apron/95-simple-polyhedra.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy --set ana.apron.domain "polyhedra"
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','apron']" --set ana.base.privatization none --set ana.apron.privatization dummy --set ana.apron.domain "polyhedra"
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf, adapted
 void main(void) {
   int X = 0;

--- a/tests/regression/42-annotated-precision/08-22_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/08-22_01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int global;
 
 int main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/42-annotated-precision/08-22_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/08-22_01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int global;
 
 int main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 int main(void) __attribute__((goblint_precision("no-interval")));
 void example1(void) __attribute__((goblint_precision("no-def_exc")));

--- a/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 int main(void) __attribute__((goblint_precision("no-interval")));
 void example1(void) __attribute__((goblint_precision("no-def_exc")));

--- a/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 void example1(void) __attribute__((goblint_precision("no-def_exc","interval")));
 void example2(void) __attribute__((goblint_precision("no-def_exc","interval")));
 

--- a/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 void example1(void) __attribute__((goblint_precision("no-def_exc","interval")));
 void example2(void) __attribute__((goblint_precision("no-def_exc","interval")));
 

--- a/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));
 void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));
 void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/13-22_07-global_array.c
+++ b/tests/regression/42-annotated-precision/13-22_07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int global_array[50];
 
 int main(void) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/13-22_07-global_array.c
+++ b/tests/regression/42-annotated-precision/13-22_07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.base.partition-arrays.enabled  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set exp.arrays-domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int global_array[50];
 
 int main(void) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/15-23_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/15-23_01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int global;
 
 int main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/42-annotated-precision/15-23_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/15-23_01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int global;
 
 int main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 int main(void) __attribute__((goblint_precision("no-interval")));
 void example1(void) __attribute__((goblint_precision("no-def_exc")));

--- a/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 int main(void) __attribute__((goblint_precision("no-interval")));
 void example1(void) __attribute__((goblint_precision("no-def_exc")));

--- a/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int main(void) {
     example1();
     example2();

--- a/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 int main(void) {
     example1();
     example2();

--- a/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 struct kala {
   int i;
   int a[5];

--- a/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.base.partition-arrays.enabled  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));
 void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set exp.arrays-domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));
 void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
+++ b/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set exp.arrays-domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));
 void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
+++ b/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.base.partition-arrays.enabled --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set exp.arrays-domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));
 void init_array(int* arr, int val) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/24-30_02-off.c
+++ b/tests/regression/42-annotated-precision/24-30_02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.base.partition-arrays.enabled --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --disable exp.fast_global_inits --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set exp.arrays-domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --disable exp.fast_global_inits --enable annotation.int.enabled --set ana.int.refinement fixpoint
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 int global_array[50];
 int global_array_multi[50][2][2];

--- a/tests/regression/42-annotated-precision/24-30_02-off.c
+++ b/tests/regression/42-annotated-precision/24-30_02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set exp.arrays-domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --disable exp.fast_global_inits --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper']" --set ana.base.privatization none --disable exp.fast_global_inits --enable annotation.int.enabled --set ana.int.refinement fixpoint
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 int global_array[50];
 int global_array_multi[50][2][2];

--- a/tests/regression/42-annotated-precision/28-02_36-calloc_struct.c
+++ b/tests/regression/42-annotated-precision/28-02_36-calloc_struct.c
@@ -1,4 +1,4 @@
-// PARAM: --set exp.arrays-domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/42-annotated-precision/28-02_36-calloc_struct.c
+++ b/tests/regression/42-annotated-precision/28-02_36-calloc_struct.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.base.partition-arrays.enabled --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set exp.arrays-domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/42-annotated-precision/33-02_36-calloc_struct_i.c
+++ b/tests/regression/42-annotated-precision/33-02_36-calloc_struct_i.c
@@ -1,4 +1,4 @@
-// PARAM: --set exp.arrays-domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/42-annotated-precision/33-02_36-calloc_struct_i.c
+++ b/tests/regression/42-annotated-precision/33-02_36-calloc_struct_i.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.base.partition-arrays.enabled --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set exp.arrays-domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 #include<stdlib.h>
 #include<assert.h>

--- a/tests/regression/54-unroll_arrays/01-simple_array.c
+++ b/tests/regression/54-unroll_arrays/01-simple_array.c
@@ -1,4 +1,5 @@
 // PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain unroll --set exp.array-unrolling-factor 5
+#include <assert.h>
 int global;
 
 int main(void)

--- a/tests/regression/54-unroll_arrays/01-simple_array.c
+++ b/tests/regression/54-unroll_arrays/01-simple_array.c
@@ -1,23 +1,23 @@
-// PARAM: --set exp.arrays-domain unroll --set exp.array-unrolling-factor 5
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain unroll --set exp.array-unrolling-factor 5
 int global;
 
 int main(void)
 {
     example1();
-    example2();
+    //example2();
     return 0;
 }
 
 void example1() {
     int a[20];
-    a[4] = 3;
-    a[6] = 3;
-    a[10] = 3;
-    assert(a[0] == 3); //UNKNOWN
-    assert(a[4] == 3);
-    assert(a[6] == 3); //UNKNOWN
+    a[4] = 4;
+    a[6] = 6;
+    a[10] = 10;
+    assert(a[0] == 0); //UNKNOWN
+    assert(a[4] == 4);
+    assert(a[6] == 6); //UNKNOWN
 
-    int i=4;
+    int i = 4;
     a[i] = 7;
     assert(a[4] == 7);
 }

--- a/tests/regression/54-unroll_arrays/01-simple_array.c
+++ b/tests/regression/54-unroll_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain unroll --set exp.array-unrolling-factor 5
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
 #include <assert.h>
 int global;
 

--- a/tests/regression/54-unroll_arrays/01-simple_array.c
+++ b/tests/regression/54-unroll_arrays/01-simple_array.c
@@ -1,0 +1,40 @@
+// PARAM: --set exp.arrays-domain unroll --set exp.array-unrolling-factor 5
+int global;
+
+int main(void)
+{
+    example1();
+    example2();
+    return 0;
+}
+
+void example1() {
+    int a[20];
+    a[4] = 3;
+    a[6] = 3;
+    a[10] = 3;
+    assert(a[0] == 3); //UNKNOWN
+    assert(a[4] == 3);
+    assert(a[6] == 3); //UNKNOWN
+
+    int i=4;
+    a[i] = 7;
+    assert(a[4] == 7);
+}
+
+//array same length of factor
+void example2() {
+    int a[5];
+    a[0] = 1;
+    a[1] = 2;
+    a[2] = 3;
+    a[3] = 4;
+    a[4] = 5;
+
+    assert(a[0] == 1);
+    assert(a[1] == 2);
+    assert(a[2] == 3);
+    assert(a[3] == 0); //FAIL
+    assert(a[4] == 0); //FAIL
+}
+

--- a/tests/regression/54-unroll_arrays/01-simple_array.c
+++ b/tests/regression/54-unroll_arrays/01-simple_array.c
@@ -4,7 +4,7 @@ int global;
 int main(void)
 {
     example1();
-    //example2();
+    example2();
     return 0;
 }
 

--- a/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
+++ b/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
@@ -1,4 +1,5 @@
 // PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain unroll --set exp.array-unrolling-factor 2
+#include <assert.h>
 int global;
 
 int main(void)

--- a/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
+++ b/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
@@ -1,12 +1,10 @@
-// PARAM: --set exp.arrays-domain unroll --set exp.array-unrolling-factor 2
+// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain unroll --set exp.array-unrolling-factor 2
 int global;
 
 int main(void)
 {
     example1();
-    //example2();
-    //example3();
-    //example4();
+    example2();
     return 0;
 }
 
@@ -29,46 +27,10 @@ void example1(void)
     assert(a[7] == 0); // UNKNOWN
     assert(a[41] == 0); // UNKNOWN
 }
-/*
-// Two values initialized in one loop
-void example2(void) {
-    int a[42];
-    int i = 0;
-
-    while (i < 42) {
-        a[i] = 0;
-        i++;
-        a[i] = 1;
-        i++;
-    }
-
-    assert(a[0] == 2);   // FAIL
-    assert(a[0] == 0);
-    assert(a[1] == 1);
-    assert(a[41] == 0);  // UNKNOWN
-    assert(a[41] == 1);  // UNKNOWN
-    assert(a[41] == -1); // FAIL
-}
-
-// Example where initialization proceeds backwards
-void example3(void) {
-    int a[42];
-    int i = 41;
-
-    while(i >= 12) {
-        a[i] = 0;
-        i--;
-    }
-
-    assert(a[i+2] == 0);
-    assert(a[41] == 0);
-    assert(a[i] == 0); //UNKNOWN
-    assert(a[0] == 0); //UNKNOWN
-}
 
 
 // Check that arrays of types different from int are handeled correctly
-void example4() {
+void example2() {
     char a[10];
     int n;
     assert(a[3] == 800); // FAIL
@@ -77,14 +39,9 @@ void example4() {
         a[i] = 7;
     }
 
-    assert(a[0] == 7);
-    assert(a[3] == 7);
-
     a[3] = (char) n;
     assert(a[3] == 800); //FAIL
     assert(a[3] == 127); //UNKNOWN
     assert(a[3] == -128); //UNKNOWN
     assert(a[3] == -129); //FAIL
 }
-
-*/

--- a/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
+++ b/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
@@ -20,13 +20,13 @@ void example1(void)
         a[i] = 0;
         assert(a[i] == 0); // UNKNOWN
         assert(a[0] == 0); // UNKNOWN
-        assert(a[17] == 0); // UNKNOWN
+        assert(a[17] == 0);
         i++;
     }
 
     assert(a[0] == 0); // UNKNOWN
-    assert(a[7] == 0); // UNKNOWN
-    assert(a[41] == 0); // UNKNOWN
+    assert(a[7] == 0);
+    assert(a[41] == 0);
 }
 
 
@@ -34,7 +34,7 @@ void example1(void)
 void example2() {
     char a[10];
     int n;
-    assert(a[3] == 800); // FAIL
+    assert(a[3] == 800); // UNKNOWN
 
     for(int i=0;i < 10; i++) {
         a[i] = 7;

--- a/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
+++ b/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.arrays-domain unroll --set exp.array-unrolling-factor 2
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 2
 #include <assert.h>
 int global;
 

--- a/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
+++ b/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
@@ -1,0 +1,90 @@
+// PARAM: --set exp.arrays-domain unroll --set exp.array-unrolling-factor 2
+int global;
+
+int main(void)
+{
+    example1();
+    //example2();
+    //example3();
+    //example4();
+    return 0;
+}
+
+// Simple example
+void example1(void)
+{
+    int a[42];
+    int i = 0;
+    int top;
+
+    while (i < 42) {
+        a[i] = 0;
+        assert(a[i] == 0); // UNKNOWN
+        assert(a[0] == 0); // UNKNOWN
+        assert(a[17] == 0); // UNKNOWN
+        i++;
+    }
+
+    assert(a[0] == 0); // UNKNOWN
+    assert(a[7] == 0); // UNKNOWN
+    assert(a[41] == 0); // UNKNOWN
+}
+/*
+// Two values initialized in one loop
+void example2(void) {
+    int a[42];
+    int i = 0;
+
+    while (i < 42) {
+        a[i] = 0;
+        i++;
+        a[i] = 1;
+        i++;
+    }
+
+    assert(a[0] == 2);   // FAIL
+    assert(a[0] == 0);
+    assert(a[1] == 1);
+    assert(a[41] == 0);  // UNKNOWN
+    assert(a[41] == 1);  // UNKNOWN
+    assert(a[41] == -1); // FAIL
+}
+
+// Example where initialization proceeds backwards
+void example3(void) {
+    int a[42];
+    int i = 41;
+
+    while(i >= 12) {
+        a[i] = 0;
+        i--;
+    }
+
+    assert(a[i+2] == 0);
+    assert(a[41] == 0);
+    assert(a[i] == 0); //UNKNOWN
+    assert(a[0] == 0); //UNKNOWN
+}
+
+
+// Check that arrays of types different from int are handeled correctly
+void example4() {
+    char a[10];
+    int n;
+    assert(a[3] == 800); // FAIL
+
+    for(int i=0;i < 10; i++) {
+        a[i] = 7;
+    }
+
+    assert(a[0] == 7);
+    assert(a[3] == 7);
+
+    a[3] = (char) n;
+    assert(a[3] == 800); //FAIL
+    assert(a[3] == 127); //UNKNOWN
+    assert(a[3] == -128); //UNKNOWN
+    assert(a[3] == -129); //FAIL
+}
+
+*/


### PR DESCRIPTION
**Implementation of the unrolling array domain**

Third abstract array domain in use. `FlagConfiguredArrayDomain` will now choose between one of three array domains (`PartitionedWithLength`, `TrivialWithLength` and `Unroll`) depending on the value of `exp.arrays-domain`.

When `unroll` is chosen, `exp.array-unrolling-factor` need to be set as well. The array representation will then consist of a tuple _(xl, xr)_. 

- _xl_ = list containing the first k values of the array.
- _xr_ = single abstract value representing the rest of the array. 

A new module `ProdList` was add in `lattice.ml` to help with the `xl` part of the unroll domain. 

All uses and references to `ana.base.partition-arrays.enabled` have been substituted by `exp.arrays-domain` = "partitioned".

Tests for this domain have also been added under _tests/regression/54-unroll_arrays_

This is the second part of a precision optimization. Displaying the first `k` iterations of the array more precisely, will help increase the precision in some cases. Specially if used together with loop unrolling.
