### PR TITLE
Parallel preprocessing

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -42,6 +42,7 @@
     json-data-encoding
     jsonrpc
     (sha (>= 1.12))
+    cpu
     (conf-gmp (>= 3)) ; only needed transitively, but they don't have lower bound, which is needed on MacOS
     (conf-ruby :with-test)
     (benchmark :with-test) ; TODO: make this optional somehow, (optional) on bench executable doesn't work

--- a/goblint.opam
+++ b/goblint.opam
@@ -38,6 +38,7 @@ depends: [
   "json-data-encoding"
   "jsonrpc"
   "sha" {>= "1.12"}
+  "cpu"
   "conf-gmp" {>= "3"}
   "conf-ruby" {with-test}
   "benchmark" {with-test}

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -32,12 +32,15 @@ depends: [
   "biniou" {= "1.2.1"}
   "camlidl" {= "1.09"}
   "cmdliner" {= "1.0.4" & with-doc}
+  "conf-autoconf" {= "0.1"}
   "conf-gmp" {= "3"}
   "conf-mpfr" {= "2"}
   "conf-perl" {= "1"}
   "conf-pkg-config" {= "2"}
   "conf-ruby" {= "1.0.0" & with-test}
+  "conf-which" {= "1"}
   "cppo" {= "1.6.7"}
+  "cpu" {= "2.0.0"}
   "dune" {= "2.9.1"}
   "dune-private-libs" {= "2.9.1"}
   "dune-site" {= "2.9.1"}

--- a/src/dune
+++ b/src/dune
@@ -8,7 +8,7 @@
   (public_name goblint.lib)
   (wrapped false)
   (modules :standard \ goblint mainarinc mainspec privPrecCompare apronPrecCompare)
-  (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc
+  (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc cpu
     ; Conditionally compile based on whether apron optional dependency is installed or not.
     ; Alternative dependencies seem like the only way to optionally depend on optional dependencies.
     ; See: https://dune.readthedocs.io/en/stable/concepts.html#alternative-dependencies.

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -284,7 +284,7 @@ let preprocess_files () =
     | Unix.WEXITED 0 -> ()
     | process_status -> failwith (GobUnix.string_of_process_status process_status)
   in
-  ProcessPool.run ~terminated preprocess_tasks;
+  ProcessPool.run ~jobs:(Goblintutil.jobs ()) ~terminated preprocess_tasks;
   List.map fst preprocessed
 
 (** Possibly merge all postprocessed files *)

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -90,6 +90,7 @@ let option_spec_list =
   let tmp_arg = ref "" in
   [ "-o"                   , Arg.String (set_string "outfile"), ""
   ; "-v"                   , Arg.Unit (fun () -> set_bool "dbg.verbose" true; set_bool "printstats" true), ""
+  ; "-j"                   , Arg.Int (set_int "jobs"), ""
   ; "-I"                   , Arg.String (set_string "includes[+]"), ""
   ; "-IK"                  , Arg.String (set_string "kernel_includes[+]"), ""
   ; "--set"                , Arg.Tuple [Arg.Set_string tmp_arg; Arg.String (fun x -> set_auto !tmp_arg x)], ""

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -183,3 +183,8 @@ let rec for_all_in_range (a, b) f =
   else f a && (for_all_in_range (BI.add a (BI.one), b) f)
 
 let dummy_obj = Obj.repr ()
+
+let jobs () =
+  match get_int "jobs" with
+  | 0 -> Cpu.numcores ()
+  | n -> n

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -217,6 +217,12 @@
       "type": "boolean",
       "default": false
     },
+    "jobs": {
+      "title": "jobs",
+      "description": "Maximum number of parallel jobs.",
+      "type": "integer",
+      "default": 1
+    },
     "server": {
       "title": "Server",
       "description": "Server mode",

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -219,9 +219,9 @@
     },
     "jobs": {
       "title": "jobs",
-      "description": "Maximum number of parallel jobs.",
+      "description": "Maximum number of parallel jobs. If 0, then number of cores is used.",
       "type": "integer",
-      "default": 1
+      "default": 0
     },
     "server": {
       "title": "Server",

--- a/src/util/processPool.ml
+++ b/src/util/processPool.ml
@@ -4,7 +4,7 @@ type task = {
 }
 
 let run ?(terminated=fun _ _ -> ()) tasks =
-  let n = 16 in (* TODO: configure *)
+  let n = GobConfig.get_int "jobs" in
   let procs = Hashtbl.create n in
   let rec run tasks =
     match tasks with

--- a/src/util/processPool.ml
+++ b/src/util/processPool.ml
@@ -3,12 +3,11 @@ type task = {
   cwd: string option;
 }
 
-let run ?(terminated=fun _ _ -> ()) tasks =
-  let n = GobConfig.get_int "jobs" in
-  let procs = Hashtbl.create n in
+let run ~jobs ?(terminated=fun _ _ -> ()) tasks =
+  let procs = Hashtbl.create jobs in
   let rec run tasks =
     match tasks with
-    | task :: tasks when Hashtbl.length procs < n ->
+    | task :: tasks when Hashtbl.length procs < jobs ->
       let old_cwd = Sys.getcwd () in
       let proc =
         match task.cwd with

--- a/src/util/processPool.ml
+++ b/src/util/processPool.ml
@@ -1,0 +1,45 @@
+type task = {
+  command: string;
+  cwd: string option;
+}
+
+let run ?(terminated=fun _ _ -> ()) tasks =
+  let n = 16 in (* TODO: configure *)
+  let procs = Hashtbl.create n in
+  let rec run tasks =
+    match tasks with
+    | task :: tasks when Hashtbl.length procs < n ->
+      let old_cwd = Sys.getcwd () in
+      let proc =
+        match task.cwd with
+        | Some cwd ->
+          Fun.protect ~finally:(fun () ->
+              Sys.chdir old_cwd
+            ) (fun () ->
+              Sys.chdir cwd;
+              Unix.open_process task.command
+            )
+        | None ->
+          Unix.open_process task.command
+      in
+      let pid = Unix.process_pid proc in
+      Hashtbl.replace procs pid (task, proc);
+      run tasks
+    | [] when Hashtbl.length procs = 0 ->
+      ()
+    | _ ->
+      let (pid, status) = Unix.wait () in
+      begin match Hashtbl.find_opt procs pid with
+        | Some (task, (proc_in, proc_out)) ->
+          (* Unix.close_process proc; *)
+          (* only part of close_process, no need to wait *)
+          close_in proc_in;
+          close_out proc_out;
+          Hashtbl.remove procs pid;
+          terminated task status
+        | None -> (* unrelated process *)
+          ()
+      end;
+      run tasks
+  in
+  run tasks


### PR DESCRIPTION
Implements the first half of #589.

The separate calling of `Unix.open_process` and `Unix.close_process` was extremely simple, but trying it out on OpenSSL it revealed a problem: it crashed with the Unix error `EMFILE` (Too many open files by the process). Apparently starting 1009 child processes at the same time isn't a good idea.

Of course `ulimit -n` could've worked around the problem, but I thought I'd be nice and implement a `ProcessPool` module, which runs at most `jobs` subprocesses in parallel.

By default (`-j 0`), the number of parallel jobs is derived from the number of CPU cores. Otherwise the `-j` command line argument (which is really the `jobs` option) controls the limit.

### OpenSSL
Trying this on OpenSSL (just preprocessing, no parsing or merging), with `-j 1` it takes:
```
real	0m37,266s
user	0m28,811s
sys	0m8,312s
```

Whereas with `-j 16` it takes:
```
real	0m5,856s
user	1m4,144s
sys	0m16,108s
```

So here the preprocessing takes **6.4 times less wall time**!