### PR TITLE
Add messagesCompare for comparing json-messages results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ sv-comp/goblint.zip
 
 privPrecCompare*
 apronPrecCompare
+messagesCompare
 tests/regression/*/run
 
 # csmith

--- a/make.sh
+++ b/make.sh
@@ -46,6 +46,11 @@ rule() {
       dune build src/apronPrecCompare.exe &&
       rm -f apronPrecCompare &&
       cp _build/default/src/apronPrecCompare.exe apronPrecCompare
+    ;; messagesCompare)
+      eval $(opam config env)
+      dune build src/messagesCompare.exe &&
+      rm -f messagesCompare &&
+      cp _build/default/src/messagesCompare.exe messagesCompare
     ;; byte)
       eval $(opam config env)
       dune build goblint.byte &&

--- a/src/dune
+++ b/src/dune
@@ -7,7 +7,7 @@
   (name goblint_lib)
   (public_name goblint.lib)
   (wrapped false)
-  (modules :standard \ goblint mainarinc mainspec privPrecCompare apronPrecCompare)
+  (modules :standard \ goblint mainarinc mainspec privPrecCompare apronPrecCompare messagesCompare)
   (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc cpu
     ; Conditionally compile based on whether apron optional dependency is installed or not.
     ; Alternative dependencies seem like the only way to optionally depend on optional dependencies.
@@ -68,6 +68,14 @@
 (executable
   (name apronPrecCompare)
   (modules apronPrecCompare)
+  (libraries goblint.lib goblint.sites.dune)
+  (preprocess (pps ppx_deriving.std ppx_deriving_hash ppx_deriving_yojson ppx_distr_guards ocaml-monadic))
+  (flags :standard -linkall)
+)
+
+(executable
+  (name messagesCompare)
+  (modules messagesCompare)
   (libraries goblint.lib goblint.sites.dune)
   (preprocess (pps ppx_deriving.std ppx_deriving_hash ppx_deriving_yojson ppx_distr_guards ocaml-monadic))
   (flags :standard -linkall)

--- a/src/messagesCompare.ml
+++ b/src/messagesCompare.ml
@@ -1,14 +1,29 @@
+module MS = Set.Make (Messages.Message)
 
 let load_messages filename =
   Yojson.Safe.from_file filename
   |> Yojson.Safe.Util.member "messages"
   |> [%of_yojson: Messages.Message.t list]
-  |> function
-  | Ok l -> l
-  | Error s -> failwith s
+  |> begin function
+    | Ok l -> l
+    | Error s -> failwith s
+  end
+  |> MS.of_list
 
 let () =
-  let messages = load_messages Sys.argv.(1) in
-  List.iter (fun message ->
-      Messages.print ~ppf:Format.std_formatter message
-    ) messages
+  GobFormat.pp_set_ansi_color_tags Format.std_formatter;
+
+  let left_messages = load_messages Sys.argv.(1) in
+  let right_messages = load_messages Sys.argv.(2) in
+  let left_only_messages = MS.diff left_messages right_messages in
+  let right_only_messages = MS.diff right_messages left_messages in
+
+  if not (MS.is_empty left_only_messages) then (
+    Printf.printf "Left-only messages (%d):\n" (MS.cardinal left_only_messages);
+    MS.iter (Messages.print) left_only_messages;
+  );
+  print_newline ();
+  if not (MS.is_empty right_only_messages) then (
+    Printf.printf "Right-only messages (%d):\n" (MS.cardinal right_only_messages);
+    MS.iter (Messages.print) right_only_messages;
+  )

--- a/src/messagesCompare.ml
+++ b/src/messagesCompare.ml
@@ -1,0 +1,14 @@
+
+let load_messages filename =
+  Yojson.Safe.from_file filename
+  |> Yojson.Safe.Util.member "messages"
+  |> [%of_yojson: Messages.Message.t list]
+  |> function
+  | Ok l -> l
+  | Error s -> failwith s
+
+let () =
+  let messages = load_messages Sys.argv.(1) in
+  List.iter (fun message ->
+      Messages.print ~ppf:Format.std_formatter message
+    ) messages

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -16,6 +16,7 @@ module Location:
 sig
   include S with type t = location
   val pp: Format.formatter -> t -> unit (* for Messages *)
+  val of_yojson: Yojson.Safe.t -> (t, string) result
 end =
 struct
   include Std
@@ -60,17 +61,34 @@ struct
         ("file", `String x.file);
         ("line", `Int x.line);
         ("column", `Int x.column);
+        ("byte", `Int x.byte);
       ]
       @
       if x.endByte >= 0 then
         [
           ("endLine", `Int x.endLine);
           ("endColumn", `Int x.endColumn);
+          ("endByte", `Int x.endByte);
         ]
       else
         []
     )
   let pp fmt x = Format.fprintf fmt "%s" (show x) (* for Messages *)
+
+  let of_yojson = function
+    | `Assoc l ->
+      begin match List.assoc_opt "file" l, List.assoc_opt "line" l, List.assoc_opt "column" l, List.assoc_opt "byte" l with
+        | Some (`String file), Some (`Int line), Some (`Int column), Some (`Int byte) ->
+          let loc = {file; line; column; byte; endLine = -1; endColumn = -1; endByte = -1} in
+          begin match List.assoc_opt "endLine" l, List.assoc_opt "endColumn" l, List.assoc_opt "endByte" l with
+            | Some (`Int endLine), Some (`Int endColumn), Some (`Int endByte) ->
+              Result.Ok {loc with endLine; endColumn; endByte}
+            | _, _, _ ->
+              Result.Ok loc
+          end
+        | _, _, _, _ -> Result.Error "CilType.Location.of_yojson"
+      end
+    | _ -> Result.Error "CilType.Location.of_yojson"
 end
 
 module Varinfo:

--- a/src/util/messageCategory.ml
+++ b/src/util/messageCategory.ml
@@ -226,3 +226,10 @@ let from_string_list (s: string list) =
     | _ -> Unknown
 
 let to_yojson x = `List (List.map (fun x -> `String x) (path_show x))
+let of_yojson = function
+  | `List l ->
+    l
+    |> List.map Yojson.Safe.Util.to_string
+    |> from_string_list
+    |> Result.ok
+  | _ -> Result.Error "MessageCategory.of_yojson"

--- a/src/util/messageCategory.ml
+++ b/src/util/messageCategory.ml
@@ -4,23 +4,23 @@ type array_oob =
   | PastEnd
   | BeforeStart
   | Unknown
-[@@deriving eq, hash]
+[@@deriving eq, ord, hash]
 
 type undefined_behavior =
   | ArrayOutOfBounds of array_oob
   | NullPointerDereference
   | UseAfterFree
-[@@deriving eq, hash]
+[@@deriving eq, ord, hash]
 
 type behavior =
   | Undefined of undefined_behavior
   | Implementation
   | Machine
-[@@deriving eq, hash]
+[@@deriving eq, ord, hash]
 
-type integer = Overflow | DivByZero [@@deriving eq, hash]
+type integer = Overflow | DivByZero [@@deriving eq, ord, hash]
 
-type cast = TypeMismatch [@@deriving eq, hash]
+type cast = TypeMismatch [@@deriving eq, ord, hash]
 
 type category =
   | Assert
@@ -33,9 +33,9 @@ type category =
   | Analyzer
   | Unsound
   | Imprecise
-[@@deriving eq, hash]
+[@@deriving eq, ord, hash]
 
-type t = category [@@deriving eq, hash]
+type t = category [@@deriving eq, ord, hash]
 
 module Behavior =
 struct


### PR DESCRIPTION
Closes #607.

Given two `json-messages` outputs, the `messagesCompare` executable will compare them as sets (ignoring order, unlike a straight `diff`). and outputs the messages that are only in one or the other using the usual pretty style.

This should make it easier to compare user-visible precision via messages.

---

I initially wanted to just throw together a quick Python script, but Python's `json.load` is so stupid that the loaded data is represented using `dict`s and `list`s, which are unhashable and cannot just be thrown into a set...