### PR TITLE
Fix imprecise AD.meet with NULL

### DIFF
--- a/src/cdomains/addressDomain.ml
+++ b/src/cdomains/addressDomain.ml
@@ -125,7 +125,7 @@ struct
       else remove Addr.NullPtr x
     in
     match is_top x, is_top y with
-    | true, true -> uop x y
+    | true, true -> no_null (no_null (uop x y) x) y
     | false, true -> no_null x y
     | true, false -> no_null y x
     | false, false -> cop x y

--- a/tests/regression/27-inv_invariants/15-unknown-null-ptr.c
+++ b/tests/regression/27-inv_invariants/15-unknown-null-ptr.c
@@ -6,10 +6,10 @@ int main() {
   if (r == NULL)
     assert(r == NULL);
   else
-    assert(r != NULL); // TODO
+    assert(r != NULL);
 
   if (r != NULL)
-    assert(r != NULL); // TODO
+    assert(r != NULL);
   else
     assert(r == NULL);
 

--- a/tests/regression/27-inv_invariants/16-sedgewick.c
+++ b/tests/regression/27-inv_invariants/16-sedgewick.c
@@ -1,0 +1,26 @@
+#include <stddef.h>
+#include <assert.h>
+
+struct node {
+  struct node *left;
+  struct node *right;
+  int key;
+};
+
+// https://old.reddit.com/r/programminghorror/comments/jgrpcu/on_sedgewicks_original_presentation_for_llrb_trees/
+struct node* min(struct node *root) {
+  struct node *x = root;
+  while (x != NULL)
+    x = x->left;
+  if (x == NULL) // WARN (dead branch)
+    return NULL;
+  else
+    return x;
+}
+
+int main() {
+  struct node *root;
+  struct node *m = min(root);
+  assert(m == NULL);
+  return 0;
+}


### PR DESCRIPTION
Closes #566.

The `merge`/`meet` of address domain handles address sets containing the unknown pointer specially: if both contain unknown, the known addresses are actually joined to be a bit more sound when it comes to invalidating etc address sets containing _some_ known pointers as well.
In two cases special logic was used to get rid of a `NULL` if possible, but now that's also done in the case where both contain unknown. So `meet {?, NULL} {?} = {?}`, which fixes the invariant imprecision.