### PR TITLE
Hack incremental accesses to only restart during postsolving

### DIFF
--- a/scripts/test-incremental.sh
+++ b/scripts/test-incremental.sh
@@ -19,7 +19,7 @@ patch -p0 -b <$patch
 
 ./goblint --conf $conf $args --enable incremental.load --set save_run $base/$test-incrementalrun $source &> $base/$test.after.incr.log
 ./goblint --conf $conf $args --enable incremental.only-rename --set save_run $base/$test-originalrun $source &> $base/$test.after.scratch.log
-./goblint --conf $conf --enable solverdiffs --compare_runs $base/$test-originalrun $base/$test-incrementalrun $source
+./goblint --conf $conf --disable dbg.compare_runs.glob --enable solverdiffs --compare_runs $base/$test-originalrun $base/$test-incrementalrun $source
 
 patch -p0 -b -R <$patch
 rm -r $base/$test-originalrun $base/$test-incrementalrun

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -25,6 +25,7 @@ struct
   module V =
   struct
     include Printable.Either (V0) (CilType.Varinfo)
+    let name () = "access" (* HACK: incremental accesses rely on this! *)
     let access x = `Left x
     let vars x = `Right x
   end

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -40,8 +40,6 @@ struct
     | _ -> Local
   let name () = "variables"
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
-  let var_id _ = "globals"
-  let node _ = MyCFG.Function Cil.dummyFunDec
 
   let arbitrary () = MyCheck.Arbitrary.varinfo
 end

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -71,7 +71,7 @@ struct
   let contexts x = `Right x
 
   (* from Basetype.Variables *)
-  let var_id _ = "globals"
+  let var_id = show (* HACK: incremental accesses rely on this! *)
   let node _ = MyCFG.Function Cil.dummyFunDec
   let pretty_trace = pretty
 end

--- a/tests/incremental/11-restart/12-mutex-simple.c
+++ b/tests/incremental/11-restart/12-mutex-simple.c
@@ -1,0 +1,23 @@
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  myglobal=myglobal+1; // RACE!
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex2);
+  myglobal=myglobal+1; // RACE!
+  pthread_mutex_unlock(&mutex2);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/incremental/11-restart/12-mutex-simple.json
+++ b/tests/incremental/11-restart/12-mutex-simple.json
@@ -1,0 +1,9 @@
+{
+    "incremental": {
+        "restart": {
+            "sided": {
+                "enabled": false
+            }
+        }
+    }
+}

--- a/tests/incremental/11-restart/12-mutex-simple.patch
+++ b/tests/incremental/11-restart/12-mutex-simple.patch
@@ -1,0 +1,24 @@
+--- tests/incremental/11-restart/12-mutex-simple.c
++++ tests/incremental/11-restart/12-mutex-simple.c
+@@ -7,7 +7,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+ void *t_fun(void *arg) {
+   pthread_mutex_lock(&mutex1);
+-  myglobal=myglobal+1; // RACE!
++  myglobal=myglobal+1; // NORACE
+   pthread_mutex_unlock(&mutex1);
+   return NULL;
+ }
+@@ -15,9 +15,9 @@ void *t_fun(void *arg) {
+ int main(void) {
+   pthread_t id;
+   pthread_create(&id, NULL, t_fun, NULL);
+-  pthread_mutex_lock(&mutex2);
+-  myglobal=myglobal+1; // RACE!
+-  pthread_mutex_unlock(&mutex2);
++  pthread_mutex_lock(&mutex1);
++  myglobal=myglobal+1; // NORACE
++  pthread_mutex_unlock(&mutex1);
+   pthread_join (id, NULL);
+   return 0;
+ }


### PR DESCRIPTION
This is on top of #391.

I'm _not_ proud to present this hack to restart incremental accesses only during postsolving. This (hopefully) works for the same reason incremental warnings work, but instead of a new generic interface this is the crudest possible way to achieve the same. **No guarantees!**