### PR TITLE
Optimize `Queries.ID`

### DIFF
--- a/bench/basic/benchTuple4.ml
+++ b/bench/basic/benchTuple4.ml
@@ -70,5 +70,72 @@ let () =
       ]
   )
 
+
+let () =
+  let for_all0 =
+    let open Batteries in
+    let to_list x = Tuple4.enum x |> List.of_enum |> List.filter_map identity in
+    let f g = g identity % to_list in
+    List.(f for_all)
+  in
+
+  let for_all1 = function
+    | (Some false, _, _, _)
+    | (_, Some false, _, _)
+    | (_, _, Some false, _)
+    | (_, _, _, Some false) ->
+      false
+    | _ ->
+      true
+  in
+
+  let for_all2 (a, b, c, d) = not (a = Some false || b = Some false || c = Some false || d = Some false) in
+
+
+  register (
+    "for_all" @>>> [
+        "all None" @> lazy (
+            let args = (None, None, None, None) in
+            throughputN 1 [
+              ("0", for_all0, args);
+              ("1", for_all1, args);
+              ("2", for_all2, args);
+            ]
+          );
+        "all Some true" @> lazy (
+            let args = (Some true, Some true, Some true, Some true) in
+            throughputN 1 [
+              ("0", for_all0, args);
+              ("1", for_all1, args);
+              ("2", for_all2, args);
+            ]
+          );
+        "all Some false" @> lazy (
+            let args = (Some false, Some false, Some false, Some false) in
+            throughputN 1 [
+              ("0", for_all0, args);
+              ("1", for_all1, args);
+              ("2", for_all2, args);
+            ]
+          );
+        "all None except last Some false" @> lazy (
+            let args = (None, None, None, Some false) in
+            throughputN 1 [
+              ("0", for_all0, args);
+              ("1", for_all1, args);
+              ("2", for_all2, args);
+            ]
+          );
+        "all Some true except last Some false" @> lazy (
+            let args = (Some true, Some true, Some true, Some false) in
+            throughputN 1 [
+              ("0", for_all0, args);
+              ("1", for_all1, args);
+              ("2", for_all2, args);
+            ]
+          );
+      ]
+  )
+
 let () =
   run_global ()

--- a/bench/basic/benchTuple4.ml
+++ b/bench/basic/benchTuple4.ml
@@ -28,45 +28,45 @@ let () =
   register (
     "exists" @>>> [
         "all None" @> lazy (
-            let args = (None, None, None, None) in
-            throughputN 1 [
-              ("0", exists0, args);
-              ("1", exists1, args);
-              ("2", exists2, args);
-            ]
-          );
+          let args = (None, None, None, None) in
+          throughputN 1 [
+            ("0", exists0, args);
+            ("1", exists1, args);
+            ("2", exists2, args);
+          ]
+        );
         "all Some true" @> lazy (
-            let args = (Some true, Some true, Some true, Some true) in
-            throughputN 1 [
-              ("0", exists0, args);
-              ("1", exists1, args);
-              ("2", exists2, args);
-            ]
-          );
+          let args = (Some true, Some true, Some true, Some true) in
+          throughputN 1 [
+            ("0", exists0, args);
+            ("1", exists1, args);
+            ("2", exists2, args);
+          ]
+        );
         "all Some false" @> lazy (
-            let args = (Some false, Some false, Some false, Some false) in
-            throughputN 1 [
-              ("0", exists0, args);
-              ("1", exists1, args);
-              ("2", exists2, args);
-            ]
-          );
+          let args = (Some false, Some false, Some false, Some false) in
+          throughputN 1 [
+            ("0", exists0, args);
+            ("1", exists1, args);
+            ("2", exists2, args);
+          ]
+        );
         "all None except last Some true" @> lazy (
-            let args = (None, None, None, Some true) in
-            throughputN 1 [
-              ("0", exists0, args);
-              ("1", exists1, args);
-              ("2", exists2, args);
-            ]
-          );
+          let args = (None, None, None, Some true) in
+          throughputN 1 [
+            ("0", exists0, args);
+            ("1", exists1, args);
+            ("2", exists2, args);
+          ]
+        );
         "all Some false except last Some true" @> lazy (
-            let args = (Some false, Some false, Some false, Some true) in
-            throughputN 1 [
-              ("0", exists0, args);
-              ("1", exists1, args);
-              ("2", exists2, args);
-            ]
-          );
+          let args = (Some false, Some false, Some false, Some true) in
+          throughputN 1 [
+            ("0", exists0, args);
+            ("1", exists1, args);
+            ("2", exists2, args);
+          ]
+        );
       ]
   )
 
