### PR TITLE
Cleanup future regression tests

### DIFF
--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -431,7 +431,7 @@ let check_arguments () =
   let warn m = eprint_color ("{yellow}Option warning: "^m) in
   if get_bool "allfuns" && not (get_bool "exp.earlyglobs") then (set_bool "exp.earlyglobs" true; warn "allfuns enables exp.earlyglobs.\n");
   if not @@ List.mem "escape" @@ get_string_list "ana.activated" then warn "Without thread escape analysis, every local variable whose address is taken is considered escaped, i.e., global!";
-  if get_string "ana.osek.oil" <> "" && not (get_string "ana.base.privatization" = "protection-vesal" || get_string "ana.base.privatization" = "protection-old") then (set_string "ana.base.privatization" "protection-vesal"; warn "oil requires protection-old/protection-vesal privatization");
+  if get_string "ana.osek.oil" <> "" && not (get_string "ana.base.privatization" = "protection-vesal" || get_string "ana.base.privatization" = "protection-old") then (set_string "ana.base.privatization" "protection-vesal"; warn "oil requires protection-old/protection-vesal privatization, setting ana.base.privatization to protection-vesal");
   if get_bool "ana.base.context.int" && not (get_bool "ana.base.context.non-ptr") then (set_bool "ana.base.context.int" false; warn "ana.base.context.int implicitly disabled by ana.base.context.non-ptr");
   (* order matters: non-ptr=false, int=true -> int=false cascades to interval=false with warning *)
   if get_bool "ana.base.context.interval" && not (get_bool "ana.base.context.int") then (set_bool "ana.base.context.interval" false; warn "ana.base.context.interval implicitly disabled by ana.base.context.int");

--- a/tests/regression/02-base/12-init_otherfun.c
+++ b/tests/regression/02-base/12-init_otherfun.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set otherfun "['f']" --set ana.activated "['base','threadid','threadflag','escape','mallocWrapper']"
+// SKIP PARAM: --set otherfun "['f']" --set ana.activated "['base','threadid','threadflag','escape','mallocWrapper','mutex','access']"
 
 int glob1 = 5;
 

--- a/tests/regression/03-practical/18-no_ctx_box.c
+++ b/tests/regression/03-practical/18-no_ctx_box.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --no mutex --set solver "'new'" --no-context base --no-context escape
+// SKIP PARAM: --set ana.activated[-] mutex --set solver "'new'" --set ana.ctx_insens[+] base --set ana.ctx_insens[+] escape --set ana.base.privatization none
 void write(int **p){
   *p=1;
 }

--- a/tests/regression/14-osek/04-cubbyhole.c
+++ b/tests/regression/14-osek/04-cubbyhole.c
@@ -1,4 +1,5 @@
-// SKIP PARAM: --set ana.activated "['base','threadid','threadflag','escape','fmode', 'OSEK', 'OSEK2', 'stack_trace_set','mallocWrapper']" --set ana.osek.oil 04-cubbyhole.oil --set ana.osek.tramp 04-defaultAppWorkstation/tpl_os_generated_configuration.h -I 04-defaultAppWorkstation/ -I 04-defaultAppWorkstation/os-minimalheaders/os_machine/posix-libpcl/ -I 04-defaultAppWorkstation/os-minimalheaders/ --set ana.osek.taskprefix function_of_ --set ana.osek.isrprefix function_of_
+// SKIP PARAM: --set ana.activated "['base','threadid','threadflag','escape','fmode', 'OSEK', 'OSEK2', 'stack_trace_set','mallocWrapper']" --set ana.osek.oil 04-cubbyhole.oil  -I 04-defaultAppWorkstation/ -I 04-defaultAppWorkstation/os-minimalheaders/os_machine/posix-libpcl/ -I 04-defaultAppWorkstation/os-minimalheaders/ --set ana.osek.taskprefix function_of_ --set ana.osek.isrprefix function_of_
+// Option 'tramp' has been removed, we used to set --set ana.osek.tramp 04-defaultAppWorkstation/tpl_os_generated_configuration.h
 
 #include <stdio.h>
 #include <string.h>

