### PR TITLE
Add nodes (with joined contexts) comparison

### DIFF
--- a/scripts/creduce/incremental.sh
+++ b/scripts/creduce/incremental.sh
@@ -17,6 +17,6 @@ sed "s/case 2:/case 2:\n    case 3:/" $FILE.c > $FILE.new.c
 $HERE/goblint --enable incremental.load --set save_run incrementalrun $FILE.new.c &> after.incr.log
 $HERE/goblint --set save_run originalrun $FILE.new.c &> after.scratch.log
 
-$HERE/goblint --enable solverdiffs --compare_runs originalrun incrementalrun $FILE.new.c &> out.log
+$HERE/goblint --enable dbg.compare_runs.diff --compare_runs originalrun incrementalrun $FILE.new.c &> out.log
 grep -F "$INTERESTING" out.log
 

--- a/scripts/test-incremental.sh
+++ b/scripts/test-incremental.sh
@@ -19,7 +19,7 @@ patch -p0 -b <$patch
 
 ./goblint --conf $conf $args --enable incremental.load --set save_run $base/$test-incrementalrun $source &> $base/$test.after.incr.log
 ./goblint --conf $conf $args --enable incremental.only-rename --set save_run $base/$test-originalrun $source &> $base/$test.after.scratch.log
-./goblint --conf $conf --enable solverdiffs --compare_runs $base/$test-originalrun $base/$test-incrementalrun $source
+./goblint --conf $conf --enable dbg.compare_runs.diff --compare_runs $base/$test-originalrun $base/$test-incrementalrun $source
 
 patch -p0 -b -R <$patch
 rm -r $base/$test-originalrun $base/$test-incrementalrun

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1055,7 +1055,7 @@ struct
       branch ctx exp tv
 end
 
