### PR TITLE
Update README.md for installation on M1 processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Both for using an up-to-date version of Goblint or developing it, the best way i
 
 ### MacOS
 1. Install GCC with `brew install gcc` (first run `xcode-select --install` if you don't want to build it from source). Goblint requires GCC while macOS's default `cpp` is Clang, which will not work.
-2. Continue using Linux instructions.
+2. ONLY for M1 (ARM64) processor: homebrew changed its install location from `/usr/local/` to `/opt/homebrew/`. For packages to find their dependecies execute `sudo ln -s /opt/homebrew/{include,lib} /usr/local/`.
+3. Continue using Linux instructions (the formulae in brew for `patch libgmp-dev libmpfr-dev` are `gpatch gmp mpfr`, respectively).
 
 ### Windows
 1. Install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10).


### PR DESCRIPTION
Home-brew changed its installation location from /usr/local/ to /opt/homebrew/. Some packages search dependencies still in the old location. For them to find their dependencies two symbolic link need to be created.