### PR TITLE
Remove `version_map` that was used for `updateCIL`

### DIFF
--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -102,4 +102,4 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
   (* We check whether functions have been added or removed *)
   Cil.iterGlobals newAST (fun glob -> if not (checkExists oldMap glob) then changes.added <- (glob::changes.added));
   Cil.iterGlobals oldAST (fun glob -> if not (checkExists newMap glob) then changes.removed <- (glob::changes.removed));
-  changes
+  changes, newMap

--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -102,7 +102,8 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
   (* We check whether functions have been added or removed *)
   Cil.iterGlobals newAST (fun glob -> if not (checkExists oldMap glob) then changes.added <- (glob::changes.added));
   Cil.iterGlobals oldAST (fun glob -> if not (checkExists newMap glob) then changes.removed <- (glob::changes.removed));
-  changes, newMap
+  changes, oldMap
 
+(** Computes a  *)
 let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
   Stats.time "compareCilFiles" (compareCilFiles ~eq oldAST) newAST

--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -103,3 +103,6 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
   Cil.iterGlobals newAST (fun glob -> if not (checkExists oldMap glob) then changes.added <- (glob::changes.added));
   Cil.iterGlobals oldAST (fun glob -> if not (checkExists newMap glob) then changes.removed <- (glob::changes.removed));
   changes, newMap
+
+let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
+  Stats.time "compareCilFiles" (compareCilFiles ~eq oldAST) newAST

--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -111,6 +111,6 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
   changes
 
 (** Given an (optional) equality function between [Cil.global]s, an old and a new [Cil.file], this function computes a [change_info],
-  which describes which [global]s are changed, unchanged, removed and added.  *)
+    which describes which [global]s are changed, unchanged, removed and added.  *)
 let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
   Stats.time "compareCilFiles" (compareCilFiles ~eq oldAST) newAST

--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -8,6 +8,12 @@ type nodes_diff = {
   primObsoleteNodes: node list; (** primary obsolete nodes -> all obsolete nodes are reachable from these *)
 }
 