-module Compare
+module CompareGlobSys
     (S:Spec)
     (Sys:GlobConstrSys with module LVar = VarF (S.C)
                         and module GVar = GVarF (S.V)
@@ -1164,19 +1164,19 @@ struct
     let h2 = PP.create 113 in
     let _  = LH.fold one_ctx l1 h1 in
     let _  = LH.fold one_ctx l2 h2 in
-    Printf.printf "\nComparing precision of %s (left) with %s (right) as GlobConstrSys:\n" name1 name2;
+    Printf.printf "\nComparing GlobConstrSys precision of %s (left) with %s (right):\n" name1 name2;
     compare_globals g1 g2;
     compare_locals h1 h2;
     compare_locals_ctx l1 l2;
     print_newline ();
 end
 
-module CompareEq (Sys: EqConstrSys) (VH: Hashtbl.S with type key = Sys.Var.t) =
+module CompareHashtbl (Var: VarType) (Dom: Lattice.S) (VH: Hashtbl.S with type key = Var.t) =
 struct
   module Var =
   struct
     include Printable.Std
-    include Sys.Var
+    include Var
 
     let pretty = pretty_trace
     include Printable.SimplePretty (
@@ -1186,11 +1186,57 @@ struct
       end
       )
   end
-  module Compare = PrecCompare.MakeHashtbl (Var) (Sys.Dom) (VH)
+
+  include PrecCompare.MakeHashtbl (Var) (Dom) (VH)
+end
+
+module CompareEqSys (Sys: EqConstrSys) (VH: Hashtbl.S with type key = Sys.Var.t) =
+struct
+  module Compare = CompareHashtbl (Sys.Var) (Sys.Dom) (VH)
 
   let compare (name1, name2) vh1 vh2 =
-    Printf.printf "\nComparing precision of %s (left) with %s (right) as EqConstrSys:\n" name1 name2;
+    Printf.printf "\nComparing EqConstrSys precision of %s (left) with %s (right):\n" name1 name2;
     let (_, msg) = Compare.compare ~name1 vh1 ~name2 vh2 in
-    ignore (Pretty.printf "Comparison summary: %t\n" (fun () -> msg));
+    ignore (Pretty.printf "EqConstrSys comparison summary: %t\n" (fun () -> msg));
+    print_newline ();
+end
+
+module CompareGlobal (GVar: VarType) (G: Lattice.S) (GH: Hashtbl.S with type key = GVar.t) =
+struct
+  module Compare = CompareHashtbl (GVar) (G) (GH)
+
+  let compare (name1, name2) vh1 vh2 =
+    Printf.printf "\nComparing globals precision of %s (left) with %s (right):\n" name1 name2;
+    let (_, msg) = Compare.compare ~name1 vh1 ~name2 vh2 in
+    ignore (Pretty.printf "Globals comparison summary: %t\n" (fun () -> msg));
+    print_newline ();
+end
+
+module CompareNode (C: Printable.S) (D: Lattice.S) (LH: Hashtbl.S with type key = VarF (C).t) =
+struct
+  module Node =
+  struct
+    include Node
+    let var_id _ = "nodes"
+    let node x = x
+  end
+  module NH = Hashtbl.Make (Node)
+
+  module Compare = CompareHashtbl (Node) (D) (NH)
+
+  let join_contexts (lh: D.t LH.t): D.t NH.t =
+    let nh = NH.create 113 in
+    LH.iter (fun (n, _) d ->
+        let d' = try D.join (NH.find nh n) d with Not_found -> d in
+        NH.replace nh n d'
+      ) lh;
+    nh
+
+  let compare (name1, name2) vh1 vh2 =
+    Printf.printf "\nComparing nodes precision of %s (left) with %s (right):\n" name1 name2;
+    let vh1' = join_contexts vh1 in
+    let vh2' = join_contexts vh2 in
+    let (_, msg) = Compare.compare ~name1 vh1' ~name2 vh2' in
+    ignore (Pretty.printf "Nodes comparison summary: %t\n" (fun () -> msg));
     print_newline ();
 end

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1082,11 +1082,11 @@ struct
       if b1 && b2 then
         f_eq ()
       else if b1 then begin
-        if get_bool "solverdiffs" then
+        if get_bool "dbg.compare_runs.diff" then
           ignore (Pretty.printf "Global %a is more precise using left:\n%a\n" Sys.GVar.pretty_trace k G.pretty_diff (v1,v2));
         f_le ()
       end else if b2 then begin
-        if get_bool "solverdiffs" then
+        if get_bool "dbg.compare_runs.diff" then
           ignore (Pretty.printf "Global %a is more precise using right:\n%a\n" Sys.GVar.pretty_trace k G.pretty_diff (v1,v2));
         f_gr ()
       end else
@@ -1105,11 +1105,11 @@ struct
         if b1 && b2 then
           incr eq
         else if b1 then begin
-          if get_bool "solverdiffs" then
+          if get_bool "dbg.compare_runs.diff" then
             ignore (Pretty.printf "%a @@ %a is more precise using left:\n%a\n" Node.pretty_plain k CilType.Location.pretty (Node.location k) D.pretty_diff (v1,v2));
           incr le
         end else if b2 then begin
-          if get_bool "solverdiffs" then
+          if get_bool "dbg.compare_runs.diff" then
             ignore (Pretty.printf "%a @@ %a is more precise using right:\n%a\n" Node.pretty_plain k CilType.Location.pretty (Node.location k) D.pretty_diff (v1,v2));
           incr gr
         end else
@@ -1137,11 +1137,11 @@ struct
         if b1 && b2 then
           f_eq ()
         else if b1 then begin
-          (* if get_bool "solverdiffs" then *)
+          (* if get_bool "dbg.compare_runs.diff" then *)
           (*   ignore (Pretty.printf "%a @@ %a is more precise using left:\n%a\n" pretty_node k CilType.Location.pretty (getLoc k) D.pretty_diff (v1,v2)); *)
           f_le ()
         end else if b2 then begin
-          (* if get_bool "solverdiffs" then *)
+          (* if get_bool "dbg.compare_runs.diff" then *)
           (*   ignore (Pretty.printf "%a @@ %a is more precise using right:\n%a\n" pretty_node k CilType.Location.pretty (getLoc k) D.pretty_diff (v1,v2)); *)
           f_gr ()
         end else
@@ -1196,7 +1196,7 @@ struct
 
   let compare (name1, name2) vh1 vh2 =
     Printf.printf "\nComparing EqConstrSys precision of %s (left) with %s (right):\n" name1 name2;
-    let verbose = get_bool "solverdiffs" in
+    let verbose = get_bool "dbg.compare_runs.diff" in
     let (_, msg) = Compare.compare ~verbose ~name1 vh1 ~name2 vh2 in
     ignore (Pretty.printf "EqConstrSys comparison summary: %t\n" (fun () -> msg));
     print_newline ();
@@ -1208,7 +1208,7 @@ struct
 
   let compare (name1, name2) vh1 vh2 =
     Printf.printf "\nComparing globals precision of %s (left) with %s (right):\n" name1 name2;
-    let verbose = get_bool "solverdiffs" in
+    let verbose = get_bool "dbg.compare_runs.diff" in
     let (_, msg) = Compare.compare ~verbose ~name1 vh1 ~name2 vh2 in
     ignore (Pretty.printf "Globals comparison summary: %t\n" (fun () -> msg));
     print_newline ();
@@ -1238,7 +1238,7 @@ struct
     Printf.printf "\nComparing nodes precision of %s (left) with %s (right):\n" name1 name2;
     let vh1' = join_contexts vh1 in
     let vh2' = join_contexts vh2 in
-    let verbose = get_bool "solverdiffs" in
+    let verbose = get_bool "dbg.compare_runs.diff" in
     let (_, msg) = Compare.compare ~verbose ~name1 vh1' ~name2 vh2' in
     ignore (Pretty.printf "Nodes comparison summary: %t\n" (fun () -> msg));
     print_newline ();

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1196,7 +1196,8 @@ struct
 
   let compare (name1, name2) vh1 vh2 =
     Printf.printf "\nComparing EqConstrSys precision of %s (left) with %s (right):\n" name1 name2;
-    let (_, msg) = Compare.compare ~name1 vh1 ~name2 vh2 in
+    let verbose = get_bool "solverdiffs" in
+    let (_, msg) = Compare.compare ~verbose ~name1 vh1 ~name2 vh2 in
     ignore (Pretty.printf "EqConstrSys comparison summary: %t\n" (fun () -> msg));
     print_newline ();
 end
@@ -1207,7 +1208,8 @@ struct
 
   let compare (name1, name2) vh1 vh2 =
     Printf.printf "\nComparing globals precision of %s (left) with %s (right):\n" name1 name2;
-    let (_, msg) = Compare.compare ~name1 vh1 ~name2 vh2 in
+    let verbose = get_bool "solverdiffs" in
+    let (_, msg) = Compare.compare ~verbose ~name1 vh1 ~name2 vh2 in
     ignore (Pretty.printf "Globals comparison summary: %t\n" (fun () -> msg));
     print_newline ();
 end
@@ -1236,7 +1238,8 @@ struct
     Printf.printf "\nComparing nodes precision of %s (left) with %s (right):\n" name1 name2;
     let vh1' = join_contexts vh1 in
     let vh2' = join_contexts vh2 in
-    let (_, msg) = Compare.compare ~name1 vh1' ~name2 vh2' in
+    let verbose = get_bool "solverdiffs" in
+    let (_, msg) = Compare.compare ~verbose ~name1 vh1' ~name2 vh2' in
     ignore (Pretty.printf "Nodes comparison summary: %t\n" (fun () -> msg));
     print_newline ();
 end

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1508,17 +1508,29 @@
           "title": "dbg.compare_runs",
           "type": "object",
           "properties": {
-            "glob": {
-              "title": "dbg.compare_runs.glob",
+            "globsys": {
+              "title": "dbg.compare_runs.globsys",
               "description": "Compare GlobConstrSys in compare_runs",
               "type": "boolean",
-              "default": true
+              "default": false
             },
-            "eq": {
-              "title": "dbg.compare_runs.eq",
+            "eqsys": {
+              "title": "dbg.compare_runs.eqsys",
               "description": "Compare EqConstrSys in compare_runs",
               "type": "boolean",
               "default": true
+            },
+            "global": {
+              "title": "dbg.compare_runs.global",
+              "description": "Compare globals in compare_runs",
+              "type": "boolean",
+              "default": false
+            },
+            "node": {
+              "title": "dbg.compare_runs.node",
+              "description": "Compare nodes (with joined contexts) in compare_runs",
+              "type": "boolean",
+              "default": false
             }
           },
           "additionalProperties": false

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -102,12 +102,6 @@
       "type": "string",
       "default": ""
     },
-    "solverdiffs": {
-      "title": "solverdiffs",
-      "description": "Print out solver differences.",
-      "type": "boolean",
-      "default": false
-    },
     "allfuns": {
       "title": "allfuns",
       "description":
@@ -1529,6 +1523,12 @@
             "node": {
               "title": "dbg.compare_runs.node",
               "description": "Compare nodes (with joined contexts) in compare_runs",
+              "type": "boolean",
+              "default": false
+            },
+            "diff": {
+              "title": "dbg.compare_runs.diff",
+              "description": "Print differences",
               "type": "boolean",
               "default": false
             }

--- a/src/util/precCompare.ml
+++ b/src/util/precCompare.ml
@@ -72,7 +72,7 @@ struct
     let compared = KH.map (fun k (v1, v2) ->
         let v1 = v1 |? D.bot () in
         let v2 = v2 |? D.bot () in
-        CompareD.compare ~name1 ~name2 v1 v2
+        CompareD.compare ~verbose ~name1 ~name2 v1 v2
       ) kh
     in
     KH.iter (fun k (c, msg) ->


### PR DESCRIPTION
### Changes
1. Add option `dbg.compare_runs.node` for that.
2. Add option `dbg.compare_runs.global` for just comparing global invariants (not needed now, but maybe useful).
3. Rename option `dbg.compare_runs.glob` → `dbg.compare_runs.globsys`.
4. Rename option `dbg.compare_runs.eq` → `dbg.compare_runs.eqsys`.
5. Change `dbg.compare_runs.eqsys` to be the only one enabled by default instead of multiple.
6. Add separate incomparable count to comparison summary.
7. Rename option `solverdiffs` → `dbg.compare_runs.diff`.