@@ -95,45 +95,45 @@ let () =
   register (
     "for_all" @>>> [
         "all None" @> lazy (
-            let args = (None, None, None, None) in
-            throughputN 1 [
-              ("0", for_all0, args);
-              ("1", for_all1, args);
-              ("2", for_all2, args);
-            ]
-          );
+          let args = (None, None, None, None) in
+          throughputN 1 [
+            ("0", for_all0, args);
+            ("1", for_all1, args);
+            ("2", for_all2, args);
+          ]
+        );
         "all Some true" @> lazy (
-            let args = (Some true, Some true, Some true, Some true) in
-            throughputN 1 [
-              ("0", for_all0, args);
-              ("1", for_all1, args);
-              ("2", for_all2, args);
-            ]
-          );
+          let args = (Some true, Some true, Some true, Some true) in
+          throughputN 1 [
+            ("0", for_all0, args);
+            ("1", for_all1, args);
+            ("2", for_all2, args);
+          ]
+        );
         "all Some false" @> lazy (
-            let args = (Some false, Some false, Some false, Some false) in
-            throughputN 1 [
-              ("0", for_all0, args);
-              ("1", for_all1, args);
-              ("2", for_all2, args);
-            ]
-          );
+          let args = (Some false, Some false, Some false, Some false) in
+          throughputN 1 [
+            ("0", for_all0, args);
+            ("1", for_all1, args);
+            ("2", for_all2, args);
+          ]
+        );
         "all None except last Some false" @> lazy (
-            let args = (None, None, None, Some false) in
-            throughputN 1 [
-              ("0", for_all0, args);
-              ("1", for_all1, args);
-              ("2", for_all2, args);
-            ]
-          );
+          let args = (None, None, None, Some false) in
+          throughputN 1 [
+            ("0", for_all0, args);
+            ("1", for_all1, args);
+            ("2", for_all2, args);
+          ]
+        );
         "all Some true except last Some false" @> lazy (
-            let args = (Some true, Some true, Some true, Some false) in
-            throughputN 1 [
-              ("0", for_all0, args);
-              ("1", for_all1, args);
-              ("2", for_all2, args);
-            ]
-          );
+          let args = (Some true, Some true, Some true, Some false) in
+          throughputN 1 [
+            ("0", for_all0, args);
+            ("1", for_all1, args);
+            ("2", for_all2, args);
+          ]
+        );
       ]
   )
 

--- a/bench/basic/benchTuple4.ml
+++ b/bench/basic/benchTuple4.ml
@@ -1,0 +1,74 @@
+(* dune exec bench/basic/benchTuple4.exe -- -a *)
+
+open Benchmark
+open Benchmark.Tree
+
+
+let () =
+  let exists0 =
+    let open Batteries in
+    let to_list x = Tuple4.enum x |> List.of_enum |> List.filter_map identity in
+    let f g = g identity % to_list in
+    List.(f exists)
+  in
+
+  let exists1 = function
+    | (Some true, _, _, _)
+    | (_, Some true, _, _)
+    | (_, _, Some true, _)
+    | (_, _, _, Some true) ->
+      true
+    | _ ->
+      false
+  in
+
+  let exists2 (a, b, c, d) = a = Some true || b = Some true || c = Some true || d = Some true in
+
+
+  register (
+    "exists" @>>> [
+        "all None" @> lazy (
+            let args = (None, None, None, None) in
+            throughputN 1 [
+              ("0", exists0, args);
+              ("1", exists1, args);
+              ("2", exists2, args);
+            ]
+          );
+        "all Some true" @> lazy (
+            let args = (Some true, Some true, Some true, Some true) in
+            throughputN 1 [
+              ("0", exists0, args);
+              ("1", exists1, args);
+              ("2", exists2, args);
+            ]
+          );
+        "all Some false" @> lazy (
+            let args = (Some false, Some false, Some false, Some false) in
+            throughputN 1 [
+              ("0", exists0, args);
+              ("1", exists1, args);
+              ("2", exists2, args);
+            ]
+          );
+        "all None except last Some true" @> lazy (
+            let args = (None, None, None, Some true) in
+            throughputN 1 [
+              ("0", exists0, args);
+              ("1", exists1, args);
+              ("2", exists2, args);
+            ]
+          );
+        "all Some false except last Some true" @> lazy (
+            let args = (Some false, Some false, Some false, Some true) in
+            throughputN 1 [
+              ("0", exists0, args);
+              ("1", exists1, args);
+              ("2", exists2, args);
+            ]
+          );
+      ]
+  )
+
+let () =
+  run_global ()

