### PR TITLE
Allow analysis abort in server mode

### DIFF
--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -136,6 +136,7 @@ let () =
         analyze serve ~reset;
         {status = if !Goblintutil.verified = Some false then VerifyError else Success}
       with Sys.Break ->
+        assert (GobConfig.get_bool "ana.opt.hashcons"); (* TODO: TD3 doesn't copy input solver data, so will modify it in place and screw up Serialize.server_solver_data accidentally *)
         {status = Aborted}
   end);
 

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -70,17 +70,13 @@ let handle_request (serv: t) (message: Message.either) (id: Id.t) =
 let serve serv =
   serv.input
   |> IO.to_input_channel
-  |> Yojson.Safe.linestream_from_channel
-  |> Stream.iter (fun line ->
-      match line with
-      | `Json json -> (
-          try
-            let message = Message.either_of_yojson json in
-            match message.id with
-            | Some id -> handle_request serv message id
-            | _ -> () (* We just ignore notifications for now. *)
-          with Json.Of_json (s, _) -> prerr_endline s)
-      | `Exn exn -> prerr_endline (Printexc.to_string exn))
+  |> Yojson.Safe.stream_from_channel
+  |> Stream.iter (fun json ->
+      let message = Message.either_of_yojson json in
+      match message.id with
+      | Some id -> handle_request serv message id
+      | _ -> () (* We just ignore notifications for now. *)
+    )
 
 let make ?(input=stdin) ?(output=stdout) file do_analyze : t = { file; do_analyze; input; output }
 


### PR DESCRIPTION
Although a TODO said to implement an abort command, that's unnecessarily complicated because while the analyze command has started the analysis, Goblint isn't reading the server mode input concurrently. Multithreading would have to be used to make it doable as a command.

Therefore this PR implements the easiest alternative: SIGINT during server mode analysis aborts the analysis (but doesn't kill Goblint itself). A SIGKILL during server mode outside of analysis still kills Goblint.

The analyze command response is also extended to return whether the analysis completed, was aborted or failed verification.

The following is untested, but I think this aborting should play well with incremental analysis, because `Serialize.server_solver_data` is overridden only when the analysis actually completes. Hence, when aborted, the incremental data is essentially undone to before analysis.

Conflicts with #591 and should be merged after that.