### PR TITLE
Optimize `MCP` by removing `assoc` usage

### DIFF
--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -177,7 +177,7 @@ struct
     if M.tracing then M.tracel "combine" "apron enter formals: %a\n" (d_list "," d_varinfo) f.sformals;
     if M.tracing then M.tracel "combine" "apron enter local: %a\n" D.pretty ctx.local;
     let arg_assigns =
-      Goblintutil.zip f.sformals args
+      GobList.combine_short f.sformals args (* TODO: is it right to ignore missing formals/args? *)
       |> List.filter (fun (x, _) -> AD.varinfo_tracked x)
       |> List.map (Tuple2.map1 V.arg)
     in
@@ -254,7 +254,7 @@ struct
     if M.tracing then M.tracel "combine" "apron args: %a\n" (d_list "," d_exp) args;
     let new_fun_apr = AD.add_vars fun_st.apr (AD.vars st.apr) in
     let arg_substitutes =
-      Goblintutil.zip f.sformals args
+      GobList.combine_short f.sformals args (* TODO: is it right to ignore missing formals/args? *)
       |> List.filter (fun (x, _) -> AD.varinfo_tracked x)
       |> List.map (Tuple2.map1 V.arg)
     in

--- a/src/analyses/arinc.ml
+++ b/src/analyses/arinc.ml
@@ -258,7 +258,7 @@ struct
     (* if not (is_single ctx || !Goblintutil.global_initialization || fst (ctx.global part_mode_var)) then raise Analyses.Deadcode; *)
     (* checkPredBot ctx.local "body" f.svar [] *)
     let module BaseMain = (val Base.get_main ()) in
-    let base_context = BaseMain.context_cpa f @@ Obj.obj @@ List.assoc "base" ctx.presub in
+    let base_context = BaseMain.context_cpa f @@ Obj.obj @@ ctx.presub "base" in
     let context_hash = Hashtbl.hash (base_context, ctx.local.pid) in
     { ctx.local with ctx = Ctx.of_int (Int64.of_int context_hash) }
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1943,7 +1943,7 @@ struct
         {st with cpa = new_cpa}
     in
     (* Assign parameters to arguments *)
-    let pa = GU.zip fundec.sformals vals in
+    let pa = GobList.combine_short fundec.sformals vals in (* TODO: is it right to ignore missing formals/args? *)
     let new_cpa = CPA.add_list pa st'.cpa in
     (* List of reachable variables *)
     let reachable = List.concat_map AD.to_var_may (reachable_vars (Analyses.ask_of_ctx ctx) (get_ptrs vals) ctx.global st) in

--- a/src/analyses/extract_arinc.ml
+++ b/src/analyses/extract_arinc.ml
@@ -212,14 +212,14 @@ struct
     ctx.local
 
   let body ctx (f:fundec) : D.t =
-    match List.assoc "base" ctx.presub with
-    | Some base ->
+    match ctx.presub "base" with
+    | base ->
       let pid, ctxh, pred = ctx.local in
       let module BaseMain = (val Base.get_main ()) in
       let base_context = BaseMain.context_cpa f @@ Obj.obj base in
       let context_hash = Hashtbl.hash (base_context, pid) in
       pid, Ctx.of_int (Int64.of_int context_hash), pred
-    | None -> ctx.local (* TODO when can this happen? *)
+    | exception Not_found -> ctx.local (* TODO when can this happen? *)
 
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local

--- a/src/analyses/extract_osek.ml
+++ b/src/analyses/extract_osek.ml
@@ -205,14 +205,14 @@ struct
     ctx.local
 
   let body ctx (f:fundec) : D.t =
-    match List.assoc "base" ctx.presub with
-    | Some base ->
+    match ctx.presub "base" with
+    | base ->
       let pid, ctxh, pred = ctx.local in
       let module BaseMain = (val Base.get_main ()) in
       let base_context = BaseMain.context_cpa f @@ Obj.obj base in
       let context_hash = Hashtbl.hash (base_context, pid) in
       pid, Ctx.of_int (Int64.of_int context_hash), pred
-    | None -> ctx.local (* TODO when can this happen? *)
+    | exception Not_found -> ctx.local (* TODO when can this happen? *)
 
   let return ctx (exp:exp option) (f:fundec) : D.t =
     ctx.local

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -84,8 +84,7 @@ struct
     activated_ctx_sens := List.filter (fun (n, _) -> not (List.mem n !cont_inse)) !activated;
     match marshal with
     | Some marshal ->
