### PR TITLE
Fix fixpoint error when comparing blobs with non-blobs

### DIFF
--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -453,8 +453,8 @@ struct
     | (`Array x, `Array y) -> CArrays.leq x y
     | (`List x, `List y) -> Lists.leq x y
     | (`Blob x, `Blob y) -> Blobs.leq x y
-    | `Blob (x,s,o), y
-    | y, `Blob (x,s,o) -> leq (x:t) y
+    | `Blob (x,s,o), y -> leq (x:t) y
+    | x, `Blob (y,s,o) -> leq x (y:t)
     | (`Thread x, `Thread y) -> Threads.leq x y
     | (`Int x, `Thread y) -> true
     | (`Address x, `Thread y) -> true

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -437,7 +437,7 @@ struct
     if GobConfig.get_bool "dbg.verbose" then
       ignore @@ printf "warn_type %s: incomparable abstr. values %s and %s at %a: %a and %a\n" op (tag_name x) (tag_name y) CilType.Location.pretty !Tracing.current_loc pretty x pretty y
 
-  let leq x y =
+  let rec leq x y =
     match (x,y) with
     | (_, `Top) -> true
     | (`Top, _) -> false
@@ -453,6 +453,8 @@ struct
     | (`Array x, `Array y) -> CArrays.leq x y
     | (`List x, `List y) -> Lists.leq x y
     | (`Blob x, `Blob y) -> Blobs.leq x y
+    | `Blob (x,s,o), y
+    | y, `Blob (x,s,o) -> leq (x:t) y
     | (`Thread x, `Thread y) -> Threads.leq x y
     | (`Int x, `Thread y) -> true
     | (`Address x, `Thread y) -> true

--- a/tests/regression/02-base/69-ipmi-struct-blob-fixpoint.c
+++ b/tests/regression/02-base/69-ipmi-struct-blob-fixpoint.c
@@ -1,0 +1,33 @@
+// PARAM: --enable kernel
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/init.h>
+#include <linux/device.h>
+#include <linux/compat.h>
+
+struct ipmi_file_private
+{
+    struct file *file;
+};
+
+static DEFINE_MUTEX(ipmi_mutex);
+
+static int ipmi_open(struct inode *inode, struct file *file)
+{
+    struct ipmi_file_private *priv;
+    priv = kmalloc(sizeof(*priv), GFP_KERNEL);
+    mutex_lock(&ipmi_mutex);
+    priv->file = file; // should reach fixpoint from priv side effect from here
+    return 0;
+}
+
+static const struct file_operations ipmi_fops = {
+    .open = ipmi_open,
+};
+
+static int __init init_ipmi_devintf(void)
+{
+    register_chrdev(0, "ipmidev", &ipmi_fops);
+    return 0;
+}
+module_init(init_ipmi_devintf);

--- a/tests/regression/02-base/69-ipmi-struct-blob-fixpoint.c
+++ b/tests/regression/02-base/69-ipmi-struct-blob-fixpoint.c
@@ -1,16 +1,29 @@
 // PARAM: --enable kernel
 #include <linux/module.h>
 #include <linux/mutex.h>
+#include <linux/spinlock.h>
+#include <linux/ipmi.h>
 #include <linux/init.h>
 #include <linux/device.h>
 #include <linux/compat.h>
 
 struct ipmi_file_private
 {
-    struct file *file;
+    ipmi_user_t          user;
+    spinlock_t           recv_msg_lock;
+    struct list_head     recv_msgs;
+    struct file          *file;
+    struct fasync_struct *fasync_queue;
+    wait_queue_head_t    wait;
+    struct mutex	     recv_mutex;
+    int                  default_retries;
+    unsigned int         default_retry_time_ms;
 };
 
 static DEFINE_MUTEX(ipmi_mutex);
+
+static struct ipmi_user_hndl ipmi_hndlrs = {
+};
 
 static int ipmi_open(struct inode *inode, struct file *file)
 {
@@ -18,6 +31,21 @@ static int ipmi_open(struct inode *inode, struct file *file)
     priv = kmalloc(sizeof(*priv), GFP_KERNEL);
     mutex_lock(&ipmi_mutex);
     priv->file = file; // should reach fixpoint from priv side effect from here
+
+    ipmi_create_user(0, &ipmi_hndlrs, priv, &(priv->user));
+    file->private_data = priv;
+
+    spin_lock_init(&(priv->recv_msg_lock));
+    INIT_LIST_HEAD(&(priv->recv_msgs));
+    init_waitqueue_head(&priv->wait);
+    priv->fasync_queue = NULL;
+    mutex_init(&priv->recv_mutex);
+
+    /* Use the low-level defaults. */
+    priv->default_retries = -1;
+    priv->default_retry_time_ms = 0;
+
+    mutex_unlock(&ipmi_mutex);
     return 0;
 }
 


### PR DESCRIPTION
This fixes the fixpoint error @vesalvojdani found in `char/ipmi/ipmi_devintf.c` from our bench.

The `join` operation allows such joins, so `leq` should also make them comparable.