--- a/bench/basic/dune
+++ b/bench/basic/dune
@@ -1,0 +1,4 @@
+(executable
+ (name benchTuple4)
+ (optional) ; TODO: for some reason this doesn't work: `dune build` still tries to compile if benchmark missing (https://github.com/ocaml/dune/issues/4065)
+ (libraries benchmark batteries.unthreaded))

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -612,7 +612,7 @@ struct
           | `Bot -> eval_next () (* Base EvalInt returns bot on incorrect type (e.g. pthread_t); ignore and continue. *)
           (* | x -> Some (`Int x) *)
           | `Lifted x -> `Int x (* cast should be unnecessary, EvalInt should guarantee right ikind already *)
-          | `Top -> assert false (* base should answer itself at least *)
+          | `Top -> `Int (ID.top_of (Cilfacade.get_ikind typ)) (* query cycle *)
         end
       | exception Cilfacade.TypeOfError _ (* Bug: typeOffset: Field on a non-compound *)
       | _ -> eval_next ()

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -632,13 +632,13 @@ struct
       match check_assert d e with
       | `True -> ID.of_bool ik true
       | `False -> ID.of_bool ik false
-      | `Top -> ID.top ()
+      | `Top -> ID.top_of ik
     else
       match eval_interval_expr d e with
       | (Some min, Some max) -> ID.of_interval ik (min, max)
       | (Some min, None) -> ID.starting ik min
       | (None, Some max) -> ID.ending ik max
-      | (None, None) -> ID.top ()
+      | (None, None) -> ID.top_of ik
 end
 
 
@@ -878,7 +878,7 @@ sig
   val assert_inv : t -> exp -> bool -> t
   val check_assert : t -> exp -> [> `False | `Top | `True ]
   val eval_interval_expr : t -> exp -> Z.t option * Z.t option
-  val eval_int : t -> exp -> IntDomain.IntDomTuple.t
+  val eval_int : t -> exp -> Queries.ID.t
 end
 
 type ('a, 'b) aproncomponents_t = { apr : 'a; priv : 'b; } [@@deriving eq, ord, hash, to_yojson]

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2514,7 +2514,24 @@ module IntDomTupleImpl = struct
 
   let to_list x = Tuple4.enum x |> List.of_enum |> List.filter_map identity (* contains only the values of activated domains *)
   let to_list_some x = List.filter_map identity @@ to_list x (* contains only the Some-values of activated domains *)
-  let exists, for_all = let f g = g identity % to_list in List.(f exists, f for_all)
+
+  let exists = function
+    | (Some true, _, _, _)
+    | (_, Some true, _, _)
+    | (_, _, Some true, _)
+    | (_, _, _, Some true) ->
+      true
+    | _ ->
+      false
+
+  let for_all = function
+    | (Some false, _, _, _)
+    | (_, Some false, _, _)
+    | (_, _, Some false, _)
+    | (_, _, _, Some false) ->
+      false
+    | _ ->
+      true
 
   (* f0: constructors *)
   let top () = create { fi = fun (type a) (module I:S with type t = a) -> I.top } ()

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2868,6 +2868,74 @@ module IntDomTupleImpl = struct
   let arbitrary ik = QCheck.(set_print show @@ quad (option (I1.arbitrary ik)) (option (I2.arbitrary ik)) (option (I3.arbitrary ik)) (option (I4.arbitrary ik)))
 end
 
