### PR TITLE
Parallel parsing

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -42,7 +42,7 @@
     json-data-encoding
     jsonrpc
     (sha (>= 1.12))
-    cpu
+    parmap
     (conf-gmp (>= 3)) ; only needed transitively, but they don't have lower bound, which is needed on MacOS
     (conf-ruby :with-test)
     (benchmark :with-test) ; TODO: make this optional somehow, (optional) on bench executable doesn't work

--- a/goblint.opam
+++ b/goblint.opam
@@ -38,7 +38,7 @@ depends: [
   "json-data-encoding"
   "jsonrpc"
   "sha" {>= "1.12"}
-  "cpu"
+  "parmap"
   "conf-gmp" {>= "3"}
   "conf-ruby" {with-test}
   "benchmark" {with-test}

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -32,16 +32,15 @@ depends: [
   "biniou" {= "1.2.1"}
   "camlidl" {= "1.09"}
   "cmdliner" {= "1.0.4" & with-doc}
-  "conf-autoconf" {= "0.1"}
   "conf-gmp" {= "3"}
   "conf-mpfr" {= "2"}
   "conf-perl" {= "1"}
   "conf-pkg-config" {= "2"}
   "conf-ruby" {= "1.0.0" & with-test}
-  "conf-which" {= "1"}
   "cppo" {= "1.6.7"}
-  "cpu" {= "2.0.0"}
+  "csexp" {= "1.5.1"}
   "dune" {= "2.9.1"}
+  "dune-configurator" {= "2.9.1"}
   "dune-private-libs" {= "2.9.1"}
   "dune-site" {= "2.9.1"}
   "easy-format" {= "1.3.2"}
@@ -66,6 +65,7 @@ depends: [
   "odoc" {= "2.0.2" & with-doc}
   "odoc-parser" {= "0.9.0" & with-doc}
   "ounit2" {= "2.2.4" & with-test}
+  "parmap" {= "1.2.4"}
   "ppx_blob" {= "0.7.2"}
   "ppx_derivers" {= "1.2.1"}
   "ppx_deriving" {= "5.2.1"}

--- a/src/dune
+++ b/src/dune
@@ -8,7 +8,7 @@
   (public_name goblint.lib)
   (wrapped false)
   (modules :standard \ goblint mainarinc mainspec privPrecCompare apronPrecCompare)
-  (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc cpu
+  (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc cpu parmap
     ; Conditionally compile based on whether apron optional dependency is installed or not.
     ; Alternative dependencies seem like the only way to optionally depend on optional dependencies.
     ; See: https://dune.readthedocs.io/en/stable/concepts.html#alternative-dependencies.

--- a/src/dune
+++ b/src/dune
@@ -8,7 +8,7 @@
   (public_name goblint.lib)
   (wrapped false)
   (modules :standard \ goblint mainarinc mainspec privPrecCompare apronPrecCompare)
-  (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc cpu parmap
+  (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc parmap
     ; Conditionally compile based on whether apron optional dependency is installed or not.
     ; Alternative dependencies seem like the only way to optionally depend on optional dependencies.
     ; See: https://dune.readthedocs.io/en/stable/concepts.html#alternative-dependencies.

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -318,7 +318,7 @@ let merge_preprocessed cpp_file_names =
     | 1 ->
       List.map Cilfacade.getAST cpp_file_names
     | jobs ->
-      let files = Parmap.parmap ~ncores:jobs Cilfacade.getAST (L cpp_file_names) in
+      let files = Parmap.parmap ~ncores:jobs ~keeporder:true Cilfacade.getAST (L cpp_file_names) in (* keeporder for iter2 below *)
       List.iter fix_ids files;
       files
   in

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -292,12 +292,17 @@ let merge_preprocessed cpp_file_names =
   (* get the AST *)
   if get_bool "dbg.verbose" then print_endline "Parsing files.";
   let get_ast_and_record_deps f =
-    let file = Cilfacade.getAST f in
-    (* Drop <built-in> and <command-line> from dependencies *)
-    Hashtbl.add Preprocessor.dependencies f @@ List.filter (fun (n,_) -> n <> "<built-in>" && n <> "<command-line>") file.files;
-    file
+    Cilfacade.getAST f
   in
-  let files_AST = List.map (get_ast_and_record_deps) cpp_file_names in
+  (* let files_AST = Parmap.parmap ~ncores:(Goblintutil.jobs ()) (get_ast_and_record_deps) (L cpp_file_names) in *)
+  let files_AST = List.map (get_ast_and_record_deps) (cpp_file_names) in
+
+  List.iter2 (fun f file ->
+      (* Drop <built-in> and <command-line> from dependencies *)
+      Hashtbl.add Preprocessor.dependencies f @@ List.filter (fun (n,_) -> n <> "<built-in>" && n <> "<command-line>") file.Cil.files;
+    ) cpp_file_names files_AST;
+
+  (* raise Exit; *)
 
   let cilout =
     if get_string "dbg.cilout" = "" then Legacy.stderr else Legacy.open_out (get_string "dbg.cilout")

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -186,5 +186,5 @@ let dummy_obj = Obj.repr ()
 
 let jobs () =
   match get_int "jobs" with
-  | 0 -> Cpu.numcores ()
+  | 0 -> Setcore.numcores ()
   | n -> n


### PR DESCRIPTION
Implements the second half of #589 on top of #597.

Uses the parmap library to parse files in parallel using forked processes. Merging still happens once in the parent process, because it's not clear whether anything more clever with `parmapfold` would help (#532).

### OpenSSL
On 250 files from OpenSSL compilation database, there's a notable improvement in preprocessing+parsing time.
With `-j 1`:
```
real	0m59,919s
user	0m55,434s
sys	0m4,429s

```
With `-j 8`:
```
real	0m16,363s
user	1m24,972s
sys	0m5,803s
```
With `-j 16` (which doesn't help much):
```
16
real	0m13,405s
user	2m10,305s
sys	0m8,085s
```

When also including merging time, the improvement is much smaller though:
With `-j 1`:
```
real	1m9,892s
user	1m6,274s
sys	0m3,579s
```
With `-j 8`:
```
real	0m43,579s
user	1m54,741s
sys	0m6,216s
```

Something quite fishy is happening with the merging of files that were parsed in parallel. Somehow they are considerably slower to merge and I'm not sure how that can be.