-      combine !activated marshal
-      |> iter (fun ((_,{spec=(module S:MCPSpec); _}), marshal) -> S.init (Some (Obj.obj marshal)))
+      iter2 (fun (_,{spec=(module S:MCPSpec); _}) marshal -> S.init (Some (Obj.obj marshal))) !activated marshal
     | None ->
       iter (fun (_,{spec=(module S:MCPSpec); _}) -> S.init None) !activated
 

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -161,7 +161,7 @@ struct
         f ((k,v::a')::a) b
     in f [] xs
 
-  let assoc_sub n xs name =
+  let assoc_sub xs name =
     let n' = List.assoc_inv name !analyses_table in
     assoc n' xs
 
@@ -237,8 +237,8 @@ struct
             ; edge   = ctx.edge
             ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
             ; emit   = (fun e -> emits := e :: !emits)
-            ; presub = assoc_sub n ctx.local
-            ; postsub= assoc_sub n post_all
+            ; presub = assoc_sub ctx.local
+            ; postsub= assoc_sub post_all
             ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
             ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
             ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -255,8 +255,8 @@ struct
             ; edge   = octx.edge
             ; ask    = (fun (type a) (q: a Queries.t) -> query octx q)
             ; emit   = (fun e -> emits := e :: !emits)
-            ; presub = assoc_sub n octx.local
-            ; postsub= assoc_sub n post_all
+            ; presub = assoc_sub octx.local
+            ; postsub= assoc_sub post_all
             ; global = (fun v      -> octx.global (v_of n v) |> g_to n |> obj)
             ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
             ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -294,8 +294,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -331,8 +331,8 @@ struct
           ; edge   = ctx.edge
           ; ask    = (fun (type b) (q: b Queries.t) -> query' asked' ctx q)
           ; emit   = (fun _ -> failwith "Cannot \"emit\" in query context.")
-          ; presub = assoc_sub n ctx.local
-          ; postsub= assoc_sub n []
+          ; presub = assoc_sub ctx.local
+          ; postsub= assoc_sub []
           ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
           ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
           ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
@@ -378,8 +378,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in access context.")
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n []
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub []
         ; global = (fun v         -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun v d       -> failwith "part_access::spawn")
         ; split  = (fun d es      -> failwith "part_access::split")
@@ -406,8 +406,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -440,8 +440,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -474,8 +474,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -509,8 +509,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -544,8 +544,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -579,8 +579,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -614,8 +614,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -649,8 +649,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -683,8 +683,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -714,8 +714,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in enter context.")
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n []
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub []
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun _ _    -> failwith "Cannot \"split\" in enter context." )
@@ -745,8 +745,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> failwith "Cannot \"split\" in combine context.")
@@ -776,8 +776,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n []
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub []
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in threadenter context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in threadenter context.")
@@ -805,8 +805,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n ctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub ctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in threadspawn context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in threadspawn context.")
@@ -823,8 +823,8 @@ struct
         ; edge   = fctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query fctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = assoc_sub n fctx.local
