### PR TITLE
Optimize CFG construction

### DIFF
--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -111,10 +111,10 @@ let computeSCCs (module Cfg: CfgBidir) nodes =
     let sccs = List.fold_left (fun sccs node ->
         if not (NH.mem node_scc node) then
           let scc = {
-              nodes = NH.create 25;
-              next = NH.create 5;
-              prev = NH.create 5
-            }
+            nodes = NH.create 1;
+            next = NH.create 1;
+            prev = NH.create 1
+          }
           in
           dfs_inner node scc;
           scc :: sccs

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -470,7 +470,8 @@ let createCFG (file: file) =
       | _ -> ()
     );
   if Messages.tracing then Messages.trace "cfg" "CFG building finished.\n\n";
-  ignore (Pretty.eprintf "cfgF (%a), cfgB (%a)\n" GobHashtbl.pretty_statistics (GobHashtbl.magic_stats cfgF) GobHashtbl.pretty_statistics (GobHashtbl.magic_stats cfgB));
+  if get_bool "dbg.verbose" then
+    ignore (Pretty.eprintf "cfgF (%a), cfgB (%a)\n" GobHashtbl.pretty_statistics (GobHashtbl.magic_stats cfgF) GobHashtbl.pretty_statistics (GobHashtbl.magic_stats cfgB));
   cfgF, cfgB
 
 let createCFG = Stats.time "createCFG" createCFG

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -467,6 +467,14 @@ let createCFG (file: file) =
       | _ -> ()
     );
   if Messages.tracing then Messages.trace "cfg" "CFG building finished.\n\n";
+  let module NH2 = Hashtbl.Make (Node) in
+  let stats (h: 'a NH.t) =
+    let h': 'a NH2.t = Obj.magic h in
+    let s = NH2.stats h' in
+    Format.eprintf "stats: bindings=%d buckets=%d max_length=%d histo=%a\n" s.num_bindings s.num_buckets s.max_bucket_length (Format.pp_print_list ~pp_sep:(fun f () -> Format.pp_print_char f ',') Format.pp_print_int) (Array.to_list s.bucket_histogram);
+  in
+  stats cfgF;
+  stats cfgB;
   cfgF, cfgB
 
 let createCFG = Stats.time "createCFG" createCFG

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -468,14 +468,7 @@ let createCFG (file: file) =
       | _ -> ()
     );
   if Messages.tracing then Messages.trace "cfg" "CFG building finished.\n\n";
