### PR TITLE
Minimal write-only restarting is insufficient

### DIFF
--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -722,6 +722,7 @@ module WP =
         print_endline "Removing data for changed and removed functions...";
         let delete_marked s = HM.iter (fun k _ -> HM.remove s k) marked_for_deletion in
         delete_marked rho;
+        delete_marked rho_write;
         delete_marked infl;
         delete_marked wpoint;
 
@@ -813,6 +814,7 @@ module WP =
         delete_marked stable;
         delete_marked side_dep;
         delete_marked side_infl;
+        delete_marked superstable;
         print_data data "Data after clean-up";
 
         (* TODO: reluctant doesn't call destabilize on removed functions or old copies of modified functions (e.g. after removing write), so those globals don't get restarted *)
@@ -979,6 +981,7 @@ module WP =
       (* restart write-only *)
       HM.iter (fun x w ->
           HM.iter (fun y d ->
+              (* ignore (Pretty.printf "rho_write restart %a\n" S.Var.pretty_trace y); *)
               HM.replace rho y (S.Dom.bot ());
             ) w
         ) rho_write;

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -54,8 +54,8 @@ module WP =
 
     let print_data data str =
       if GobConfig.get_bool "dbg.verbose" then
-        Printf.printf "%s:\n|rho|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|side_dep|=%d\n|side_infl|=%d\n"
-          str (HM.length data.rho) (HM.length data.stable) (HM.length data.infl) (HM.length data.wpoint) (HM.length data.side_dep) (HM.length data.side_infl)
+        Printf.printf "%s:\n|rho|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|side_dep|=%d\n|side_infl|=%d\n|rho_write|=%d\n"
+          str (HM.length data.rho) (HM.length data.stable) (HM.length data.infl) (HM.length data.wpoint) (HM.length data.side_dep) (HM.length data.side_infl) (HM.length data.rho_write)
 
     let exists_key f hm = HM.fold (fun k _ a -> a || f k) hm false
 
@@ -143,9 +143,9 @@ module WP =
       let prev_dep_vals = HM.create 10 in
 
       let () = print_solver_stats := fun () ->
-        Printf.printf "|rho|=%d\n|called|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|side_dep|=%d\n|side_infl|=%d\n"
-          (HM.length rho) (HM.length called) (HM.length stable) (HM.length infl) (HM.length wpoint) (HM.length side_dep) (HM.length side_infl);
-        print_context_stats rho
+          Printf.printf "|rho|=%d\n|called|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|side_dep|=%d\n|side_infl|=%d\n|rho_write|=%d\n"
+            (HM.length rho) (HM.length called) (HM.length stable) (HM.length infl) (HM.length wpoint) (HM.length side_dep) (HM.length side_infl) (HM.length rho_write);
+          print_context_stats rho
       in
 
       if GobConfig.get_bool "incremental.load" then print_data data "Loaded data for incremental analysis";

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -779,6 +779,13 @@
                 "kmalloc", "__kmalloc", "usb_alloc_urb", "__builtin_alloca",
                 "kzalloc"
               ]
+            },
+            "include-node" : {
+              "title": "ana.malloc.include-node",
+              "description":
+                "Whether the node at which memory is allocated is part of its variable ID",
+              "type": "boolean",
+              "default" : true
             }
           },
           "additionalProperties": false

--- a/tests/incremental/13-restart-write/04-malloc-node.c
+++ b/tests/incremental/13-restart-write/04-malloc-node.c
@@ -1,0 +1,21 @@
+#include <pthread.h>
+#include <assert.h>
+
+void *t_fun(void *arg) {
+  int *iarg = (int*) arg;
+  *iarg = 1;
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  int *iarg;
+
+  for (int i = 0; i < 10; i++) {
+    iarg = malloc(sizeof(int));
+    *iarg = 0;
+    pthread_create(&id, NULL, t_fun, (void*) iarg);
+  }
+
+  return 0;
+}

--- a/tests/incremental/13-restart-write/04-malloc-node.json
+++ b/tests/incremental/13-restart-write/04-malloc-node.json
@@ -1,0 +1,14 @@
+{
+    "incremental": {
+        "restart": {
+            "sided": {
+                "enabled": false
+            }
+        }
+    },
+    "ana": {
+        "thread": {
+            "include-node": false
+        }
+    }
+}

--- a/tests/incremental/13-restart-write/04-malloc-node.json
+++ b/tests/incremental/13-restart-write/04-malloc-node.json
@@ -9,6 +9,9 @@
     "ana": {
         "thread": {
             "include-node": false
+        },
+        "malloc": {
+            "include-node": false
         }
     }
 }

