### PR TITLE
Call `sync` after `assign` transfer function in global initializers to make `None` privatization work properly

### DIFF
--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -275,7 +275,11 @@ struct
               (try funs := Cilfacade.find_varinfo_fundec f :: !funs with Not_found -> ())
             | _ -> ()
           );
-          Spec.assign {ctx with local = st} lval exp
+          let res = Spec.assign {ctx with local = st} lval exp in
+          (* Needed for privatizations (e.g. None) that do not side immediately *)
+          let res' = Spec.sync {ctx with local = res} `Normal in
+          if M.tracing then M.trace "global_inits" "\t\t -> state:%a\n" Spec.D.pretty res;
+          res'
         | _                       -> failwith "Unsupported global initializer edge"
       in
       let with_externs = do_extern_inits ctx file in

--- a/tests/regression/00-sanity/30-both_branches.c
+++ b/tests/regression/00-sanity/30-both_branches.c
@@ -16,6 +16,7 @@ int main(int argc , char **argv )
   int rc = 0;
 
   assert(sqlite3Config.blarg == 0);
+  assert(sqlite3Config.m.iValdue == 0);
 
   if ((unsigned long )sqlite3Config.blarg == (unsigned long )((void *(*)(int  ))0)) {
       rc = 5;

--- a/tests/regression/00-sanity/30-both_branches.c
+++ b/tests/regression/00-sanity/30-both_branches.c
@@ -15,6 +15,8 @@ int main(int argc , char **argv )
 {
   int rc = 0;
 
+  assert(sqlite3Config.blarg == 0);
+  
   if ((unsigned long )sqlite3Config.blarg == (unsigned long )((void *(*)(int  ))0)) {
       rc = 5;
   }

--- a/tests/regression/00-sanity/30-both_branches.c
+++ b/tests/regression/00-sanity/30-both_branches.c
@@ -16,7 +16,7 @@ int main(int argc , char **argv )
   int rc = 0;
 
   assert(sqlite3Config.blarg == 0);
-  
+
   if ((unsigned long )sqlite3Config.blarg == (unsigned long )((void *(*)(int  ))0)) {
       rc = 5;
   }

--- a/tests/regression/00-sanity/30-both_branches.c
+++ b/tests/regression/00-sanity/30-both_branches.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.base.privatization none --enable exp.earlyglobs
+// PARAM: --set ana.base.privatization none --enable exp.earlyglobs --disable exp.fast_global_inits
 union bloirg {
    int iValdue ;
 };

--- a/tests/regression/00-sanity/30-both_branches.c
+++ b/tests/regression/00-sanity/30-both_branches.c
@@ -1,0 +1,28 @@
+
+union bloirg {
+   char *zToken ;
+   int iValue ;
+};
+
+
+struct Sqlite3Config {
+   union bloirg m ;
+   int* blarg;
+};
+
+struct Sqlite3Config sqlite3Config;
+
+
+int main(int argc , char **argv )
+{
+   int rc = 0;
+
+  if ((unsigned long )sqlite3Config.blarg == (unsigned long )((void *(*)(int  ))0)) {
+      rc = 5;
+  }
+
+  rc = 1;
+  assert(1);
+
+   int r = 8;
+}

--- a/tests/regression/00-sanity/30-both_branches.c
+++ b/tests/regression/00-sanity/30-both_branches.c
@@ -1,4 +1,4 @@
-
+// PARAM: --set ana.base.privatization none --enable exp.earlyglobs
 union bloirg {
    char *zToken ;
    int iValue ;

--- a/tests/regression/00-sanity/30-both_branches.c
+++ b/tests/regression/00-sanity/30-both_branches.c
@@ -1,9 +1,7 @@
 // PARAM: --set ana.base.privatization none --enable exp.earlyglobs
 union bloirg {
-   char *zToken ;
-   int iValue ;
+   int iValdue ;
 };
-
 
 struct Sqlite3Config {
    union bloirg m ;
@@ -15,14 +13,11 @@ struct Sqlite3Config sqlite3Config;
 
 int main(int argc , char **argv )
 {
-   int rc = 0;
+  int rc = 0;
 
   if ((unsigned long )sqlite3Config.blarg == (unsigned long )((void *(*)(int  ))0)) {
       rc = 5;
   }
 
-  rc = 1;
   assert(1);
-
-   int r = 8;
 }


### PR DESCRIPTION
Short version: Some privatizations (e.g. `None`) do not immediately side-effect globals but keep them in the local state to be side-effected upon `sync`. 
For global initializers, the call to the `sync` transfer function that gets added by the `FromSpec` functor automatically inside the solver needs to be called manually after `assign`, to ensure the values do get side-effected as expected.

**Longer version**:

The writes always happened to the local state, but the value was correctly read from the globals. Thus, e.g. for structs, the value read from the global was always `ValueDomain.bot ()` (our default for values that are not found), which lead to Goblint creating a `bot` of the appropriate type for the variable, and then updating one of its components. By this mechanism, only the last component to be updated arrived in the information that was passed to the solver, while all other components had the value of their appropriate `bot`.

Thus, in the example that I added (extracted from https://github.com/goblint/bench/issues/19), either `sqlite3Config.blarg` or `sqlite3Config.m.iValdue` would have the value bot of their type (instead of `{NULL}` and `0` respectively)

If it was `sqlite3Config.blarg` that was `{}`, this lead to both branches over the if being dead, and control flow dying out at this if and never reaching the end of `main`.

Final twist: The initializers are stored inside a hashtable that also includes the location of the declarations. Thus, a change in whitespace could change which one of these initializers happens last, and by extension whether control flow actually reaches the end of main or not in the example. (such fun to debug things like this)