-        ; postsub= assoc_sub n post_all
+        ; presub = assoc_sub fctx.local
+        ; postsub= assoc_sub post_all
         ; global = (fun v      -> fctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in threadspawn context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in threadspawn context.")

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -368,7 +368,7 @@ struct
     query' QuerySet.empty ctx q
 
   and access (ctx:(D.t, G.t, C.t, V.t) ctx) e vo w: MCPAccess.A.t =
-    let f (acc: MCPAccess.A.t) (n, (module S: MCPSpec), d) : MCPAccess.A.t =
+    let f (n, (module S: MCPSpec), d) =
       let ctx' : (S.D.t, S.G.t, S.C.t, S.V.t) ctx =
         { local  = obj d
         ; node   = ctx.node
@@ -387,9 +387,9 @@ struct
         ; assign = (fun ?name v e -> failwith "part_access::assign")
         }
       in
-      (n, repr (S.access ctx' e vo w)) :: acc
+      (n, repr (S.access ctx' e vo w))
     in
-    List.fold_left f [] (spec_list ctx.local) (* map without deadcode *)
+    BatList.map f (spec_list ctx.local) (* map without deadcode *)
 
   let assign (ctx:(D.t, G.t, C.t, V.t) ctx) l e =
     let spawns = ref [] in

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -162,14 +162,8 @@ struct
     in f [] xs
 
   let assoc_sub n xs name =
-    let f n =
-      let x = try assoc n !analyses_table with Not_found -> Printf.eprintf "filter_presubs: Analysis '%d' not registered.\n" n; failwith "filter_presubs" in
-      let y = try assoc n xs with Not_found ->
-        (*iter (Printf.printf "%s\n" % flip assoc !analyses_table % fst) xs;*)
-        Printf.eprintf "filter_presubs: Analysis '%s' (%d) not found.\n" x n; failwith "filter_presubs" in
-      x, y
-    in
-    assoc name (map f (assoc n !dep_list))
+    let n' = List.assoc_inv name !analyses_table in
+    assoc n' xs
 
   let do_spawns ctx (xs:(varinfo * (int * lval option * exp list)) list) =
     let spawn_one v d =

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -161,7 +161,7 @@ struct
         f ((k,v::a')::a) b
     in f [] xs
 
-  let filter_presubs n xs =
+  let assoc_sub n xs name =
     let f n =
       let x = try assoc n !analyses_table with Not_found -> Printf.eprintf "filter_presubs: Analysis '%d' not registered.\n" n; failwith "filter_presubs" in
       let y = try assoc n xs with Not_found ->
@@ -169,7 +169,7 @@ struct
         Printf.eprintf "filter_presubs: Analysis '%s' (%d) not found.\n" x n; failwith "filter_presubs" in
       x, y
     in
-    map f (assoc n !dep_list)
+    assoc name (map f (assoc n !dep_list))
 
   let do_spawns ctx (xs:(varinfo * (int * lval option * exp list)) list) =
     let spawn_one v d =
@@ -243,8 +243,8 @@ struct
             ; edge   = ctx.edge
             ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
             ; emit   = (fun e -> emits := e :: !emits)
-            ; presub = filter_presubs n ctx.local
-            ; postsub= filter_presubs n post_all
+            ; presub = assoc_sub n ctx.local
+            ; postsub= assoc_sub n post_all
             ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
             ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
             ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -261,8 +261,8 @@ struct
             ; edge   = octx.edge
             ; ask    = (fun (type a) (q: a Queries.t) -> query octx q)
             ; emit   = (fun e -> emits := e :: !emits)
-            ; presub = filter_presubs n octx.local
-            ; postsub= filter_presubs n post_all
+            ; presub = assoc_sub n octx.local
+            ; postsub= assoc_sub n post_all
             ; global = (fun v      -> octx.global (v_of n v) |> g_to n |> obj)
             ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
             ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -300,8 +300,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -337,8 +337,8 @@ struct
           ; edge   = ctx.edge
           ; ask    = (fun (type b) (q: b Queries.t) -> query' asked' ctx q)
           ; emit   = (fun _ -> failwith "Cannot \"emit\" in query context.")
-          ; presub = filter_presubs n ctx.local
-          ; postsub= []
+          ; presub = assoc_sub n ctx.local
+          ; postsub= assoc_sub n []
           ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
           ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
           ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
@@ -384,8 +384,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in access context.")
-        ; presub = filter_presubs n ctx.local
-        ; postsub= []
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n []
         ; global = (fun v         -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun v d       -> failwith "part_access::spawn")
         ; split  = (fun d es      -> failwith "part_access::split")
@@ -412,8 +412,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -446,8 +446,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -480,8 +480,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -515,8 +515,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -550,8 +550,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -585,8 +585,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -620,8 +620,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -655,8 +655,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -689,8 +689,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> splits := (n,(repr d,es)) :: !splits)
@@ -720,8 +720,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in enter context.")
-        ; presub = filter_presubs n ctx.local
-        ; postsub= []
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n []
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun _ _    -> failwith "Cannot \"split\" in enter context." )
@@ -751,8 +751,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun l v a  -> spawns := (v,(n,l,a)) :: !spawns)
         ; split  = (fun d es   -> failwith "Cannot \"split\" in combine context.")
@@ -782,8 +782,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= []
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n []
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in threadenter context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in threadenter context.")
@@ -811,8 +811,8 @@ struct
         ; edge   = ctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query ctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n ctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n ctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in threadspawn context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in threadspawn context.")
@@ -829,8 +829,8 @@ struct
         ; edge   = fctx.edge
         ; ask    = (fun (type a) (q: a Queries.t) -> query fctx q)
         ; emit   = (fun e -> emits := e :: !emits)
-        ; presub = filter_presubs n fctx.local
-        ; postsub= filter_presubs n post_all
+        ; presub = assoc_sub n fctx.local
+        ; postsub= assoc_sub n post_all
         ; global = (fun v      -> fctx.global (v_of n v) |> g_to n |> obj)
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in threadspawn context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in threadspawn context.")

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -47,15 +47,15 @@ struct
     in rev % f [] []
 
   let topo_sort_an xs =
-    let msg (x,_) = failwith ("Analyses have circular dependencies, conflict for "^assoc x !analyses_table^".") in
+    let msg (x,_) = failwith ("Analyses have circular dependencies, conflict for "^find_spec_name x^".") in
     let deps (y,_) = map (fun x -> x, assoc x xs) @@ assoc y !dep_list in
     topo_sort deps msg xs
 
   let check_deps xs =
     let check_dep x y =
       if not (exists (fun (y',_) -> y=y') xs) then begin
-        let xn = assoc x !analyses_table in
-        let yn = assoc y !analyses_table in
+        let xn = find_spec_name x in
+        let yn = find_spec_name y in
         Legacy.Printf.eprintf "Activated analysis '%s' depends on '%s' and '%s' is not activated.\n" xn yn yn;
         raise Exit
       end
@@ -99,7 +99,6 @@ struct
   let spec x = (assoc x !analyses_list).spec
   let spec_list xs =
     map (fun (n,x) -> (n,spec n,x)) xs
-  let spec_name (n:int) : string = assoc n !analyses_table
 
   let map_deadcode f xs =
     let dead = ref false in
@@ -187,7 +186,7 @@ struct
         let (module S:MCPSpec) = spec n in
         let assign_one d (lval, exp, name, ctx) =
           match name with
-          | Some x when x <> spec_name n -> obj d (* do nothing if current spec name is filtered out *)
+          | Some x when x <> find_spec_name n -> obj d (* do nothing if current spec name is filtered out *)
           | _ ->
             let ctx' = {(obj ctx) with local = obj d} in
             S.assign ctx' lval exp

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -76,20 +76,20 @@ struct
     let xs = get_string_list "ana.activated" in
     let xs = map' find_id xs in
     base_id := find_id "base";
-    analyses_list := map (fun s -> s, find_spec s) xs;
+    activated := map (fun s -> s, find_spec s) xs;
     path_sens := map' find_id @@ get_string_list "ana.path_sens";
     cont_inse := map' find_id @@ get_string_list "ana.ctx_insens";
-    check_deps !analyses_list;
-    analyses_list := topo_sort_an !analyses_list;
-    activated_ctx_sens := List.filter (fun (n, _) -> not (List.mem n !cont_inse)) !analyses_list;
+    check_deps !activated;
+    activated := topo_sort_an !activated;
+    activated_ctx_sens := List.filter (fun (n, _) -> not (List.mem n !cont_inse)) !activated;
     match marshal with
     | Some marshal ->
-      combine !analyses_list marshal
+      combine !activated marshal
       |> iter (fun ((_,{spec=(module S:MCPSpec); _}), marshal) -> S.init (Some (Obj.obj marshal)))
     | None ->
-      iter (fun (_,{spec=(module S:MCPSpec); _}) -> S.init None) !analyses_list
+      iter (fun (_,{spec=(module S:MCPSpec); _}) -> S.init None) !activated
 
-  let finalize () = map (fun (_,{spec=(module S:MCPSpec); _}) -> Obj.repr (S.finalize ())) !analyses_list
+  let finalize () = map (fun (_,{spec=(module S:MCPSpec); _}) -> Obj.repr (S.finalize ())) !activated
 
   let spec x = (find_spec x).spec
   let spec_list xs =
@@ -127,8 +127,8 @@ struct
     let zipped = zip3 specs xs ys in
     List.for_all should_join zipped
 
-  let exitstate  v = map (fun (n,{spec=(module S:MCPSpec); _}) -> n, repr @@ S.exitstate  v) !analyses_list
-  let startstate v = map (fun (n,{spec=(module S:MCPSpec); _}) -> n, repr @@ S.startstate v) !analyses_list
+  let exitstate  v = map (fun (n,{spec=(module S:MCPSpec); _}) -> n, repr @@ S.exitstate  v) !activated
+  let startstate v = map (fun (n,{spec=(module S:MCPSpec); _}) -> n, repr @@ S.startstate v) !activated
   let morphstate v x = map (fun (n,(module S:MCPSpec),d) -> n, repr @@ S.morphstate v (obj d)) (spec_list x)
 
   let call_descr f xs =

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -731,6 +731,10 @@ struct
     let sides  = ref [] in
     let assigns = ref [] in
     let emits = ref [] in
+    (* Like spec_list2 but for three lists. Tail recursion like map3_rev would have.
+       Due to context-insensitivity, second list is optional and may only contain a subset of analyses
+       in the same order, so some skipping needs to happen to align the three lists.
+       See https://github.com/goblint/analyzer/pull/578/files#r794376508. *)
     let rec spec_list3_rev_acc acc l1 l2_opt l3 = match l1, l2_opt, l3 with
       | [], _, [] -> acc
       | (n, x) :: l1, Some ((n', y) :: l2), (n'', z) :: l3 when n = n' -> (* context-sensitive *)

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -82,6 +82,7 @@ struct
     dep_list  := map (fun (n,d) -> (n,map' (flip assoc_inv !analyses_table) d)) !dep_list';
     check_deps !analyses_list;
     analyses_list := topo_sort_an !analyses_list;
+    activated_ctx_sens := List.filter (fun (n, _) -> not (List.mem n !cont_inse)) !analyses_list;
     (*iter (fun (x,y) -> Printf.printf "%s -> %a\n"  (flip assoc !analyses_table x) (List.print (fun f -> String.print f % flip assoc !analyses_table)) y) !dep_list_trans;
       Printf.printf "\n";
       iter (Printf.printf "%s\n" % flip assoc !analyses_table % fst) !analyses_list;

--- a/src/analyses/mCPAccess.ml
+++ b/src/analyses/mCPAccess.ml
@@ -21,10 +21,7 @@ struct
     let f a n d1 d2 =
       f a n (assoc_dom n) d1 d2
     in
-    try if length x <> length y
-      then raise (DomListBroken "binop_fold : differing lengths")
-      else fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
-    with Not_found -> raise (DomListBroken "binop_fold : assoc failure")
+    fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
 
   let may_race x y = binop_fold (fun a n (module S: Analyses.MCPA) x y ->
       a && S.may_race (obj x) (obj y)

--- a/src/analyses/mCPAccess.ml
+++ b/src/analyses/mCPAccess.ml
@@ -26,12 +26,19 @@ struct
 
   let pretty () a =
     (* filter with should_print *)
-    let a' = unop_fold (fun acc n (module S: Analyses.MCPA) x ->
+    let xs = unop_fold (fun acc n (module S: Analyses.MCPA) x ->
         if S.should_print (obj x) then
-          (n, x) :: acc
+          Pretty.dprintf "%s:%a" (S.name ()) S.pretty (obj x) :: acc
         else
           acc
       ) [] a
     in
-    pretty () a'
+    (* duplicates DomListPrintable *)
+    let open Pretty in
+    match xs with
+    | [] -> text "[]"
+    | x :: [] -> x
+    | x :: y ->
+      let rest  = List.fold_left (fun p n->p ++ text "," ++ break ++ n) nil y in
+      text "[" ++ align ++ x ++ rest ++ unalign ++ text "]"
 end

--- a/src/analyses/mCPAccess.ml
+++ b/src/analyses/mCPAccess.ml
@@ -15,10 +15,7 @@ struct
     fold_left2 (fun a (n,d) (n',s) -> assert (n = n'); f a n s d) a x (domain_list ())
 
   let binop_fold f a (x:t) (y:t) =
-    let f a n d1 d2 =
-      f a n (assoc_dom n) d1 d2
-    in
-    fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
+    GobList.fold_left3 (fun a (n,d) (n',d') (n'',s) -> assert (n = n' && n = n''); f a n s d d') a x y (domain_list ())
 
   let may_race x y = binop_fold (fun a n (module S: Analyses.MCPA) x y ->
       a && S.may_race (obj x) (obj y)

--- a/src/analyses/mCPAccess.ml
+++ b/src/analyses/mCPAccess.ml
@@ -12,10 +12,7 @@ struct
   include DomListPrintable (PrintableOfMCPASpec (AccListSpec))
 
   let unop_fold f a (x:t) =
-    let f a n d =
-      f a n (assoc_dom n) d
-    in
-    fold_left (fun a (n,d) -> f a n d) a x
+    fold_left2 (fun a (n,d) (n',s) -> assert (n = n'); f a n s d) a x (domain_list ())
 
   let binop_fold f a (x:t) (y:t) =
     let f a n d1 d2 =

--- a/src/analyses/mCPAccess.ml
+++ b/src/analyses/mCPAccess.ml
@@ -23,7 +23,7 @@ struct
     in
     try if length x <> length y
       then raise (DomListBroken "binop_fold : differing lengths")
-      else fold_left (fun a (n,d) -> f a n d @@ assoc n y) a x
+      else fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
     with Not_found -> raise (DomListBroken "binop_fold : assoc failure")
 
   let may_race x y = binop_fold (fun a n (module S: Analyses.MCPA) x y ->

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -90,10 +90,7 @@ struct
   type t = (int * unknown) list
 
   let unop_fold f a (x:t) =
-    let f a n d =
-      f a n (assoc_dom n) d
-    in
-    fold_left (fun a (n,d) -> f a n d) a x
+    fold_left2 (fun a (n,d) (n',s) -> assert (n = n'); f a n s d) a x (domain_list ())
 
   let pretty () x =
     let f a n (module S : Printable.S) x = Pretty.dprintf "%s:%a" (S.name ()) S.pretty (obj x) :: a in
@@ -247,10 +244,7 @@ struct
     List.rev @@ binop_fold (fun a n s d1 d2 -> (n, f s d1 d2) :: a) [] x y
 
   let unop_fold f a (x:t) =
-    let f a n d =
-      f a n (assoc_dom n) d
-    in
-    fold_left (fun a (n,d) -> f a n d) a x
+    fold_left2 (fun a (n,d) (n',s) -> assert (n = n'); f a n s d) a x (domain_list ())
 
   let narrow = binop_map (fun (module S : Lattice.S) x y -> repr @@ S.narrow (obj x) (obj y))
   let widen  = binop_map (fun (module S : Lattice.S) x y -> repr @@ S.widen  (obj x) (obj y))

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -126,7 +126,7 @@ struct
     in
     try if length x <> length y
       then raise (DomListBroken "binop_fold : differing lengths")
-      else fold_left (fun a (n,d) -> f a n d @@ assoc n y) a x
+      else fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
     with Not_found -> raise (DomListBroken "binop_fold : assoc failure")
 
   let equal   x y = binop_fold (fun a n (module S : Printable.S) x y -> a && S.equal (obj x) (obj y)) true x y
@@ -248,7 +248,7 @@ struct
     in
     try if length x <> length y
       then raise (DomListBroken "binop_fold : differing lengths")
-      else fold_left (fun a (n,d) -> f a n d @@ assoc n y) a x
+      else fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
     with Not_found -> raise (DomListBroken "binop_fold : assoc failure")
 
   let binop_map (f: (module Lattice.S) -> Obj.t -> Obj.t -> Obj.t) x y =

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -116,10 +116,7 @@ struct
     in `Assoc (unop_fold f [] xs)
 
   let binop_fold f a (x:t) (y:t) =
-    let f a n d1 d2 =
-      f a n (assoc_dom n) d1 d2
-    in
-    fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
+    GobList.fold_left3 (fun a (n,d) (n',d') (n'',s) -> assert (n = n' && n = n''); f a n s d d') a x y (domain_list ())
 
   let equal   x y = binop_fold (fun a n (module S : Printable.S) x y -> a && S.equal (obj x) (obj y)) true x y
   let compare x y = binop_fold (fun a n (module S : Printable.S) x y -> if a <> 0 then a else S.compare (obj x) (obj y)) 0 x y
@@ -235,10 +232,7 @@ struct
   include DomListPrintable (PrintableOfLatticeSpec (DLSpec))
 
   let binop_fold f a (x:t) (y:t) =
-    let f a n d1 d2 =
-      f a n (assoc_dom n) d1 d2
-    in
-    fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
+    GobList.fold_left3 (fun a (n,d) (n',d') (n'',s) -> assert (n = n' && n = n''); f a n s d d') a x y (domain_list ())
 
   let binop_map (f: (module Lattice.S) -> Obj.t -> Obj.t -> Obj.t) x y =
     List.rev @@ binop_fold (fun a n s d1 d2 -> (n, f s d1 d2) :: a) [] x y

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -77,8 +77,6 @@ struct
     List.map (fun (x,y) -> (x,f y)) (D.domain_list ())
 end
 
-exception DomListBroken of string
-
 module DomListPrintable (DLSpec : DomainListPrintableSpec)
   : Printable.S with type t = (int * unknown) list
 =
@@ -124,10 +122,7 @@ struct
     let f a n d1 d2 =
       f a n (assoc_dom n) d1 d2
     in
-    try if length x <> length y
-      then raise (DomListBroken "binop_fold : differing lengths")
-      else fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
-    with Not_found -> raise (DomListBroken "binop_fold : assoc failure")
+    fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
 
   let equal   x y = binop_fold (fun a n (module S : Printable.S) x y -> a && S.equal (obj x) (obj y)) true x y
   let compare x y = binop_fold (fun a n (module S : Printable.S) x y -> if a <> 0 then a else S.compare (obj x) (obj y)) 0 x y
@@ -246,10 +241,7 @@ struct
     let f a n d1 d2 =
       f a n (assoc_dom n) d1 d2
     in
-    try if length x <> length y
-      then raise (DomListBroken "binop_fold : differing lengths")
-      else fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
-    with Not_found -> raise (DomListBroken "binop_fold : assoc failure")
+    fold_left2 (fun a (n,d) (n',d') -> assert (n = n'); f a n d d') a x y
 
   let binop_map (f: (module Lattice.S) -> Obj.t -> Obj.t -> Obj.t) x y =
     List.rev @@ binop_fold (fun a n s d1 d2 -> (n, f s d1 d2) :: a) [] x y
@@ -291,9 +283,8 @@ struct
   include DomVariantPrintable (PrintableOfLatticeSpec (DLSpec))
 
   let binop_map' (f: int -> (module Lattice.S) -> Obj.t -> Obj.t -> 'a) (n1, d1) (n2, d2) =
-    if n1 <> n2
-    then raise (DomListBroken "binop_fold : differing variants")
-    else f n1 (assoc_dom n1) d1 d2
+    assert (n1 = n2);
+    f n1 (assoc_dom n1) d1 d2
 
   let binop_map (f: (module Lattice.S) -> Obj.t -> Obj.t -> Obj.t) =
     binop_map' (fun n s d1 d2 -> (n, f s d1 d2))

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -35,6 +35,8 @@ let register_analysis =
     count := !count + 1
 
 
+let find_spec_name n = List.assoc n !analyses_table (* TODO: don't use assoc *)
+
 type unknown = Obj.t
 
 module type DomainListPrintableSpec =
@@ -106,14 +108,14 @@ struct
 
   let show x =
     let xs = unop_fold (fun a n (module S : Printable.S) x ->
-        let analysis_name = assoc n !analyses_table in
+        let analysis_name = find_spec_name n in
         (analysis_name ^ ":(" ^ S.show (obj x) ^ ")") :: a) [] x
     in
     IO.to_string (List.print ~first:"[" ~last:"]" ~sep:", " String.print) (rev xs)
 
   let to_yojson xs =
     let f a n (module S : Printable.S) x =
-      let name = BatList.assoc n !analyses_table in
+      let name = find_spec_name n in
       (name, S.to_yojson (obj x)) :: a
     in `Assoc (unop_fold f [] xs)
 
@@ -129,14 +131,14 @@ struct
 
   let name () =
     let domain_name (n, (module D: Printable.S)) =
-      let analysis_name = assoc n !analyses_table in
+      let analysis_name = find_spec_name n in
       analysis_name ^ ":(" ^ D.name () ^ ")"
     in
     IO.to_string (List.print ~first:"[" ~last:"]" ~sep:", " String.print) (map domain_name @@ domain_list ())
 
   let printXml f xs =
     let print_one a n (module S : Printable.S) x : unit =
-      BatPrintf.fprintf f "<analysis name=\"%s\">\n" (List.assoc n !analyses_table);
+      BatPrintf.fprintf f "<analysis name=\"%s\">\n" (find_spec_name n);
       S.printXml f (obj x);
       BatPrintf.fprintf f "</analysis>\n"
     in
@@ -171,14 +173,14 @@ struct
     )
 
   let show = unop_map (fun n (module S: Printable.S) x ->
-      let analysis_name = assoc n !analyses_table in
+      let analysis_name = find_spec_name n in
       analysis_name ^ ":" ^ S.show (obj x)
     )
 
   let to_yojson x =
     `Assoc [
       unop_map (fun n (module S: Printable.S) x ->
-          let name = BatList.assoc n !analyses_table in
+          let name = find_spec_name n in
           (name, S.to_yojson (obj x))
         ) x
     ]
@@ -203,13 +205,13 @@ struct
 
   let name () =
     let domain_name (n, (module S: Printable.S)) =
-      let analysis_name = assoc n !analyses_table in
+      let analysis_name = find_spec_name n in
       analysis_name ^ ":" ^ S.name ()
     in
     IO.to_string (List.print ~first:"" ~last:"" ~sep:" | " String.print) (map domain_name @@ domain_list ())
 
   let printXml f = unop_map (fun n (module S: Printable.S) x ->
-      BatPrintf.fprintf f "<analysis name=\"%s\">\n" (List.assoc n !analyses_table);
+      BatPrintf.fprintf f "<analysis name=\"%s\">\n" (find_spec_name n);
       S.printXml f (obj x);
       BatPrintf.fprintf f "</analysis>\n"
     )

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -10,8 +10,7 @@ type spec_modules = { name : string
                     ; var  : (module Printable.S)
                     ; acc  : (module MCPA) }
 
-let analyses_list  : (int * spec_modules) list ref = ref []
-
+let activated  : (int * spec_modules) list ref = ref []
 let activated_ctx_sens: (int * spec_modules) list ref = ref []
 let registered: (int, spec_modules) Hashtbl.t = Hashtbl.create 100
 let registered_name: (string, int) Hashtbl.t = Hashtbl.create 100
@@ -308,13 +307,13 @@ module DomVariantLattice (DLSpec : DomainListLatticeSpec) =
 module LocalDomainListSpec : DomainListLatticeSpec =
 struct
   let assoc_dom n = (find_spec n).dom
-  let domain_list () = List.map (fun (n,p) -> n, p.dom) !analyses_list
+  let domain_list () = List.map (fun (n,p) -> n, p.dom) !activated
 end
 
 module GlobalDomainListSpec : DomainListLatticeSpec =
 struct
   let assoc_dom n = (find_spec n).glob
-  let domain_list () = List.map (fun (n,p) -> n, p.glob) !analyses_list
+  let domain_list () = List.map (fun (n,p) -> n, p.glob) !activated
 end
 
 module ContextListSpec : DomainListPrintableSpec =
@@ -326,11 +325,11 @@ end
 module VarListSpec : DomainListPrintableSpec =
 struct
   let assoc_dom n = (find_spec n).var
-  let domain_list () = List.map (fun (n,p) -> n, p.var) !analyses_list
+  let domain_list () = List.map (fun (n,p) -> n, p.var) !activated
 end
 
 module AccListSpec : DomainListMCPASpec =
 struct
   let assoc_dom n = (find_spec n).acc
-  let domain_list () = List.map (fun (n,p) -> n, p.acc) !analyses_list
+  let domain_list () = List.map (fun (n,p) -> n, p.acc) !activated
 end

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -15,6 +15,8 @@ let dep_list'      : (int * (string list)) list ref= ref []
 
 let analyses_table = ref []
 
+let activated_ctx_sens: (int * spec_modules) list ref = ref []
+
 let register_analysis =
   let count = ref 0 in
   fun ?(dep=[]) (module S:MCPSpec) ->
@@ -314,8 +316,8 @@ end
 
 module ContextListSpec : DomainListPrintableSpec =
 struct
-  let assoc_dom n = (List.assoc n !analyses_list).cont
-  let domain_list () = List.map (fun (n,p) -> n, p.cont) !analyses_list
+  let assoc_dom n = (List.assoc n !activated_ctx_sens).cont
+  let domain_list () = List.map (fun (n,p) -> n, p.cont) !activated_ctx_sens
 end
 
 module VarListSpec : DomainListPrintableSpec =

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -57,8 +57,8 @@ struct
   let pretty () x = Pretty.text (show x)
 end
 
-let get_flag (state: (string * Obj.t) list) : Flag.t =
-  (Obj.obj (List.assoc "threadflag" state), fst (Obj.obj (List.assoc "threadid" state)))
+let get_flag (state: string -> Obj.t) : Flag.t =
+  (Obj.obj (state "threadflag"), fst (Obj.obj (state "threadid")))
 
 
 module Spec =
@@ -355,7 +355,7 @@ struct
   let strip_flags acc_list = List.map proj2_1 acc_list
 
   let get_flags state: Flags.t =
-    Obj.obj (List.assoc "fmode" state)
+    Obj.obj (state "fmode")
 
   (*/flagstuff*)
   (*prioritystuff*)

--- a/src/analyses/osektransactionality.ml
+++ b/src/analyses/osektransactionality.ml
@@ -21,8 +21,8 @@ struct
 
   let should_join x y = D.equal x y
 
-  let get_lockset ctx = Obj.obj (List.assoc "OSEK" ctx.postsub)
-  let get_stack   ctx = Obj.obj (List.assoc "stack_trace_set" ctx.postsub)
+  let get_lockset ctx = Obj.obj (ctx.postsub "OSEK")
+  let get_stack   ctx = Obj.obj (ctx.postsub "stack_trace_set")
 
   let pry_d dom_elem =
     if Mutex.Lockset.is_top dom_elem then -1 else

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -314,8 +314,8 @@ type ('d,'g,'c,'v) ctx =
   ; edge     : MyCFG.edge
   ; local    : 'd
   ; global   : 'v -> 'g
-  ; presub   : (string * Obj.t) list
-  ; postsub  : (string * Obj.t) list
+  ; presub   : string -> Obj.t (** raises [Not_found] if such dependency analysis doesn't exist *)
+  ; postsub  : string -> Obj.t (** raises [Not_found] if such dependency analysis doesn't exist *)
   ; spawn    : lval option -> varinfo -> exp list -> unit
   ; split    : 'd -> Events.t list -> unit
   ; sideg    : 'v -> 'g -> unit

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -493,8 +493,8 @@ struct
       ; edge    = edge
       ; local   = pval
       ; global  = getg
-      ; presub  = []
-      ; postsub = []
+      ; presub  = (fun _ -> raise Not_found)
+      ; postsub = (fun _ -> raise Not_found)
       ; spawn   = spawn
       ; split   = (fun (d:D.t) es -> assert (List.is_empty es); r := d::!r)
       ; sideg   = sideg

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -482,7 +482,8 @@ struct
               if get_bool "dbg.verbose" then (
                 print_endline ("Saving the analysis table to " ^ analyses ^ ", the CIL state to " ^ cil ^ ", the warning table to " ^ warnings ^ ", and the runtime stats to " ^ stats);
               );
-              Serialize.marshal !MCP.analyses_table analyses;
+              let analyses_table = Hashtbl.bindings MCPRegistry.registered_name |> List.map Tuple2.swap in (* TODO: marshal something more direct? *)
+              Serialize.marshal analyses_table analyses;
               Serialize.marshal (file, Cabs2cil.environment) cil;
               Serialize.marshal !Messages.Table.messages_list warnings;
               Serialize.marshal (Stats.top, Gc.quick_stat ()) stats

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -245,8 +245,8 @@ struct
         ; edge    = MyCFG.Skip
         ; local   = Spec.D.top ()
         ; global  = getg
-        ; presub  = []
-        ; postsub = []
+        ; presub  = (fun _ -> raise Not_found)
+        ; postsub = (fun _ -> raise Not_found)
         ; spawn   = (fun _ -> failwith "Global initializers should never spawn threads. What is going on?")
         ; split   = (fun _ -> failwith "Global initializers trying to split paths.")
         ; sideg   = sideg
@@ -343,8 +343,8 @@ struct
         ; edge    = MyCFG.Skip
         ; local   = st
         ; global  = getg
-        ; presub  = []
-        ; postsub = []
+        ; presub  = (fun _ -> raise Not_found)
+        ; postsub = (fun _ -> raise Not_found)
         ; spawn   = (fun _ -> failwith "Bug1: Using enter_func for toplevel functions with 'otherstate'.")
         ; split   = (fun _ -> failwith "Bug2: Using enter_func for toplevel functions with 'otherstate'.")
         ; sideg   = sideg
@@ -378,8 +378,8 @@ struct
         ; edge    = MyCFG.Skip
         ; local   = st
         ; global  = getg
-        ; presub  = []
-        ; postsub = []
+        ; presub  = (fun _ -> raise Not_found)
+        ; postsub = (fun _ -> raise Not_found)
         ; spawn   = (fun _ -> failwith "Bug1: Using enter_func for toplevel functions with 'otherstate'.")
         ; split   = (fun _ -> failwith "Bug2: Using enter_func for toplevel functions with 'otherstate'.")
         ; sideg   = sideg
@@ -569,8 +569,8 @@ struct
             ; edge    = MyCFG.Skip
             ; local  = Hashtbl.find joined loc
             ; global = GHT.find gh
-            ; presub = []
-            ; postsub= []
+            ; presub = (fun _ -> raise Not_found)
+            ; postsub= (fun _ -> raise Not_found)
             ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
             ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
             ; sideg  = (fun v g    -> failwith "Cannot \"split\" in query context.")
@@ -624,8 +624,8 @@ struct
         ; edge    = MyCFG.Skip
         ; local  = snd (List.hd startvars) (* bot and top both silently raise and catch Deadcode in DeadcodeLifter *)
         ; global = (fun v -> try GHT.find gh v with Not_found -> EQSys.G.bot ())
-        ; presub = []
-        ; postsub= []
+        ; presub = (fun _ -> raise Not_found)
+        ; postsub= (fun _ -> raise Not_found)
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
         ; sideg  = (fun v g    -> failwith "Cannot \"split\" in query context.")

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -482,8 +482,7 @@ struct
               if get_bool "dbg.verbose" then (
                 print_endline ("Saving the analysis table to " ^ analyses ^ ", the CIL state to " ^ cil ^ ", the warning table to " ^ warnings ^ ", and the runtime stats to " ^ stats);
               );
-              let analyses_table = Hashtbl.bindings MCPRegistry.registered_name |> List.map Tuple2.swap in (* TODO: marshal something more direct? *)
-              Serialize.marshal analyses_table analyses;
+              Serialize.marshal MCPRegistry.registered_name analyses;
               Serialize.marshal (file, Cabs2cil.environment) cil;
               Serialize.marshal !Messages.Table.messages_list warnings;
               Serialize.marshal (Stats.top, Gc.quick_stat ()) stats

--- a/src/util/gobList.ml
+++ b/src/util/gobList.ml
@@ -1,3 +1,8 @@
+(** The normal haskell zip that throws no exception *)
+let rec combine_short l1 l2 = match l1, l2 with
+  | x1 :: l1, x2 :: l2 -> (x1, x2) :: combine_short l1 l2
+  | _, _ -> []
+
 let rec fold_left3 f acc l1 l2 l3 = match l1, l2, l3 with
   | [], [], [] -> acc
   | x1 :: l1, x2 :: l2, x3 :: l3 -> fold_left3 f (f acc x1 x2 x3) l1 l2 l3

--- a/src/util/gobList.ml
+++ b/src/util/gobList.ml
@@ -1,7 +1,12 @@
+open Batteries
+
 (** The normal haskell zip that throws no exception *)
 let rec combine_short l1 l2 = match l1, l2 with
   | x1 :: l1, x2 :: l2 -> (x1, x2) :: combine_short l1 l2
   | _, _ -> []
+
+let assoc_eq_opt (eq: 'a -> 'a -> bool) (x: 'a) (ys: ('a * 'b) list) : ('b option) =
+  Option.map Tuple2.second (List.find_opt (fun (x',_) -> eq x x') ys)
 
 let rec fold_left3 f acc l1 l2 l3 = match l1, l2, l3 with
   | [], [], [] -> acc

--- a/src/util/gobList.ml
+++ b/src/util/gobList.ml
@@ -1,0 +1,4 @@
+let rec fold_left3 f acc l1 l2 l3 = match l1, l2, l3 with
+  | [], [], [] -> acc
+  | x1 :: l1, x2 :: l2, x3 :: l3 -> fold_left3 f (f acc x1 x2 x3) l1 l2 l3
+  | _, _, _ -> invalid_arg "GobList.fold_left3"

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -186,7 +186,4 @@ let rec for_all_in_range (a, b) f =
   then true
   else f a && (for_all_in_range (BI.add a (BI.one), b) f)
 
-let assoc_eq (x: 'a) (ys: ('a * 'b) list) (eq: 'a -> 'a -> bool): ('b option) =
-  Option.map Batteries.Tuple2.second (List.find_opt (fun (x',_) -> eq x x') ys)
-
 let dummy_obj = Obj.repr ()

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -180,11 +180,6 @@ let signal_of_string = let open Sys in function
 
 let self_signal signal = Unix.kill (Unix.getpid ()) signal
 
-(* The normal haskell zip that throws no exception *)
-let rec zip x y = match x,y with
-  | (x::xs), (y::ys) -> (x,y) :: zip xs ys
-  | _ -> []
-
 let rec for_all_in_range (a, b) f =
   let module BI = IntOps.BigIntOps in
   if BI.compare a b > 0

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -304,8 +304,8 @@ struct
         ; edge    = MyCFG.Skip
         ; local  = local
         ; global = GHT.find gh
-        ; presub = []
-        ; postsub= []
+        ; presub = (fun _ -> raise Not_found)
+        ; postsub= (fun _ -> raise Not_found)
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in witness context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in witness context.")
         ; sideg  = (fun v g    -> failwith "Cannot \"sideg\" in witness context.")


### PR DESCRIPTION
### Changes
1. Change `presub` and `postsub` from eagerly constructed assoc lists to lazy functions. This avoids the expensive (~5% of total runtime) `filter_presubs`, which constructed those lists for each transfer function, but they aren't even used by anything other than ARINC and OSEK. This slowdown was my original motivation for getting rid of these (#460), but now that they aren't slowing down the usual analyses, they're not so much of a problem.
2. Reimplement `unop_fold` and `binop_fold` of `MCP`'s `Printable` and `Lattice` using `fold_left2` and `fold_left3` respectively, by folding the domain elements simultaneously with the list of activated analysis `Spec`s. This avoids any `assoc` in those operations. To avoid nasty segfaults, there are assertions to check that the component IDs still match up.
3. Reimplement `MCP`'s `combine` and `threadspawn` by folding over both domain elements (and optional contexts) simultaneously.
4. Replace `MCPRegistry` global assoc lists with `Hashtbl`s for faster lookup where still needed.

### TODO
- [x] Benchmark.
- [x] Figure out what Gobview needs the old `MCP.analyses_table` for, which was just a list of (analysis ID, analysis name) pairs.