--- a/tests/incremental/13-restart-write/04-malloc-node.patch
+++ b/tests/incremental/13-restart-write/04-malloc-node.patch
@@ -1,0 +1,13 @@
+diff --git tests/incremental/13-restart-write/04-malloc-node.c tests/incremental/13-restart-write/04-malloc-node.c
+index 87bbc0f14..3cd6dc5c7 100644
+--- tests/incremental/13-restart-write/04-malloc-node.c
++++ tests/incremental/13-restart-write/04-malloc-node.c
+@@ -11,6 +11,8 @@ int main() {
+   pthread_t id;
+   int *iarg;
+ 
++  assert(1);
++
+   for (int i = 0; i < 10; i++) {
+     iarg = malloc(sizeof(int));
+     *iarg = 0;

--- a/tests/incremental/13-restart-write/05-race-call-remove.c
+++ b/tests/incremental/13-restart-write/05-race-call-remove.c
@@ -1,0 +1,20 @@
+#include <pthread.h>
+#include <assert.h>
+
+int g;
+
+void *t_fun(void *arg) {
+  g++; // RACE!
+  return NULL;
+}
+
+void foo() {
+  g++; // RACE!
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  foo();
+  return 0;
+}

--- a/tests/incremental/13-restart-write/05-race-call-remove.json
+++ b/tests/incremental/13-restart-write/05-race-call-remove.json
@@ -1,0 +1,14 @@
+{
+    "incremental": {
+        "restart": {
+            "sided": {
+                "enabled": false
+            }
+        }
+    },
+    "ana": {
+        "thread": {
+            "include-node": false
+        }
+    }
+}

--- a/tests/incremental/13-restart-write/05-race-call-remove.patch
+++ b/tests/incremental/13-restart-write/05-race-call-remove.patch
@@ -1,0 +1,25 @@
+diff --git tests/incremental/13-restart-write/05-race-call-remove.c tests/incremental/13-restart-write/05-race-call-remove.c
+index cf9f5c713..20e09db1a 100644
+--- tests/incremental/13-restart-write/05-race-call-remove.c
++++ tests/incremental/13-restart-write/05-race-call-remove.c
+@@ -4,17 +4,16 @@
+ int g;
+ 
+ void *t_fun(void *arg) {
+-  g++; // RACE!
++  g++; // NORACE (unique thread)
+   return NULL;
+ }
+ 
+ void foo() {
+-  g++; // RACE!
++  g++; // NORACE
+ }
+ 
+ int main() {
+   pthread_t id;
+   pthread_create(&id, NULL, t_fun, NULL);
+-  foo();
+   return 0;
+ }
+\ No newline at end of file


### PR DESCRIPTION
Turns out #634, which performs minimal restarting for write-only globals like accesses, is insufficient to even guarantee from-scratch consistency of write-only globals. Hence there's no from-scratch consistency of race warnings either!

# Problems

## `malloc` nodes
In `tests/incremental/13-restart-write/04-malloc-node.c` the incremental run gives two memory locations (old and new malloc) instead of just the expected one. This causes an inconsistency in the number of race warnings because the number of memory locations isn't even consistent (not to mention anything about their raciness).
This is because `alloc` variables are based on the node of `malloc`, which changes if the function is incrementally changed.

The possible solution for this is to not include nodes in `alloc` variables, just like the disabling of `ana.thread.include-node` doesn't include them in thread IDs. But then `alloc` variables would be just per-function, so all `malloc` data from a single function gets joined together. If two different types of data are stored, then we immediately get value domain supertop, which is far from ideal.

**EDIT:** I have now added `ana.malloc.include-node`, which does fix this specific problem.

### Broader issue
We've seen the node-based things be a problem for incrementality in thread IDs and now `alloc` variables, but the issue is much more general. It really means that nothing should be based on nodes since incremental changes may change their IDs. This possibly also includes access collecting (which refer to nodes as their origin), but maybe more things which don't immediately pop into mind.

So really what we need is very fine-grained update, which keeps statement IDs for everything that didn't actually change and simply removes/adds IDs for actually removed/added statements.

## Indirect access removal
In `tests/incremental/13-restart-write/05-race-call-remove.c` the incremental run has a race, whereas it should not. When the call to a function accessing the global in a racy way is removed, then minimal write-only restarting doesn't get rid of that access, because it doesn't originate from a changed function. The destabilization of the old copy doesn't destabilize anything in `foo`, because normal destabilization only follows `infl`, but not `side_infl`.

The possible solution for this is something like the transitive sides restarting with `destabilize_with_side`, but slightly weaker: it doesn't need to restart anything, but only destabilize via `infl` _and_ `side_infl`.
This also fixes the above `malloc` node issue on the original knot_comb race benchmark, but doubles the basic incremental runtime from 15s to 30s (from-scratch is ~60s). Despite just being more extensive destabilization, it causes a lot more recomputation, which aborting doesn't even help with.

### Broader issue
This again is not just specific to write-only restarting, but incremental postsolving in general. To avoid reevaluating everything we make the assumption that all `superstable` unknowns are reachable and don't prune them. But that's an overapproximation of the reachable unknowns, since in the call removal case it similarly would still think that the unknowns of `foo` are reachable since they never get destabilized. Destabilization along `side_infl` would also fix that, but at the same high cost.

