### PR TITLE
Refactor mutex analyses

### DIFF
--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -412,12 +412,12 @@ struct
     let st = ctx.local in
     match e with
     | Events.Lock (addr, _) when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      Priv.lock (Analyses.ask_of_ctx octx) octx.global st addr
+      Priv.lock (Analyses.ask_of_ctx ctx) ctx.global st addr
     | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      Priv.unlock (Analyses.ask_of_ctx octx) octx.global octx.sideg st addr
+      Priv.unlock (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st addr
     (* No need to handle escape because escaped variables are always referenced but this analysis only considers unreferenced variables. *)
     | Events.EnterMultiThreaded ->
-      Priv.enter_multithreaded (Analyses.ask_of_ctx octx) octx.global octx.sideg st
+      Priv.enter_multithreaded (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st
     | _ ->
       st
 

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -408,16 +408,16 @@ struct
   let threadspawn ctx lval f args fctx =
     ctx.local
 
-  let event ctx e aprx =
+  let event ctx e octx =
     let st = ctx.local in
     match e with
     | Events.Lock (addr, _) when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      Priv.lock (Analyses.ask_of_ctx aprx) aprx.global st addr
+      Priv.lock (Analyses.ask_of_ctx octx) octx.global st addr
     | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      Priv.unlock (Analyses.ask_of_ctx aprx) aprx.global aprx.sideg st addr
+      Priv.unlock (Analyses.ask_of_ctx octx) octx.global octx.sideg st addr
     (* No need to handle escape because escaped variables are always referenced but this analysis only considers unreferenced variables. *)
     | Events.EnterMultiThreaded ->
-      Priv.enter_multithreaded (Analyses.ask_of_ctx aprx) aprx.global aprx.sideg st
+      Priv.enter_multithreaded (Analyses.ask_of_ctx octx) octx.global octx.sideg st
     | _ ->
       st
 

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -411,9 +411,9 @@ struct
   let event ctx e aprx =
     let st = ctx.local in
     match e with
-    | Events.Lock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+    | Events.MustLock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       Priv.lock (Analyses.ask_of_ctx aprx) aprx.global st addr
-    | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+    | Events.MustUnlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       Priv.unlock (Analyses.ask_of_ctx aprx) aprx.global aprx.sideg st addr
     (* No need to handle escape because escaped variables are always referenced but this analysis only considers unreferenced variables. *)
     | Events.EnterMultiThreaded ->

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -414,6 +414,8 @@ struct
     | Events.Lock (addr, _) when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       Priv.lock (Analyses.ask_of_ctx ctx) ctx.global st addr
     | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+      if addr = UnknownPtr then
+        M.info ~category:Unsound "Unknown mutex unlocked, apron privatization unsound"; (* TODO: something more sound *)
       Priv.unlock (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st addr
     (* No need to handle escape because escaped variables are always referenced but this analysis only considers unreferenced variables. *)
     | Events.EnterMultiThreaded ->

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -411,9 +411,9 @@ struct
   let event ctx e aprx =
     let st = ctx.local in
     match e with
-    | Events.MustLock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+    | Events.Lock (addr, _) when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       Priv.lock (Analyses.ask_of_ctx aprx) aprx.global st addr
-    | Events.MustUnlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+    | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       Priv.unlock (Analyses.ask_of_ctx aprx) aprx.global aprx.sideg st addr
     (* No need to handle escape because escaped variables are always referenced but this analysis only considers unreferenced variables. *)
     | Events.EnterMultiThreaded ->

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -438,12 +438,17 @@ struct
     {st with apr = apr_local'}
 
   let lock ask getg (st: apron_components_t) m =
-    let apr = st.apr in
-    let get_m = get_m_with_mutex_inits ask getg m in
-    (* Additionally filter get_m in case it contains variables it no longer protects. E.g. in 36/22. *)
-    let get_m = keep_only_protected_globals ask m get_m in
-    let apr' = AD.meet apr get_m in
-    {st with apr = apr'}
+    (* TODO: somehow actually unneeded here? *)
+    if Locksets.(not (Lockset.mem m (current_lockset ask))) then (
+      let apr = st.apr in
+      let get_m = get_m_with_mutex_inits ask getg m in
+      (* Additionally filter get_m in case it contains variables it no longer protects. E.g. in 36/22. *)
+      let get_m = keep_only_protected_globals ask m get_m in
+      let apr' = AD.meet apr get_m in
+      {st with apr = apr'}
+    )
+    else
+      st (* sound w.r.t. recursive lock *)
 
   let unlock ask getg sideg (st: apron_components_t) m: apron_components_t =
     let apr = st.apr in
@@ -942,15 +947,19 @@ struct
     {apr = apr_local'; priv = (W.add g w,LMust.add lm lmust,l')}
 
   let lock ask getg (st: apron_components_t) m =
-    let apr = st.apr in
-    let _,lmust,l = st.priv in
-    let lm = LLock.mutex m in
-    let get_m = get_m_with_mutex_inits (not (LMust.mem lm lmust)) ask getg m in
-    let local_m = BatOption.default (LAD.bot ()) (L.find_opt lm l) in
-    (* Additionally filter get_m in case it contains variables it no longer protects. E.g. in 36/22. *)
-    let local_m = Cluster.keep_only_protected_globals ask m local_m in
-    let apr = Cluster.lock apr local_m get_m in
-    {st with apr}
+    if Locksets.(not (Lockset.mem m (current_lockset ask))) then (
+      let apr = st.apr in
+      let _,lmust,l = st.priv in
+      let lm = LLock.mutex m in
+      let get_m = get_m_with_mutex_inits (not (LMust.mem lm lmust)) ask getg m in
+      let local_m = BatOption.default (LAD.bot ()) (L.find_opt lm l) in
+      (* Additionally filter get_m in case it contains variables it no longer protects. E.g. in 36/22. *)
+      let local_m = Cluster.keep_only_protected_globals ask m local_m in
+      let apr = Cluster.lock apr local_m get_m in
+      {st with apr}
+    )
+    else
+      st (* sound w.r.t. recursive lock *)
 
   let unlock ask getg sideg (st: apron_components_t) m: apron_components_t =
     let apr = st.apr in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2371,6 +2371,8 @@ struct
       if M.tracing then M.tracel "priv" "LOCK EVENT %a\n" LockDomain.Addr.pretty addr;
       Priv.lock (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) st addr
     | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+      if addr = UnknownPtr then
+        M.info ~category:Unsound "Unknown mutex unlocked, base privatization unsound"; (* TODO: something more sound *)
       Priv.unlock (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st addr
     | Events.Escape escaped ->
       Priv.escape (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st escaped

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2367,10 +2367,10 @@ struct
   let event ctx e octx =
     let st: store = ctx.local in
     match e with
-    | Events.Lock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+    | Events.MustLock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       if M.tracing then M.tracel "priv" "LOCK EVENT %a\n" LockDomain.Addr.pretty addr;
       Priv.lock (Analyses.ask_of_ctx octx) (priv_getg octx.global) st addr
-    | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+    | Events.MustUnlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       Priv.unlock (Analyses.ask_of_ctx octx) (priv_getg octx.global) (priv_sideg octx.sideg) st addr
     | Events.Escape escaped ->
       Priv.escape (Analyses.ask_of_ctx octx) (priv_getg octx.global) (priv_sideg octx.sideg) st escaped

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2367,10 +2367,10 @@ struct
   let event ctx e octx =
     let st: store = ctx.local in
     match e with
-    | Events.MustLock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+    | Events.Lock (addr, _) when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       if M.tracing then M.tracel "priv" "LOCK EVENT %a\n" LockDomain.Addr.pretty addr;
       Priv.lock (Analyses.ask_of_ctx octx) (priv_getg octx.global) st addr
-    | Events.MustUnlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+    | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       Priv.unlock (Analyses.ask_of_ctx octx) (priv_getg octx.global) (priv_sideg octx.sideg) st addr
     | Events.Escape escaped ->
       Priv.escape (Analyses.ask_of_ctx octx) (priv_getg octx.global) (priv_sideg octx.sideg) st escaped

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2369,13 +2369,13 @@ struct
     match e with
     | Events.Lock (addr, _) when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       if M.tracing then M.tracel "priv" "LOCK EVENT %a\n" LockDomain.Addr.pretty addr;
-      Priv.lock (Analyses.ask_of_ctx octx) (priv_getg octx.global) st addr
+      Priv.lock (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) st addr
     | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      Priv.unlock (Analyses.ask_of_ctx octx) (priv_getg octx.global) (priv_sideg octx.sideg) st addr
+      Priv.unlock (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st addr
     | Events.Escape escaped ->
-      Priv.escape (Analyses.ask_of_ctx octx) (priv_getg octx.global) (priv_sideg octx.sideg) st escaped
+      Priv.escape (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st escaped
     | Events.EnterMultiThreaded ->
-      Priv.enter_multithreaded (Analyses.ask_of_ctx octx) (priv_getg octx.global) (priv_sideg octx.sideg) st
+      Priv.enter_multithreaded (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st
     | Events.AssignSpawnedThread (lval, tid) ->
       (* TODO: is this type right? *)
       set ~ctx:(Some ctx) (Analyses.ask_of_ctx ctx) ctx.global ctx.local (eval_lv (Analyses.ask_of_ctx ctx) ctx.global ctx.local lval) (Cilfacade.typeOfLval lval) (`Thread (ValueDomain.Threads.singleton tid))

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -276,18 +276,23 @@ struct
     cpa' *)
 
   let lock ask getg (st: BaseComponents (D).t) m =
-    let get_m = get_m_with_mutex_inits ask getg m in
-    (* Really we want is_unprotected, but pthread_cond_wait emits unlock-lock events,
-       where our (necessary) original context still has the mutex,
-       so the query would be on the wrong lockset.
-       TODO: Fixing the event contexts is hard: https://github.com/goblint/analyzer/pull/487#discussion_r765905029.
-       Therefore, just use _without to exclude the mutex we shouldn't have.
-       In non-cond locks we don't have it anyway, so there's no difference.
-       No other privatization uses is_unprotected, so this hack is only needed here. *)
-    let is_in_V x _ = is_protected_by ask m x && is_unprotected_without ask x m in
-    let cpa' = CPA.filter is_in_V get_m in
-    if M.tracing then M.tracel "priv" "PerMutexOplusPriv.lock m=%a cpa'=%a\n" LockDomain.Addr.pretty m CPA.pretty cpa';
-    {st with cpa = CPA.fold CPA.add cpa' st.cpa}
+    if Locksets.(not (Lockset.mem m (current_lockset ask))) then (
+      let get_m = get_m_with_mutex_inits ask getg m in
+      (* Really we want is_unprotected, but pthread_cond_wait emits unlock-lock events,
+        where our (necessary) original context still has the mutex,
+        so the query would be on the wrong lockset.
+        TODO: Fixing the event contexts is hard: https://github.com/goblint/analyzer/pull/487#discussion_r765905029.
+        Therefore, just use _without to exclude the mutex we shouldn't have.
+        In non-cond locks we don't have it anyway, so there's no difference.
+        No other privatization uses is_unprotected, so this hack is only needed here. *)
+      let is_in_V x _ = is_protected_by ask m x && is_unprotected_without ask x m in
+      let cpa' = CPA.filter is_in_V get_m in
+      if M.tracing then M.tracel "priv" "PerMutexOplusPriv.lock m=%a cpa'=%a\n" LockDomain.Addr.pretty m CPA.pretty cpa';
+      {st with cpa = CPA.fold CPA.add cpa' st.cpa}
+    )
+    else
+      st (* sound w.r.t. recursive lock *)
+
   let unlock ask getg sideg (st: BaseComponents (D).t) m =
     let is_in_Gm x _ = is_protected_by ask m x in
     let side_m_cpa = CPA.filter is_in_Gm st.cpa in
@@ -351,15 +356,20 @@ struct
     ignore (Pretty.printf "WRITE GLOBAL %a %a = %a\n" d_varinfo x VD.pretty v CPA.pretty cpa');
     cpa' *)
 
-  let lock ask getg (st: BaseComponents (D).t) m =
-    let get_m = get_m_with_mutex_inits ask getg m in
-    (* Additionally filter get_m in case it contains variables it no longer protects. *)
-    let is_in_Gm x _ = is_protected_by ask m x in
-    let get_m = CPA.filter is_in_Gm get_m in
-    let long_meet m1 m2 = CPA.long_map2 VD.meet m1 m2 in
-    let meet = long_meet st.cpa get_m in
-    if M.tracing then M.tracel "priv" "LOCK %a:\n  get_m: %a\n  meet: %a\n" LockDomain.Addr.pretty m CPA.pretty get_m CPA.pretty meet;
-    {st with cpa = meet}
+  let lock (ask: Queries.ask) getg (st: BaseComponents (D).t) m =
+    if Locksets.(not (Lockset.mem m (current_lockset ask))) then (
+      let get_m = get_m_with_mutex_inits ask getg m in
+      (* Additionally filter get_m in case it contains variables it no longer protects. *)
+      let is_in_Gm x _ = is_protected_by ask m x in
+      let get_m = CPA.filter is_in_Gm get_m in
+      let long_meet m1 m2 = CPA.long_map2 VD.meet m1 m2 in
+      let meet = long_meet st.cpa get_m in
+      if M.tracing then M.tracel "priv" "LOCK %a:\n  get_m: %a\n  meet: %a\n" LockDomain.Addr.pretty m CPA.pretty get_m CPA.pretty meet;
+      {st with cpa = meet}
+    )
+    else
+      st (* sound w.r.t. recursive lock *)
+
   let unlock ask getg sideg (st: BaseComponents (D).t) m =
     let is_in_Gm x _ = is_protected_by ask m x in
     sideg (V.mutex m) (CPA.filter is_in_Gm st.cpa);

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -127,7 +127,7 @@ struct
     if !GU.global_initialization then
       Lockset.empty ()
     else
-      let ls = ask.f Queries.CurrentLockset in
+      let ls = ask.f Queries.MustLockset in
       Q.LS.fold (fun (var, offs) acc ->
           Lockset.add (Lock.from_var_offset (var, conv_offset offs)) acc
         ) ls (Lockset.empty ())

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -48,11 +48,11 @@ struct
 
   let event ctx e octx =
     match e with
-    | Events.Lock2 l ->
+    | Events.Lock l ->
       let lockAddr = fst l in
       addLockingInfo {addr = lockAddr; loc = !Tracing.current_loc } ctx.local;
       D.add {addr = lockAddr; loc = !Tracing.current_loc } ctx.local
-    | Events.Unlock2 l ->
+    | Events.Unlock l ->
       let inLockAddrs e = ValueDomain.Addr.equal (fst l) e.addr in
       D.filter (neg inLockAddrs) ctx.local
     | _ ->

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -60,4 +60,4 @@ struct
 end
 
 let _ =
-  MCP.register_analysis (module Spec : MCPSpec)
+  MCP.register_analysis ~dep:["mutexEvents"] (module Spec : MCPSpec)

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -3,7 +3,6 @@
 open Prelude.Ana
 open Analyses
 open DeadlockDomain
-open ValueDomain
 
 let forbiddenList : ( (myowntypeEntry*myowntypeEntry) list ref) = ref []
 

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -18,9 +18,8 @@ struct
     in
 
     let may_equal l1 l2 = match l1, l2 with
-      | {addr = a; _}, _ when Addr.equal a (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
-        true
-      | _, {addr = a; _} when Addr.equal a (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
+      | {addr = UnknownPtr; _}, _
+      | _, {addr = UnknownPtr; _} ->
         true
       | _, _ -> MyLock.equal l1 l2
     in

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -64,6 +64,9 @@ struct
     | Events.Unlock l when Addr.equal l (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
       (* unlock nothing *)
       ctx.local
+    | Events.Unlock Addr (v, _) when ctx.ask (IsMultiple v) ->
+      (* unlock nothing *)
+      ctx.local
     | Events.Unlock l ->
       let inLockAddrs e = ValueDomain.Addr.equal l e.addr in
       D.filter (neg inLockAddrs) ctx.local

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -61,6 +61,9 @@ struct
       let lockAddr = fst l in
       addLockingInfo {addr = lockAddr; loc = !Tracing.current_loc } ctx.local;
       D.add {addr = lockAddr; loc = !Tracing.current_loc } ctx.local
+    | Events.Unlock l when Addr.equal l (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
+      (* unlock nothing *)
+      ctx.local
     | Events.Unlock l ->
       let inLockAddrs e = ValueDomain.Addr.equal l e.addr in
       D.filter (neg inLockAddrs) ctx.local

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -53,7 +53,7 @@ struct
       addLockingInfo {addr = lockAddr; loc = !Tracing.current_loc } ctx.local;
       D.add {addr = lockAddr; loc = !Tracing.current_loc } ctx.local
     | Events.Unlock l ->
-      let inLockAddrs e = ValueDomain.Addr.equal (fst l) e.addr in
+      let inLockAddrs e = ValueDomain.Addr.equal l e.addr in
       D.filter (neg inLockAddrs) ctx.local
     | _ ->
       ctx.local

--- a/src/analyses/locksetAnalysis.ml
+++ b/src/analyses/locksetAnalysis.ml
@@ -41,7 +41,7 @@ struct
     match e with
     | Events.Lock l ->
       Arg.add ctx l (* add all locks, including blob and unknown *)
-    | Events.Unlock l when Addr.equal l (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
+    | Events.Unlock UnknownPtr ->
       ctx.local (* don't remove any locks, including unknown itself *)
     | Events.Unlock Addr (v, _) when ctx.ask (IsMultiple v) ->
       ctx.local (* don't remove non-unique lock *)
@@ -65,13 +65,13 @@ struct
 
   let event ctx e octx =
     match e with
-    | Events.Lock (a, _) when Addr.equal a (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
+    | Events.Lock (UnknownPtr, _) ->
       ctx.local (* don't add unknown lock *)
     | Events.Lock (Addr (v, _), _) when ctx.ask (IsMultiple v) ->
       ctx.local (* don't add non-unique lock *)
     | Events.Lock l ->
       Arg.add ctx l (* add definite lock or none in parallel if ambiguous *)
-    | Events.Unlock l when Addr.equal l (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
+    | Events.Unlock UnknownPtr ->
       Arg.remove_all ctx (* remove all locks *)
     | Events.Unlock l ->
       Arg.remove ctx l (* remove definite lock or all in parallel if ambiguous (blob lock is never added) *)

--- a/src/analyses/locksetAnalysis.ml
+++ b/src/analyses/locksetAnalysis.ml
@@ -4,24 +4,19 @@ open Prelude.Ana
 open Analyses
 open ValueDomain
 
-module type Arg =
-sig
-  module D: sig
-    include Lattice.S
-    val empty: unit -> t
-  end
 
-  val add: (D.t, _, D.t, _) ctx -> LockDomain.Lockset.Lock.t -> D.t
-  val remove: (D.t, _, D.t, _) ctx -> Addr.t -> D.t
+module type DS =
+sig
+  include Lattice.S
+  val empty: unit -> t
 end
 
-
-module Make (Arg: Arg): MCPSpec with module D = Arg.D and module C = Arg.D =
+module Make (D: DS) =
 struct
   include Analyses.IdentitySpec
   let name () = "lockset"
 
-  module D = Arg.D
+  module D = D
   module C = D
 
   let startstate v = D.empty ()
@@ -30,9 +25,16 @@ struct
 end
 
 
-module MakeMay (Arg: Arg): MCPSpec with module D = Arg.D and module C = Arg.D =
+module type MayArg =
+sig
+  module D: DS
+  val add: (D.t, _, D.t, _) ctx -> LockDomain.Lockset.Lock.t -> D.t
+  val remove: (D.t, _, D.t, _) ctx -> Addr.t -> D.t
+end
+
+module MakeMay (Arg: MayArg) =
 struct
-  include Make (Arg)
+  include Make (Arg.D)
   let name () = "mayLockset"
 
   let event ctx e octx =
@@ -45,6 +47,30 @@ struct
     | Events.Unlock Addr (v, _) when ctx.ask (IsMultiple v) ->
       (* unlock nothing *)
       ctx.local
+    | Events.Unlock l ->
+      Arg.remove ctx l
+    | _ ->
+      ctx.local
+end
+
+
+module type MustArg =
+sig
+  include MayArg
+  val remove_all: (D.t, _, D.t, _) ctx -> D.t
+end
+
+module MakeMust (Arg: MustArg) =
+struct
+  include Make (Arg.D)
+  let name () = "mustLockset"
+
+  let event ctx e octx =
+    match e with
+    | Events.Lock ((Addr (v, _) as a, _) as l) when not (Addr.equal a (Addr.from_var_offset (dummyFunDec.svar, `NoOffset))) && not (ctx.ask (IsMultiple v)) ->
+      Arg.add ctx l
+    | Events.Unlock l when Addr.equal l (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
+      Arg.remove_all ctx
     | Events.Unlock l ->
       Arg.remove ctx l
     | _ ->

--- a/src/analyses/locksetAnalysis.ml
+++ b/src/analyses/locksetAnalysis.ml
@@ -2,7 +2,6 @@
 
 open Prelude.Ana
 open Analyses
-open ValueDomain
 
 
 module type DS =
@@ -29,7 +28,7 @@ module type MayArg =
 sig
   module D: DS
   val add: (D.t, _, D.t, _) ctx -> LockDomain.Lockset.Lock.t -> D.t
-  val remove: (D.t, _, D.t, _) ctx -> Addr.t -> D.t
+  val remove: (D.t, _, D.t, _) ctx -> ValueDomain.Addr.t -> D.t
 end
 
 module MakeMay (Arg: MayArg) =

--- a/src/analyses/locksetAnalysis.ml
+++ b/src/analyses/locksetAnalysis.ml
@@ -1,0 +1,52 @@
+(** Basic lockset analyses. *)
+
+open Prelude.Ana
+open Analyses
+open ValueDomain
+
+module type Arg =
+sig
+  module D: sig
+    include Lattice.S
+    val empty: unit -> t
+  end
+
+  val add: (D.t, _, D.t, _) ctx -> LockDomain.Lockset.Lock.t -> D.t
+  val remove: (D.t, _, D.t, _) ctx -> Addr.t -> D.t
+end
+
+
+module Make (Arg: Arg): MCPSpec with module D = Arg.D and module C = Arg.D =
+struct
+  include Analyses.IdentitySpec
+  let name () = "lockset"
+
+  module D = Arg.D
+  module C = D
+
+  let startstate v = D.empty ()
+  let threadenter ctx lval f args = [D.empty ()]
+  let exitstate  v = D.empty ()
+end
+
+
+module MakeMay (Arg: Arg): MCPSpec with module D = Arg.D and module C = Arg.D =
+struct
+  include Make (Arg)
+  let name () = "mayLockset"
+
+  let event ctx e octx =
+    match e with
+    | Events.Lock l ->
+      Arg.add ctx l
+    | Events.Unlock l when Addr.equal l (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
+      (* unlock nothing *)
+      ctx.local
+    | Events.Unlock Addr (v, _) when ctx.ask (IsMultiple v) ->
+      (* unlock nothing *)
+      ctx.local
+    | Events.Unlock l ->
+      Arg.remove ctx l
+    | _ ->
+      ctx.local
+end

--- a/src/analyses/mayLocks.ml
+++ b/src/analyses/mayLocks.ml
@@ -12,27 +12,6 @@ struct
   module D = LockDomain.MayLockset
   module C = LockDomain.MayLockset
 
-  (* locking logic -- add all locks we can add *)
-  (* let lock ctx rw may_fail return_value_on_success a lv arglist ls : D.ReverseAddrSet.t =
-    let add_one ls e = D.add (e,rw) ls in
-    let nls = List.fold_left add_one ls (List.concat_map (eval_exp_addr a) arglist) in
-    match lv with
-    | None -> nls
-    | Some lv ->
-      ctx.split nls [Events.SplitBranch (Lval lv, return_value_on_success)];
-      if may_fail then ctx.split ls [Events.SplitBranch (Lval lv, not return_value_on_success)];
-      raise Analyses.Deadcode *)
-
-  (* let remove_rw x st = D.remove (x,true) (D.remove (x,false) st)
-  (* unlocking logic *)
-  let unlock remove_fn =
-    match arglist with
-    | x::xs -> begin match  (eval_exp_addr (Analyses.ask_of_ctx ctx) x) with
-        | [x] -> remove_fn x ctx.local
-        | _ -> ctx.local
-      end
-    | _ -> ctx.local *)
-
   let startstate v = D.empty ()
   let threadenter ctx lval f args = [D.empty ()]
   let exitstate  v = D.top ()

--- a/src/analyses/mayLocks.ml
+++ b/src/analyses/mayLocks.ml
@@ -41,7 +41,7 @@ struct
     | Events.Lock l ->
       D.add l ctx.local
     | Events.Unlock l ->
-      D.remove l ctx.local
+      D.remove (l, true) (D.remove (l, false) ctx.local)
     | _ ->
       ctx.local
 end

--- a/src/analyses/mayLocks.ml
+++ b/src/analyses/mayLocks.ml
@@ -47,4 +47,4 @@ struct
 end
 
 let _ =
-  MCP.register_analysis (module Spec : MCPSpec)
+  MCP.register_analysis ~dep:["mutexEvents"] (module Spec : MCPSpec)

--- a/src/analyses/mayLocks.ml
+++ b/src/analyses/mayLocks.ml
@@ -5,38 +5,14 @@ open Analyses
 
 module Spec =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.IdentitySpec
 
   let name () = "maylocks"
   module D = LockDomain.MayLockset
   module C = LockDomain.MayLockset
 
-  (* transfer functions : usual operation just propagates the value *)
-  let assign ctx (lval:lval) (rval:exp) : D.t = ctx.local
-  let branch ctx (exp:exp) (tv:bool) : D.t = ctx.local
-  let body ctx (f:fundec) : D.t = ctx.local
-  let return ctx (exp:exp option) (f:fundec) : D.t = ctx.local
-  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list = [ctx.local,ctx.local]
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) : D.t = au
-
-  (* Helper function to convert query-offsets to valuedomain-offsets *)
-  let rec conv_offset x =
-    match x with
-    | `NoOffset    -> `NoOffset
-    | `Index (Const (CInt (i,ikind,s)),o) -> `Index (IntDomain.of_const (i,ikind,s), conv_offset o)
-    | `Index (_,o) -> `Index (ValueDomain.IndexDomain.top (), conv_offset o)
-    | `Field (f,o) -> `Field (f, conv_offset o)
-
-  (* Query the value (of the locking argument) to a list of locks. *)
-  let eval_exp_addr (a: Queries.ask) exp =
-    let gather_addr (v,o) b = ValueDomain.Addr.from_var_offset (v,conv_offset o) :: b in
-    match a.f (Queries.MayPointTo exp) with
-    | a when not (Queries.LS.is_top a) ->
-      Queries.LS.fold gather_addr (Queries.LS.remove (dummyFunDec.svar, `NoOffset) a) []
-    | b -> Messages.warn "Could not evaluate '%a' to an points-to set, instead got '%a'." d_exp exp Queries.LS.pretty b; []
-
   (* locking logic -- add all locks we can add *)
-  let lock ctx rw may_fail return_value_on_success a lv arglist ls : D.ReverseAddrSet.t =
+  (* let lock ctx rw may_fail return_value_on_success a lv arglist ls : D.ReverseAddrSet.t =
     let add_one ls e = D.add (e,rw) ls in
     let nls = List.fold_left add_one ls (List.concat_map (eval_exp_addr a) arglist) in
     match lv with
@@ -44,32 +20,30 @@ struct
     | Some lv ->
       ctx.split nls [Events.SplitBranch (Lval lv, return_value_on_success)];
       if may_fail then ctx.split ls [Events.SplitBranch (Lval lv, not return_value_on_success)];
-      raise Analyses.Deadcode
+      raise Analyses.Deadcode *)
 
-  (* transfer function to handle library functions --- for us locking & unlocking *)
-  let special ctx (lv: lval option) (f:varinfo) (arglist:exp list) : D.t =
-    let remove_rw x st = D.remove (x,true) (D.remove (x,false) st) in
-    (* unlocking logic *)
-    let unlock remove_fn =
-      match arglist with
-      | x::xs -> begin match  (eval_exp_addr (Analyses.ask_of_ctx ctx) x) with
-          | [x] -> remove_fn x ctx.local
-          | _ -> ctx.local
-        end
-      | _ -> ctx.local
-    in
-    match (LibraryFunctions.classify f.vname arglist, f.vname) with
-    | `Lock (failing, rw, return_value_on_success), _
-      -> lock ctx rw failing return_value_on_success (Analyses.ask_of_ctx ctx) lv arglist ctx.local
-    | `Unlock, _
-      -> unlock remove_rw
-
-    | _ -> ctx.local
+  (* let remove_rw x st = D.remove (x,true) (D.remove (x,false) st)
+  (* unlocking logic *)
+  let unlock remove_fn =
+    match arglist with
+    | x::xs -> begin match  (eval_exp_addr (Analyses.ask_of_ctx ctx) x) with
+        | [x] -> remove_fn x ctx.local
+        | _ -> ctx.local
+      end
+    | _ -> ctx.local *)
 
   let startstate v = D.empty ()
   let threadenter ctx lval f args = [D.empty ()]
-  let threadspawn ctx lval f args fctx = ctx.local
   let exitstate  v = D.top ()
+
+  let event ctx e octx =
+    match e with
+    | Events.Lock2 l ->
+      D.add l ctx.local
+    | Events.Unlock2 l ->
+      D.remove l ctx.local
+    | _ ->
+      ctx.local
 end
 
 let _ =

--- a/src/analyses/mayLocks.ml
+++ b/src/analyses/mayLocks.ml
@@ -1,4 +1,4 @@
-(** May-lockset analysis. *)
+(** May lockset analysis (unused). *)
 
 open Prelude.Ana
 open Analyses

--- a/src/analyses/mayLocks.ml
+++ b/src/analyses/mayLocks.ml
@@ -2,6 +2,7 @@
 
 open Prelude.Ana
 open Analyses
+open ValueDomain
 
 module Spec =
 struct
@@ -40,6 +41,9 @@ struct
     match e with
     | Events.Lock l ->
       D.add l ctx.local
+    | Events.Unlock l when Addr.equal l (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
+      (* unlock nothing *)
+      ctx.local
     | Events.Unlock l ->
       D.remove (l, true) (D.remove (l, false) ctx.local)
     | _ ->

--- a/src/analyses/mayLocks.ml
+++ b/src/analyses/mayLocks.ml
@@ -38,9 +38,9 @@ struct
 
   let event ctx e octx =
     match e with
-    | Events.Lock2 l ->
+    | Events.Lock l ->
       D.add l ctx.local
-    | Events.Unlock2 l ->
+    | Events.Unlock l ->
       D.remove l ctx.local
     | _ ->
       ctx.local

--- a/src/analyses/mayLocks.ml
+++ b/src/analyses/mayLocks.ml
@@ -44,6 +44,9 @@ struct
     | Events.Unlock l when Addr.equal l (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
       (* unlock nothing *)
       ctx.local
+    | Events.Unlock Addr (v, _) when ctx.ask (IsMultiple v) ->
+      (* unlock nothing *)
+      ctx.local
     | Events.Unlock l ->
       D.remove (l, true) (D.remove (l, false) ctx.local)
     | _ ->

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -125,14 +125,14 @@ struct
         | None -> M.info ~category:Unsound "Write to unknown address: privatization is unsound."
       end;
       ctx.local
-    | Events.Lock2 l ->
+    | Events.Lock l ->
       let nls = D.add l ctx.local in
       if not (D.equal ctx.local nls) then
-        ctx.emit (Lock (fst l));
+        ctx.emit (MustLock (fst l));
       nls
-    | Events.Unlock2 l ->
+    | Events.Unlock l ->
       if snd l then
-        ctx.emit (Unlock (fst l));
+        ctx.emit (MustUnlock (fst l));
       D.remove l ctx.local
     | _ ->
       ctx.local

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -125,7 +125,7 @@ struct
         | None -> M.info ~category:Unsound "Write to unknown address: privatization is unsound."
       end;
       ctx.local
-    | Events.Lock ((Addr (v, _), _) as l) when not (ctx.ask (IsMultiple v)) ->
+    | Events.Lock ((Addr (v, _) as a, _) as l) when not (Addr.equal a (Addr.from_var_offset (dummyFunDec.svar, `NoOffset))) && not (ctx.ask (IsMultiple v)) ->
       let nls = D.add l ctx.local in
       if not (D.equal ctx.local nls) then
         ctx.emit (MustLock (fst l));

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -135,6 +135,7 @@ struct
       Mutexes.iter (fun m ->
           ctx.emit (MustUnlock m)
         ) (D.export_locks ctx.local);
+      (* TODO: used to have remove_nonspecial, which kept v.vname.[0] = '{' variables *)
       D.empty ()
     | Events.Unlock l ->
       ctx.emit (MustUnlock l);

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -125,7 +125,7 @@ struct
         | None -> M.info ~category:Unsound "Write to unknown address: privatization is unsound."
       end;
       ctx.local
-    | Events.Lock l ->
+    | Events.Lock ((Addr (v, _), _) as l) when not (ctx.ask (IsMultiple v)) ->
       let nls = D.add l ctx.local in
       if not (D.equal ctx.local nls) then
         ctx.emit (MustLock (fst l));

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -131,7 +131,8 @@ struct
         ctx.emit (Lock (fst l));
       nls
     | Events.Unlock2 l ->
-      ctx.emit (Unlock (fst l));
+      if snd l then
+        ctx.emit (Unlock (fst l));
       D.remove l ctx.local
     | _ ->
       ctx.local

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -14,18 +14,16 @@ struct
   module D = Lockset
 
   let add ctx l =
-    let nls = D.add l ctx.local in
-    ctx.emit (MustLock (fst l));
-    nls
+    D.add l ctx.local
 
   let remove ctx l =
-    ctx.emit (MustUnlock l);
     D.remove (l, true) (D.remove (l, false) ctx.local)
 
   let remove_all ctx =
-    Mutexes.iter (fun m ->
+    (* TODO: implement in privatizations? *)
+    (* Mutexes.iter (fun m ->
         ctx.emit (MustUnlock m)
-      ) (D.export_locks ctx.local);
+      ) (D.export_locks ctx.local); *)
     (* TODO: used to have remove_nonspecial, which kept v.vname.[0] = '{' variables *)
     D.empty ()
 end

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -131,9 +131,8 @@ struct
         ctx.emit (MustLock (fst l));
       nls
     | Events.Unlock l ->
-      if snd l then
-        ctx.emit (MustUnlock (fst l));
-      D.remove l ctx.local
+      ctx.emit (MustUnlock l);
+      D.remove (l, true) (D.remove (l, false) ctx.local)
     | _ ->
       ctx.local
 

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -130,6 +130,12 @@ struct
       if not (D.equal ctx.local nls) then
         ctx.emit (MustLock (fst l));
       nls
+    | Events.Unlock l when Addr.equal l (Addr.from_var_offset (dummyFunDec.svar, `NoOffset)) ->
+      (* unlock everything! *)
+      Mutexes.iter (fun m ->
+          ctx.emit (MustUnlock m)
+        ) (D.export_locks ctx.local);
+      D.empty ()
     | Events.Unlock l ->
       ctx.emit (MustUnlock l);
       D.remove (l, true) (D.remove (l, false) ctx.local)

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -15,8 +15,7 @@ struct
 
   let add ctx l =
     let nls = D.add l ctx.local in
-    if not (D.equal ctx.local nls) then
-      ctx.emit (MustLock (fst l));
+    ctx.emit (MustLock (fst l));
     nls
 
   let remove ctx l =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -1,4 +1,4 @@
-(** Mutex analysis. *)
+(** Protecting mutex analysis. Must locksets locally and for globals. *)
 
 module M = Messages
 module Addr = ValueDomain.Addr
@@ -17,7 +17,6 @@ sig
   val check_fun: ?write:bool -> Lockset.t -> G.t
 end
 
-(** Mutex analyzer without base --- this is the new standard *)
 module MakeSpec (P: SpecParam) =
 struct
   module Arg =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -38,70 +38,12 @@ struct
 
   let should_join x y = D.equal x y
 
-  (* NB! Currently we care only about concrete indexes. Base (seeing only a int domain
-     element) answers with the string "unknown" on all non-concrete cases. *)
-  let rec conv_offset x =
-    match x with
-    | `NoOffset    -> `NoOffset
-    | `Index (Const (CInt (i,_,s)),o) -> `Index (IntDomain.of_const (i,Cilfacade.ptrdiff_ikind (),s), conv_offset o)
-    | `Index (_,o) -> `Index (ValueDomain.IndexDomain.top (), conv_offset o)
-    | `Field (f,o) -> `Field (f, conv_offset o)
-
   let rec conv_offset_inv = function
     | `NoOffset -> `NoOffset
     | `Field (f, o) -> `Field (f, conv_offset_inv o)
     (* TODO: better indices handling *)
     | `Index (_, o) -> `Index (MyCFG.unknown_exp, conv_offset_inv o)
 
-
-  let eval_exp_addr (a: Queries.ask) exp =
-    let gather_addr (v,o) b = ValueDomain.Addr.from_var_offset (v,conv_offset o) :: b in
-    match a.f (Queries.MayPointTo exp) with
-    | a when not (Queries.LS.is_top a)
-                   && not (Queries.LS.mem (dummyFunDec.svar,`NoOffset) a) ->
-      Queries.LS.fold gather_addr (Queries.LS.remove (dummyFunDec.svar, `NoOffset) a) []
-    | _ -> []
-
-  let lock ctx rw may_fail nonzero_return_when_aquired a lv arglist ls =
-    let is_a_blob addr =
-      match LockDomain.Addr.to_var addr with
-      | Some a -> a.vname.[0] = '('
-      | None -> false
-    in
-    let lock_one (e:LockDomain.Addr.t) =
-      if is_a_blob e then
-        ls
-      else begin
-        let nls = Lockset.add (e,rw) ls in
-        let changed = Lockset.compare ls nls <> 0 in
-        match lv with
-        | None ->
-          if may_fail then
-            ls
-          else (
-            (* If the lockset did not change, do not emit Lock event *)
-            if changed then ctx.emit (Events.Lock e);
-            nls
-          )
-        | Some lv ->
-          let sb = Events.SplitBranch (Lval lv, nonzero_return_when_aquired) in
-          if changed then
-            ctx.split nls [sb; Events.Lock e]
-          else
-            ctx.split nls [sb];
-          if may_fail then (
-            let fail_exp = if nonzero_return_when_aquired then Lval lv else BinOp(Gt, Lval lv, zero, intType) in
-            ctx.split ls [Events.SplitBranch (fail_exp, not nonzero_return_when_aquired)]
-          );
-          raise Analyses.Deadcode
-      end
-    in
-    match arglist with
-    | [x] -> begin match  (eval_exp_addr a x) with
-        | [e]  -> lock_one e
-        | _ -> ls
-      end
-    | _ -> Lockset.top ()
 
 
   (** We just lift start state, global and dependency functions: *)
@@ -179,101 +121,13 @@ struct
     ctx.local
 
   let return ctx exp fundec : D.t =
-    (* deprecated but still valid SV-COMP convention for atomic block *)
-    if get_bool "ana.sv-comp.functions" && String.starts_with fundec.svar.vname "__VERIFIER_atomic_" then (
-      ctx.emit (Events.Unlock verifier_atomic);
-      Lockset.remove (verifier_atomic, true) ctx.local
-    )
-    else
-      ctx.local
+    ctx.local
 
   let body ctx f : D.t =
-    (* deprecated but still valid SV-COMP convention for atomic block *)
-    if get_bool "ana.sv-comp.functions" && String.starts_with f.svar.vname "__VERIFIER_atomic_" then (
-      ctx.emit (Events.Lock verifier_atomic);
-      Lockset.add (verifier_atomic, true) ctx.local
-    )
-    else
-      ctx.local
+    ctx.local
 
   let special ctx lv f arglist : D.t =
-    let remove_rw x st =
-      ctx.emit (Events.Unlock x);
-      Lockset.remove (x,true) (Lockset.remove (x,false) st)
-    in
-    let unlock remove_fn =
-      let remove_nonspecial x =
-        if Lockset.is_top x then x else
-          Lockset.filter (fun (v,_) -> match LockDomain.Addr.to_var v with
-              | Some v when v.vname.[0] = '{' -> true
-              | _ -> false
-            ) x
-      in
-      match arglist with
-      | x::xs -> begin match  (eval_exp_addr (Analyses.ask_of_ctx ctx) x) with
-          | [] -> remove_nonspecial ctx.local
-          | es -> List.fold_right remove_fn es ctx.local
-        end
-      | _ -> ctx.local
-    in
-    match (LF.classify f.vname arglist, f.vname) with
-    | _, "_lock_kernel" ->
-      ctx.emit (Events.Lock big_kernel_lock);
-      Lockset.add (big_kernel_lock,true) ctx.local
-    | _, "_unlock_kernel" ->
-      ctx.emit (Events.Unlock big_kernel_lock);
-      Lockset.remove (big_kernel_lock,true) ctx.local
-    | `Lock (failing, rw, nonzero_return_when_aquired), _
-      -> let arglist = if f.vname = "LAP_Se_WaitSemaphore" then [List.hd arglist] else arglist in
-      (*print_endline @@ "Mutex `Lock "^f.vname;*)
-      lock ctx rw failing nonzero_return_when_aquired (Analyses.ask_of_ctx ctx) lv arglist ctx.local
-    | `Unlock, "__raw_read_unlock"
-    | `Unlock, "__raw_write_unlock"  ->
-      let drop_raw_lock x =
-        let rec drop_offs o =
-          match o with
-          | `Field ({fname="raw_lock"; _},`NoOffset) -> `NoOffset
-          | `Field (f1,o1) -> `Field (f1, drop_offs o1)
-          | `Index (i1,o1) -> `Index (i1, drop_offs o1)
-          | `NoOffset -> `NoOffset
-        in
-        match Addr.to_var_offset x with
-        | Some (v,o) -> Addr.from_var_offset (v, drop_offs o)
-        | None -> x
-      in
-      unlock (fun l -> remove_rw (drop_raw_lock l))
-    | `Unlock, _ ->
-      (*print_endline @@ "Mutex `Unlock "^f.vname;*)
-      unlock remove_rw
-    | _, "spinlock_check" -> ctx.local
-    | _, "acquire_console_sem" when get_bool "kernel" ->
-      ctx.emit (Events.Lock console_sem);
-      Lockset.add (console_sem,true) ctx.local
-    | _, "release_console_sem" when get_bool "kernel" ->
-      ctx.emit (Events.Unlock console_sem);
-      Lockset.remove (console_sem,true) ctx.local
-    | _, "__builtin_prefetch" | _, "misc_deregister" ->
-      ctx.local
-    | _, "__VERIFIER_atomic_begin" when get_bool "ana.sv-comp.functions" ->
-      ctx.emit (Events.Lock verifier_atomic);
-      Lockset.add (verifier_atomic, true) ctx.local
-    | _, "__VERIFIER_atomic_end" when get_bool "ana.sv-comp.functions" ->
-      ctx.emit (Events.Unlock verifier_atomic);
-      Lockset.remove (verifier_atomic, true) ctx.local
-    | _, "pthread_cond_wait"
-    | _, "pthread_cond_timedwait" ->
-      (* mutex is unlocked while waiting but relocked when returns *)
-      (* emit unlock-lock events for privatization *)
-      let m_arg = List.nth arglist 1 in
-      let ms = eval_exp_addr (Analyses.ask_of_ctx ctx) m_arg in
-      List.iter (fun m ->
-          (* unlock-lock each possible mutex as a split to be dependent *)
-          (* otherwise may-point-to {a, b} might unlock a, but relock b *)
-          ctx.split ctx.local [Events.Unlock m; Events.Lock m];
-        ) ms;
-      raise Deadcode (* splits cover all cases *)
-    | _, x ->
-      ctx.local
+    ctx.local
 
   let enter ctx lv f args : (D.t * D.t) list =
     [(ctx.local,ctx.local)]
@@ -298,6 +152,14 @@ struct
         | None -> M.info ~category:Unsound "Write to unknown address: privatization is unsound."
       end;
       ctx.local
+    | Events.Lock2 l ->
+      let nls = D.add l ctx.local in
+      if not (D.equal ctx.local nls) then
+        ctx.emit (Lock (fst l));
+      nls
+    | Events.Unlock2 l ->
+      ctx.emit (Unlock (fst l));
+      D.remove l ctx.local
     | _ ->
       ctx.local
 
@@ -334,4 +196,4 @@ end
 module Spec = MakeSpec (WriteBased)
 
 let _ =
-  MCP.register_analysis ~dep:["access"] (module Spec : MCPSpec)
+  MCP.register_analysis ~dep:["mutexEvents"; "access"] (module Spec : MCPSpec)

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -52,8 +52,13 @@ struct
   let rec conv_offset_inv = function
     | `NoOffset -> `NoOffset
     | `Field (f, o) -> `Field (f, conv_offset_inv o)
-    (* TODO: better indices handling *)
-    | `Index (_, o) -> `Index (MyCFG.unknown_exp, conv_offset_inv o)
+    | `Index (i, o) ->
+      let i_exp =
+        match ValueDomain.IndexDomain.to_int i with
+        | Some i -> Const (CInt (i, Cilfacade.ptrdiff_ikind (), Some (Z.to_string i)))
+        | None -> MyCFG.unknown_exp
+      in
+      `Index (i_exp, conv_offset_inv o)
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     let non_overlapping locks1 locks2 =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -87,7 +87,7 @@ struct
         true
       else *)
         G.leq (ctx.global global) held_locks
-    | Queries.CurrentLockset ->
+    | Queries.MustLockset ->
       let held_locks = Lockset.export_locks (Lockset.filter snd ctx.local) in
       let ls = Mutexes.fold (fun addr ls ->
           match Addr.to_var_offset addr with

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -9,10 +9,6 @@ open Prelude.Ana
 open Analyses
 open GobConfig
 
-let big_kernel_lock = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType))
-let console_sem = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[console semaphore]" intType))
-let verifier_atomic = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[__VERIFIER_atomic]" intType))
-
 module Arg =
 struct
   module D = Lockset
@@ -102,7 +98,7 @@ struct
       ls
     | Queries.MustBeAtomic ->
       let held_locks = Lockset.export_locks (Lockset.filter snd ctx.local) in
-      Mutexes.mem verifier_atomic held_locks
+      Mutexes.mem MutexEventsAnalysis.verifier_atomic held_locks
     | _ -> Queries.Result.top q
 
   module A =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -33,7 +33,6 @@ struct
       D.remove (l, true) (D.remove (l, false) ctx.local)
 
     let remove_all ctx =
-      (* TODO: implement in privatizations? *)
       (* Mutexes.iter (fun m ->
           ctx.emit (MustUnlock m)
         ) (D.export_locks ctx.local); *)

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -23,7 +23,7 @@ end
 (** Mutex analyzer without base --- this is the new standard *)
 module MakeSpec (P: SpecParam) =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.IdentitySpec
 
   (** name for the analysis (btw, it's "Only Mutex Must") *)
   let name () = "mutex"
@@ -111,33 +111,6 @@ struct
     else
       (* when reading: bump reader locks to exclusive as they protect reads *)
       Lockset.map (fun (x,_) -> (x,true)) ctx.local
-
-  (** Transfer functions: *)
-
-  let assign ctx lval rval : D.t =
-    ctx.local
-
-  let branch ctx exp tv : D.t =
-    ctx.local
-
-  let return ctx exp fundec : D.t =
-    ctx.local
-
-  let body ctx f : D.t =
-    ctx.local
-
-  let special ctx lv f arglist : D.t =
-    ctx.local
-
-  let enter ctx lv f args : (D.t * D.t) list =
-    [(ctx.local,ctx.local)]
-
-  let combine ctx lv fexp f args fc al =
-    al
-
-
-  let threadspawn ctx lval f args fctx =
-    ctx.local
 
   let event ctx e octx =
     match e with

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -132,7 +132,7 @@ struct
       end;
       ctx.local
     | _ ->
-      event ctx e octx
+      event ctx e octx (* delegate to must lockset analysis *)
 end
 
 module MyParam =

--- a/src/analyses/mutexEventsAnalysis.ml
+++ b/src/analyses/mutexEventsAnalysis.ml
@@ -1,0 +1,202 @@
+(** Mutex analysis. *)
+
+module M = Messages
+module Addr = ValueDomain.Addr
+module Lockset = LockDomain.Lockset
+module Mutexes = LockDomain.Mutexes
+module LF = LibraryFunctions
+open Prelude.Ana
+open Analyses
+open GobConfig
+
+let big_kernel_lock = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType))
+let console_sem = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[console semaphore]" intType))
+let verifier_atomic = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[__VERIFIER_atomic]" intType))
+
+module Spec: MCPSpec =
+struct
+  include UnitAnalysis.Spec
+  let name () = "mutexEvents"
+
+
+  (* NB! Currently we care only about concrete indexes. Base (seeing only a int domain
+     element) answers with the string "unknown" on all non-concrete cases. *)
+  let rec conv_offset x =
+    match x with
+    | `NoOffset    -> `NoOffset
+    | `Index (Const (CInt (i,_,s)),o) -> `Index (IntDomain.of_const (i,Cilfacade.ptrdiff_ikind (),s), conv_offset o)
+    | `Index (_,o) -> `Index (ValueDomain.IndexDomain.top (), conv_offset o)
+    | `Field (f,o) -> `Field (f, conv_offset o)
+
+  let rec conv_offset_inv = function
+    | `NoOffset -> `NoOffset
+    | `Field (f, o) -> `Field (f, conv_offset_inv o)
+    (* TODO: better indices handling *)
+    | `Index (_, o) -> `Index (MyCFG.unknown_exp, conv_offset_inv o)
+
+
+  let eval_exp_addr (a: Queries.ask) exp =
+    let gather_addr (v,o) b = ValueDomain.Addr.from_var_offset (v,conv_offset o) :: b in
+    match a.f (Queries.MayPointTo exp) with
+    | a when not (Queries.LS.is_top a) && not (Queries.LS.mem (dummyFunDec.svar,`NoOffset) a) ->
+      Queries.LS.fold gather_addr (Queries.LS.remove (dummyFunDec.svar, `NoOffset) a) []
+    | _ -> []
+
+  let lock ctx rw may_fail nonzero_return_when_aquired a lv arglist (ls: unit) =
+    let is_a_blob addr =
+      match LockDomain.Addr.to_var addr with
+      | Some a -> a.vname.[0] = '('
+      | None -> false
+    in
+    let lock_one (e:LockDomain.Addr.t) =
+      if is_a_blob e then
+        ls
+      else begin
+        (* let nls = Lockset.add (e,rw) ls in *)
+        let nls = ls in
+        (* let changed = Lockset.compare ls nls <> 0 in *)
+        let changed = true in
+        match lv with
+        | None ->
+          if may_fail then
+            ls
+          else (
+            (* If the lockset did not change, do not emit Lock event *)
+            if changed then ctx.emit (Events.Lock e);
+            nls
+          )
+        | Some lv ->
+          let sb = Events.SplitBranch (Lval lv, nonzero_return_when_aquired) in
+          if changed then
+            ctx.split nls [sb; Events.Lock e]
+          else
+            ctx.split nls [sb];
+          if may_fail then (
+            let fail_exp = if nonzero_return_when_aquired then Lval lv else BinOp(Gt, Lval lv, zero, intType) in
+            ctx.split ls [Events.SplitBranch (fail_exp, not nonzero_return_when_aquired)]
+          );
+          raise Analyses.Deadcode
+      end
+    in
+    match arglist with
+    | [x] -> begin match  (eval_exp_addr a x) with
+        | [e]  -> lock_one e
+        | _ -> ls
+      end
+    | _ ->
+      (* Lockset.top () *)
+      ()
+
+
+
+  let return ctx exp fundec : D.t =
+    (* deprecated but still valid SV-COMP convention for atomic block *)
+    if get_bool "ana.sv-comp.functions" && String.starts_with fundec.svar.vname "__VERIFIER_atomic_" then (
+      ctx.emit (Events.Unlock verifier_atomic);
+      (* Lockset.remove (verifier_atomic, true) ctx.local *)
+      ctx.local
+    )
+    else
+      ctx.local
+
+  let body ctx f : D.t =
+    (* deprecated but still valid SV-COMP convention for atomic block *)
+    if get_bool "ana.sv-comp.functions" && String.starts_with f.svar.vname "__VERIFIER_atomic_" then (
+      ctx.emit (Events.Lock verifier_atomic);
+      (* Lockset.add (verifier_atomic, true) ctx.local *)
+      ctx.local
+    )
+    else
+      ctx.local
+
+  let special (ctx: (unit, _, _, _) ctx) lv f arglist : D.t =
+    let remove_rw x st =
+      ctx.emit (Events.Unlock x);
+      (* Lockset.remove (x,true) (Lockset.remove (x,false) st) *)
+      st
+    in
+    let unlock remove_fn =
+      let remove_nonspecial x =
+        (* if Lockset.is_top x then x else
+           Lockset.filter (fun (v,_) -> match LockDomain.Addr.to_var v with
+               | Some v when v.vname.[0] = '{' -> true
+               | _ -> false
+             ) x *)
+        ()
+      in
+      match arglist with
+      | x::xs -> begin match  (eval_exp_addr (Analyses.ask_of_ctx ctx) x) with
+          | [] -> remove_nonspecial ctx.local
+          | es -> List.fold_right remove_fn es ctx.local
+        end
+      | _ -> ctx.local
+    in
+    match (LF.classify f.vname arglist, f.vname) with
+    | _, "_lock_kernel" ->
+      ctx.emit (Events.Lock big_kernel_lock);
+      (* Lockset.add (big_kernel_lock,true) ctx.local *)
+      ctx.local
+    | _, "_unlock_kernel" ->
+      ctx.emit (Events.Unlock big_kernel_lock);
+      (* Lockset.remove (big_kernel_lock,true) ctx.local *)
+      ctx.local
+    | `Lock (failing, rw, nonzero_return_when_aquired), _
+      -> let arglist = if f.vname = "LAP_Se_WaitSemaphore" then [List.hd arglist] else arglist in
+      (*print_endline @@ "Mutex `Lock "^f.vname;*)
+      lock ctx rw failing nonzero_return_when_aquired (Analyses.ask_of_ctx ctx) lv arglist ctx.local
+    | `Unlock, "__raw_read_unlock"
+    | `Unlock, "__raw_write_unlock"  ->
+      let drop_raw_lock x =
+        let rec drop_offs o =
+          match o with
+          | `Field ({fname="raw_lock"; _},`NoOffset) -> `NoOffset
+          | `Field (f1,o1) -> `Field (f1, drop_offs o1)
+          | `Index (i1,o1) -> `Index (i1, drop_offs o1)
+          | `NoOffset -> `NoOffset
+        in
+        match Addr.to_var_offset x with
+        | Some (v,o) -> Addr.from_var_offset (v, drop_offs o)
+        | None -> x
+      in
+      unlock (fun l -> remove_rw (drop_raw_lock l))
+    | `Unlock, _ ->
+      (*print_endline @@ "Mutex `Unlock "^f.vname;*)
+      unlock remove_rw
+    | _, "spinlock_check" -> ctx.local
+    | _, "acquire_console_sem" when get_bool "kernel" ->
+      ctx.emit (Events.Lock console_sem);
+      (* Lockset.add (console_sem,true) ctx.local *)
+      ctx.local
+    | _, "release_console_sem" when get_bool "kernel" ->
+      ctx.emit (Events.Unlock console_sem);
+      (* Lockset.remove (console_sem,true) ctx.local *)
+      ctx.local
+    | _, "__builtin_prefetch" | _, "misc_deregister" ->
+      ctx.local
+    | _, "__VERIFIER_atomic_begin" when get_bool "ana.sv-comp.functions" ->
+      ctx.emit (Events.Lock verifier_atomic);
+      (* Lockset.add (verifier_atomic, true) ctx.local *)
+      ctx.local
+    | _, "__VERIFIER_atomic_end" when get_bool "ana.sv-comp.functions" ->
+      ctx.emit (Events.Unlock verifier_atomic);
+      (* Lockset.remove (verifier_atomic, true) ctx.local *)
+      ctx.local
+    | _, "pthread_cond_wait"
+    | _, "pthread_cond_timedwait" ->
+      (* mutex is unlocked while waiting but relocked when returns *)
+      (* emit unlock-lock events for privatization *)
+      let m_arg = List.nth arglist 1 in
+      let ms = eval_exp_addr (Analyses.ask_of_ctx ctx) m_arg in
+      List.iter (fun m ->
+          (* unlock-lock each possible mutex as a split to be dependent *)
+          (* otherwise may-point-to {a, b} might unlock a, but relock b *)
+          ctx.split ctx.local [Events.Unlock m; Events.Lock m];
+        ) ms;
+      raise Deadcode (* splits cover all cases *)
+    | _, x ->
+      ctx.local
+
+end
+
+let _ =
+  MCP.register_analysis (module Spec : MCPSpec)

--- a/src/analyses/mutexEventsAnalysis.ml
+++ b/src/analyses/mutexEventsAnalysis.ml
@@ -52,8 +52,10 @@ struct
       if not (is_a_blob e) then begin
         match lv with
         | None ->
-          if not may_fail then
-            ctx.emit (Events.Lock (e, rw))
+          ctx.split () [Events.Lock (e, rw)];
+          if may_fail then
+            ctx.split () [];
+          raise Analyses.Deadcode
         | Some lv ->
           let sb = Events.SplitBranch (Lval lv, nonzero_return_when_aquired) in
           ctx.split () [sb; Events.Lock (e, rw)];

--- a/src/analyses/mutexEventsAnalysis.ml
+++ b/src/analyses/mutexEventsAnalysis.ml
@@ -78,14 +78,6 @@ struct
   let special (ctx: (unit, _, _, _) ctx) lv f arglist : D.t =
     let remove_rw x = x in
     let unlock remove_fn =
-      (* let remove_nonspecial x =
-        (* if Lockset.is_top x then x else
-           Lockset.filter (fun (v,_) -> match LockDomain.Addr.to_var v with
-               | Some v when v.vname.[0] = '{' -> true
-               | _ -> false
-             ) x *)
-        ()
-      in *)
       match arglist with
       | [arg] ->
         List.iter (fun e ->

--- a/src/analyses/mutexEventsAnalysis.ml
+++ b/src/analyses/mutexEventsAnalysis.ml
@@ -1,4 +1,4 @@
-(** Mutex analysis. *)
+(** Mutex events analysis (Lock and Unlock). *)
 
 module M = Messages
 module Addr = ValueDomain.Addr
@@ -19,8 +19,7 @@ struct
   let name () = "mutexEvents"
 
 
-  (* NB! Currently we care only about concrete indexes. Base (seeing only a int domain
-     element) answers with the string "unknown" on all non-concrete cases. *)
+  (* Currently we care only about concrete indexes. *)
   let rec conv_offset x =
     match x with
     | `NoOffset    -> `NoOffset

--- a/src/analyses/mutexEventsAnalysis.ml
+++ b/src/analyses/mutexEventsAnalysis.ml
@@ -39,9 +39,14 @@ struct
     let gather_addr (v,o) b = ValueDomain.Addr.from_var_offset (v,conv_offset o) :: b in
     match a.f (Queries.MayPointTo exp) with
     | a when Queries.LS.is_top a ->
-      [ValueDomain.Addr.from_var_offset (dummyFunDec.svar, `NoOffset)]
+      [Addr.UnknownPtr]
     | a ->
-      Queries.LS.fold gather_addr a []
+      let top_elt = (dummyFunDec.svar, `NoOffset) in
+      let addrs = Queries.LS.fold gather_addr (Queries.LS.remove top_elt a) [] in
+      if Queries.LS.mem top_elt a then
+        Addr.UnknownPtr :: addrs
+      else
+        addrs
 
   let lock ctx rw may_fail nonzero_return_when_aquired a lv arg =
     match lv with

--- a/src/analyses/mutexEventsAnalysis.ml
+++ b/src/analyses/mutexEventsAnalysis.ml
@@ -28,13 +28,6 @@ struct
     | `Index (_,o) -> `Index (ValueDomain.IndexDomain.top (), conv_offset o)
     | `Field (f,o) -> `Field (f, conv_offset o)
 
-  let rec conv_offset_inv = function
-    | `NoOffset -> `NoOffset
-    | `Field (f, o) -> `Field (f, conv_offset_inv o)
-    (* TODO: better indices handling *)
-    | `Index (_, o) -> `Index (MyCFG.unknown_exp, conv_offset_inv o)
-
-
   let eval_exp_addr (a: Queries.ask) exp =
     let gather_addr (v,o) b = ValueDomain.Addr.from_var_offset (v,conv_offset o) :: b in
     match a.f (Queries.MayPointTo exp) with

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -261,9 +261,9 @@ struct
       (* simulate old mutex analysis special by emitting events directly, a la mutexEvents *)
       begin match f.vname, args with
         | ("GetResource" | "GetSpinlock"), [lock] ->
-          ctx.emit (Events.Lock2 (extract_lock lock, true))
+          ctx.emit (Events.Lock (extract_lock lock, true))
         | ("ReleaseResource" | "ReleaseSpinlock"), [lock] ->
-          ctx.emit (Events.Unlock2 (extract_lock lock, true))
+          ctx.emit (Events.Unlock (extract_lock lock, true))
         | _, _ -> ()
       end;
       special ctx lval f args

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -586,7 +586,7 @@ struct
           (*             offpry_flags flagstate v *)
           (*           end *)
         in off > pry
-    | Queries.CurrentLockset -> (* delegate for MinePriv *)
+    | Queries.MustLockset -> (* delegate for MinePriv *)
       (* TODO: delegate other queries? *)
       M.query ctx q
     | _ -> Queries.Result.top q

--- a/src/analyses/osek.ml
+++ b/src/analyses/osek.ml
@@ -263,7 +263,7 @@ struct
         | ("GetResource" | "GetSpinlock"), [lock] ->
           ctx.emit (Events.Lock (extract_lock lock, true))
         | ("ReleaseResource" | "ReleaseSpinlock"), [lock] ->
-          ctx.emit (Events.Unlock (extract_lock lock, true))
+          ctx.emit (Events.Unlock (extract_lock lock))
         | _, _ -> ()
       end;
       special ctx lval f args

--- a/src/analyses/tutorials/unitAnalysis.ml
+++ b/src/analyses/tutorials/unitAnalysis.ml
@@ -3,7 +3,7 @@
 open Prelude.Ana
 open Analyses
 
-module Spec : Analyses.MCPSpec =
+module Spec : Analyses.MCPSpec with module D = Lattice.Unit and module C = Lattice.Unit =
 struct
   include Analyses.DefaultSpec
 

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -1,10 +1,10 @@
 open Prelude.Ana
 
 type t =
-  | Lock of LockDomain.Addr.t  (** This is only emitted if the mutex was not previously held *)
-  | Unlock of LockDomain.Addr.t
-  | Lock2 of LockDomain.Lockset.Lock.t
-  | Unlock2 of LockDomain.Lockset.Lock.t
+  | MustLock of LockDomain.Addr.t  (** This is only emitted if the mutex was not previously held *)
+  | MustUnlock of LockDomain.Addr.t
+  | Lock of LockDomain.Lockset.Lock.t
+  | Unlock of LockDomain.Lockset.Lock.t
   | Escape of EscapeDomain.EscapedVars.t
   | EnterMultiThreaded
   | SplitBranch of exp * bool (** Used to simulate old branch-based split. *)
@@ -13,10 +13,10 @@ type t =
   | Assign of {lval: CilType.Lval.t; exp: CilType.Exp.t} (** Used to simulate old [ctx.assign]. *)
 
 let pretty () = function
-  | Lock m -> dprintf "Lock %a" LockDomain.Addr.pretty m
-  | Unlock m -> dprintf "Unlock %a" LockDomain.Addr.pretty m
-  | Lock2 m -> dprintf "Lock2 %a" LockDomain.Lockset.Lock.pretty m
-  | Unlock2 m -> dprintf "Unlock2 %a" LockDomain.Lockset.Lock.pretty m
+  | MustLock m -> dprintf "MustLock %a" LockDomain.Addr.pretty m
+  | MustUnlock m -> dprintf "MustUnlock %a" LockDomain.Addr.pretty m
+  | Lock m -> dprintf "Lock %a" LockDomain.Lockset.Lock.pretty m
+  | Unlock m -> dprintf "Unlock %a" LockDomain.Lockset.Lock.pretty m
   | Escape escaped -> dprintf "Escape %a" EscapeDomain.EscapedVars.pretty escaped
   | EnterMultiThreaded -> text "EnterMultiThreaded"
   | SplitBranch (exp, tv) -> dprintf "SplitBranch (%a, %B)" d_exp exp tv

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -3,6 +3,8 @@ open Prelude.Ana
 type t =
   | Lock of LockDomain.Addr.t  (** This is only emitted if the mutex was not previously held *)
   | Unlock of LockDomain.Addr.t
+  | Lock2 of LockDomain.Lockset.Lock.t
+  | Unlock2 of LockDomain.Lockset.Lock.t
   | Escape of EscapeDomain.EscapedVars.t
   | EnterMultiThreaded
   | SplitBranch of exp * bool (** Used to simulate old branch-based split. *)
@@ -13,6 +15,8 @@ type t =
 let pretty () = function
   | Lock m -> dprintf "Lock %a" LockDomain.Addr.pretty m
   | Unlock m -> dprintf "Unock %a" LockDomain.Addr.pretty m
+  | Lock2 m -> dprintf "Lock2 %a" LockDomain.Lockset.Lock.pretty m
+  | Unlock2 m -> dprintf "Unock2 %a" LockDomain.Lockset.Lock.pretty m
   | Escape escaped -> dprintf "Escape %a" EscapeDomain.EscapedVars.pretty escaped
   | EnterMultiThreaded -> text "EnterMultiThreaded"
   | SplitBranch (exp, tv) -> dprintf "SplitBranch (%a, %B)" d_exp exp tv

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -14,9 +14,9 @@ type t =
 
 let pretty () = function
   | Lock m -> dprintf "Lock %a" LockDomain.Addr.pretty m
-  | Unlock m -> dprintf "Unock %a" LockDomain.Addr.pretty m
+  | Unlock m -> dprintf "Unlock %a" LockDomain.Addr.pretty m
   | Lock2 m -> dprintf "Lock2 %a" LockDomain.Lockset.Lock.pretty m
-  | Unlock2 m -> dprintf "Unock2 %a" LockDomain.Lockset.Lock.pretty m
+  | Unlock2 m -> dprintf "Unlock2 %a" LockDomain.Lockset.Lock.pretty m
   | Escape escaped -> dprintf "Escape %a" EscapeDomain.EscapedVars.pretty escaped
   | EnterMultiThreaded -> text "EnterMultiThreaded"
   | SplitBranch (exp, tv) -> dprintf "SplitBranch (%a, %B)" d_exp exp tv

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -4,7 +4,7 @@ type t =
   | MustLock of LockDomain.Addr.t  (** This is only emitted if the mutex was not previously held *)
   | MustUnlock of LockDomain.Addr.t
   | Lock of LockDomain.Lockset.Lock.t
-  | Unlock of LockDomain.Lockset.Lock.t
+  | Unlock of LockDomain.Addr.t
   | Escape of EscapeDomain.EscapedVars.t
   | EnterMultiThreaded
   | SplitBranch of exp * bool (** Used to simulate old branch-based split. *)
@@ -16,7 +16,7 @@ let pretty () = function
   | MustLock m -> dprintf "MustLock %a" LockDomain.Addr.pretty m
   | MustUnlock m -> dprintf "MustUnlock %a" LockDomain.Addr.pretty m
   | Lock m -> dprintf "Lock %a" LockDomain.Lockset.Lock.pretty m
-  | Unlock m -> dprintf "Unlock %a" LockDomain.Lockset.Lock.pretty m
+  | Unlock m -> dprintf "Unlock %a" LockDomain.Addr.pretty m
   | Escape escaped -> dprintf "Escape %a" EscapeDomain.EscapedVars.pretty escaped
   | EnterMultiThreaded -> text "EnterMultiThreaded"
   | SplitBranch (exp, tv) -> dprintf "SplitBranch (%a, %B)" d_exp exp tv

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -1,8 +1,6 @@
 open Prelude.Ana
 
 type t =
-  | MustLock of LockDomain.Addr.t  (** This is only emitted if the mutex was not previously held *)
-  | MustUnlock of LockDomain.Addr.t
   | Lock of LockDomain.Lockset.Lock.t
   | Unlock of LockDomain.Addr.t
   | Escape of EscapeDomain.EscapedVars.t
@@ -13,8 +11,6 @@ type t =
   | Assign of {lval: CilType.Lval.t; exp: CilType.Exp.t} (** Used to simulate old [ctx.assign]. *)
 
 let pretty () = function
-  | MustLock m -> dprintf "MustLock %a" LockDomain.Addr.pretty m
-  | MustUnlock m -> dprintf "MustUnlock %a" LockDomain.Addr.pretty m
   | Lock m -> dprintf "Lock %a" LockDomain.Lockset.Lock.pretty m
   | Unlock m -> dprintf "Unlock %a" LockDomain.Addr.pretty m
   | Escape escaped -> dprintf "Escape %a" EscapeDomain.EscapedVars.pretty escaped

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -73,7 +73,7 @@ type _ t =
   | MayBePublic: maybepublic -> MayBool.t t (* old behavior with write=false *)
   | MayBePublicWithout: maybepublicwithout -> MayBool.t t
   | MustBeProtectedBy: mustbeprotectedby -> MustBool.t t
-  | CurrentLockset: LS.t t
+  | MustLockset: LS.t t
   | MustBeAtomic: MustBool.t t
   | MustBeSingleThreaded: MustBool.t t
   | MustBeUniqueThread: MustBool.t t
@@ -120,7 +120,7 @@ struct
     | MayPointTo _ -> (module LS)
     | ReachableFrom _ -> (module LS)
     | Regions _ -> (module LS)
-    | CurrentLockset -> (module LS)
+    | MustLockset -> (module LS)
     | EvalFunvar _ -> (module LS)
     | ReachableUkTypes _ -> (module TS)
     | MayEscape _ -> (module MayBool)
@@ -171,7 +171,7 @@ struct
     | MayPointTo _ -> LS.top ()
     | ReachableFrom _ -> LS.top ()
     | Regions _ -> LS.top ()
-    | CurrentLockset -> LS.top ()
+    | MustLockset -> LS.top ()
     | EvalFunvar _ -> LS.top ()
     | ReachableUkTypes _ -> TS.top ()
     | MayEscape _ -> MayBool.top ()
@@ -224,7 +224,7 @@ struct
     | Any (MayBePublic _) -> 7
     | Any (MayBePublicWithout _) -> 8
     | Any (MustBeProtectedBy _) -> 9
-    | Any CurrentLockset -> 10
+    | Any MustLockset -> 10
     | Any MustBeAtomic -> 11
     | Any MustBeSingleThreaded -> 12
     | Any MustBeUniqueThread -> 13

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -291,7 +291,7 @@
           "items": { "type": "string" },
           "default": [
             "expRelation", "base", "threadid", "threadflag", "threadreturn",
-            "escape", "mutex", "access", "mallocWrapper", "mhp"
+            "escape", "mutexEvents", "mutex", "access", "mallocWrapper", "mhp"
           ]
         },
         "path_sens": {

--- a/tests/regression/02-base/06-side_effect1.c
+++ b/tests/regression/02-base/06-side_effect1.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']"
+// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper']"
 
 #include<pthread.h>
 #include<assert.h>

--- a/tests/regression/02-base/07-side_effect2.c
+++ b/tests/regression/02-base/07-side_effect2.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']"
+// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper']"
 
 #include<pthread.h>
 #include<assert.h>

--- a/tests/regression/02-base/09-ambigpointer.c
+++ b/tests/regression/02-base/09-ambigpointer.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']"
+// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper']"
 #include<pthread.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/10-init_allfuns.c
+++ b/tests/regression/02-base/10-init_allfuns.c
@@ -1,4 +1,4 @@
-// PARAM: --enable allfuns --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']"
+// PARAM: --enable allfuns --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper']"
 int glob1 = 5;
 int glob2 = 7;
 

--- a/tests/regression/02-base/23-malloc_globmt.c
+++ b/tests/regression/02-base/23-malloc_globmt.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']"
+// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper']"
 #include <stdlib.h>
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/02-base/30-escape_sound.c
+++ b/tests/regression/02-base/30-escape_sound.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']"
+// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper']"
 
 #include<pthread.h>
 #include<stdio.h>

--- a/tests/regression/02-base/41-calloc_globmt.c
+++ b/tests/regression/02-base/41-calloc_globmt.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']" --set ana.int.interval true --set ana.base.arrays.domain partitioned
+// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper']" --set ana.int.interval true --set ana.base.arrays.domain partitioned
 #include <stdlib.h>
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/03-practical/14-call_by_pointer.c
+++ b/tests/regression/03-practical/14-call_by_pointer.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutex','access','mallocWrapper']"
+// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper']"
 #include <assert.h>
 
 /**

--- a/tests/regression/04-mutex/63-unknown_unlock_rc.c
+++ b/tests/regression/04-mutex/63-unknown_unlock_rc.c
@@ -1,0 +1,23 @@
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  pthread_mutex_t *m; // unknown
+  pthread_mutex_unlock(m);
+  myglobal=myglobal+1; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex1);
+  myglobal=myglobal+1; // RACE!
+  pthread_mutex_unlock(&mutex1);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/15-deadlock/19-fail_deadlock.c
+++ b/tests/regression/15-deadlock/19-fail_deadlock.c
@@ -1,0 +1,38 @@
+// PARAM: --set ana.activated[+] deadlock --enable sem.lock.fail
+#include <pthread.h>
+#include <stdio.h>
+
+int g1, g2;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t1(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  pthread_mutex_lock(&mutex2); // DEADLOCK
+  g1 = g2 + 1;
+  pthread_mutex_unlock(&mutex2);
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+void *t2(void *arg) {
+  pthread_mutex_lock(&mutex2);
+  pthread_mutex_lock(&mutex1); // DEADLOCK
+  g2 = g1 + 1;
+  pthread_mutex_unlock(&mutex1);
+  pthread_mutex_unlock(&mutex2);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id1, id2;
+  int i;
+  for (i = 0; i < 10000; i++) {
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_create(&id2, NULL, t2, NULL);
+    pthread_join (id1, NULL);
+    pthread_join (id2, NULL);
+    printf("%d: g1 = %d, g2 = %d.\n", i, g1, g2);
+  }
+  return 0;
+}

--- a/tests/regression/15-deadlock/19-fail_deadlock.c
+++ b/tests/regression/15-deadlock/19-fail_deadlock.c
@@ -7,7 +7,7 @@ pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t1(void *arg) {
-  pthread_mutex_lock(&mutex1);
+  pthread_mutex_lock(&mutex1); // DEADLOCK
   pthread_mutex_lock(&mutex2); // DEADLOCK
   g1 = g2 + 1;
   pthread_mutex_unlock(&mutex2);
@@ -16,7 +16,7 @@ void *t1(void *arg) {
 }
 
 void *t2(void *arg) {
-  pthread_mutex_lock(&mutex2);
+  pthread_mutex_lock(&mutex2); // DEADLOCK
   pthread_mutex_lock(&mutex1); // DEADLOCK
   g2 = g1 + 1;
   pthread_mutex_unlock(&mutex1);

--- a/tests/regression/15-deadlock/20-ambig_deadlock.c
+++ b/tests/regression/15-deadlock/20-ambig_deadlock.c
@@ -8,7 +8,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t mutex3 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t1(void *arg) {
-  pthread_mutex_lock(&mutex1);
+  pthread_mutex_lock(&mutex1); // DEADLOCK
   pthread_mutex_lock(&mutex2); // DEADLOCK
   g1 = g2 + 1;
   pthread_mutex_unlock(&mutex2);
@@ -23,7 +23,7 @@ void *t2(void *arg) {
     m = &mutex2;
   else
     m = &mutex3;
-  pthread_mutex_lock(m);
+  pthread_mutex_lock(m); // DEADLOCK
   pthread_mutex_lock(&mutex1); // DEADLOCK
   g2 = g1 + 1;
   pthread_mutex_unlock(&mutex1);

--- a/tests/regression/15-deadlock/20-ambig_deadlock.c
+++ b/tests/regression/15-deadlock/20-ambig_deadlock.c
@@ -1,0 +1,45 @@
+// PARAM: --set ana.activated[+] deadlock --set ana.path_sens[-] mutex
+#include <pthread.h>
+#include <stdio.h>
+
+int g1, g2;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex3 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t1(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  pthread_mutex_lock(&mutex2); // DEADLOCK
+  g1 = g2 + 1;
+  pthread_mutex_unlock(&mutex2);
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+void *t2(void *arg) {
+  int k = rand() % 2;
+  pthread_mutex_t *m;
+  if (k)
+    m = &mutex2;
+  else
+    m = &mutex3;
+  pthread_mutex_lock(m);
+  pthread_mutex_lock(&mutex1); // DEADLOCK
+  g2 = g1 + 1;
+  pthread_mutex_unlock(&mutex1);
+  pthread_mutex_unlock(m);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id1, id2;
+  int i;
+  for (i = 0; i < 1000000; i++) {
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_create(&id2, NULL, t2, NULL);
+    pthread_join (id1, NULL);
+    pthread_join (id2, NULL);
+    printf("%d: g1 = %d, g2 = %d.\n", i, g1, g2);
+  }
+  return 0;
+}

--- a/tests/regression/15-deadlock/21-unknown_deadlock.c
+++ b/tests/regression/15-deadlock/21-unknown_deadlock.c
@@ -1,0 +1,41 @@
+// PARAM: --set ana.activated[+] deadlock
+#include <pthread.h>
+#include <stdio.h>
+
+int g1, g2;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex3 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t1(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  pthread_mutex_lock(&mutex2); // DEADLOCK
+  g1 = g2 + 1;
+  pthread_mutex_unlock(&mutex2);
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+void *t2(void *arg) {
+  int k = rand() % 2;
+  pthread_mutex_t *m; // unknown
+  pthread_mutex_lock(m);
+  pthread_mutex_lock(&mutex1); // DEADLOCK
+  g2 = g1 + 1;
+  pthread_mutex_unlock(&mutex1);
+  pthread_mutex_unlock(m);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id1, id2;
+  int i;
+  for (i = 0; i < 1000000; i++) {
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_create(&id2, NULL, t2, NULL);
+    pthread_join (id1, NULL);
+    pthread_join (id2, NULL);
+    printf("%d: g1 = %d, g2 = %d.\n", i, g1, g2);
+  }
+  return 0;
+}

--- a/tests/regression/15-deadlock/21-unknown_deadlock.c
+++ b/tests/regression/15-deadlock/21-unknown_deadlock.c
@@ -8,8 +8,8 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t mutex3 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t1(void *arg) {
-  pthread_mutex_lock(&mutex1);
-  pthread_mutex_lock(&mutex2); // DEADLOCK
+  pthread_mutex_lock(&mutex1); // TODO DEADLOCK?
+  pthread_mutex_lock(&mutex2); // TODO DEADLOCK?
   g1 = g2 + 1;
   pthread_mutex_unlock(&mutex2);
   pthread_mutex_unlock(&mutex1);
@@ -19,7 +19,7 @@ void *t1(void *arg) {
 void *t2(void *arg) {
   int k = rand() % 2;
   pthread_mutex_t *m; // unknown
-  pthread_mutex_lock(m);
+  pthread_mutex_lock(m); // DEADLOCK
   pthread_mutex_lock(&mutex1); // DEADLOCK
   g2 = g1 + 1;
   pthread_mutex_unlock(&mutex1);

--- a/tests/regression/15-deadlock/22-ambig_unlock_deadlock.c
+++ b/tests/regression/15-deadlock/22-ambig_unlock_deadlock.c
@@ -1,0 +1,51 @@
+// PARAM: --set ana.activated[+] deadlock --set ana.path_sens[-] mutex
+#include <pthread.h>
+#include <stdio.h>
+
+int g1, g2;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex3 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t1(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  pthread_mutex_lock(&mutex2); // DEADLOCK
+  g1 = g2 + 1;
+  pthread_mutex_unlock(&mutex2);
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+void *t2(void *arg) {
+  int k = rand() % 2;
+  int l = rand() % 2;
+  pthread_mutex_t *m, *n;
+  if (k)
+    m = &mutex2;
+  else
+    m = &mutex3;
+  if (l)
+    n = &mutex2;
+  else
+    n = &mutex3;
+  pthread_mutex_lock(m);
+  pthread_mutex_unlock(n);
+  pthread_mutex_lock(&mutex1); // DEADLOCK
+  g2 = g1 + 1;
+  pthread_mutex_unlock(&mutex1);
+  pthread_mutex_unlock(m);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id1, id2;
+  int i;
+  for (i = 0; i < 1000000; i++) {
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_create(&id2, NULL, t2, NULL);
+    pthread_join (id1, NULL);
+    pthread_join (id2, NULL);
+    printf("%d: g1 = %d, g2 = %d.\n", i, g1, g2);
+  }
+  return 0;
+}

--- a/tests/regression/15-deadlock/22-ambig_unlock_deadlock.c
+++ b/tests/regression/15-deadlock/22-ambig_unlock_deadlock.c
@@ -8,7 +8,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t mutex3 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t1(void *arg) {
-  pthread_mutex_lock(&mutex1);
+  pthread_mutex_lock(&mutex1); // DEADLOCK
   pthread_mutex_lock(&mutex2); // DEADLOCK
   g1 = g2 + 1;
   pthread_mutex_unlock(&mutex2);
@@ -28,7 +28,7 @@ void *t2(void *arg) {
     n = &mutex2;
   else
     n = &mutex3;
-  pthread_mutex_lock(m);
+  pthread_mutex_lock(m); // DEADLOCK
   pthread_mutex_unlock(n);
   pthread_mutex_lock(&mutex1); // DEADLOCK
   g2 = g1 + 1;

--- a/tests/regression/15-deadlock/23-unknown_unlock_deadlock.c
+++ b/tests/regression/15-deadlock/23-unknown_unlock_deadlock.c
@@ -1,0 +1,42 @@
+// PARAM: --set ana.activated[+] deadlock
+#include <pthread.h>
+#include <stdio.h>
+
+int g1, g2;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex3 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t1(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  pthread_mutex_lock(&mutex2); // DEADLOCK
+  g1 = g2 + 1;
+  pthread_mutex_unlock(&mutex2);
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+void *t2(void *arg) {
+  int k = rand() % 2;
+  pthread_mutex_t *m, *n; // unknown
+  pthread_mutex_lock(m);
+  pthread_mutex_unlock(n);
+  pthread_mutex_lock(&mutex1); // DEADLOCK
+  g2 = g1 + 1;
+  pthread_mutex_unlock(&mutex1);
+  pthread_mutex_unlock(m);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id1, id2;
+  int i;
+  for (i = 0; i < 1000000; i++) {
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_create(&id2, NULL, t2, NULL);
+    pthread_join (id1, NULL);
+    pthread_join (id2, NULL);
+    printf("%d: g1 = %d, g2 = %d.\n", i, g1, g2);
+  }
+  return 0;
+}

--- a/tests/regression/15-deadlock/24-malloc_unlock_deadlock.c
+++ b/tests/regression/15-deadlock/24-malloc_unlock_deadlock.c
@@ -1,0 +1,49 @@
+// PARAM: --set ana.activated[+] deadlock
+#include <pthread.h>
+#include <stdio.h>
+
+int g1, g2;
+pthread_mutex_t *p, *q;
+
+void *t1(void *arg) {
+  pthread_mutex_lock(p);
+  pthread_mutex_lock(q); // DEADLOCK
+  g1 = g2 + 1;
+  pthread_mutex_unlock(q);
+  pthread_mutex_unlock(p);
+  return NULL;
+}
+
+void *t2(void *arg) {
+  pthread_mutex_lock(p);
+  pthread_mutex_unlock(p);
+  pthread_mutex_lock(q); // DEADLOCK
+  g2 = g1 + 1;
+  pthread_mutex_unlock(q);
+  pthread_mutex_unlock(p);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id1, id2;
+  int i;
+  pthread_mutex_t *a;
+
+  for (i=0; i < 10; i++){
+    a = malloc(sizeof(pthread_mutex_t));
+    pthread_mutex_init(a,0);
+    if (i==3)
+      p = a;
+    if (i==7)
+      q = a;
+  }
+
+  for (i = 0; i < 1000000; i++) {
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_create(&id2, NULL, t2, NULL);
+    pthread_join (id1, NULL);
+    pthread_join (id2, NULL);
+    printf("%d: g1 = %d, g2 = %d.\n", i, g1, g2);
+  }
+  return 0;
+}

--- a/tests/regression/15-deadlock/24-malloc_unlock_deadlock.c
+++ b/tests/regression/15-deadlock/24-malloc_unlock_deadlock.c
@@ -6,7 +6,7 @@ int g1, g2;
 pthread_mutex_t *p, *q;
 
 void *t1(void *arg) {
-  pthread_mutex_lock(p);
+  pthread_mutex_lock(p); // DEADLOCK
   pthread_mutex_lock(q); // DEADLOCK
   g1 = g2 + 1;
   pthread_mutex_unlock(q);
@@ -15,7 +15,7 @@ void *t1(void *arg) {
 }
 
 void *t2(void *arg) {
-  pthread_mutex_lock(p);
+  pthread_mutex_lock(p); // DEADLOCK
   pthread_mutex_unlock(p);
   pthread_mutex_lock(q); // DEADLOCK
   g2 = g1 + 1;

--- a/tests/regression/15-deadlock/25-malloc_deadlock.c
+++ b/tests/regression/15-deadlock/25-malloc_deadlock.c
@@ -1,0 +1,48 @@
+// PARAM: --set ana.activated[+] deadlock
+#include <pthread.h>
+#include <stdio.h>
+
+int g1, g2;
+pthread_mutex_t *p, *q;
+
+void *t1(void *arg) {
+  pthread_mutex_lock(p);
+  pthread_mutex_lock(q); // DEADLOCK
+  g1 = g2 + 1;
+  pthread_mutex_unlock(q);
+  pthread_mutex_unlock(p);
+  return NULL;
+}
+
+void *t2(void *arg) {
+  pthread_mutex_lock(p);
+  pthread_mutex_lock(q); // DEADLOCK
+  g2 = g1 + 1;
+  pthread_mutex_unlock(q);
+  pthread_mutex_unlock(p);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id1, id2;
+  int i;
+  pthread_mutex_t *a;
+
+  for (i=0; i < 10; i++){
+    a = malloc(sizeof(pthread_mutex_t));
+    pthread_mutex_init(a,0);
+    if (i==3)
+      p = a;
+    if (i==7)
+      q = a;
+  }
+
+  for (i = 0; i < 1000000; i++) {
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_create(&id2, NULL, t2, NULL);
+    pthread_join (id1, NULL);
+    pthread_join (id2, NULL);
+    printf("%d: g1 = %d, g2 = %d.\n", i, g1, g2);
+  }
+  return 0;
+}

--- a/tests/regression/15-deadlock/25-malloc_deadlock.c
+++ b/tests/regression/15-deadlock/25-malloc_deadlock.c
@@ -6,7 +6,7 @@ int g1, g2;
 pthread_mutex_t *p, *q;
 
 void *t1(void *arg) {
-  pthread_mutex_lock(p);
+  pthread_mutex_lock(p); // DEADLOCK
   pthread_mutex_lock(q); // DEADLOCK
   g1 = g2 + 1;
   pthread_mutex_unlock(q);
@@ -15,7 +15,7 @@ void *t1(void *arg) {
 }
 
 void *t2(void *arg) {
-  pthread_mutex_lock(p);
+  pthread_mutex_lock(p); // DEADLOCK
   pthread_mutex_lock(q); // DEADLOCK
   g2 = g1 + 1;
   pthread_mutex_unlock(q);

--- a/tests/regression/15-deadlock/26-unknown_deadlock2.c
+++ b/tests/regression/15-deadlock/26-unknown_deadlock2.c
@@ -8,23 +8,22 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t mutex3 = PTHREAD_MUTEX_INITIALIZER;
 
 void *t1(void *arg) {
-  pthread_mutex_lock(&mutex1); // TODO DEADLOCK?
   pthread_mutex_lock(&mutex2); // TODO DEADLOCK?
+  pthread_mutex_lock(&mutex1); // TODO DEADLOCK?
   g1 = g2 + 1;
-  pthread_mutex_unlock(&mutex2);
   pthread_mutex_unlock(&mutex1);
+  pthread_mutex_unlock(&mutex2);
   return NULL;
 }
 
 void *t2(void *arg) {
   int k = rand() % 2;
-  pthread_mutex_t *m, *n; // unknown
-  pthread_mutex_lock(m); // DEADLOCK
-  pthread_mutex_unlock(n);
+  pthread_mutex_t *m; // unknown
   pthread_mutex_lock(&mutex1); // DEADLOCK
+  pthread_mutex_lock(m); // DEADLOCK
   g2 = g1 + 1;
-  pthread_mutex_unlock(&mutex1);
   pthread_mutex_unlock(m);
+  pthread_mutex_unlock(&mutex1);
   return NULL;
 }
 

--- a/tests/regression/15-deadlock/27-self_deadlock.c
+++ b/tests/regression/15-deadlock/27-self_deadlock.c
@@ -1,0 +1,38 @@
+// PARAM: --set ana.activated[+] deadlock
+#include <pthread.h>
+#include <stdio.h>
+
+int g1, g2;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t1(void *arg) {
+  pthread_mutex_lock(&mutex1); // DEADLOCK
+  pthread_mutex_lock(&mutex1); // DEADLOCK
+  g1 = g2 + 1;
+  pthread_mutex_unlock(&mutex1);
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+void *t2(void *arg) {
+  pthread_mutex_lock(&mutex2); // DEADLOCK
+  pthread_mutex_lock(&mutex2); // DEADLOCK
+  g2 = g1 + 1;
+  pthread_mutex_unlock(&mutex2);
+  pthread_mutex_unlock(&mutex2);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id1, id2;
+  int i;
+  for (i = 0; i < 10000; i++) {
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_create(&id2, NULL, t2, NULL);
+    pthread_join (id1, NULL);
+    pthread_join (id2, NULL);
+    printf("%d: g1 = %d, g2 = %d.\n", i, g1, g2);
+  }
+  return 0;
+}


### PR DESCRIPTION
Closes #659.

### Changes
1. Add mutexEvents analysis to emit events handled by mutex, mayLocks and deadlock analyses.
2. Replace analysis-specific ambiguous lock pointer handling with path splitting via `ctx.split`. One split is introduced for each possible mutex pointer. Joining of paths automagically takes care of the ambiguity (see table below).
    This also increases the precision of locking an ambiguous lock pointer in the path-sensitive mutex analysis: previously no must locks were added, but now it properly splits into multiple paths with different locksets.
4. Add more complete handling of failing locks (includes try locks) by just having an extra path split via `ctx.split` if failure is allowed. Again, the joining of paths takes care of everything by considering the extra path where no lock was acquired,
5. Add more complete handling of blob locks via `IsMultiple` query (see table below). This should additionally account for weakly updated locals too.
6. Add more complete handling of unknown lock pointers using `Addr.UnknownPtr` (see table below). Previously lockset analyses just dropped these from the `MayPointsTo` query result conversion.
7. Fix deadlock detection w.r.t. ambiguous, blob and unknown lock pointers.
8. Extract very simple must and may lockset analysis functors and instantiate mutex, maylocks and deadlock analyses using these.

### Behavior
The following tables give an overview of all the cases that are now considered.

#### Must lockset
| | Definite pointer | Ambiguous pointer | Blob pointer | Unknown pointer | Failing lock |
| --- | --- | --- | --- | --- | --- |
| Lock | Add pointer | Don't add any | Don't add | Don't add | Don't add |
| Unlock | Remove pointer | Remove all ambiguous pointers | N/A (never added) | Remove all | N/A |

#### May lockset
| | Definite pointer | Ambiguous pointer | Blob pointer | Unknown pointer | Failing lock |
| --- | --- | --- | --- | --- | --- |
| Lock | Add pointer | Add all ambiguous pointers | Add blob pointer | Add unknown pointer | Add |
| Unlock | Remove pointer | Don't remove any | Don't remove | Don't remove any | N/A |

### TODO
- [x] Add unknown mutex pointer handling for both must and may locksets.
- [x] Make failing locks emit all events.
- [x] Fix mayLocks and deadlock unlocking.
- [x] Determine whether `MustLock` and `MustUnlock` events are still necessary.
- [x] Merge #655.