+type unchanged_global = {
+  old: global;
+  current: global
+}
+(** For semantically unchanged globals, still keep old and current version of global for resetting current to old. *)
+
 type changed_global = {
   old: global;
   current: global;
@@ -17,7 +23,7 @@ type changed_global = {
 
 type change_info = {
   mutable changed: changed_global list;
-  mutable unchanged: global list;
+  mutable unchanged: unchanged_global list;
   mutable removed: global list;
   mutable added: global list
 }
@@ -82,7 +88,7 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
       (* Do a (recursive) equal comparison ignoring location information *)
       let identical, unchangedHeader, diff = eq old_global global cfgs in
       if identical
-      then changes.unchanged <- global :: changes.unchanged
+      then changes.unchanged <- {current = global; old = old_global} :: changes.unchanged
       else changes.changed <- {current = global; old = old_global; unchangedHeader; diff} :: changes.changed
     with Not_found -> () (* Global was no variable or function, it does not belong into the map *)
   in
@@ -102,7 +108,7 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
   (* We check whether functions have been added or removed *)
   Cil.iterGlobals newAST (fun glob -> if not (checkExists oldMap glob) then changes.added <- (glob::changes.added));
   Cil.iterGlobals oldAST (fun glob -> if not (checkExists newMap glob) then changes.removed <- (glob::changes.removed));
-  changes, oldMap
+  changes
 
 (** Computes a  *)
 let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =

--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -110,6 +110,7 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
   Cil.iterGlobals oldAST (fun glob -> if not (checkExists newMap glob) then changes.removed <- (glob::changes.removed));
   changes
 
-(** Computes a  *)
+(** Given an (optional) equality function between [Cil.global]s, an old and a new [Cil.file], this function computes a [change_info],
+  which describes which [global]s are changed, unchanged, removed and added.  *)
 let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
   Stats.time "compareCilFiles" (compareCilFiles ~eq oldAST) newAST

--- a/src/incremental/maxIdUtil.ml
+++ b/src/incremental/maxIdUtil.ml
@@ -29,6 +29,6 @@ let get_file_max_ids (new_file: Cil.file) =
   Cil.iterGlobals new_file (fun g -> update_max_ids max_vid max_sid g);
   {max_sid = !max_sid; max_vid = !max_vid}
 
-(* Loads the max sid and vid from a previous run *)
+(** Loads the max sid and vid from a previous run *)
 let load_max_ids () =
   Serialize.load_data Serialize.VersionData

--- a/src/incremental/maxIdUtil.ml
+++ b/src/incremental/maxIdUtil.ml
@@ -19,15 +19,16 @@ let update_vids vid_max (glob: global) = match glob with
   | GVarDecl (v,_) -> update_id_max vid_max v.vid
   | _ -> ()
 
-let update_max_ids vid_max sid_max (glob: global) =
-  update_vids vid_max glob; update_sids sid_max glob
+let update_max_ids ~sid_max ~vid_max (glob: global) =
+  update_sids sid_max glob;
+  update_vids vid_max glob
 
 (** Obtains the maximum sid and vid from a Cil.file *)
 let get_file_max_ids (new_file: Cil.file) =
-  let max_sid = ref 0 in
-  let max_vid = ref 0 in
-  Cil.iterGlobals new_file (fun g -> update_max_ids max_vid max_sid g);
-  {max_sid = !max_sid; max_vid = !max_vid}
+  let sid_max = ref 0 in
+  let vid_max = ref 0 in
+  Cil.iterGlobals new_file (fun g -> update_max_ids ~sid_max ~vid_max g);
+  {max_sid = !sid_max; max_vid = !vid_max}
 
 (** Loads the max sid and vid from a previous run *)
 let load_max_ids () =

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -1,6 +1,6 @@
 open Cil
 open CompareCIL
-open VersionLookup
+open MaxIdUtil
 open MyCFG
 
 module NodeMap = Hashtbl.Make(Node)

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -115,11 +115,10 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: global Glo
   in
   let update_globals (glob: global) =
     try
-      let old_glob = GlobalMap.find (CompareCFG.identifier_of_global glob) map in
-      match glob, old_glob with
-      | GFun (nw, _), GFun (old, _) -> update_fun nw
-      | GVar (nw, _, _), GVar (old, _, _) -> update_var nw
-      | GVarDecl (nw, _), GVarDecl (old, _) -> update_var nw
+      match glob with
+      | GFun (nw, _) -> update_fun nw
+      | GVar (nw, _, _) -> update_var nw
+      | GVarDecl (nw, _) -> update_var nw
       | _ -> ()
     with Failure m -> ()
   in

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -17,7 +17,7 @@ let getLoc (node: Node.t) =
 let store_node_location (n: Node.t) (l: location): unit =
   NodeMap.add !location_map n l
 
-let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_identifier, Cil.global) Hashtbl.t) (changes: change_info) =
+let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: global GlobalMap.t) (changes: change_info) =
   let vid_max = ref ids.max_vid in
   let sid_max = ref ids.max_sid in
 
@@ -62,7 +62,7 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_id
   in
   let reset_globals (glob: global) =
     try
-      let old_glob = Hashtbl.find map (CompareCFG.identifier_of_global glob) in
+      let old_glob = GlobalMap.find (CompareCFG.identifier_of_global glob) map in
       match glob, old_glob with
       | GFun (nw, _), GFun (old, _) -> reset_fun nw old
       | GVar (nw, _, _), GVar (old, _, _) -> reset_var nw old
