### PR TITLE
Add option `files`

### DIFF
--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -111,6 +111,11 @@ let option_spec_list =
 let parse_arguments () =
   let anon_arg = set_string "files[+]" in
   Arg.parse option_spec_list anon_arg "Look up options using 'goblint --help'.";
+  if get_string_list "files" = [] then (
+    prerr_endline "No files for Goblint?";
+    prerr_endline "Try `goblint --help' for more information.";
+    raise Exit
+  );
   if !writeconffile <> "" then (GobConfig.write_file !writeconffile; raise Exit)
 
 (** Initialize some globals in other modules. *)
@@ -291,8 +296,8 @@ let merge_preprocessed cpp_file_names =
   let merged_AST =
     match files_AST with
     | [one] -> Cilfacade.callConstructors one
-    | [] -> prerr_endline "No arguments for Goblint?";
-      prerr_endline "Try `goblint --help' for more information.";
+    | [] ->
+      prerr_endline "No files to analyze!";
       raise Exit
     | xs -> Cilfacade.getMergedAST xs |> Cilfacade.callConstructors
   in

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -251,14 +251,14 @@ let preprocess_files () =
       [basic_preprocess ~all_cppflags filename]
   in
 
-  let extra_arg_files = ref [] in
+  let extra_files = ref [] in
 
-  extra_arg_files := find_custom_include "stdlib.c" :: find_custom_include "pthread.c" :: !extra_arg_files;
+  extra_files := find_custom_include "stdlib.c" :: find_custom_include "pthread.c" :: !extra_files;
 
   if get_bool "ana.sv-comp.functions" then
-    extra_arg_files := find_custom_include "sv-comp.c" :: !extra_arg_files;
+    extra_files := find_custom_include "sv-comp.c" :: !extra_files;
 
-  let preprocessed = List.concat_map preprocess_arg_file (!extra_arg_files @ get_string_list "files") in
+  let preprocessed = List.concat_map preprocess_arg_file (!extra_files @ get_string_list "files") in
   if not (get_bool "pre.exist") then (
     let preprocess_tasks = List.filter_map snd preprocessed in
     let terminated task = function

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -107,13 +107,10 @@ let option_spec_list =
   ] @ defaults_spec_list (* lowest priority *)
 
 
-(** Parse arguments and fill [arg_files]. Print help if needed. *)
+(** Parse arguments. Print help if needed. *)
 let parse_arguments () =
-  let anon_arg filename =
-    arg_files := filename :: !arg_files
-  in
+  let anon_arg = set_string "files[+]" in
   Arg.parse option_spec_list anon_arg "Look up options using 'goblint --help'.";
-  arg_files := List.rev !arg_files; (* reverse files to get given order *)
   if !writeconffile <> "" then (GobConfig.write_file !writeconffile; raise Exit)
 
 (** Initialize some globals in other modules. *)
@@ -261,7 +258,7 @@ let preprocess_files () =
   if get_bool "ana.sv-comp.functions" then
     extra_arg_files := find_custom_include "sv-comp.c" :: !extra_arg_files;
 
-  let preprocessed = List.concat_map preprocess_arg_file (!extra_arg_files @ !arg_files) in
+  let preprocessed = List.concat_map preprocess_arg_file (!extra_arg_files @ get_string_list "files") in
   if not (get_bool "pre.exist") then (
     let preprocess_tasks = List.filter_map snd preprocessed in
     let terminated task = function

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -7,9 +7,6 @@ open GobConfig
 (** Outputs information about what the goblin is doing *)
 (* let verbose = ref false *)
 
-(** Files given as arguments. *)
-let arg_files : string list ref = ref []
-
 (** If this is true we output messages and collect accesses.
     This is set to true in control.ml before we verify the result (or already before solving if warn = 'early') *)
 let should_warn = ref false

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -2,6 +2,15 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
+    "files": {
+      "title": "files",
+      "description": "Files to analyze.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
     "outfile": {
       "title": "outfile",
       "description": "File to print output to.",


### PR DESCRIPTION
Closes #636.

Adds the option `files`. This is completely backwards compatible, because anonymous arguments, which previously were added to the `arg_files` list are now simply appended to the option.