### PR TITLE
Fix no offset assert

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1165,8 +1165,7 @@ struct
         (* Optimization to avoid evaluating integer values when setting them.
            The case when invariant = true requires the old_value to be sound for the meet.
            Allocated blocks are representend by Blobs with additional information, so they need to be looked-up. *)
-        let old_value = if not invariant && Cil.isIntegralType x.vtype && not (a.f (IsHeapVar x)) then begin
-            assert (offs = `NoOffset); (* We expect `NoOffset for this case *)
+        let old_value = if not invariant && Cil.isIntegralType x.vtype && not (a.f (IsHeapVar x)) && offs = `NoOffset then begin
             VD.bot_value lval_type
           end else
             Priv.read_global a priv_getg st x

--- a/tests/regression/02-base/73-no-eval-on-write-offset.c
+++ b/tests/regression/02-base/73-no-eval-on-write-offset.c
@@ -1,0 +1,8 @@
+// PARAM: --enable exp.earlyglobs
+char a;
+int c;
+
+int main() {
+  *(&c + 0) = a;
+  return 0;
+}


### PR DESCRIPTION
When trying to run Goblint on [chrony](https://chrony.tuxfamily.org/) I discovered a case where a pointer points to something and has an integral type and has an offset. This causes the assert that checks that there is no offset in the optimization that avoids the evaluation of integer values when setting them to fail.

I added a minimal example as regression test in this PR. The proposed fix that I discussed with @michael-schwarz and @jerhard is to not apply the optimization if the integral type has an offset.