@@ -115,7 +115,7 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: (global_id
   in
   let update_globals (glob: global) =
     try
-      let old_glob = Hashtbl.find map (CompareCFG.identifier_of_global glob) in
+      let old_glob = GlobalMap.find (CompareCFG.identifier_of_global glob) map in
       match glob, old_glob with
       | GFun (nw, _), GFun (old, _) -> update_fun nw
       | GVar (nw, _, _), GVar (old, _, _) -> update_var nw

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -128,7 +128,7 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: global Glo
   List.iter update_globals changes.added;
 
   (* Update the sid_max and vid_max *)
-  Cil.iterGlobals new_file (update_max_ids vid_max sid_max);
+  Cil.iterGlobals new_file (update_max_ids ~sid_max ~vid_max);
   (* increment the sid so that the *unreachable* nodes that are introduced afterwards get unique sids *)
   while !sid_max > Cil.new_sid () do
     ()

--- a/src/incremental/updateCil.ml
+++ b/src/incremental/updateCil.ml
@@ -17,7 +17,7 @@ let getLoc (node: Node.t) =
 let store_node_location (n: Node.t) (l: location): unit =
   NodeMap.add !location_map n l
 
-let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: global GlobalMap.t) (changes: change_info) =
+let update_ids (old_file: file) (ids: max_ids) (new_file: file) (changes: change_info) =
   let vid_max = ref ids.max_vid in
   let sid_max = ref ids.max_sid in
 
