### PR TITLE
Improve cfg comparison

### DIFF
--- a/src/incremental/compareCFG.ml
+++ b/src/incremental/compareCFG.ml
@@ -106,11 +106,11 @@ let reexamine f1 f2 (same : biDirectionNodeMap ref) (diffNodes1 : unit NH.t) (mo
           let n1 = NH.find !same.node2to1 n in
           NH.replace diffNodes1 n1 ();
           NH.remove !same.node1to2 n1; NH.remove !same.node2to1 n;
-          repeat (); false
+          false
         ) else check_nodes_in_same ps' n in
     let rec check_predecessors ls = match ls with
       | [] -> ()
-      | (n2::ls') -> if Node.equal n2 entry2 || check_nodes_in_same (List.map snd (CfgNewPred.prev n2)) n2 then check_predecessors ls' in
+      | (n2::ls') -> if Node.equal n2 entry2 || check_nodes_in_same (List.map snd (CfgNewPred.prev n2)) n2 then check_predecessors ls' else repeat () in
     check_predecessors ls
   in repeat (); NH.to_seq !same.node1to2, NH.to_seq_keys diffNodes1
 

--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -44,9 +44,8 @@ let eqF (a: Cil.fundec) (b: Cil.fundec) (cfgs : (cfg * (cfg * cfg)) option) =
         | None -> eq_block (a.sbody, a) (b.sbody, b), None
         | Some (cfgOld, (cfgNew, cfgNewBack)) ->
           let module CfgOld : MyCFG.CfgForward = struct let next = cfgOld end in
-          let module CfgNew : MyCFG.CfgForward = struct let next = cfgNew end in
-          let module CfgNewBack : MyCFG.CfgBackward = struct let prev = cfgNewBack end in
-          let matches, diffNodes1 = compareFun (module CfgOld) (module CfgNew) (module CfgNewBack) a b in
+          let module CfgNew : MyCFG.CfgBidir = struct let prev = cfgNewBack let next = cfgNew end in
+          let matches, diffNodes1 = compareFun (module CfgOld) (module CfgNew) a b in
           if diffNodes1 = [] then (true, None)
           else (false, Some {unchangedNodes = matches; primObsoleteNodes = diffNodes1})
   in

--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -6,7 +6,6 @@ include CompareCFG
 type nodes_diff = {
   unchangedNodes: (node * node) list;
   primObsoleteNodes: node list; (** primary obsolete nodes -> all obsolete nodes are reachable from these *)
-  primNewNodes: node list (** primary new nodes -> all differing nodes in the new CFG are reachable from these *)
 }
 
 type changed_global = {
@@ -31,7 +30,7 @@ let should_reanalyze (fdec: Cil.fundec) =
 (* If some CFGs of the two functions to be compared are provided, a fine-grained CFG comparison is done that also determines which
  * nodes of the function changed. If on the other hand no CFGs are provided, the "old" AST comparison on the CIL.file is
  * used for functions. Then no information is collected regarding which parts/nodes of the function changed. *)
-let eqF (a: Cil.fundec) (b: Cil.fundec) (cfgs : (cfg * cfg) option) =
+let eqF (a: Cil.fundec) (b: Cil.fundec) (cfgs : (cfg * (cfg * cfg)) option) =
   let unchangedHeader = eq_varinfo a.svar b.svar && GobList.equal eq_varinfo a.sformals b.sformals in
   let identical, diffOpt =
     if should_reanalyze a then
@@ -43,16 +42,17 @@ let eqF (a: Cil.fundec) (b: Cil.fundec) (cfgs : (cfg * cfg) option) =
       else
         match cfgs with
         | None -> eq_block (a.sbody, a) (b.sbody, b), None
-        | Some (cfgOld, cfgNew) ->
+        | Some (cfgOld, (cfgNew, cfgNewBack)) ->
           let module CfgOld : MyCFG.CfgForward = struct let next = cfgOld end in
           let module CfgNew : MyCFG.CfgForward = struct let next = cfgNew end in
-          let matches, diffNodes1, diffNodes2 = compareFun (module CfgOld) (module CfgNew) a b in
-          if diffNodes1 = [] && diffNodes2 = [] then (true, None)
-          else (false, Some {unchangedNodes = matches; primObsoleteNodes = diffNodes1; primNewNodes = diffNodes2})
+          let module CfgNewBack : MyCFG.CfgBackward = struct let prev = cfgNewBack end in
+          let matches, diffNodes1 = compareFun (module CfgOld) (module CfgNew) (module CfgNewBack) a b in
+          if diffNodes1 = [] then (true, None)
+          else (false, Some {unchangedNodes = matches; primObsoleteNodes = diffNodes1})
   in
   identical, unchangedHeader, diffOpt
 
-let eq_glob (a: global) (b: global) (cfgs : (cfg * cfg) option) = match a, b with
+let eq_glob (a: global) (b: global) (cfgs : (cfg * (cfg * cfg)) option) = match a, b with
   | GFun (f,_), GFun (g,_) -> eqF f g cfgs
   | GVar (x, init_x, _), GVar (y, init_y, _) -> eq_varinfo x y, false, None (* ignore the init_info - a changed init of a global will lead to a different start state *)
   | GVarDecl (x, _), GVarDecl (y, _) -> eq_varinfo x y, false, None
@@ -60,7 +60,7 @@ let eq_glob (a: global) (b: global) (cfgs : (cfg * cfg) option) = match a, b wit
 
 let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
   let cfgs = if GobConfig.get_string "incremental.compare" = "cfg"
-    then Some (CfgTools.getCFG oldAST |> fst, CfgTools.getCFG newAST |> fst)
+    then Some (CfgTools.getCFG oldAST |> fst, CfgTools.getCFG newAST)
     else None in
 
   let addGlobal map global  =


### PR DESCRIPTION
This PR contains an alternative implementation of the phase 2 from the CFG comparison. I prefer it over the previous one because I think it is easier to understand and read and it also seems to be quite a bit faster at least on this small example:
https://github.com/goblint/bench/blob/master/pthread/knot_comb.c with https://github.com/goblint/bench/blob/master/pthread/knot_comb01.patch:
```
TOTAL                           1.503 s
  parse                           0.027 s
  convert to CIL                  0.021 s
  compareCilFiles                 0.019 s
    compare-phase1                  0.003 s
    compare-phase2                  0.001 s
  analysis                        1.438 s
    global_inits                    0.003 s
    solving                         1.383 s
      S.Dom.equal                     0.009 s
      postsolver                      0.317 s
    warn_global                     0.026 s
      access                          0.026 s
```
previously:
```
TOTAL                           4.824 s
  parse                           0.028 s
  convert to CIL                  0.021 s
  compareCilFiles                 3.492 s
    compare-phase1                  0.003 s
    compare-phase2                  3.469 s
  analysis                        1.285 s
    global_inits                    0.002 s
    solving                         1.268 s
      S.Dom.equal                     0.008 s
      postsolver                      0.278 s
    warn_global                     0.006 s
      access                          0.005 s
```

In phase 1 of the CFG comparison all matching nodes are collected, that are reachable via at least one path of matching nodes from the entry node of the function. This set of nodes is however too big because it might contain a node that is influenced by a change through a new back edge (which was not recorded in the old `infl` map and will therefore not lead to the nodes destabilization before solving).
Phase 2 therefore refines this set of matching nodes found in phase 1. Previously a DFS on the new CFG was used to detect possible back edges and remove influenced nodes from the set of matching nodes. Now I implemented something like a fixpoint algorithm, that removes nodes from the set of matching nodes that have a predecessor which is not in the set of matching nodes, until it stabilizes. Any node that is removed will also be added to the set of differing nodes (an over-approximation of the set of nodes that must be destabilized).
For the set of matching nodes I now maintain two hash maps to find the corresponding node fast no matter whether the first or second node needs to be looked up.

EDIT: I'm still wondering a little about how big the difference in performance is. But so far I couldn't find any problematic behavior or bugs