### PR TITLE
Quote source code in messages output

### DIFF
--- a/src/util/messages.ml
+++ b/src/util/messages.ml
@@ -184,18 +184,15 @@ let print ?(ppf= !formatter) (m: Message.t) =
         | _ -> assert false
       end
   in
-  let pp_piece1 ppf piece =
+  let pp_piece ppf piece =
     let pp_cut_quote ppf = Format.fprintf ppf "@,@[<v 0>%a@,@]" (Format.pp_print_option pp_quote) in
     Format.fprintf ppf "%a%a" pp_piece piece pp_cut_quote piece.loc
   in
-  let pp_piece2 ppf piece =
-    let pp_cut_quote ppf = Format.fprintf ppf "@,@[<v 0>%a@,@]" (Format.pp_print_option pp_quote) in
-    Format.fprintf ppf "@[<v 2>%a%a@]" pp_piece piece pp_cut_quote piece.loc
-  in
   let pp_multipiece ppf = match m.multipiece with
     | Single piece ->
-      pp_piece1 ppf piece
+      pp_piece ppf piece
     | Group {group_text; pieces} ->
+      let pp_piece2 ppf = Format.fprintf ppf "@[<v 2>%a@]" pp_piece in (* indented box for quote *)
       Format.fprintf ppf "@{<%s>%s:@}@,@[<v>%a@]" severity_stag group_text (Format.pp_print_list pp_piece2) pieces
   in
   Format.fprintf ppf "@[<v 2>%t %t@]\n%!" pp_prefix pp_multipiece

--- a/src/util/messages.ml
+++ b/src/util/messages.ml
@@ -172,7 +172,7 @@ let print ?(ppf= !formatter) (m: Message.t) =
       let prefix = BatString.slice ~last:(loc.column - 1) line in
       let middle = BatString.slice ~first:(loc.column - 1) ~last:(loc.endColumn - 1) line in
       let suffix = BatString.slice ~first:(loc.endColumn - 1) line in
-      Format.fprintf ppf "@{<turquoise>%s@}@{<TURQUOISE>%s@}@{<turquoise>%s@}" prefix middle suffix
+      Format.fprintf ppf "%s@{<turquoise>%s@}%s" prefix middle suffix
     | first :: rest ->
       begin match BatList.split_at (List.length rest - 1) rest with
         | (middles, [last]) ->
@@ -180,7 +180,7 @@ let print ?(ppf= !formatter) (m: Message.t) =
           let first_middle = BatString.slice ~first:(loc.column - 1) first in
           let last_middle = BatString.slice ~last:(loc.endColumn - 1) last in
           let last_suffix = BatString.slice ~first:(loc.endColumn - 1) last in
-          Format.fprintf ppf "@{<turquoise>%s@}@{<TURQUOISE>%a@}@{<turquoise>%s@}" first_prefix (Format.pp_print_list Format.pp_print_string) (first_middle :: middles @ [last_middle]) last_suffix
+          Format.fprintf ppf "%s@{<turquoise>%a@}%s" first_prefix (Format.pp_print_list Format.pp_print_string) (first_middle :: middles @ [last_middle]) last_suffix
         | _ -> assert false
       end
   in

--- a/src/util/messages.ml
+++ b/src/util/messages.ml
@@ -161,11 +161,42 @@ let print ?(ppf= !formatter) (m: Message.t) =
     let pp_loc ppf = Format.fprintf ppf " @{<violet>(%a)@}" CilType.Location.pp in
     Format.fprintf ppf "@{<%s>%s@}%a" severity_stag (Piece.text_with_context piece) (Format.pp_print_option pp_loc) piece.loc
   in