@@ -60,10 +60,9 @@ let update_ids (old_file: file) (ids: max_ids) (new_file: file) (map: global Glo
     v.vid <- old_v.vid;
     update_vid_max v.vid;
   in
-  let reset_globals (glob: global) =
+  let reset_globals (glob: unchanged_global) =
     try
-      let old_glob = GlobalMap.find (CompareCFG.identifier_of_global glob) map in
-      match glob, old_glob with
+      match glob.current, glob.old with
       | GFun (nw, _), GFun (old, _) -> reset_fun nw old
       | GVar (nw, _, _), GVar (old, _, _) -> reset_var nw old
       | GVarDecl (nw, _), GVarDecl (old, _) -> reset_var nw old

--- a/src/incremental/versionLookup.ml
+++ b/src/incremental/versionLookup.ml
@@ -22,12 +22,9 @@ let update_vids vid_max (glob: global) = match glob with
 let update_max_ids vid_max sid_max (glob: global) =
   update_vids vid_max glob; update_sids sid_max glob
 
-let updateMap (oldFile: Cil.file) (newFile: Cil.file) (ht: (global_identifier, Cil.global) Hashtbl.t) =
-  let changes = Stats.time "compareCilFiles" (fun () -> compareCilFiles oldFile newFile) () in
+let updateMap (oldFile: Cil.file) (newFile: Cil.file) =
+  Stats.time "compareCilFiles" (fun () -> compareCilFiles oldFile newFile) ()
   (* TODO: For updateCIL, we have to show whether the new data is from an changed or added functiong  *)
-  List.iter (fun (glob: global) ->  Hashtbl.replace ht (identifier_of_global glob) glob) (List.map (fun a -> a.current) changes.changed);
-  List.iter (fun (glob: global) ->  Hashtbl.replace ht (identifier_of_global glob) glob) changes.added;
-  (ht, changes)
 
 let create_map (new_file: Cil.file) =
   let max_sid = ref 0 in
@@ -47,7 +44,7 @@ let load_and_update_map (oldFile: Cil.file) (newFile: Cil.file) =
   if not (Serialize.results_exist ()) then
     failwith "Cannot restore map when no results exist."
   else begin
-    let oldMap, max_ids = Serialize.load_data Serialize.VersionData in
-    let updated, changes = updateMap oldFile newFile oldMap in
-    updated, changes, max_ids
+    let max_ids = Serialize.load_data Serialize.VersionData in
+    let changes, map = updateMap oldFile newFile in
+    changes, map, max_ids
   end

--- a/src/incremental/versionLookup.ml
+++ b/src/incremental/versionLookup.ml
@@ -22,29 +22,13 @@ let update_vids vid_max (glob: global) = match glob with
 let update_max_ids vid_max sid_max (glob: global) =
   update_vids vid_max glob; update_sids sid_max glob
 
-let updateMap (oldFile: Cil.file) (newFile: Cil.file) =
-  Stats.time "compareCilFiles" (fun () -> compareCilFiles oldFile newFile) ()
-  (* TODO: For updateCIL, we have to show whether the new data is from an changed or added functiong  *)
-
-let create_map (new_file: Cil.file) =
+(** Obtains the maximum sid and vid from a Cil.file *)
+let get_file_max_ids (new_file: Cil.file) =
   let max_sid = ref 0 in
   let max_vid = ref 0 in
-  let add_to_hashtbl tbl (global: Cil.global) =
-    match global with
-    | GFun _
-    | GVar _
-    | GVarDecl _ -> Hashtbl.replace tbl (identifier_of_global global) global
-    | _ -> () in
-  let tbl : (global_identifier, Cil.global) Hashtbl.t = Hashtbl.create 1000 in
-  Cil.iterGlobals new_file (fun g -> add_to_hashtbl tbl g; update_max_ids max_vid max_sid g);
-  tbl, {max_sid = !max_sid; max_vid = !max_vid}
+  Cil.iterGlobals new_file (fun g -> update_max_ids max_vid max_sid g);
+  {max_sid = !max_sid; max_vid = !max_vid}
 
-(* Load and update the version map *)
-let load_and_update_map (oldFile: Cil.file) (newFile: Cil.file) =
-  if not (Serialize.results_exist ()) then
-    failwith "Cannot restore map when no results exist."
-  else begin
-    let max_ids = Serialize.load_data Serialize.VersionData in
-    let changes, map = updateMap oldFile newFile in
-    changes, map, max_ids
-  end
+(* Loads the max sid and vid from a previous run *)
+let load_max_ids () =
+  Serialize.load_data Serialize.VersionData

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -481,11 +481,12 @@ let diff_and_rename current_file =
     let (changes, old_file, max_ids) =
       if Serialize.results_exist () && GobConfig.get_bool "incremental.load" then begin
         let old_file = Serialize.load_data Serialize.CilFile in
-        let (changes, map, max_ids) = VersionLookup.load_and_update_map old_file current_file in
+        let changes, map = CompareCIL.compareCilFiles old_file current_file in
+        let max_ids = VersionLookup.load_max_ids () in
         let max_ids = UpdateCil.update_ids old_file max_ids current_file map changes in
         (changes, Some old_file, max_ids)
       end else begin
-        let (version_map, max_ids) = VersionLookup.create_map current_file in
+        let max_ids = VersionLookup.get_file_max_ids current_file in
         (CompareCIL.empty_change_info (), None, max_ids)
       end
     in

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -496,7 +496,7 @@ let diff_and_rename current_file =
     in
     if GobConfig.get_bool "incremental.save" then begin
       Serialize.store_data current_file Serialize.CilFile;
-      Serialize.store_data (max_ids) Serialize.VersionData
+      Serialize.store_data max_ids Serialize.VersionData
     end;
     let old_data = match old_file, solver_data with
       | Some cil_file, Some solver_data -> Some ({cil_file; solver_data}: Analyses.analyzed_data)

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -481,9 +481,9 @@ let diff_and_rename current_file =
     let (changes, old_file, max_ids) =
       if Serialize.results_exist () && GobConfig.get_bool "incremental.load" then begin
         let old_file = Serialize.load_data Serialize.CilFile in
-        let changes, map = CompareCIL.compareCilFiles old_file current_file in
+        let changes = CompareCIL.compareCilFiles old_file current_file in
         let max_ids = MaxIdUtil.load_max_ids () in
-        let max_ids = UpdateCil.update_ids old_file max_ids current_file map changes in
+        let max_ids = UpdateCil.update_ids old_file max_ids current_file changes in
         (changes, Some old_file, max_ids)
       end else begin
         let max_ids = MaxIdUtil.get_file_max_ids current_file in

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -482,11 +482,11 @@ let diff_and_rename current_file =
       if Serialize.results_exist () && GobConfig.get_bool "incremental.load" then begin
         let old_file = Serialize.load_data Serialize.CilFile in
         let changes, map = CompareCIL.compareCilFiles old_file current_file in
-        let max_ids = VersionLookup.load_max_ids () in
+        let max_ids = MaxIdUtil.load_max_ids () in
         let max_ids = UpdateCil.update_ids old_file max_ids current_file map changes in
         (changes, Some old_file, max_ids)
       end else begin
-        let max_ids = VersionLookup.get_file_max_ids current_file in
+        let max_ids = MaxIdUtil.get_file_max_ids current_file in
         (CompareCIL.empty_change_info (), None, max_ids)
       end
     in

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -5,7 +5,7 @@ exception Failure of Response.Error.Code.t * string
 
 type t = {
   mutable file: Cil.file;
-  mutable max_ids: VersionLookup.max_ids;
+  mutable max_ids: MaxIdUtil.max_ids;
   input: IO.input;
   output: unit IO.output;
 }
@@ -79,7 +79,7 @@ let serve serv =
     )
 
 let make ?(input=stdin) ?(output=stdout) file : t =
