### PR TITLE
Refactor MCP transfer functions and add query cache

### DIFF
--- a/src/analyses/arinc.ml
+++ b/src/analyses/arinc.ml
@@ -337,7 +337,7 @@ struct
       let assign_id exp id =
         match exp with
         (* call assign for all analyses (we only need base)! *)
-        | AddrOf lval -> ctx.assign ~name:"base" lval (mkAddrOf @@ var id)
+        | AddrOf lval -> ctx.emit (Assign {lval; exp = mkAddrOf @@ var id})
         (* TODO not needed for the given code, but we could use Queries.MayPointTo exp in this case *)
         | _ -> failwith @@ "Could not assign id. Expected &id. Found "^sprint d_exp exp
       in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1027,13 +1027,13 @@ struct
         match e1_val, e2_val with
         | `Int i1, `Int i2 -> begin
             match ID.to_int i1, ID.to_int i2 with
-            | Some i1', Some i2' when i1' = i2' -> true
+            | Some i1', Some i2' when Z.equal i1' i2' -> true
             | _ -> false
             end
         | _ -> false
       end
     | Q.MayBeEqual (e1, e2) -> begin
-        (* Printf.printf "---------------------->  may equality check for %s and %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
+        (* Printf.printf "---------------------->  may equality check for %s and %s \n" (CilType.Exp.show e1) (CilType.Exp.show e2); *)
         let e1_val = eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e1 in
         let e2_val = eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e2 in
         match e1_val, e2_val with
@@ -1044,7 +1044,7 @@ struct
             let ik= Cil.commonIntKind e1_ik e2_ik in
             if ID.is_bot (ID.meet (ID.cast_to ik i1) (ID.cast_to ik i2)) then
               begin
-                (* Printf.printf "----------------------> NOPE may equality check for %s and %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
+                (* Printf.printf "----------------------> NOPE may equality check for %s and %s \n" (CilType.Exp.show e1) (CilType.Exp.show e2); *)
                 false
               end
             else true
@@ -1052,16 +1052,16 @@ struct
         | _ -> true
       end
     | Q.MayBeLess (e1, e2) -> begin
-        (* Printf.printf "----------------------> may check for %s < %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
+        (* Printf.printf "----------------------> may check for %s < %s \n" (CilType.Exp.show e1) (CilType.Exp.show e2); *)
         let e1_val = eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e1 in
         let e2_val = eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e2 in
         match e1_val, e2_val with
         | `Int i1, `Int i2 -> begin
             match (ID.minimal i1), (ID.maximal i2) with
             | Some i1', Some i2' ->
-              if i1' >= i2' then
+              if Z.geq i1' i2' then
                 begin
-                  (* Printf.printf "----------------------> NOPE may check for %s < %s \n" (ExpDomain.short 20 (`Lifted e1)) (ExpDomain.short 20 (`Lifted e2)); *)
+                  (* Printf.printf "----------------------> NOPE may check for %s < %s \n" (CilType.Exp.show e1) (CilType.Exp.show e2); *)
                   false
                 end
               else true

--- a/src/analyses/extract_arinc.ml
+++ b/src/analyses/extract_arinc.ml
@@ -272,7 +272,7 @@ struct
         let assign_id exp id =
           if M.tracing then M.trace "extract_arinc" "assign_id %a %s\n" d_exp exp id.vname;
           match exp with
-          | AddrOf lval -> ctx.assign ~name:"base" lval (mkAddrOf @@ var id)
+          | AddrOf lval -> ctx.emit (Assign {lval; exp = mkAddrOf @@ var id})
           | _ -> failwith @@ "Could not assign id. Expected &id. Found "^sprint d_exp exp
         in
         (* evaluates an argument and returns a list of possible values for that argument. *)

--- a/src/analyses/extract_osek.ml
+++ b/src/analyses/extract_osek.ml
@@ -265,7 +265,7 @@ struct
         let assign_id exp id =
           if M.tracing then M.trace "extract_osek" "assign_id %a %s\n" d_exp exp id.vname;
           match exp with
-          | AddrOf lval -> ctx.assign ~name:"base" lval (mkAddrOf @@ var id)
+          | AddrOf lval -> ctx.emit (Assign {lval; exp = mkAddrOf @@ var id})
           | _ -> failwith @@ "Could not assign id. Expected &id. Found "^sprint d_exp exp
         in
         (* evaluates an argument and returns a list of possible values for that argument. *)

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -328,17 +328,14 @@ struct
       | Some splits -> (fun d es   -> splits := (n,(repr d,es)) :: !splits)
       | None -> (fun _ _    -> failwith ("Cannot \"split\" in " ^ tfname ^ " context."))
     in
-    let rec ctx' =
-      { ctx with
-        local  = obj d
-      ; context = (fun () -> ctx.context () |> assoc n |> obj)
-      ; postsub= assoc_sub post_all
-      ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
-      ; split
-      ; sideg  = (fun v g    -> ctx.sideg (v_of n v) (g_of n g))
-      }
-    in
-    ctx'
+    { ctx with
+      local  = obj d
+    ; context = (fun () -> ctx.context () |> assoc n |> obj)
+    ; postsub= assoc_sub post_all
+    ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
+    ; split
+    ; sideg  = (fun v g    -> ctx.sideg (v_of n v) (g_of n g))
+    }
 
   and assign (ctx:(D.t, G.t, C.t, V.t) ctx) l e =
     let spawns = ref [] in

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -22,6 +22,7 @@ struct
 
   open List open Obj
   let v_of n v = (n, repr v)
+  let g_of n g = `Lifted (n, repr g)
   let g_to n = function
     | `Lifted (n', g) ->
       assert (n = n');
@@ -334,7 +335,7 @@ struct
       ; postsub= assoc_sub post_all
       ; global = (fun v      -> ctx.global (v_of n v) |> g_to n |> obj)
       ; split
-      ; sideg  = (fun v g    -> ctx.sideg (v_of n v) (`Lifted (n, repr g)))
+      ; sideg  = (fun v g    -> ctx.sideg (v_of n v) (g_of n g))
       }
     in
     ctx'

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -161,9 +161,9 @@ struct
     let n' = find_id name in
     assoc n' xs
 
-  let do_spawns ctx (xs:(varinfo * (int * lval option * exp list)) list) =
+  let do_spawns ctx (xs:(varinfo * (lval option * exp list)) list) =
     let spawn_one v d =
-      List.iter (fun (n, lval, args) -> ctx.spawn lval v args) d
+      List.iter (fun (lval, args) -> ctx.spawn lval v args) d
     in
     if not (get_bool "exp.single-threaded") then
       iter (uncurry spawn_one) @@ group_assoc_eq Basetype.Variables.equal xs
@@ -314,7 +314,7 @@ struct
 
   and outer_ctx ?spawns ?sides ?emits ctx =
     let spawn = match spawns with
-      | Some spawns -> (fun l v a  -> spawns := (v,(-1,l,a)) :: !spawns) (* TODO: n doesn't matter, remove *)
+      | Some spawns -> (fun l v a  -> spawns := (v,(l,a)) :: !spawns)
       | None -> (fun v d    -> failwith "Cannot \"spawn\" in query context.")
     in
     let sideg = match sides with

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -264,46 +264,48 @@ struct
 
   (* Explicitly polymorphic type required here for recursive GADT call in ask. *)
   and query': type a. querycache:Obj.t QueryHash.t -> QuerySet.t -> (D.t, G.t, C.t, V.t) ctx -> a Queries.t -> a Queries.result = fun ~querycache asked ctx q ->
-    let module Result = (val Queries.Result.lattice q) in
-    if QuerySet.mem (Any q) asked then
-      Result.top () (* query cycle *)
-    else if QueryHash.mem querycache (Any q) then
-      Obj.obj (QueryHash.find querycache (Any q))
-    else
-      let asked' = QuerySet.add (Any q) asked in
-      let sides = ref [] in
-      let ctx'' = outer_ctx "query" ~sides ctx in
-      let f ~q a (n,(module S:MCPSpec),d) =
-        let ctx' : (S.D.t, S.G.t, S.C.t, S.V.t) ctx = inner_ctx "query" ctx'' n d in
-        (* sideg is discouraged in query, because they would bypass sides grouping in other transfer functions.
-           See https://github.com/goblint/analyzer/pull/214. *)
-        let ctx' : (S.D.t, S.G.t, S.C.t, S.V.t) ctx =
-          { ctx' with
-            ask    = (fun (type b) (q: b Queries.t) -> query' ~querycache asked' ctx q)
-          }
+    let anyq = Queries.Any q in
+    match QueryHash.find_option querycache anyq with
+    | Some r -> Obj.obj r
+    | None ->
+      let module Result = (val Queries.Result.lattice q) in
+      if QuerySet.mem anyq asked then
+        Result.top () (* query cycle *)
+      else
+        let asked' = QuerySet.add anyq asked in
+        let sides = ref [] in
+        let ctx'' = outer_ctx "query" ~sides ctx in
+        let f ~q a (n,(module S:MCPSpec),d) =
+          let ctx' : (S.D.t, S.G.t, S.C.t, S.V.t) ctx = inner_ctx "query" ctx'' n d in
+          (* sideg is discouraged in query, because they would bypass sides grouping in other transfer functions.
+            See https://github.com/goblint/analyzer/pull/214. *)
+          let ctx' : (S.D.t, S.G.t, S.C.t, S.V.t) ctx =
+            { ctx' with
+              ask    = (fun (type b) (q: b Queries.t) -> query' ~querycache asked' ctx q)
+            }
+          in
+          (* meet results so that precision from all analyses is combined *)
+          Result.meet a @@ S.query ctx' q
         in
-        (* meet results so that precision from all analyses is combined *)
-        Result.meet a @@ S.query ctx' q
-      in
-      match q with
-      | Queries.PrintFullState ->
-        ignore (Pretty.printf "Current State:\n%a\n\n" D.pretty ctx.local);
-        ()
-      | Queries.WarnGlobal g ->
-        (* WarnGlobal is special: it only goes to corresponding analysis and the argument variant is unlifted for it *)
-        let (n, g): V.t = Obj.obj g in
-        f ~q:(WarnGlobal (Obj.repr g)) (Result.top ()) (n, spec n, assoc n ctx.local)
-      | Queries.PartAccess {exp; var_opt; write} ->
-        Obj.repr (access ctx exp var_opt write)
-      (* | EvalInt e ->
-        (* TODO: only query others that actually respond to EvalInt *)
-        (* 2x speed difference on SV-COMP nla-digbench-scaling/ps6-ll_valuebound5.c *)
-        f (Result.top ()) (!base_id, spec !base_id, assoc !base_id ctx.local) *)
-      | _ ->
-        let r = fold_left (f ~q) (Result.top ()) @@ spec_list ctx.local in
-        do_sideg ctx !sides;
-        QueryHash.replace querycache (Any q) (Obj.repr r);
-        r
+        match q with
+        | Queries.PrintFullState ->
+          ignore (Pretty.printf "Current State:\n%a\n\n" D.pretty ctx.local);
+          ()
+        | Queries.WarnGlobal g ->
+          (* WarnGlobal is special: it only goes to corresponding analysis and the argument variant is unlifted for it *)
+          let (n, g): V.t = Obj.obj g in
+          f ~q:(WarnGlobal (Obj.repr g)) (Result.top ()) (n, spec n, assoc n ctx.local)
+        | Queries.PartAccess {exp; var_opt; write} ->
+          Obj.repr (access ctx exp var_opt write)
+        (* | EvalInt e ->
+          (* TODO: only query others that actually respond to EvalInt *)
+          (* 2x speed difference on SV-COMP nla-digbench-scaling/ps6-ll_valuebound5.c *)
+          f (Result.top ()) (!base_id, spec !base_id, assoc !base_id ctx.local) *)
+        | _ ->
+          let r = fold_left (f ~q) (Result.top ()) @@ spec_list ctx.local in
+          do_sideg ctx !sides;
+          QueryHash.replace querycache anyq (Obj.repr r);
+          r
 
   and query: type a. (D.t, G.t, C.t, V.t) ctx -> a Queries.t -> a Queries.result = fun ctx q ->
     let querycache = QueryHash.create 13 in

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -8,6 +8,7 @@ type t =
   | SplitBranch of exp * bool (** Used to simulate old branch-based split. *)
   | AssignSpawnedThread of lval * ThreadIdDomain.Thread.t (** Assign spawned thread's ID to lval. *)
   | Access of {var_opt: CilType.Varinfo.t option; write: bool} (** Access varinfo (unknown if None). *)
+  | Assign of {lval: CilType.Lval.t; exp: CilType.Exp.t} (** Used to simulate old [ctx.assign]. *)
 
 let pretty () = function
   | Lock m -> dprintf "Lock %a" LockDomain.Addr.pretty m
@@ -17,3 +18,4 @@ let pretty () = function
   | SplitBranch (exp, tv) -> dprintf "SplitBranch (%a, %B)" d_exp exp tv
   | AssignSpawnedThread (lval, tid) -> dprintf "AssignSpawnedThread (%a, %a)" d_lval lval ThreadIdDomain.Thread.pretty tid
   | Access {var_opt; write} -> dprintf "Access {var_opt=%a, write=%B}" (docOpt (CilType.Varinfo.pretty ())) var_opt write
+  | Assign {lval; exp} -> dprintf "Assugn {lval=%a, exp=%a}" CilType.Lval.pretty lval CilType.Exp.pretty exp

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -280,7 +280,7 @@ struct
         [%ord: CilType.Exp.t * CilType.Exp.t] (e1, e2) (e3, e4)
       | Any (MayBeEqual (e1, e2)), Any (MayBeEqual (e3, e4)) ->
         [%ord: CilType.Exp.t * CilType.Exp.t] (e1, e2) (e3, e4)
-      | Any (MayBeLess (e1, e2)), Any (MayBeEqual (e3, e4)) ->
+      | Any (MayBeLess (e1, e2)), Any (MayBeLess (e3, e4)) ->
         [%ord: CilType.Exp.t * CilType.Exp.t] (e1, e2) (e3, e4)
       | Any (IsHeapVar v1), Any (IsHeapVar v2) -> CilType.Varinfo.compare v1 v2
       | Any (IsMultiple v1), Any (IsMultiple v2) -> CilType.Varinfo.compare v1 v2

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -56,10 +56,10 @@ module MustBool = BoolDomain.MustBool
 module Unit = Lattice.Unit
 
 (* Helper definitions for deriving complex parts of Any.compare below. *)
-type maybepublic = {global: CilType.Varinfo.t; write: bool} [@@deriving ord]
-type maybepublicwithout = {global: CilType.Varinfo.t; write: bool; without_mutex: PreValueDomain.Addr.t} [@@deriving ord]
-type mustbeprotectedby = {mutex: PreValueDomain.Addr.t; global: CilType.Varinfo.t; write: bool} [@@deriving ord]
-type partaccess = {exp: CilType.Exp.t; var_opt: CilType.Varinfo.t option; write: bool} [@@deriving ord]
+type maybepublic = {global: CilType.Varinfo.t; write: bool} [@@deriving ord, hash]
+type maybepublicwithout = {global: CilType.Varinfo.t; write: bool; without_mutex: PreValueDomain.Addr.t} [@@deriving ord, hash]
+type mustbeprotectedby = {mutex: PreValueDomain.Addr.t; global: CilType.Varinfo.t; write: bool} [@@deriving ord, hash]
+type partaccess = {exp: CilType.Exp.t; var_opt: CilType.Varinfo.t option; write: bool} [@@deriving ord, hash]
 
 (** GADT for queries with specific result type. *)
 type _ t =
@@ -213,45 +213,45 @@ struct
   type t = any_query
 
   (* deriving ord doesn't work for GADTs (t and any_query) so this must be done manually... *)
+  let order = function
+    | Any (EqualSet _) -> 0
+    | Any (MayPointTo _) -> 1
+    | Any (ReachableFrom _) -> 2
+    | Any (ReachableUkTypes _) -> 3
+    | Any (Regions _) -> 4
+    | Any (MayEscape _) -> 5
+    | Any (Priority _) -> 6
+    | Any (MayBePublic _) -> 7
+    | Any (MayBePublicWithout _) -> 8
+    | Any (MustBeProtectedBy _) -> 9
+    | Any CurrentLockset -> 10
+    | Any MustBeAtomic -> 11
+    | Any MustBeSingleThreaded -> 12
+    | Any MustBeUniqueThread -> 13
+    | Any CurrentThreadId -> 14
+    | Any MayBeThreadReturn -> 15
+    | Any (EvalFunvar _) -> 16
+    | Any (EvalInt _) -> 17
+    | Any (EvalStr _) -> 18
+    | Any (EvalLength _) -> 19
+    | Any (BlobSize _) -> 20
+    | Any PrintFullState -> 21
+    | Any (CondVars _) -> 22
+    | Any (PartAccess _) -> 23
+    | Any (IterPrevVars _) -> 24
+    | Any (IterVars _) -> 25
+    | Any (MustBeEqual _) -> 26
+    | Any (MayBeEqual _) -> 27
+    | Any (MayBeLess _) -> 28
+    | Any HeapVar -> 29
+    | Any (IsHeapVar _) -> 30
+    | Any (IsMultiple _) -> 31
+    | Any (EvalThread _) -> 32
+    | Any CreatedThreads -> 33
+    | Any MustJoinedThreads -> 34
+    | Any (WarnGlobal _) -> 35
+
   let compare a b =
-    let order = function
-      | Any (EqualSet _) -> 0
-      | Any (MayPointTo _) -> 1
-      | Any (ReachableFrom _) -> 2
-      | Any (ReachableUkTypes _) -> 3
-      | Any (Regions _) -> 4
-      | Any (MayEscape _) -> 5
-      | Any (Priority _) -> 6
-      | Any (MayBePublic _) -> 7
-      | Any (MayBePublicWithout _) -> 8
-      | Any (MustBeProtectedBy _) -> 9
-      | Any CurrentLockset -> 10
-      | Any MustBeAtomic -> 11
-      | Any MustBeSingleThreaded -> 12
-      | Any MustBeUniqueThread -> 13
-      | Any CurrentThreadId -> 14
-      | Any MayBeThreadReturn -> 15
-      | Any (EvalFunvar _) -> 16
-      | Any (EvalInt _) -> 17
-      | Any (EvalStr _) -> 18
-      | Any (EvalLength _) -> 19
-      | Any (BlobSize _) -> 20
-      | Any PrintFullState -> 21
-      | Any (CondVars _) -> 22
-      | Any (PartAccess _) -> 23
-      | Any (IterPrevVars _) -> 24
-      | Any (IterVars _) -> 25
-      | Any (MustBeEqual _) -> 26
-      | Any (MayBeEqual _) -> 27
-      | Any (MayBeLess _) -> 28
-      | Any HeapVar -> 29
-      | Any (IsHeapVar _) -> 30
-      | Any (IsMultiple _) -> 31
-      | Any (EvalThread _) -> 32
-      | Any CreatedThreads -> 33
-      | Any MustJoinedThreads -> 34
-      | Any (WarnGlobal _) -> 35
-    in
     let r = Stdlib.compare (order a) (order b) in
     if r <> 0 then
       r
@@ -291,5 +291,35 @@ struct
 
   let equal x y = compare x y = 0
 
-  let hash x = 0
+  let hash_arg = function
+    | Any (EqualSet e) -> CilType.Exp.hash e
+    | Any (MayPointTo e) -> CilType.Exp.hash e
+    | Any (ReachableFrom e) -> CilType.Exp.hash e
+    | Any (ReachableUkTypes e) -> CilType.Exp.hash e
+    | Any (Regions e) -> CilType.Exp.hash e
+    | Any (MayEscape vi) -> CilType.Varinfo.hash vi
+    | Any (Priority s) -> Hashtbl.hash s
+    | Any (MayBePublic x) -> hash_maybepublic x
+    | Any (MayBePublicWithout x) -> hash_maybepublicwithout x
+    | Any (MustBeProtectedBy x) -> hash_mustbeprotectedby x
+    | Any (EvalFunvar e) -> CilType.Exp.hash e
+    | Any (EvalInt e) -> CilType.Exp.hash e
+    | Any (EvalStr e) -> CilType.Exp.hash e
+    | Any (EvalLength e) -> CilType.Exp.hash e
+    | Any (BlobSize e) -> CilType.Exp.hash e
+    | Any (CondVars e) -> CilType.Exp.hash e
+    | Any (PartAccess p) -> hash_partaccess p
+    | Any (IterPrevVars i) -> 0
+    | Any (IterVars i) -> 0
+    | Any (MustBeEqual (e1, e2)) -> [%hash: CilType.Exp.t * CilType.Exp.t] (e1, e2)
+    | Any (MayBeEqual (e1, e2)) -> [%hash: CilType.Exp.t * CilType.Exp.t] (e1, e2)
+    | Any (MayBeLess (e1, e2)) -> [%hash: CilType.Exp.t * CilType.Exp.t] (e1, e2)
+    | Any (IsHeapVar v) -> CilType.Varinfo.hash v
+    | Any (IsMultiple v) -> CilType.Varinfo.hash v
+    | Any (EvalThread e) -> CilType.Exp.hash e
+    | Any (WarnGlobal vi) -> Hashtbl.hash vi
+    (* only argumentless queries should remain *)
+    | _ -> 0
+
+  let hash x = 31 * order x + hash_arg x
 end

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -288,4 +288,8 @@ struct
       | Any (WarnGlobal vi1), Any (WarnGlobal vi2) -> compare (Hashtbl.hash vi1) (Hashtbl.hash vi2)
       (* only argumentless queries should remain *)
       | _, _ -> Stdlib.compare (order a) (order b)
+
+  let equal x y = compare x y = 0
+
+  let hash x = 0
 end

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -315,7 +315,6 @@ type ('d,'g,'c,'v) ctx =
   ; spawn    : lval option -> varinfo -> exp list -> unit
   ; split    : 'd -> Events.t list -> unit
   ; sideg    : 'v -> 'g -> unit
-  ; assign   : ?name:string -> lval -> exp -> unit
   }
 
 exception Ctx_failure of string

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -498,7 +498,6 @@ struct
       ; spawn   = spawn
       ; split   = (fun (d:D.t) es -> assert (List.is_empty es); r := d::!r)
       ; sideg   = sideg
-      ; assign = (fun ?name _    -> failwith "Cannot \"assign\" in common context.")
       }
     and spawn lval f args =
       (* TODO: adjust ctx node/edge? *)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -250,7 +250,6 @@ struct
         ; spawn   = (fun _ -> failwith "Global initializers should never spawn threads. What is going on?")
         ; split   = (fun _ -> failwith "Global initializers trying to split paths.")
         ; sideg   = sideg
-        ; assign  = (fun ?name _ -> failwith "Global initializers trying to assign.")
         }
       in
       let edges = CfgTools.getGlobalInits file in
@@ -348,7 +347,6 @@ struct
         ; spawn   = (fun _ -> failwith "Bug1: Using enter_func for toplevel functions with 'otherstate'.")
         ; split   = (fun _ -> failwith "Bug2: Using enter_func for toplevel functions with 'otherstate'.")
         ; sideg   = sideg
-        ; assign  = (fun ?name _ -> failwith "Bug4: Using enter_func for toplevel functions with 'otherstate'.")
         }
       in
       let args = List.map (fun x -> MyCFG.unknown_exp) fd.sformals in
@@ -383,7 +381,6 @@ struct
         ; spawn   = (fun _ -> failwith "Bug1: Using enter_func for toplevel functions with 'otherstate'.")
         ; split   = (fun _ -> failwith "Bug2: Using enter_func for toplevel functions with 'otherstate'.")
         ; sideg   = sideg
-        ; assign  = (fun ?name _ -> failwith "Bug4: Using enter_func for toplevel functions with 'otherstate'.")
         }
       in
       (* TODO: don't hd *)
@@ -574,7 +571,6 @@ struct
             ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
             ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
             ; sideg  = (fun v g    -> failwith "Cannot \"split\" in query context.")
-            ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in query context.")
             }
           in
           Spec.query ctx
@@ -629,7 +625,6 @@ struct
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
         ; sideg  = (fun v g    -> failwith "Cannot \"split\" in query context.")
-        ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in query context.")
         }
       in
       Spec.query ctx (WarnGlobal (Obj.repr g))

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -309,7 +309,6 @@ struct
         ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in witness context.")
         ; split  = (fun d es   -> failwith "Cannot \"split\" in witness context.")
         ; sideg  = (fun v g    -> failwith "Cannot \"sideg\" in witness context.")
-        ; assign = (fun ?name _ -> failwith "Cannot \"assign\" in witness context.")
         }
       in
       Spec.query ctx


### PR DESCRIPTION
### Changes
1. Removes all `ctx` duplication from `MCP` transfer functions. This significantly shortens its code and makes future changes much easier as opposed to having to change a dozen `ctx`s.
2. The extracted `ctx` creation allows to easily add a cache for queries for the duration of a single transfer function. Hopefully this gives a performance benefit.
3. Replace `ctx.assign` with `Assign` event.

### TODO
- [x] Benchmark.