### PR TITLE
Make directories for incremental data load and store configurable

### DIFF
--- a/src/incremental/serialize.ml
+++ b/src/incremental/serialize.ml
@@ -1,21 +1,28 @@
 open Prelude
 
 let base_directory = ref (Sys.getcwd ()) (* base directory where incremental results are stored *)
-let goblint_dirname = "incremental_data"
 let version_map_filename = "version.data"
 let cil_file_name = "ast.data"
 let solver_data_file_name = "solver.data"
 let analysis_data_file_name = "analysis.data"
 let results_dir = "results"
 let results_tmp_dir = "results_tmp"
-let gob_directory () = let src_dir = !base_directory in
-  Filename.concat src_dir goblint_dirname
 
-let gob_results_dir () =
-  Filename.concat (gob_directory ()) results_dir
+type operation = Save | Load
 
-let gob_results_tmp_dir () =
-  Filename.concat (gob_directory ()) results_tmp_dir
+(** Returns the name of the directory used for loading/saving incremental data *)
+let incremental_dirname op = match op with
+  | Load -> GobConfig.get_string "incremental.load-dir"
+  | Save -> GobConfig.get_string "incremental.save-dir"
+
+let gob_directory op = let src_dir = !base_directory in
+  Filename.concat src_dir (incremental_dirname op)
+
+let gob_results_dir op =
+  Filename.concat (gob_directory op) results_dir
+
+let gob_results_tmp_dir op =
+  Filename.concat (gob_directory op) results_tmp_dir
 
 let server () = GobConfig.get_bool "server.enabled"
 
@@ -30,7 +37,7 @@ let unmarshal fileName =
 
 let results_exist () =
   (* If Goblint did not crash irregularly, the existence of the result directory indicates that there are results *)
-  let r = gob_results_dir () in
+  let r = gob_results_dir Load in
   Sys.file_exists r && Sys.is_directory r
 
 (* Convenience enumeration of the different data types we store for incremental analysis, so file-name logic is concentrated in one place *)
@@ -54,7 +61,7 @@ let load_data (data_type: incremental_data_kind) =
     | AnalysisData -> !server_analysis_data |> Option.get |> Obj.obj
     | _ -> failwith "Can only load solver and analysis data"
   else
-    let p = Filename.concat (gob_results_dir ()) (type_to_file_name data_type) in
+    let p = Filename.concat (gob_results_dir Load) (type_to_file_name data_type) in
     unmarshal p
 
 (** Stores data for future incremental runs at the appropriate file, given the data and what kind of data it is. *)
@@ -65,16 +72,17 @@ let store_data (data : 'a) (data_type : incremental_data_kind) =
     | AnalysisData -> server_analysis_data := Some (Obj.repr data)
     | _ -> ()
   else (
-    GobSys.mkdir_or_exists (gob_directory ());
-    let d = gob_results_tmp_dir () in
+    GobSys.mkdir_or_exists (gob_directory Save);
+    let d = gob_results_tmp_dir Save in
     GobSys.mkdir_or_exists d;
     let p = Filename.concat d (type_to_file_name data_type) in
     marshal data p)
 
 (** Deletes previous analysis results and moves the freshly created results there.*)
 let move_tmp_results_to_results () =
+  let op = Save in
   if not (server ()) then (
-    if Sys.file_exists (gob_results_dir ()) then begin
-      Goblintutil.rm_rf (gob_results_dir ());
+    if Sys.file_exists (gob_results_dir op) then begin
+      Goblintutil.rm_rf (gob_results_dir op);
     end;
-    Sys.rename (gob_results_tmp_dir ()) (gob_results_dir ()))
+    Sys.rename (gob_results_tmp_dir op) (gob_results_dir op))

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -891,6 +891,12 @@
           "type": "boolean",
           "default": false
         },
+        "load-dir": {
+          "title": "incremental.load-dir",
+          "description": "Location where to load incremental analysis results from.",
+          "type": "string",
+          "default": "incremental_data"
+        },
         "only-rename": {
           "title": "incremental.only-rename",
           "description":
@@ -903,6 +909,12 @@
           "description": "Store incremental analysis results.",
           "type": "boolean",
           "default": false
+        },
+        "save-dir": {
+          "title": "incremental.save-dir",
+          "description": "Location where to save incremental analysis results to.",
+          "type": "string",
+          "default": "incremental_data"
         },
         "stable": {
           "title": "incremental.stable",


### PR DESCRIPTION
This patch allows to configure the name of the directory where incremental data is loaded from and stored to. This is just a quick-fix that helps for benchmarking.