### PR TITLE
Ignore exceptions from `Cilfacade.typeOf` when computing an equivalent array expression

### DIFF
--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -767,24 +767,22 @@ struct
           | Some (v') ->
             begin
               try
-                begin
-                  (* This should mean the entire expression we have here is a pointer into the array *)
-                  if Cil.isArrayType (Cilfacade.typeOfLval v') then
-                    let expr = ptr in
-                    let start_of_array = StartOf v' in
-                    let start_type = typeSigWithoutArraylen (Cilfacade.typeOf start_of_array) in
-                    let expr_type = typeSigWithoutArraylen (Cilfacade.typeOf ptr) in
-                    (* Comparing types for structural equality is incorrect here, use typeSig *)
-                    (* as explained at https://people.eecs.berkeley.edu/~necula/cil/api/Cil.html#TYPEtyp *)
-                    if start_type = expr_type then
-                      `Lifted (equiv_expr expr v')
-                    else
-                      (* If types do not agree here, this means that we were looking at pointers that *)
-                      (* contain more than one array access. Those are not supported. *)
-                      ExpDomain.top ()
+                (* This should mean the entire expression we have here is a pointer into the array *)
+                if Cil.isArrayType (Cilfacade.typeOfLval v') then
+                  let expr = ptr in
+                  let start_of_array = StartOf v' in
+                  let start_type = typeSigWithoutArraylen (Cilfacade.typeOf start_of_array) in
+                  let expr_type = typeSigWithoutArraylen (Cilfacade.typeOf ptr) in
+                  (* Comparing types for structural equality is incorrect here, use typeSig *)
+                  (* as explained at https://people.eecs.berkeley.edu/~necula/cil/api/Cil.html#TYPEtyp *)
+                  if start_type = expr_type then
+                    `Lifted (equiv_expr expr v')
                   else
+                    (* If types do not agree here, this means that we were looking at pointers that *)
+                    (* contain more than one array access. Those are not supported. *)
                     ExpDomain.top ()
-                end
+                else
+                  ExpDomain.top ()
               with (Cilfacade.TypeOfError _) -> ExpDomain.top ()
             end
           | _ ->

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -766,22 +766,26 @@ struct
           match v with
           | Some (v') ->
             begin
-              (* This should mean the entire expression we have here is a pointer into the array *)
-              if Cil.isArrayType (Cilfacade.typeOfLval v') then
-                let expr = ptr in
-                let start_of_array = StartOf v' in
-                let start_type = typeSigWithoutArraylen (Cilfacade.typeOf start_of_array) in
-                let expr_type = typeSigWithoutArraylen (Cilfacade.typeOf ptr) in
-                (* Comparing types for structural equality is incorrect here, use typeSig *)
-                (* as explained at https://people.eecs.berkeley.edu/~necula/cil/api/Cil.html#TYPEtyp *)
-                if start_type = expr_type then
-                  `Lifted (equiv_expr expr v')
-                else
-                  (* If types do not agree here, this means that we were looking at pointers that *)
-                  (* contain more than one array access. Those are not supported. *)
-                  ExpDomain.top ()
-              else
-                ExpDomain.top ()
+              try
+                begin
+                  (* This should mean the entire expression we have here is a pointer into the array *)
+                  if Cil.isArrayType (Cilfacade.typeOfLval v') then
+                    let expr = ptr in
+                    let start_of_array = StartOf v' in
+                    let start_type = typeSigWithoutArraylen (Cilfacade.typeOf start_of_array) in
+                    let expr_type = typeSigWithoutArraylen (Cilfacade.typeOf ptr) in
+                    (* Comparing types for structural equality is incorrect here, use typeSig *)
+                    (* as explained at https://people.eecs.berkeley.edu/~necula/cil/api/Cil.html#TYPEtyp *)
+                    if start_type = expr_type then
+                      `Lifted (equiv_expr expr v')
+                    else
+                      (* If types do not agree here, this means that we were looking at pointers that *)
+                      (* contain more than one array access. Those are not supported. *)
+                      ExpDomain.top ()
+                  else
+                    ExpDomain.top ()
+                end
+              with (Cilfacade.TypeOfError _) -> ExpDomain.top ()
             end
           | _ ->
             ExpDomain.top ()


### PR DESCRIPTION
We have long had some issues with strange offsets appearing in addresses. This one here leads to Goblint crashing on zstd if one adds more malloc wrappers to potentially make race detection more precise.

The place where it fails is when trying to compute an equivalent expression for an array access that would then be used by the partitioned array. Here it is always sound to put the top expression, so I suggest to ignore errors here.