+  let pp_quote ppf (loc: Cil.location) =
+    let lines = BatFile.lines_of loc.file in
+    BatEnum.drop (loc.line - 1) lines;
+    let lines = BatEnum.take (loc.endLine - loc.line + 1) lines in
+    let lines = BatList.of_enum lines in
+    match lines with
+    | [] -> assert false
+    | [line] ->
+      let prefix = BatString.slice ~last:(loc.column - 1) line in
+      let middle = BatString.slice ~first:(loc.column - 1) ~last:(loc.endColumn - 1) line in
+      let suffix = BatString.slice ~first:(loc.endColumn - 1) line in
+      Format.fprintf ppf "@{<turquoise>%s@}@{<TURQUOISE>%s@}@{<turquoise>%s@}" prefix middle suffix
+    | first :: rest ->
+      begin match BatList.split_at (List.length rest - 1) rest with
+        | (middles, [last]) ->
+          let first_prefix = BatString.slice ~last:(loc.column - 1) first in
+          let first_middle = BatString.slice ~first:(loc.column - 1) first in
+          let last_middle = BatString.slice ~last:(loc.endColumn - 1) last in
+          let last_suffix = BatString.slice ~first:(loc.endColumn - 1) last in
+          Format.fprintf ppf "@{<turquoise>%s@}@{<TURQUOISE>%a@}@{<turquoise>%s@}" first_prefix (Format.pp_print_list Format.pp_print_string) (first_middle :: middles @ [last_middle]) last_suffix
+        | _ -> assert false
+      end
+  in
+  let pp_piece1 ppf piece =
+    let pp_cut_quote ppf = Format.fprintf ppf "@,@[<v 0>%a@,@]" (Format.pp_print_option pp_quote) in
+    Format.fprintf ppf "%a%a" pp_piece piece pp_cut_quote piece.loc
+  in
+  let pp_piece2 ppf piece =
+    let pp_cut_quote ppf = Format.fprintf ppf "@,@[<v 0>%a@,@]" (Format.pp_print_option pp_quote) in
+    Format.fprintf ppf "@[<v 2>%a%a@]" pp_piece piece pp_cut_quote piece.loc
+  in
   let pp_multipiece ppf = match m.multipiece with
     | Single piece ->
-      pp_piece ppf piece
+      pp_piece1 ppf piece
     | Group {group_text; pieces} ->
-      Format.fprintf ppf "@{<%s>%s:@}@,@[<v>%a@]" severity_stag group_text (Format.pp_print_list pp_piece) pieces
+      Format.fprintf ppf "@{<%s>%s:@}@,@[<v>%a@]" severity_stag group_text (Format.pp_print_list pp_piece2) pieces
   in
   Format.fprintf ppf "@[<v 2>%t %t@]\n%!" pp_prefix pp_multipiece
 

--- a/src/util/messages.ml
+++ b/src/util/messages.ml
@@ -185,8 +185,12 @@ let print ?(ppf= !formatter) (m: Message.t) =
       end
   in
   let pp_piece ppf piece =
-    let pp_cut_quote ppf = Format.fprintf ppf "@,@[<v 0>%a@,@]" (Format.pp_print_option pp_quote) in
-    Format.fprintf ppf "%a%a" pp_piece piece pp_cut_quote piece.loc
+    if get_bool "warn.quote-code" then (
+      let pp_cut_quote ppf = Format.fprintf ppf "@,@[<v 0>%a@,@]" (Format.pp_print_option pp_quote) in
+      Format.fprintf ppf "%a%a" pp_piece piece pp_cut_quote piece.loc
+    )
+    else
+      pp_piece ppf piece
   in
   let pp_multipiece ppf = match m.multipiece with
     | Single piece ->

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1598,6 +1598,12 @@
           "description": "Success severity messages",
           "type": "boolean",
           "default": true
+        },
+        "quote-code": {
+          "title": "warn.quote-code",
+          "description": "Quote code in message output.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Here's a fun feature that nobody asked for! Quoting of relevant source code _a la_ any normal compiler:
```
[Success][Assert] Assertion "success" will succeed (tests/regression/00-sanity/01-assert.c:9:3-9:18)
    assert(success);
  
[Error][Assert] Assertion "fail" will fail. (tests/regression/00-sanity/01-assert.c:10:3-10:15)
    assert(fail); // FAIL!
  
[Warning][Assert] Assertion "unknown == 4" is unknown. (tests/regression/00-sanity/01-assert.c:11:3-11:23)
    assert(unknown == 4); // UNKNOWN!
  
[Warning][Deadcode] Function 'main' has dead code:
  on line 13 (tests/regression/00-sanity/01-assert.c:13-13)
      assert(silence); // NOWARN!
```
Also works for multiline location ranges and in a terminal the range is highlighted with a turquoise color (the only color that our rainbow :rainbow: output doesn't yet use).

It is disabled via `warn.quote-code` by default since getting the quotes for all messages involves opening the files to read out the corresponding lines, which might otherwise negatively impact benchmarking.