### PR TITLE
Incremental analysis: Eagerly analyze functions in `force-reanalyze`, even when `reluctant` is on

### DIFF
--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -23,10 +23,9 @@ type change_info = {
   mutable unchanged: global list;
   mutable removed: global list;
   mutable added: global list;
-
-  (* Set of functions that are to be force-reanalyzed.
-     These functions are additionally to be included in the [changed] field *)
   mutable force_reanalyze: VarinfoSet.t;
+  (** Set of functions that are to be force-reanalyzed.
+      These functions are additionally included in the [changed] field, among the other changed globals. *)
 }
 
 let empty_change_info () : change_info =
@@ -34,7 +33,7 @@ let empty_change_info () : change_info =
 
 type change_status = Unchanged | Changed | ForceReanalyze of Cil.fundec
 
-(** Give a boolean that indicates whether the code object is identical to the previous version, returns the corresponding [change_status]*)
+(** Given a boolean that indicates whether the code object is identical to the previous version, returns the corresponding [change_status]*)
 let unchanged_to_change_status = function
   | true -> Unchanged
   | false -> Changed

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -16,8 +16,6 @@ open Messages
 open CompareCIL
 open Cil
 
-module VarinfoSet = Set.Make(CilType.Varinfo)
-
 module WP =
   functor (Arg: IncrSolverArg) ->
   functor (S:EqConstrSys) ->
@@ -630,11 +628,10 @@ module WP =
         in
 
         let reluctant = GobConfig.get_bool "incremental.reluctant.on" in
-        let force_reanalyze = VarinfoSet.of_list (List.map (fun f -> f.svar) S.increment.changes.force_reanalyze) in
         let reanalyze_entry f =
           (* destabilize the entry points of a changed function when reluctant is off,
              or the function is to be force-reanalyzed  *)
-          (not reluctant) || VarinfoSet.mem f.svar force_reanalyze
+          (not reluctant) || CompareCIL.VarinfoSet.mem f.svar S.increment.changes.force_reanalyze
         in
         let obsolete_ret = HM.create 103 in
         let obsolete_entry = HM.create 103 in

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -642,7 +642,7 @@ module WP =
         let obsolete_prim = HM.create 103 in
 
         (* When reluctant is on:
-          Only add function entry nodes to obsolete_entry if they are in force-reanalyze *)
+           Only add function entry nodes to obsolete_entry if they are in force-reanalyze *)
         List.iter (fun f ->
             if reanalyze_entry f then
               (* collect function entry for eager destabilization *)
@@ -671,7 +671,7 @@ module WP =
         );
 
         if not (HM.is_empty obsolete_entry) || not (HM.is_empty obsolete_prim) then
-           print_endline "Destabilizing changed functions and primary old nodes ...";
+          print_endline "Destabilizing changed functions and primary old nodes ...";
         HM.iter (fun k _ ->
             if HM.mem stable k then
               destabilize k

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -16,8 +16,6 @@ open Messages
 open CompareCIL
 open Cil
 
-module StringSet = Set.Make(Printable.Strings)
-
 module WP =
   functor (Arg: IncrSolverArg) ->
   functor (S:EqConstrSys) ->
@@ -629,7 +627,9 @@ module WP =
             )
         in
 
-        let force_reanalyze = StringSet.of_list @@ GobConfig.get_string_list "incremental.force-reanalyze.funs" in
+        let force_reanalyze = S.increment.changes.force_reanalyze in 
+
+          (* StringSet.of_list @@ GobConfig.get_string_list "incremental.force-reanalyze.funs" in *)
         let reluctant = GobConfig.get_bool "incremental.reluctant.on" in
         let reanalyze_entry f =
           (* destabilize the entry points of a changed function when reluctant is off,

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -651,12 +651,15 @@ module WP =
               (* collect function return for reluctant analysis *)
               mark_node obsolete_ret f (Function f)
           ) changed_funs;