+module IntDomLifter2 (I: Y) =
+struct
+  include Lattice.Lift (I) (Printable.DefaultNames)
+
+  type int_t = I.int_t
+
+  let lift'' op x = `Lifted (op x)
+
+  let bot_of = lift'' I.bot_of
+  let top_of = lift'' I.top_of
+
+  let lift op x = match x with
+    | `Lifted x -> `Lifted (op x)
+    | _ -> failwith "IntDomLifter2.lift"
+  let lift' op x = match x with
+    | `Lifted x -> op x
+    | _ -> failwith "IntDomLifter2.lift'"
+  let is_top_of ik = lift' (I.is_top_of ik)
+
+  let lift2 op x y = match x, y with
+    | `Lifted x, `Lifted y -> `Lifted (op x y)
+    | _, _ -> failwith "IntDomLifter2.lift2"
+
+  let neg = lift I.neg
+  let add = lift2 I.add
+  let sub = lift2 I.sub
+  let mul = lift2 I.mul
+  let div = lift2 I.div
+  let rem = lift2 I.rem
+  let lt = lift2 I.lt
+  let gt = lift2 I.gt
+  let le = lift2 I.le
+  let ge = lift2 I.ge
+  let eq = lift2 I.eq
+  let ne = lift2 I.ne
+  let bitnot = lift I.bitnot
+  let bitand = lift2 I.bitand
+  let bitor = lift2 I.bitor
+  let bitxor = lift2 I.bitxor
+  let shift_left = lift2 I.shift_left
+  let shift_right = lift2 I.shift_right
+  let lognot = lift I.lognot
+  let logand = lift2 I.logand
+  let logor = lift2 I.logor
+
+  let to_int = lift' I.to_int
+  let is_int = lift' I.is_int
+  let to_bool = lift' I.to_bool
+  let is_bool = lift' I.is_bool
+  let to_excl_list = lift' I.to_excl_list
+  let is_excl_list = lift' I.is_excl_list
+  let to_incl_list = lift' I.to_incl_list
+  let of_int ik = lift'' (I.of_int ik)
+  let of_bool ik = lift'' (I.of_bool ik)
+  let of_interval ik = lift'' (I.of_interval ik)
+  let of_excl_list ik = lift'' (I.of_excl_list ik)
+  let of_congruence ik = lift'' (I.of_congruence ik)
+  let starting ik = lift'' (I.starting ik)
+  let ending ik = lift'' (I.ending ik)
+
+  let minimal = lift' I.minimal
+  let maximal = lift' I.maximal
+
+  let cast_to ?torg ik = lift (I.cast_to ?torg ik)
+  let equal_to i = lift' (I.equal_to i)
+  let project p = lift (I.project p)
+end
+
 module IntDomTuple =
 struct
  module I = IntDomLifter (IntDomTupleImpl)
@@ -2876,6 +2944,16 @@ struct
  let top () = failwith "top in IntDomTuple not supported. Use top_of instead."
  let no_interval (x: I.t) = {x with v = IntDomTupleImpl.no_interval x.v}
 
+end
+
+module IntDomTuple2 =
+struct
+  include IntDomLifter2 (IntDomTuple)
+
+  let is_bot_ikind = function
+    | `Bot -> false
+    | `Lifted x -> IntDomTuple.is_bot x
+    | `Top -> false
 end
 
 let of_const (i, ik, str) = IntDomTuple.of_int ik i

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2868,74 +2868,6 @@ module IntDomTupleImpl = struct
   let arbitrary ik = QCheck.(set_print show @@ quad (option (I1.arbitrary ik)) (option (I2.arbitrary ik)) (option (I3.arbitrary ik)) (option (I4.arbitrary ik)))
 end
 
