### PR TITLE
Fix unnecessary initial double parsing in server mode with reparse

### DIFF
--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -170,7 +170,7 @@ struct
         (* If the function is not defined, and yet has been included to the
           * analysis result, we generate a warning. *)
         with Not_found ->
-          Messages.warn "Calculated state for undefined function: unexpected node %a" Node.pretty_plain n
+          Messages.warn "Calculated state for undefined function: unexpected node %a" Node.pretty_trace n
     in
     LHT.iter add_local_var h;
     res

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -170,7 +170,7 @@ struct
         (* If the function is not defined, and yet has been included to the
           * analysis result, we generate a warning. *)
         with Not_found ->
-          Messages.warn "Calculated state for undefined function: unexpected node %a" Node.pretty_trace n
+          Messages.debug ~category:Analyzer ~loc:(CilLocation loc) "Calculated state for undefined function: unexpected node %a" Node.pretty_trace n
     in
     LHT.iter add_local_var h;
     res

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -24,8 +24,8 @@ let pretty_plain_short () = function
 (** Pretty node for solver variable tracing with short stmt. *)
 let pretty_trace () = function
   | Statement stmt   -> dprintf "node %d \"%a\"" stmt.sid Cilfacade.stmt_pretty_short stmt
-  | Function      fd -> dprintf "call of %s" fd.svar.vname
-  | FunctionEntry fd -> dprintf "entry state of %s" fd.svar.vname
+  | Function      fd -> dprintf "call of %s (%d)" fd.svar.vname fd.svar.vid
+  | FunctionEntry fd -> dprintf "entry state of %s (%d)" fd.svar.vname fd.svar.vid
 
 (** Output functions for Printable interface *)
 let pretty () x = pretty_trace () x

--- a/src/goblint.ml
+++ b/src/goblint.ml
@@ -23,18 +23,30 @@ let main () =
       print_endline (localtime ());
       print_endline command;
     );
-    let file = Fun.protect ~finally:GoblintDir.finalize preprocess_and_merge in
-    if get_bool "server.enabled" then Server.start file else (
+    let file = lazy (Fun.protect ~finally:GoblintDir.finalize preprocess_and_merge) in
+    if get_bool "server.enabled" then (
+      let file =
+        if get_bool "server.reparse" then
+          None
+        else
+          Some (Lazy.force file)
+      in
+      Server.start file
+    )
+    else (
+      let file = Lazy.force file in
       let changeInfo =
         if GobConfig.get_bool "incremental.load" || GobConfig.get_bool "incremental.save" then
           diff_and_rename file
         else
-          Analyses.empty_increment_data file in
-      file|> do_analyze changeInfo;
+          Analyses.empty_increment_data file
+      in
+      file |> do_analyze changeInfo;
       do_stats ();
       do_html_output ();
       do_gobview ();
-      if !verified = Some false then exit 3)  (* verifier failed! *)
+      if !verified = Some false then exit 3 (* verifier failed! *)
+    )
   with
   | Exit ->
     exit 1

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -6,6 +6,8 @@ open MyCFG
 include UpdateCil0
 
 let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_identifier, Cil.global) Hashtbl.t) (changes: change_info) =
+  UpdateCil0.init (); (* reset for server mode *)
+
   let vid_max = ref ids.max_vid in
   let sid_max = ref ids.max_sid in
 

--- a/src/incremental/updateCil0.ml
+++ b/src/incremental/updateCil0.ml
@@ -4,6 +4,9 @@ module NodeMap = Hashtbl.Make(Node0)
 
 let location_map = ref (NodeMap.create 103: Cil.location NodeMap.t)
 