-        List.iter (fun (f, pn, _) ->
-            List.iter (fun n ->
-                mark_node obsolete_prim f n
-              ) pn;
-            mark_node obsolete_ret f (Function f);
-          ) part_changed_funs;
+        (* Unknowns from partially changed functions need only to be collected for eager destabilization when reluctant is off *)
+        if eager then (
+          List.iter (fun (f, pn, _) ->
+              List.iter (fun n ->
+                  mark_node obsolete_prim f n
+                ) pn;
+              mark_node obsolete_ret f (Function f);
+            ) part_changed_funs;
+        );
 
         let old_ret = HM.create 103 in
         if GobConfig.get_bool "incremental.reluctant.on" then (

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -16,6 +16,8 @@ open Messages
 open CompareCIL
 open Cil
 
+module VarinfoSet = Set.Make(CilType.Varinfo)
+
 module WP =
   functor (Arg: IncrSolverArg) ->
   functor (S:EqConstrSys) ->
@@ -627,16 +629,13 @@ module WP =
             )
         in
 
-        let force_reanalyze = S.increment.changes.force_reanalyze in 
-
-          (* StringSet.of_list @@ GobConfig.get_string_list "incremental.force-reanalyze.funs" in *)
         let reluctant = GobConfig.get_bool "incremental.reluctant.on" in
+        let force_reanalyze = VarinfoSet.of_list (List.map (fun f -> f.svar) S.increment.changes.force_reanalyze) in
         let reanalyze_entry f =
           (* destabilize the entry points of a changed function when reluctant is off,
              or the function is to be force-reanalyzed  *)
-          (not reluctant) || StringSet.mem f.svar.vname force_reanalyze
+          (not reluctant) || VarinfoSet.mem f.svar force_reanalyze
         in
-
         let obsolete_ret = HM.create 103 in
         let obsolete_entry = HM.create 103 in
         let obsolete_prim = HM.create 103 in

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -652,6 +652,7 @@ module WP =
               mark_node obsolete_ret f (Function f)
           ) changed_funs;
         (* Unknowns from partially changed functions need only to be collected for eager destabilization when reluctant is off *)
+        (* We utilize that force-reanalyzed functions are always considered as completely changed (and not partially changed) *)
         if not reluctant then (
           List.iter (fun (f, pn, _) ->
               List.iter (fun n ->

--- a/tests/incremental/01-force-reanalyze/01-int-reluctant.c
+++ b/tests/incremental/01-force-reanalyze/01-int-reluctant.c
@@ -1,0 +1,17 @@
+#include<assert.h>
+
+int f(int in){
+  while(in < 17) {
+    in++;
+  }
+  assert(in == 17); //UNKNOWN
+  return in;
+}
+
+int main() {
+  int a = 0;
+  assert(a); // FAIL!
+  a = f(a);
+  assert(a == 17); //UNKNOWN
+  return 0;
+}

--- a/tests/incremental/01-force-reanalyze/01-int-reluctant.json
+++ b/tests/incremental/01-force-reanalyze/01-int-reluctant.json
@@ -1,0 +1,20 @@
+{
+    "annotation" : {
+        "int" : {
+            "enabled" : true
+        }
+    },
+    "ana" : {
+        "int" : {
+            "refinement" : "fixpoint"
+        }
+    },
+    "incremental" : {
+        "force-reanalyze" : {
+            "funs": ["f"]
+        },
+        "reluctant" : {
+        "on": true
+        }
+    }
+}

--- a/tests/incremental/01-force-reanalyze/01-int-reluctant.json
+++ b/tests/incremental/01-force-reanalyze/01-int-reluctant.json
@@ -14,7 +14,8 @@
             "funs": ["f"]
         },
         "reluctant" : {
-        "on": true
-        }
+            "on": true
+        },
+        "verify": false
     }
 }