-  let max_ids = VersionLookup.get_file_max_ids file in
+  let max_ids = MaxIdUtil.get_file_max_ids file in
   {
     file;
     max_ids;
@@ -137,7 +137,7 @@ let analyze ?(reset=false) (s: t) =
   Messages.Table.messages_list := [];
   let file, reparsed = reparse s in
   if reset then (
-    let max_ids = VersionLookup.get_file_max_ids file in
+    let max_ids = MaxIdUtil.get_file_max_ids file in
     s.max_ids <- max_ids;
     Serialize.server_solver_data := None;
     Serialize.server_analysis_data := None);

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -79,7 +79,7 @@ let serve serv =
     )
 
 let make ?(input=stdin) ?(output=stdout) file : t =
-  let version_map, max_ids = VersionLookup.create_map file in
+  let max_ids = VersionLookup.get_file_max_ids file in
   {
     file;
     max_ids;
@@ -122,7 +122,7 @@ let virtual_changes file =
 
 let increment_data (s: t) file reparsed = match !Serialize.server_solver_data with
   | Some solver_data when reparsed ->
-    let changes, map = VersionLookup.updateMap s.file file in
+    let changes, map = CompareCIL.compareCilFiles s.file file in
     let old_data = Some { Analyses.cil_file = s.file; solver_data } in
     s.max_ids <- UpdateCil.update_ids s.file s.max_ids file map changes;
     { Analyses.changes; old_data; new_file = file }, false
@@ -137,7 +137,7 @@ let analyze ?(reset=false) (s: t) =
   Messages.Table.messages_list := [];
   let file, reparsed = reparse s in
   if reset then (
-    let version_map, max_ids = VersionLookup.create_map file in
+    let max_ids = VersionLookup.get_file_max_ids file in
     s.max_ids <- max_ids;
     Serialize.server_solver_data := None;
     Serialize.server_analysis_data := None);

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -122,12 +122,12 @@ let virtual_changes file =
 
 let increment_data (s: t) file reparsed = match !Serialize.server_solver_data with
   | Some solver_data when reparsed ->
-    let changes, map = CompareCIL.compareCilFiles s.file file in
+    let changes = CompareCIL.compareCilFiles s.file file in
     let old_data = Some { Analyses.cil_file = s.file; solver_data } in
-    s.max_ids <- UpdateCil.update_ids s.file s.max_ids file map changes;
+    s.max_ids <- UpdateCil.update_ids s.file s.max_ids file changes;
     { Analyses.changes; old_data; new_file = file }, false
   | Some solver_data ->
-    let changes, _ = virtual_changes file in
+    let changes = virtual_changes file in
     let old_data = Some { Analyses.cil_file = file; solver_data } in
     { Analyses.changes; old_data; new_file = file }, false
   | _ -> Analyses.empty_increment_data file, true


### PR DESCRIPTION
This PR removes  the `version_map` that was kept for `updateCil` in the incremental analysis.
 
The mapping was used to to reset the identifiers in unchanged global (e.g. unchanged function). Namely, for a semantically unchanged global, the identifiers were changed back to those of the oldest version of the global that had the same semantics. This step is important, as there still might be results in the solver hashtables that are associated to the id of the first time we encountered the (semantically same) global.  

We got rid of this map as follows :  
- Now, if an unchanged function is encountered during `compareCIL`, it is recorded together with the version of the global in the old file. In `updateCIL`, this old version of the global is then used for resetting the ids of the global. 
 - We already store the CIL-files only after updating the ids. This way, the *old version of the global* that we load already has the id of the oldest version of the unchanged function. 
 
 Closes #679