-module IntDomLifter2 (I: Y) =
-struct
-  include Lattice.Lift (I) (Printable.DefaultNames)
-
-  type int_t = I.int_t
-
-  let lift'' op x = `Lifted (op x)
-
-  let bot_of = lift'' I.bot_of
-  let top_of = lift'' I.top_of
-
-  let lift op x = match x with
-    | `Lifted x -> `Lifted (op x)
-    | _ -> failwith "IntDomLifter2.lift"
-  let lift' op x = match x with
-    | `Lifted x -> op x
-    | _ -> failwith "IntDomLifter2.lift'"
-  let is_top_of ik = lift' (I.is_top_of ik)
-
-  let lift2 op x y = match x, y with
-    | `Lifted x, `Lifted y -> `Lifted (op x y)
-    | _, _ -> failwith "IntDomLifter2.lift2"
-
-  let neg = lift I.neg
-  let add = lift2 I.add
-  let sub = lift2 I.sub
-  let mul = lift2 I.mul
-  let div = lift2 I.div
-  let rem = lift2 I.rem
-  let lt = lift2 I.lt
-  let gt = lift2 I.gt
-  let le = lift2 I.le
-  let ge = lift2 I.ge
-  let eq = lift2 I.eq
-  let ne = lift2 I.ne
-  let bitnot = lift I.bitnot
-  let bitand = lift2 I.bitand
-  let bitor = lift2 I.bitor
-  let bitxor = lift2 I.bitxor
-  let shift_left = lift2 I.shift_left
-  let shift_right = lift2 I.shift_right
-  let lognot = lift I.lognot
-  let logand = lift2 I.logand
-  let logor = lift2 I.logor
-
-  let to_int = lift' I.to_int
-  let is_int = lift' I.is_int
-  let to_bool = lift' I.to_bool
-  let is_bool = lift' I.is_bool
-  let to_excl_list = lift' I.to_excl_list
-  let is_excl_list = lift' I.is_excl_list
-  let to_incl_list = lift' I.to_incl_list
-  let of_int ik = lift'' (I.of_int ik)
-  let of_bool ik = lift'' (I.of_bool ik)
-  let of_interval ik = lift'' (I.of_interval ik)
-  let of_excl_list ik = lift'' (I.of_excl_list ik)
-  let of_congruence ik = lift'' (I.of_congruence ik)
-  let starting ik = lift'' (I.starting ik)
-  let ending ik = lift'' (I.ending ik)
-
-  let minimal = lift' I.minimal
-  let maximal = lift' I.maximal
-
-  let cast_to ?torg ik = lift (I.cast_to ?torg ik)
-  let equal_to i = lift' (I.equal_to i)
-  let project p = lift (I.project p)
-end
-
 module IntDomTuple =
 struct
  module I = IntDomLifter (IntDomTupleImpl)
@@ -2944,16 +2876,6 @@ struct
  let top () = failwith "top in IntDomTuple not supported. Use top_of instead."
  let no_interval (x: I.t) = {x with v = IntDomTupleImpl.no_interval x.v}
 
-end
-
-module IntDomTuple2 =
-struct
-  include IntDomLifter2 (IntDomTuple)
-
-  let is_bot_ikind = function
-    | `Bot -> false
-    | `Lifted x -> IntDomTuple.is_bot x
-    | `Top -> false
 end
 
 let of_const (i, ik, str) = IntDomTuple.of_int ik i

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -325,6 +325,11 @@ module IntDomTuple : sig
   val no_interval: t -> t
 end
 
+module IntDomTuple2: sig
+  include Z with type t = [`Bot | `Lifted of IntDomTuple.t | `Top]
+  val is_bot_ikind: t -> bool
+end
+
 val of_const: Cilint.cilint * Cil.ikind * string option -> IntDomTuple.t
 
 

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -325,11 +325,6 @@ module IntDomTuple : sig
   val no_interval: t -> t
 end
 
-module IntDomTuple2: sig
-  include Z with type t = [`Bot | `Lifted of IntDomTuple.t | `Top]
-  val is_bot_ikind: t -> bool
-end
-
 val of_const: Cilint.cilint * Cil.ikind * string option -> IntDomTuple.t
 
 

--- a/src/domains/hoareDomain.ml
+++ b/src/domains/hoareDomain.ml
@@ -224,7 +224,7 @@ struct
           fold (fun other acc ->
               (dprintf "not leq %a because %a\n" B.pretty other B.pretty_diff (evil, other)) ++ acc
             ) s2 nil
-      with _ ->
+      with Not_found ->
         dprintf "choose failed b/c of empty set s1: %d s2: %d"
         (cardinal s1)
         (cardinal s2)
