### PR TITLE
Do not allow to collect globals with duplicate identifiers in map

### DIFF
--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -69,7 +69,13 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
 
   let addGlobal map global  =
     try
-      GlobalMap.add (identifier_of_global global) global map
+      let gid = identifier_of_global global in
+      let gid_to_string gid = match gid.global_t with
+        | Var -> "Var " ^ gid.name
+        | Decl -> "Decl " ^ gid.name
+        | Fun -> "Fun " ^ gid.name
+        | _ -> raise (NoGlobalIdentifier global) in
+      if GlobalMap.mem gid map then failwith ("Duplicate global identifier: " ^ gid_to_string gid) else GlobalMap.add gid global map
     with
       NoGlobalIdentifier _ -> map
   in


### PR DESCRIPTION
The general comparison for the incremental analysis (used for both, the cfg and ast comparison) assumes that globals have a unique identifier. But it is not warned if this is not the case. Instead, the incremental analysis run will often fail later on in `UpdateCil.ml` because `List.iter2` expects lists of the same length. This happened for example in https://github.com/goblint/bench/issues/16.
This PR only inserts a warning when globals with duplicate identifiers are found to make it easier for now to detect this problem. One could of course also think further about how to make the comparison robust against globals with the same name.