### PR TITLE
Exclude functions with changed header from reluctant destabilization

### DIFF
--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -100,12 +100,10 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
         changes.changed <- {current = global; old = old_global; unchangedHeader; diff} :: changes.changed
       in
       match change_status with
-      | ChangedFunHeader f ->
-        changes.exclude_from_rel_destab <- VarinfoSet.add f.svar changes.exclude_from_rel_destab;
-        append_to_changed ~unchangedHeader:false
       | Changed ->
         append_to_changed ~unchangedHeader:true
       | Unchanged -> changes.unchanged <- global :: changes.unchanged
+      | ChangedFunHeader f
       | ForceReanalyze f ->
         changes.exclude_from_rel_destab <- VarinfoSet.add f.svar changes.exclude_from_rel_destab;
         append_to_changed ~unchangedHeader:false;

--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -96,19 +96,19 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
       let old_global = GlobalMap.find ident map in
       (* Do a (recursive) equal comparison ignoring location information *)
       let change_status, diff = eq old_global global cfgs in
-      let append_to_changed (unchangedHeader) =
+      let append_to_changed ~unchangedHeader =
         changes.changed <- {current = global; old = old_global; unchangedHeader; diff} :: changes.changed
       in
       match change_status with
       | ChangedFunHeader f ->
         changes.exclude_from_rel_destab <- VarinfoSet.add f.svar changes.exclude_from_rel_destab;
-        append_to_changed false
+        append_to_changed ~unchangedHeader:false
       | Changed ->
-        append_to_changed true
+        append_to_changed ~unchangedHeader:true
       | Unchanged -> changes.unchanged <- global :: changes.unchanged
       | ForceReanalyze f ->
         changes.exclude_from_rel_destab <- VarinfoSet.add f.svar changes.exclude_from_rel_destab;
-        append_to_changed false;
+        append_to_changed ~unchangedHeader:false;
     with Not_found -> () (* Global was no variable or function, it does not belong into the map *)
   in
   let checkExists map global =

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -634,7 +634,7 @@ module WP =
         let reanalyze_entry f =
           (* destabilize the entry points of a changed function when reluctant is off,
              or the function is to be force-reanalyzed  *)
-          (not reluctant) || CompareCIL.VarinfoSet.mem f.svar S.increment.changes.force_reanalyze
+          (not reluctant) || CompareCIL.VarinfoSet.mem f.svar S.increment.changes.exclude_from_rel_destab
         in
         let obsolete_ret = HM.create 103 in
         let obsolete_entry = HM.create 103 in

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -132,8 +132,8 @@ let reparse (s: t) =
 (* Only called when the file has not been reparsed, so we can skip the expensive CFG comparison. *)
 let virtual_changes file =
   let eq (glob: Cil.global) _ _ = match glob with
-    | GFun (fdec, _) when CompareCIL.should_reanalyze fdec -> CompareCIL.ForceReanalyze fdec, false, None
-    | _ -> Unchanged, false, None
+    | GFun (fdec, _) when CompareCIL.should_reanalyze fdec -> CompareCIL.ForceReanalyze fdec, None
+    | _ -> Unchanged, None
   in
   CompareCIL.compareCilFiles ~eq file file
 


### PR DESCRIPTION
We discovered that one common case where reluctant destabilization leads to a greater number of evaluation and a worse runtime as without reluctant destabilization, is when the header (that is for example the type) of a function changes.

When the type of a function changes, the contexts for which it needs to be analyzed also change and therefore it is superfluous to analyze it for the previous but outdated context first. Also for functions whose type changed, the program point where this function is called is also detected to have changed, so the changed function is destabilized completely anyway. 

This optimization substantially reduces the number of commits in the zstd repository for which reluctant destabilization deteriorates the runtime of an incremental analysis. 