--- a/tests/regression/14-osek/06-suffix.c
+++ b/tests/regression/14-osek/06-suffix.c
@@ -1,5 +1,5 @@
-// SKIP PARAM: --set ana.activated "['base','threadid','threadflag','escape','fmode', 'OSEK', 'OSEK2', 'stack_trace_set','mallocWrapper']" --set ana.osek.oil 02-example.oil --set ana.osek.tramp 06-suffix-tramp.h --set ana.osek.tasksuffix _func --set ana.osek.isrsuffix _func
-
+// SKIP PARAM: --set ana.activated "['base','threadid','threadflag','escape','fmode', 'OSEK', 'OSEK2', 'stack_trace_set','mallocWrapper']" --set ana.osek.oil 02-example.oil --set ana.osek.tasksuffix _func --set ana.osek.isrsuffix _func
+// Option 'tramp' has been removed, we used to set --set ana.osek.tramp 06-suffix-tramp.h 
 int x;
 int y;
 int z;

--- a/tests/regression/14-osek/17-multicore.c
+++ b/tests/regression/14-osek/17-multicore.c
@@ -1,4 +1,4 @@
-//SKIP! PARAM: --set ana.activated "['mallocWrapper','base','threadid','threadflag','escape','fmode', 'OSEK', 'OSEK2', 'stack_trace_set']" --set ana.base.privatization protection-old --set ana.osek.oil 17-multicore.oil --set ana.osek.taskprefix function_of_ --set ana.osek.isrprefix function_of_
+//SKIP! PARAM: --set ana.activated "['mallocWrapper','base','threadid','threadflag','escape','fmode', 'OSEK', 'OSEK2', 'stack_trace_set']" --set ana.osek.oil 17-multicore.oil --set ana.osek.taskprefix function_of_ --set ana.osek.isrprefix function_of_
 
 int x = 0;
 int y;

--- a/tests/regression/14-osek/17-multicore.c
+++ b/tests/regression/14-osek/17-multicore.c
@@ -1,4 +1,4 @@
-//SKIP! PARAM: --set ana.activated "['base','threadid','threadflag','escape','fmode', 'OSEK', 'OSEK2', 'stack_trace_set']" --set ana.osek.oil 17-multicore.oil --set ana.osek.taskprefix function_of_ --set ana.osek.isrprefix function_of_
+//SKIP! PARAM: --set ana.activated "['mallocWrapper','base','threadid','threadflag','escape','fmode', 'OSEK', 'OSEK2', 'stack_trace_set']" --set ana.base.privatization protection-old --set ana.osek.oil 17-multicore.oil --set ana.osek.taskprefix function_of_ --set ana.osek.isrprefix function_of_
 
 int x = 0;
 int y;

--- a/tests/regression/29-svcomp/26-ikinds_if.c
+++ b/tests/regression/29-svcomp/26-ikinds_if.c
@@ -1,5 +1,4 @@
-// SKIP PARAM: --conf=./conf/svcomp21.json  --set ana.specification ./tests/sv-comp/unreach-call-__VERIFIER_error.prp
-// TODO: specific parameters instead of SV-COMP
+//PARAM: --enable ana.int.interval --set ana.specification ./tests/sv-comp/unreach-call-__VERIFIER_error.prp
 #include<stdlib.h>
 
 static long sound_ioctl(unsigned int cmd , unsigned long arg )

--- a/tests/regression/29-svcomp/26-ikinds_if.c
+++ b/tests/regression/29-svcomp/26-ikinds_if.c
@@ -1,4 +1,4 @@
-//PARAM: --enable ana.int.interval --set ana.specification ./tests/sv-comp/unreach-call-__VERIFIER_error.prp
+//PARAM: --enable ana.int.interval
 #include<stdlib.h>
 
 static long sound_ioctl(unsigned int cmd , unsigned long arg )


### PR DESCRIPTION
This issue has been open for over 5 years now. This fixes it by adapting the parameters of `future` regression tests to our recent changes (or removing the option in case of the non-functional option `ana.osek.tramp`).
Now, all future regression tests do at least run.

Closes #61.