### PR TITLE
Apron: Better handling of asserts containing `LNot`

### DIFF
--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -573,9 +573,10 @@ struct
 
   include Tracked
 
-  let exp_is_cons = function
+  let rec exp_is_cons = function
     (* constraint *)
     | BinOp ((Lt | Gt | Le | Ge | Eq | Ne), _, _, _) -> true
+    | UnOp (LNot,e,_) -> exp_is_cons e
     (* expression *)
     | _ -> false
 
@@ -592,6 +593,7 @@ struct
       let assert_gt = assert_cons d (BinOp (Gt, lhs, rhs, intType)) (not negate) in
       let assert_lt = assert_cons d (BinOp (Lt, lhs, rhs, intType)) (not negate) in
       join assert_gt assert_lt
+    | UnOp (LNot,e,_) -> assert_cons d e (not negate)
     | _ ->
       begin match Convert.tcons1_of_cil_exp d (A.env d) e negate with
         | tcons1 ->

--- a/tests/regression/36-apron/01-octagon_simple.c
+++ b/tests/regression/36-apron/01-octagon_simple.c
@@ -19,4 +19,35 @@ void main(void) {
     // currently we can't detect this
     N = 42;
   }
+
+  two();
+}
+
+void two() {
+  int X ;
+  int N ;
+  int tmp ;
+
+  X = 0;
+  tmp = rand();
+  N = tmp;
+
+
+  if (N < 0) {
+    N = 0;
+  }
+
+  assert(X <= N);
+
+  while (1) {
+    while_continue: /* CIL Label */ ;
+    if (! (X < N)) {
+      goto while_break;
+    }
+    X ++;
+  }
+  while_break: /* CIL Label */ ;
+
+  assert(X - N == 0);
+  assert(X == N);
 }

--- a/tests/regression/36-apron/09-branch.c
+++ b/tests/regression/36-apron/09-branch.c
@@ -12,4 +12,21 @@ void main() {
     // doesn't imply i - 1 != 1   (i != 2)
     assert(i == 2); // UNKNOWN!
   }
+  
+  two();
+}
+
+void two() {
+  int i = __VERIFIER_nondet_int();
+  int j =  __VERIFIER_nondet_int();
+
+  if(i<j) {
+    assert(i<j);
+  }
+
+  if(!(i<j)) {
+
+  } else {
+    assert(i<j);
+  }
 }


### PR DESCRIPTION
During #157, I discovered that Goblint sometimes fails to establish invariants it has written out itself.
As @sim642 suspected, this was due to not handling `UnOp(LNot,e,...)` guards in a smart way.

They got transformed into expressions of the form `BinOp (Ne,UnOp(LNot,e,...), zero, intType)` before being asserted.

After this PR, if the expression inside the negation is suitable (i.e., is a comparison), we directly assert it by flipping the `negate` argument to `assert_cons`.

This PR also adds two small tests cases for this behavior.