@@ -336,7 +336,7 @@ struct
           fold' (fun other otherr acc ->
               (dprintf "not leq %a because %a\nand not mem %a because %a\n" SpecD.pretty other SpecD.pretty_diff (evil, other) R.pretty otherr R.pretty_diff (R.singleton evilr', otherr)) ++ acc
             ) s2 nil
-      with _ ->
+      with Not_found ->
         dprintf "choose failed b/c of empty set s1: %d s2: %d"
         (cardinal s1)
         (cardinal s2)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -3,7 +3,37 @@
 open Cil
 
 module GU = Goblintutil
-module ID = IntDomain.IntDomTuple2
+module ID =
+struct
+  module I = IntDomain.IntDomTuple
+  include Lattice.Lift (I) (Printable.DefaultNames)
+
+  let lift op x = `Lifted (op x)
+  let unlift op x = match x with
+    | `Lifted x -> op x
+    | _ -> failwith "Queries.ID.unlift"
+
+  let bot_of = lift I.bot_of
+  let top_of = lift I.top_of
+
+  let of_int ik = lift (I.of_int ik)
+  let of_bool ik = lift (I.of_bool ik)
+  let of_interval ik = lift (I.of_interval ik)
+  let of_excl_list ik = lift (I.of_excl_list ik)
+  let of_congruence ik = lift (I.of_congruence ik)
+  let starting ik = lift (I.starting ik)
+  let ending ik = lift (I.ending ik)
+
+  let to_int x = unlift I.to_int x
+  let is_int x = unlift I.is_int x
+  let to_bool x = unlift I.to_bool x
+  let is_bool x = unlift I.is_bool x
+
+  let is_bot_ikind = function
+    | `Bot -> false
+    | `Lifted x -> I.is_bot x
+    | `Top -> false
+end
 module LS = SetDomain.ToppedSet (Lval.CilLval) (struct let topname = "All" end)
 module TS = SetDomain.ToppedSet (CilType.Typ) (struct let topname = "All" end)
 module ES = SetDomain.Reverse (SetDomain.ToppedSet (Exp.Exp) (struct let topname = "All" end))

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -3,33 +3,7 @@
 open Cil
 
 module GU = Goblintutil
-module ID =
-struct
-  include IntDomain.IntDomTuple
-  (* Special IntDomTuple that has _some_ top and bot which MCP2.query can use *)
-  let top () = top_of IInt
-  let is_top x = is_top_of IInt x
-  let bot () = bot_of IInt
-  let is_bot x = is_bot x (* no is_bot_of *)
-  let join x y =
-    if is_top x || is_top y then
-      top ()
-    else if is_bot x then
-      y
-    else if is_bot y then
-      x
-    else
-      join x y
-  let meet x y =
-    if is_bot x || is_bot y then
-      bot ()
-    else if is_top x then
-      y
-    else if is_top y then
-      x
-    else
-      meet x y
-end
+module ID = IntDomain.IntDomTuple2
 module LS = SetDomain.ToppedSet (Lval.CilLval) (struct let topname = "All" end)
 module TS = SetDomain.ToppedSet (CilType.Typ) (struct let topname = "All" end)
 module ES = SetDomain.Reverse (SetDomain.ToppedSet (Exp.Exp) (struct let topname = "All" end))

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -8,9 +8,9 @@ struct
   include IntDomain.IntDomTuple
   (* Special IntDomTuple that has _some_ top and bot which MCP2.query can use *)
   let top () = top_of IInt
-  let is_top x = equal (top ()) x
+  let is_top x = is_top_of IInt x
   let bot () = bot_of IInt
-  let is_bot x = equal (bot ()) x
+  let is_bot x = is_bot x (* no is_bot_of *)
   let join x y =
     if is_top x || is_top y then
       top ()

--- a/src/transform/expressionEvaluation.ml
+++ b/src/transform/expressionEvaluation.ml
@@ -127,7 +127,7 @@ module ExpEval : Transform.S =
             (* Evaluable: Definite *)
           | Some x when Queries.ID.is_int x -> Some (Some (not(IntOps.BigIntOps.equal (Option.get @@ Queries.ID.to_int x) IntOps.BigIntOps.zero)))
             (* Inapplicable: Unreachable *)
-          | Some x when Queries.ID.is_bot x -> None
+          | Some x when Queries.ID.is_bot_ikind x -> None
             (* Evaluable: Inconclusive *)
           | Some x -> Some None
             (* Inapplicable: Unlisted *)

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -88,7 +88,15 @@ struct
     let bot () = failwith "VIE bot"
     let is_bot _ = failwith "VIE is_bot"
 
-    let pretty_diff () _ = failwith "VIE pretty_diff"
+    let pretty_diff () (((v, c, x'), e), ((w, d, y'), f)) =
+      if not (Node.equal v w) then
+        Pretty.dprintf "%a not equal %a" Node.pretty v Node.pretty w
+      else if not (Spec.C.equal c d) then
+        Pretty.dprintf "%a not equal %a" Spec.C.pretty c Spec.C.pretty d
+      else if not (Edge.equal e f) then
+        Pretty.dprintf "%a not equal %a" Edge.pretty e Edge.pretty f
+      else
+        I.pretty_diff () (x', y')
   end
   (* Bot is needed for Hoare widen *)
   (* TODO: could possibly rewrite Hoare to avoid introducing bots in widen which get reduced away anyway? *)

--- a/unittest/cdomains/intDomainTest.ml
+++ b/unittest/cdomains/intDomainTest.ml
@@ -200,6 +200,56 @@ let test_ex_set _ =
   assert_equal (Some true) (T.to_bool tex10);
   assert_equal None (T.to_bool tex1)
 
+module IntDomTuple =
+struct
+  let exists0 =
+    let open Batteries in
+    let to_list x = Tuple4.enum x |> List.of_enum |> List.filter_map identity in
+    let f g = g identity % to_list in
+    List.(f exists)
+
+  let exists1 = function
+    | (Some true, _, _, _)
+    | (_, Some true, _, _)
+    | (_, _, Some true, _)
+    | (_, _, _, Some true) ->
+      true
+    | _ ->
+      false
+
+  let bool_option = QCheck.option QCheck.bool
+  let arb = QCheck.quad bool_option bool_option bool_option bool_option
+
+  let test_exists = QCheck.Test.make ~name:"exists" arb (fun args ->
+      exists0 args = exists1 args
+    )
+
+  let for_all0 =
+    let open Batteries in
+    let to_list x = Tuple4.enum x |> List.of_enum |> List.filter_map identity in
+    let f g = g identity % to_list in
+    List.(f for_all)
+
+  let for_all1 = function
+    | (Some false, _, _, _)
+    | (_, Some false, _, _)
+    | (_, _, Some false, _)
+    | (_, _, _, Some false) ->
+      false
+    | _ ->
+      true
+
+  let test_for_all = QCheck.Test.make ~name:"for_all" arb (fun args ->
+      for_all0 args = for_all1 args
+    )
+
+
+  let test () = QCheck_ounit.to_ounit2_test_list [
+      test_exists;
+      test_for_all;
+    ]
+end
+
 let test () = "intDomainTest" >:::
               [ "int_Integers"  >::: A.test ();
                 "int_Flattened" >::: B.test ();
@@ -208,4 +258,5 @@ let test () = "intDomainTest" >:::
                 "test_join"     >::  test_join;
                 "test_meet"     >::  test_meet;
                 "test_excl_list">::  test_ex_set;
+                "intDomTuple" >::: IntDomTuple.test ();
               ]


### PR DESCRIPTION
`Queries.ID`, which is the domain used for the result of queries like `EvalInt` needs `top` and `bot`, but `IntDomTuple` itself does not have those. The previous hack was to abuse the top and bottom of `IInt` for that purpose, but this was far from ideal:
1. Implementations of `join` and `meet` were overridden to provide special behavior for those to avoid crashing due to mismatching ikinds. The implementations of the checks were like `let is_top x = equal (top ()) x`, which was straightforward, but awfully inefficient because every `meet` of the query result called that two times and each call of `IntDomTuple.top ()` looked up four options to know which int domains to activate. These accounted for most of the option lookups during execution, despite their caching.
2. Reimplementing `is_top` to delegate to `IntDomTuple.is_top_of` improved it a bit, but not much. This was due to the horribly inefficient `exists` and `for_all` implementations in `IntDomTuple`, which did the check through multiple levels of intermediate conversions (`BatEnum` and `List`). According to the added `BenchTuple4`, straight pattern matching is _hundreds of times faster_.
3. Reimplementing `is_bot` like that wasn't possible since there's no `is_bot_of`.
4. Abusing `IInt` ikind for a special purpose creates a conflict, where some actual `IInt` results could be treated differently from other ikinds.

Therefore this PR changes `Queries.ID` to lift `IntDomTuple` to fix all the above issues: there are explicit `Top` and `Bot` variants which are much cheaper to construct, check, join and meet, while being distinct from anything inside `IntDomTuple`.

### TODO
- [x] Add benchmark results.
- [x] Try to explain high variance in long-running benchmarks.