--- a/tests/incremental/01-force-reanalyze/01-int-reluctant.patch
+++ b/tests/incremental/01-force-reanalyze/01-int-reluctant.patch
@@ -1,0 +1,31 @@
+--- tests/incremental/01-force-reanalyze/01-int-reluctant.c
++++ tests/incremental/01-force-reanalyze/01-int-reluctant.c
+@@ -4,7 +4,7 @@ int f(int in){
+   while(in < 17) {
+     in++;
+   }
+-  assert(in == 17); //UNKNOWN
++  assert(in == 17);
+   return in;
+ }
+
+@@ -12,6 +12,6 @@ int main() {
+   int a = 0;
+   assert(a); // FAIL!
+   a = f(a);
+-  assert(a == 17); //UNKNOWN
++  assert(a == 17);
+   return 0;
+ }
+--- tests/incremental/01-force-reanalyze/01-int-reluctant.json
++++ tests/incremental/01-force-reanalyze/01-int-reluctant.json
+@@ -2,6 +2,9 @@
+     "annotation" : {
+         "int" : {
+             "enabled" : true
++        },
++        "goblint_precision": {
++            "interval" : ["f"]
+         }
+     },
+     "ana" : {

--- a/tests/incremental/01-force-reanalyze/01-int-reluctant.patch
+++ b/tests/incremental/01-force-reanalyze/01-int-reluctant.patch
@@ -1,3 +1,5 @@
+diff --git tests/incremental/01-force-reanalyze/01-int-reluctant.c tests/incremental/01-force-reanalyze/01-int-reluctant.c
+index 38187f1c0..6126fe8cf 100644
 --- tests/incremental/01-force-reanalyze/01-int-reluctant.c
 +++ tests/incremental/01-force-reanalyze/01-int-reluctant.c
 @@ -4,7 +4,7 @@ int f(int in){
@@ -8,7 +10,7 @@
 +  assert(in == 17);
    return in;
  }
-
+ 
 @@ -12,6 +12,6 @@ int main() {
    int a = 0;
    assert(a); // FAIL!
@@ -17,15 +19,19 @@
 +  assert(a == 17);
    return 0;
  }
+diff --git tests/incremental/01-force-reanalyze/01-int-reluctant.json tests/incremental/01-force-reanalyze/01-int-reluctant.json
+index d58c2254b..8834d182d 100644
 --- tests/incremental/01-force-reanalyze/01-int-reluctant.json
 +++ tests/incremental/01-force-reanalyze/01-int-reluctant.json
-@@ -2,6 +2,9 @@
+@@ -2,6 +2,11 @@
      "annotation" : {
          "int" : {
              "enabled" : true
 +        },
 +        "goblint_precision": {
-+            "interval" : ["f"]
++            "interval": [
++                "f"
++            ]
          }
      },
      "ana" : {

--- a/tests/incremental/03-precision-annotation/02-reluctant-int-annotation.c
+++ b/tests/incremental/03-precision-annotation/02-reluctant-int-annotation.c
@@ -1,0 +1,17 @@
+#include<assert.h>
+
+int f(int in){
+  while(in < 17) {
+    in++;
+  }
+  assert(in == 17); //UNKNOWN
+  return in;
+}
+
+int main() {
+  int a = 0;
+  assert(a); // FAIL!
+  a = f(a);
+  assert(a == 17); //UNKNOWN
+  return 0;
+}

--- a/tests/incremental/03-precision-annotation/02-reluctant-int-annotation.json
+++ b/tests/incremental/03-precision-annotation/02-reluctant-int-annotation.json
@@ -1,0 +1,18 @@
+{
+    "annotation": {
+        "int": {
+            "enabled": true
+        }
+    },
+    "ana": {
+        "int": {
+            "refinement": "fixpoint"
+        }
+    },
+    "incremental": {
+        "reluctant": {
+            "on": true
+        },
+        "verify": false
+    }
+}

--- a/tests/incremental/03-precision-annotation/02-reluctant-int-annotation.patch
+++ b/tests/incremental/03-precision-annotation/02-reluctant-int-annotation.patch
@@ -1,0 +1,25 @@
+diff --git tests/incremental/03-precision-annotation/02-reluctant-int-annotation.c tests/incremental/03-precision-annotation/02-reluctant-int-annotation.c
+index 38187f1c0..698e45b62 100644
+--- tests/incremental/03-precision-annotation/02-reluctant-int-annotation.c
++++ tests/incremental/03-precision-annotation/02-reluctant-int-annotation.c
+@@ -1,10 +1,11 @@
+ #include<assert.h>
+ 
++int f(int in) __attribute__ ((goblint_precision("def_exc", "interval")));
+ int f(int in){
+   while(in < 17) {
+     in++;
+   }
+-  assert(in == 17); //UNKNOWN
++  assert(in == 17);
+   return in;
+ }
+ 
+@@ -12,6 +13,6 @@ int main() {
+   int a = 0;
+   assert(a); // FAIL!
+   a = f(a);
+-  assert(a == 17); //UNKNOWN
++  assert(a == 17);
+   return 0;
+ }

--- a/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c
+++ b/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c
@@ -19,6 +19,6 @@ int main() {
   int a = 0;
   assert(a); // FAIL!
   a = fun(a);
-  assert(a == 17); //UNKOWN
+  assert(a == 17); //UNKNOWN
   return 0;
 }

--- a/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c
+++ b/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c
@@ -1,0 +1,24 @@
+#include<assert.h>
+
+typedef int int_to_int_fun (int);
+
+int f(int in){
+  while(in < 17) {
+    in++;
+  }
+  assert(in == 17); //UNKNOWN
+  return in;
+}
+
+int_to_int_fun *get_fun(){
+  return &f;
+}
+
+int main() {
+  int_to_int_fun *fun = get_fun();
+  int a = 0;
+  assert(a); // FAIL!
+  a = fun(a);
+  assert(a == 17); //UNKOWN
+  return 0;
+}

--- a/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.json
+++ b/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.json
@@ -1,0 +1,18 @@
+{
+    "annotation": {
+        "int": {
+            "enabled": true
+        }
+    },
+    "ana": {
+        "int": {
+            "refinement": "fixpoint"
+        }
+    },
+    "incremental": {
+        "reluctant": {
+            "on": true
+        },
+        "verify": false
+    }
+}

--- a/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.patch
+++ b/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.patch
@@ -1,0 +1,26 @@
+diff --git tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c
+index 58781ecd7..4d2620e84 100644
+--- tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c
++++ tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c
+@@ -2,11 +2,12 @@
+ 
+ typedef int int_to_int_fun (int);
+ 
++int f(int in) __attribute__ ((goblint_precision("def_exc", "interval")));
+ int f(int in){
+   while(in < 17) {
+     in++;
+   }
+-  assert(in == 17); //UNKNOWN
++  assert(in == 17);
+   return in;
+ }
+ 
+@@ -19,6 +20,6 @@ int main() {
+   int a = 0;
+   assert(a); // FAIL!
+   a = fun(a);
+-  assert(a == 17); //UNKOWN
++  assert(a == 17);
+   return 0;
+ }

--- a/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.patch
+++ b/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.patch
@@ -1,5 +1,5 @@
 diff --git tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c
-index 58781ecd7..4d2620e84 100644
+index 30391cdf6..4d2620e84 100644
 --- tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c
 +++ tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.c
 @@ -2,11 +2,12 @@
@@ -20,7 +20,7 @@ index 58781ecd7..4d2620e84 100644
    int a = 0;
    assert(a); // FAIL!
    a = fun(a);
--  assert(a == 17); //UNKOWN
+-  assert(a == 17); //UNKNOWN
 +  assert(a == 17);
    return 0;
  }


### PR DESCRIPTION
#### Problem
For functions for which the precision setting was changed for the incremental run, the analysis cannot be done reluctantly, as the `enter` needs to be redone for the precision adjustment to take effect, which does not happen in an reluctant incremental analysis. See issue #508.
Functions for which the precision was adjusted are listed in `incremental.force-reanalyze.funs`. Thus, a reluctant analysis should not be performed for functions contained in this set.

Note that functions for which the precision was changed *through an in-code annotation* there is no problem with the reluctant analysis: This is because the call-sites of such functions are detected as changed; thus all functions calling such a function with a new in-code precision annotation are reanalyzed. So no further changes are required for the in-code annotation case.

#### Background on reluctant incremental analysis
The reluctant analysis stores the old abstract values at the return nodes of changed functions; it omits the eager destabilization of these changed functions. Instead it calls solve on the return nodes of changed functions and checks whether the abstract state changed.

#### Description of changes
This PR adapts the reluctant analysis such that the entry nodes of functions in force-reanalyze are eagerly destabilized. This is done by collecting the function entry nodes of such functions, and performing the destabilization of  such function entry unknowns (in `obsolete_entry`) even when `reluctant` is on.  
The call to `solve` on the return node of these functions is therefore omitted. This is achieved by not collecting unknowns belonging to return nodes of functions in `incremental.force-reanalyze.funs` in `obsolete_ret`.

Closes #508.