### PR TITLE
Rename and split `exp.precious_globs` to `exp.exclude_from_earlyglobs` and `exp.exclude_from_invalidation`

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -486,7 +486,7 @@ struct
   let context (fd: fundec) (st: store): store =
     let f keep drop_fn (st: store) = if keep then st else { st with cpa = drop_fn st.cpa} in
     st |>
-    f (not !GU.earlyglobs) (CPA.filter (fun k v -> not (Basetype.Variables.is_global k) || is_precious_glob k))
+    f (not !GU.earlyglobs) (CPA.filter (fun k v -> not (Basetype.Variables.is_global k) || is_excluded_from_earlyglobs k))
     %> f (ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.base.context.non-ptr" ~removeAttr:"base.no-non-ptr" ~keepAttr:"base.non-ptr" fd) drop_non_ptrs
     %> f (ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.base.context.int" ~removeAttr:"base.no-int" ~keepAttr:"base.int" fd) drop_ints
     %> f (ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.base.context.interval" ~removeAttr:"base.no-interval" ~keepAttr:"base.interval" fd) drop_interval
@@ -1903,7 +1903,7 @@ struct
     in
     let invalids = invalidate_exp exps in
     let is_fav_addr x =
-      List.exists BaseUtil.is_precious_glob (AD.to_var_may x)
+      List.exists BaseUtil.is_excluded_from_invalidation (AD.to_var_may x)
     in
     let invalids' = List.filter (fun (x,_,_) -> not (is_fav_addr x)) invalids in
     if M.tracing && exps <> [] then (

--- a/src/analyses/baseUtil.ml
+++ b/src/analyses/baseUtil.ml
@@ -9,11 +9,15 @@ let is_static (v:varinfo): bool = v.vstorage = Static
 
 let is_always_unknown variable = variable.vstorage = Extern || Ciltools.is_volatile_tp variable.vtype
 
-let precious_globs = ref []
-let is_precious_glob v = List.mem v.vname !precious_globs
+let exclude_from_earlyglobs = ref []
+let exclude_from_invalidation = ref []
+
+let is_excluded_from_earlyglobs v = List.mem v.vname !exclude_from_earlyglobs
+let is_excluded_from_invalidation v =  List.mem v.vname !exclude_from_invalidation
 
 let after_config () =
-  precious_globs := get_string_list "exp.precious_globs"
+  exclude_from_earlyglobs := get_string_list "exp.exclude_from_earlyglobs";
+  exclude_from_invalidation := get_string_list "exp.exclude_from_invalidation"
 
 let _ =
   AfterConfig.register after_config

--- a/src/analyses/baseUtil.ml
+++ b/src/analyses/baseUtil.ml
@@ -9,15 +9,5 @@ let is_static (v:varinfo): bool = v.vstorage = Static
 
 let is_always_unknown variable = variable.vstorage = Extern || Ciltools.is_volatile_tp variable.vtype
 
-let exclude_from_earlyglobs = ref []
-let exclude_from_invalidation = ref []
-
-let is_excluded_from_earlyglobs v = List.mem v.vname !exclude_from_earlyglobs
-let is_excluded_from_invalidation v =  List.mem v.vname !exclude_from_invalidation
-
-let after_config () =
-  exclude_from_earlyglobs := get_string_list "exp.exclude_from_earlyglobs";
-  exclude_from_invalidation := get_string_list "exp.exclude_from_invalidation"
-
-let _ =
-  AfterConfig.register after_config
+let is_excluded_from_earlyglobs v = List.mem v.vname (get_string_list "exp.exclude_from_earlyglobs")
+let is_excluded_from_invalidation v =  List.mem v.vname (get_string_list "exp.exclude_from_invalidation")

--- a/src/analyses/baseUtil.mli
+++ b/src/analyses/baseUtil.mli
@@ -3,4 +3,5 @@ open Cil
 val is_global: Queries.ask -> varinfo -> bool
 val is_static: varinfo -> bool
 val is_always_unknown: varinfo -> bool
-val is_precious_glob: varinfo -> bool
+val is_excluded_from_earlyglobs: varinfo -> bool
+val is_excluded_from_invalidation: varinfo -> bool

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -42,7 +42,7 @@ module Protection =
 struct
   let is_unprotected ask x: bool =
     let multi = ThreadFlag.is_multi ask in
-    (!GU.earlyglobs && not multi && not (is_precious_glob x)) ||
+    (!GU.earlyglobs && not multi && not (is_excluded_from_earlyglobs x)) ||
     (
       multi &&
       ask.f (Q.MayBePublic {global=x; write=true})

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1258,10 +1258,18 @@
           "type": "boolean",
           "default": false
         },
-        "precious_globs": {
-          "title": "exp.precious_globs",
+        "exclude_from_earlyglobs": {
+          "title": "exp.exclude_from_earlyglobs",
           "description":
             "Global variables that should be handled flow-sensitively when using earlyglobs.",
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        },
+        "exclude_from_invalidation" : {
+          "title": "exp.exclude_from_invalidation",
+          "description":
+            "Global variables that should not be invalidated. This assures the analysis that such globals are only modified through known code",
           "type": "array",
           "items": { "type": "string" },
           "default": []

--- a/tests/regression/01-cpa/50-earlyglobs_precious.c
+++ b/tests/regression/01-cpa/50-earlyglobs_precious.c
@@ -1,4 +1,4 @@
-// PARAM: --set exp.earlyglobs true --set exp.exclude_from_earlyglobs[+] "'g'" --set exp.exclude_from_invalidation[+] "'g'"
+// PARAM: --set exp.earlyglobs true --set exp.exclude_from_earlyglobs[+] "'g'"
 
 int g = 10;
 int main(void){

--- a/tests/regression/01-cpa/50-earlyglobs_precious.c
+++ b/tests/regression/01-cpa/50-earlyglobs_precious.c
@@ -1,4 +1,4 @@
-// PARAM: --set exp.earlyglobs true --set exp.precious_globs[+] "'g'"
+// PARAM: --set exp.earlyglobs true --set exp.exclude_from_earlyglobs[+] "'g'" --set exp.exclude_from_invalidation[+] "'g'"
 
 int g = 10;
 int main(void){


### PR DESCRIPTION
Before, the name was not really telling, and it did two things at the same time:

- Exclude them from flow-insensitive treatment if `earlyglobs` is enabled
- Exclude them from invalidation 

These are conceptually different, so I now pulled them apart and also gave the options are more telling name.

Closes #192. I think we can put the the remarks about special to the side for now, as the library analysis will be completely redone by @jerhard.