### PR TITLE
`exp.apron.prec-dump`: Speedup Apron dumping for Octagons, Warning in general

### DIFF
--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -437,13 +437,16 @@ struct
   let store_data file =
     let convert (m: AD.t RH.t): OctApron.t RH.t =
       let convert_single (a: AD.t): OctApron.t =
-        let generator = AD.to_lincons_array a in
-        OctApron.of_lincons_array generator
+        if Oct.manager_is_oct AD.Man.mgr then
+          Oct.Abstract1.to_oct a
+        else
+          let generator = AD.to_lincons_array a in
+          OctApron.of_lincons_array generator
       in
       RH.map (fun _ -> convert_single) m
     in
     let post_process m =
-      let m = convert m in
+      let m = Stats.time "convert" convert m in
       RH.map (fun _ v -> OctApron.marshal v) m
     in
     let results = post_process results in
@@ -454,7 +457,8 @@ struct
   let finalize () =
     let file = GobConfig.get_string "exp.apron.prec-dump" in
     if file <> "" then begin
-      Stats.time "apron,prec-dump" store_data file
+      Printf.printf "exp.apron.prec-dump is potentially costly (for domains other than octagons), do not use for performance data!\n";
+      Stats.time "apron.prec-dump" store_data file
     end;
     Priv.finalize ()
 end


### PR DESCRIPTION
Fixes #668 