### PR TITLE
Handling relative paths in compilation database processing

### DIFF
--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -274,7 +274,7 @@ let preprocess_files () =
     | filename when Sys.is_directory filename ->
       let dir_files = Sys.readdir filename in
       if Array.mem CompilationDatabase.basename dir_files then (* prefer compilation database to Makefile in case both exist, because compilation database is more robust *)
-        preprocess_arg_file (Filename.concat filename CompilationDatabase.basename)
+        preprocess_arg_file (Unix.realpath (Filename.concat filename CompilationDatabase.basename))
       else if Array.mem "Makefile" dir_files then
         preprocess_arg_file (Filename.concat filename "Makefile")
       else

--- a/src/util/compilationDatabase.ml
+++ b/src/util/compilationDatabase.ml
@@ -35,7 +35,8 @@ let load_and_preprocess ~all_cppflags filename =
   in
   let preprocessed_dir = GobFilename.absolute (GoblintDir.preprocessed ()) in (* absolute due to cwd changes *)
   let preprocess obj =
-    let file = obj.file in
+    let filepath = if Filename.is_relative obj.file then Filename.concat obj.directory obj.file else obj.file in
+    let file = Unix.realpath filepath in
     let extension = Filename.extension file in
     if extension = ".s" || extension = ".S" then
       None


### PR DESCRIPTION
For a command from the compilation databases, the field `file` can contain a relative or absolute path. Differences can for example be observed when generating the compilation database with different tools (i.e. `compiledb` and `bear`). With `compiledb`, the file path is only a relative path whereas with bear it is an absolute path. To be able to run goblint with differently generated compilation databases, I adapted the path handling in the compilation database processing slightly, to concat the `file` path with the `directory` path when necessary.

Also, to be able to specify the repository to be analyzed with a relative path, I take the `realpath` of the concatenation of the repository directory and the compilation database file name.