-  let module NH2 = Hashtbl.Make (Node) in
-  let stats (h: 'a NH.t) =
-    let h': 'a NH2.t = Obj.magic h in
-    let s = NH2.stats h' in
-    Format.eprintf "stats: bindings=%d buckets=%d max_length=%d histo=%a load=%f\n" s.num_bindings s.num_buckets s.max_bucket_length (Format.pp_print_list ~pp_sep:(fun f () -> Format.pp_print_char f ',') Format.pp_print_int) (Array.to_list s.bucket_histogram) (float_of_int s.num_bindings /. float_of_int s.num_buckets);
-  in
-  stats cfgF;
-  stats cfgB;
+  ignore (Pretty.eprintf "cfgF (%a), cfgB (%a)\n" GobHashtbl.pretty_statistics (GobHashtbl.magic_stats cfgF) GobHashtbl.pretty_statistics (GobHashtbl.magic_stats cfgB));
   cfgF, cfgB
 
 let createCFG = Stats.time "createCFG" createCFG

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -472,7 +472,7 @@ let createCFG (file: file) =
   let stats (h: 'a NH.t) =
     let h': 'a NH2.t = Obj.magic h in
     let s = NH2.stats h' in
-    Format.eprintf "stats: bindings=%d buckets=%d max_length=%d histo=%a\n" s.num_bindings s.num_buckets s.max_bucket_length (Format.pp_print_list ~pp_sep:(fun f () -> Format.pp_print_char f ',') Format.pp_print_int) (Array.to_list s.bucket_histogram);
+    Format.eprintf "stats: bindings=%d buckets=%d max_length=%d histo=%a load=%f\n" s.num_bindings s.num_buckets s.max_bucket_length (Format.pp_print_list ~pp_sep:(fun f () -> Format.pp_print_char f ',') Format.pp_print_int) (Array.to_list s.bucket_histogram) (float_of_int s.num_bindings /. float_of_int s.num_buckets);
   in
   stats cfgF;
   stats cfgB;

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -136,6 +136,8 @@ let computeSCCs (module Cfg: CfgBidir) nodes =
   );
   r
 
+let computeSCCs x = Stats.time "computeSCCs" (computeSCCs x)
+
 let rec pretty_edges () = function
   | [] -> Pretty.dprintf ""
   | [_,x] -> Edge.pretty_plain () x
@@ -380,7 +382,7 @@ let createCFG (file: file) =
           | ComputedGoto _ ->
             failwith "MyCFG.createCFG: unsupported stmt"
         in
-        List.iter handle fd.sallstmts;
+        Stats.time "handle" (List.iter handle) fd.sallstmts;
 
         if Messages.tracing then Messages.trace "cfg" "Over\n";
 
@@ -455,7 +457,7 @@ let createCFG (file: file) =
           else
             NH.iter (NH.add node_scc_global) node_scc; (* there's no merge inplace *)
         in
-        iter_connect ();
+        Stats.time "iter_connect" iter_connect ();
 
         (* Verify that function is now connected *)
         let reachable_return' = find_backwards_reachable (module TmpCfg) (Function fd) in
@@ -466,6 +468,8 @@ let createCFG (file: file) =
     );
   if Messages.tracing then Messages.trace "cfg" "CFG building finished.\n\n";
   cfgF, cfgB
+
+let createCFG = Stats.time "createCFG" createCFG
 
 
 let minimizeCFG (fw,bw) =

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -717,7 +717,7 @@ struct
         | Some scc when NodeH.mem scc.prev v && NodeH.length scc.prev = 1 ->
           (* Limited to loops with only one entry node. Otherwise unsound as is. *)
           (* TODO: Is it possible to do soundly for multi-entry loops? *)
-          let stricts = NodeH.find_all scc.prev v in
+          let stricts = NodeH.find_default scc.prev v [] in
           let xs_stricts = List.map tf' stricts in
           if List.for_all S.D.is_bot xs_stricts then
             S.D.bot ()

--- a/src/util/gobHashtbl.ml
+++ b/src/util/gobHashtbl.ml
@@ -1,0 +1,7 @@
+let magic_stats h =
+  let h: _ Hashtbl.t = Obj.magic h in (* Batteries Hashtables don't expose stats yet...: https://github.com/ocaml-batteries-team/batteries-included/pull/1079 *)
+  Hashtbl.stats h
+
+let pretty_statistics () (s: Hashtbl.statistics) =
+  let load_factor = float_of_int s.num_bindings /. float_of_int s.num_buckets in
+  Pretty.dprintf "bindings=%d buckets=%d max_length=%d histo=%a load=%f" s.num_bindings s.num_buckets s.max_bucket_length (Pretty.docList (Pretty.dprintf "%d")) (Array.to_list s.bucket_histogram) load_factor


### PR DESCRIPTION
In light of #603, I spent a bunch of time myself trying to understand what's going on and finding ways to optimize the situation. These changes have been cherry-picked from #609 as they should be in working condition and mergeable.

### Changes
1. Add timing to CFG construction with minimal indent changes.
2. Output CFG hashtable statistics.
3. Replace `add` and `find_all` with `replace` and the values being lists. This gives equivalent multimap behavior but makes it more explicit and notably keeps the hashtable bucket sizes much smaller. For example, on a subset of 50 OpenSSL files, instead of maximum bucket length of 198, it now is 9.
4. Decrease initial sizes of some hashtables. Otherwise there are large amounts of hashtables that have very low load factor, so they allocate unnecessarily long arrays for a handful of elements. This is also detrimental to memory usage and caching.

### TODO
- [x] Decrease initial sizes of more hashtables.
- [x] Change multimap presentation in SCCs as well.