### PR TITLE
Fix incorrect relative paths when parsing preprocessed files

### DIFF
--- a/goblint.opam
+++ b/goblint.opam
@@ -66,7 +66,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 pin-depends: [
-  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#da5e1941db81643ef0d2133960cd28a7de311131" ]
+  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#3ce2279efab8c1f5ccf5ca1c8e9a9f973087d482" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # quoter workaround reverted for release, so no pin needed

--- a/goblint.opam
+++ b/goblint.opam
@@ -66,7 +66,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 pin-depends: [
-  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#cc00d8e9ce2dab95f2b91c5a718482ba19ee3390" ]
+  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#faff341f1e8f070121d828aa6301370b4a8918d6" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # quoter workaround reverted for release, so no pin needed

--- a/goblint.opam
+++ b/goblint.opam
@@ -66,7 +66,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 pin-depends: [
-  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#3ce2279efab8c1f5ccf5ca1c8e9a9f973087d482" ]
+  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#cc00d8e9ce2dab95f2b91c5a718482ba19ee3390" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # quoter workaround reverted for release, so no pin needed

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -116,7 +116,7 @@ version: "dev"
 pin-depends: [
   [
     "goblint-cil.1.8.2"
-    "git+https://github.com/goblint/cil.git#cc00d8e9ce2dab95f2b91c5a718482ba19ee3390"
+    "git+https://github.com/goblint/cil.git#faff341f1e8f070121d828aa6301370b4a8918d6"
   ]
   [
     "apron.v0.9.13"

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -116,7 +116,7 @@ version: "dev"
 pin-depends: [
   [
     "goblint-cil.1.8.2"
-    "git+https://github.com/goblint/cil.git#da5e1941db81643ef0d2133960cd28a7de311131"
+    "git+https://github.com/goblint/cil.git#3ce2279efab8c1f5ccf5ca1c8e9a9f973087d482"
   ]
   [
     "apron.v0.9.13"

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -116,7 +116,7 @@ version: "dev"
 pin-depends: [
   [
     "goblint-cil.1.8.2"
-    "git+https://github.com/goblint/cil.git#3ce2279efab8c1f5ccf5ca1c8e9a9f973087d482"
+    "git+https://github.com/goblint/cil.git#cc00d8e9ce2dab95f2b91c5a718482ba19ee3390"
   ]
   [
     "apron.v0.9.13"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -1,7 +1,7 @@
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 pin-depends: [
-  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#cc00d8e9ce2dab95f2b91c5a718482ba19ee3390" ]
+  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#faff341f1e8f070121d828aa6301370b4a8918d6" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # quoter workaround reverted for release, so no pin needed

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -1,7 +1,7 @@
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 pin-depends: [
-  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#3ce2279efab8c1f5ccf5ca1c8e9a9f973087d482" ]
+  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#cc00d8e9ce2dab95f2b91c5a718482ba19ee3390" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # quoter workaround reverted for release, so no pin needed

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -1,7 +1,7 @@
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 pin-depends: [
-  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#da5e1941db81643ef0d2133960cd28a7de311131" ]
+  [ "goblint-cil.1.8.2" "git+https://github.com/goblint/cil.git#3ce2279efab8c1f5ccf5ca1c8e9a9f973087d482" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # quoter workaround reverted for release, so no pin needed

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -74,19 +74,9 @@ let d_acct () = function
   | `Type t -> dprintf "(%a)" d_type t
   | `Struct (s,o) -> dprintf "(struct %s)%a" s.cname d_offs o
 
-let file_re = Str.regexp "\\(.*/\\|\\)\\([^/]*\\)"
-let d_loc () loc =
-  let loc =
-    if Str.string_match file_re loc.file 0 then
-      {loc with file = Str.matched_group 2 loc.file}
-    else
-      loc
-  in
-  CilType.Location.pretty () loc
-
 let d_memo () (t, lv) =
   match lv with
-  | Some (v,o) -> dprintf "%a%a@@%a" Basetype.Variables.pretty v d_offs o d_loc v.vdecl
+  | Some (v,o) -> dprintf "%a%a@@%a" Basetype.Variables.pretty v d_offs o CilType.Location.pretty v.vdecl
   | None       -> dprintf "%a" d_acct t
 
 let rec get_type (fb: typ) : exp -> acc_typ = function

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -268,10 +268,8 @@ struct
       printf "Writing Sarif to file: %s\n%!" (get_string "outfile");
       Yojson.Safe.to_channel ~std:true out (Sarif.to_yojson (List.rev !Messages.Table.messages_list));
     | "json-messages" ->
-      let files = Hashtbl.to_list Preprocessor.dependencies in
-      let filter_system = List.filter_map (fun (f,system) -> if system then None else Some f) in
       let json = `Assoc [
-          ("files", `Assoc (List.map (Tuple2.map Fpath.to_string (fun deps -> [%to_yojson: GobFpath.t list] @@ filter_system deps)) files));
+          ("files", Preprocessor.dependencies_to_yojson ());
           ("messages", Messages.Table.to_yojson ());
         ]
       in

--- a/src/util/gobFpath.ml
+++ b/src/util/gobFpath.ml
@@ -1,5 +1,9 @@
 type t = Fpath.t [@@deriving show]
 
+let equal = Fpath.equal
+let compare = Fpath.compare
+let hash p = Hashtbl.hash (Fpath.to_string p)
+
 let pretty () p = Pretty.text (Fpath.to_string p)
 
 let to_yojson p = `String (Fpath.to_string p)

--- a/src/util/preprocessor.ml
+++ b/src/util/preprocessor.ml
@@ -36,5 +36,23 @@ let cpp =
 
 let get_cpp () = Lazy.force cpp
 
+module FpathH = Hashtbl.Make (GobFpath)
+let dependencies: bool Fpath.Map.t FpathH.t = FpathH.create 3 (* bool is system_header *)
 
-let dependencies: (Fpath.t, (Fpath.t * bool) list) Hashtbl.t = Hashtbl.create 3
+let dependencies_to_yojson () =
+  dependencies
+  |> FpathH.enum
+  |> Enum.map (fun (p, deps) ->
+      let deps' =
+        deps
+        |> Fpath.Map.bindings
+        |> List.filter_map (function
+            | (dep, false) -> Some dep
+            | (_, true) -> None
+          )
+        |> [%to_yojson: GobFpath.t list]
+      in
+      (Fpath.to_string p, deps')
+    )
+  |> List.of_enum
+  |> (fun l -> `Assoc l)


### PR DESCRIPTION
This should fix the issue @karoliineh found, where Goblint provided incorrect relative paths on zstd due to directory changes in the compilation database.

It depends on the corresponding hook to be added to CIL, using which we can transform the paths while still knowing the original locations of the files.

### TODO
- [x] Update opam pin after https://github.com/goblint/cil/pull/89.