+let init () =
+  NodeMap.clear !location_map
+
 let getLoc (node: Node0.t) =
   (* In case this belongs to a changed function, we will find the true location in the map*)
   try

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -490,6 +490,7 @@ let find_original_name vi = VarinfoH.find_opt (ResettableLazy.force original_nam
 
 
 let reset_lazy () =
+  StmtH.clear pseudo_return_to_fun;
   ResettableLazy.reset stmt_fundecs;
   ResettableLazy.reset varinfo_fundecs;
   ResettableLazy.reset name_fundecs;

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -4,7 +4,7 @@ open Jsonrpc
 exception Failure of Response.Error.Code.t * string
 
 type t = {
-  mutable file: Cil.file;
+  mutable file: Cil.file option;
   mutable version_map: (CompareCIL.global_identifier, Cil.global) Hashtbl.t;
   mutable max_ids: VersionLookup.max_ids;
   input: IO.input;
@@ -80,7 +80,11 @@ let serve serv =
     )
 
 let make ?(input=stdin) ?(output=stdout) file : t =
-  let version_map, max_ids = VersionLookup.create_map file in
+  let version_map, max_ids =
+    match file with
+    | Some file -> VersionLookup.create_map file
+    | None -> VersionLookup.create_map Cil.dummyFile (* TODO: avoid this altogether *)
+  in
   {
     file;
     version_map;
@@ -111,8 +115,19 @@ let start file =
 let reparse (s: t) =
   if GobConfig.get_bool "server.reparse" then (
     GoblintDir.init ();
-    Fun.protect ~finally:GoblintDir.finalize Maingoblint.preprocess_and_merge, true)
-  else s.file, false
+    let file = Fun.protect ~finally:GoblintDir.finalize Maingoblint.preprocess_and_merge in
+    begin match s.file with
+      | None ->
+        let version_map, max_ids = VersionLookup.create_map file in
+        s.version_map <- version_map;
+        s.max_ids <- max_ids
+      | Some _ ->
+        ()
+    end;
+    (file, true)
+  )
+  else
+    (Option.get s.file, false)
 
 (* Only called when the file has not been reparsed, so we can skip the expensive CFG comparison. *)
 let virtual_changes file =
@@ -124,9 +139,10 @@ let virtual_changes file =
 
 let increment_data (s: t) file reparsed = match !Serialize.server_solver_data with
   | Some solver_data when reparsed ->
-    let _, changes = VersionLookup.updateMap s.file file s.version_map in
-    let old_data = Some { Analyses.cil_file = s.file; solver_data } in
-    s.max_ids <- UpdateCil.update_ids s.file s.max_ids file s.version_map changes;
+    let s_file = Option.get s.file in
+    let _, changes = VersionLookup.updateMap s_file file s.version_map in
+    let old_data = Some { Analyses.cil_file = s_file; solver_data } in
+    s.max_ids <- UpdateCil.update_ids s_file s.max_ids file s.version_map changes;
     (* TODO: get globals for restarting from config *)
     { Analyses.changes; old_data; new_file = file; restarting = [] }, false
   | Some solver_data ->
@@ -151,12 +167,12 @@ let analyze ?(reset=false) (s: t) =
   WideningThresholds.reset_lazy ();
   IntDomain.reset_lazy ();
   ApronDomain.reset_lazy ();
-  s.file <- file;
+  s.file <- Some file;
   GobConfig.set_bool "incremental.load" (not fresh);
   Fun.protect ~finally:(fun () ->
       GobConfig.set_bool "incremental.load" true
     ) (fun () ->
-      Maingoblint.do_analyze increment_data s.file
+      Maingoblint.do_analyze increment_data (Option.get s.file)
     )
 
 let () =

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -140,9 +140,10 @@ let virtual_changes file =
 let increment_data (s: t) file reparsed = match !Serialize.server_solver_data with
   | Some solver_data when reparsed ->
     let s_file = Option.get s.file in
-    let _, changes = VersionLookup.updateMap s_file file s.version_map in
+    let version_map, changes = VersionLookup.updateMap s_file file s.version_map in
     let old_data = Some { Analyses.cil_file = s_file; solver_data } in
     s.max_ids <- UpdateCil.update_ids s_file s.max_ids file s.version_map changes;
+    s.version_map <- version_map;
     (* TODO: get globals for restarting from config *)
     { Analyses.changes; old_data; new_file = file; restarting = [] }, false
   | Some solver_data ->


### PR DESCRIPTION
Closes #623.

When starting server mode without reparse, input files are parsed once at the beginning, just like for normal analysis. When starting server mode with reparse, they were similarly parsed, but when invoking the first analyze command, it repeated parsing the input files. In the latter case, the initial parsing is pointless.

To my surprise, this fixes the issue. I think the problematic statement came from that initial parse and the first reparse in the server mode somehow screws something up. There might be a deeper issue with the incrementality and reparsing in server mode, but I couldn't figure out what that would be.

Additionally this PR includes a couple of additional global data resets in server mode that I initially thought might be the cause.