### PR TITLE
Primitive malloc freshness analysis

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -131,6 +131,13 @@ struct
   (* Evaluating Cil's unary operators. *)
   let evalunop op typ = function
     | `Int v1 -> `Int (ID.cast_to (Cilfacade.get_ikind typ) (unop_ID op v1))
+    | `Address a when op = LNot ->
+      if AD.is_null a then
+        `Int (ID.of_bool (Cilfacade.get_ikind typ) true)
+      else if AD.is_not_null a then
+        `Int (ID.of_bool (Cilfacade.get_ikind typ) false)
+      else
+        `Int (ID.top_of (Cilfacade.get_ikind typ))
     | `Bot -> `Bot
     | _ -> VD.top ()
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1813,6 +1813,11 @@ struct
         if M.tracing then M.tracel "branchosek" "A The branch %B is dead!\n" tv;
         raise Deadcode
       end
+    (* for some reason refine () can refine these, but not raise Deadcode in struct *)
+    | `Address ad when tv && AD.is_null ad ->
+      raise Deadcode
+    | `Address ad when not tv && AD.is_not_null ad ->
+      raise Deadcode
     | `Bot ->
       if M.tracing then M.traceu "branch" "The branch %B is dead!\n" tv;
       if M.tracing then M.tracel "branchosek" "B The branch %B is dead!\n" tv;

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -39,6 +39,11 @@ let classify' fn exps =
       | size::_ -> `Malloc size
       | _ -> strange_arguments ()
     end
+  | "ZSTD_customMalloc" -> (* only used with extraspecials *)
+    begin match exps with
+      | size::_ -> `Malloc size
+      | _ -> strange_arguments ()
+    end
   | "kzalloc" ->
     begin match exps with
       | size::_ -> `Calloc (Cil.one, size)
@@ -47,6 +52,11 @@ let classify' fn exps =
   | "calloc" ->
     begin match exps with
       | n::size::_ -> `Calloc (n, size)
+      | _ -> strange_arguments ()
+    end
+  | "ZSTD_customCalloc" -> (* only used with extraspecials *)
+    begin match exps with
+      | size::_ -> `Calloc (Cil.one, size)
       | _ -> strange_arguments ()
     end
   | "realloc" ->

--- a/src/analyses/mallocFresh.ml
+++ b/src/analyses/mallocFresh.ml
@@ -7,7 +7,7 @@ struct
   include Analyses.IdentitySpec
 
   (* must fresh variables *)
-  module D = SetDomain.Reverse (SetDomain.Make (CilType.Varinfo))
+  module D = SetDomain.Reverse (SetDomain.ToppedSet (CilType.Varinfo) (struct let topname = "All variables" end)) (* need bot (top) for hoare widen *)
   module C = D
 
   let name () = "mallocFresh"

--- a/src/analyses/mallocFresh.ml
+++ b/src/analyses/mallocFresh.ml
@@ -1,0 +1,71 @@
+open Prelude.Ana
+open Analyses
+
+
+module Spec =
+struct
+  include Analyses.IdentitySpec
+
+  (* must fresh variables *)
+  module D = SetDomain.Reverse (SetDomain.Make (CilType.Varinfo))
+  module C = D
+
+  let name () = "mallocFresh"
+
+  let startstate _ = D.empty ()
+  let exitstate _ = D.empty ()
+
+  let assign_lval (ask: Queries.ask) lval local =
+    match ask.f (MayPointTo (AddrOf lval)) with
+    | ls when Queries.LS.is_top ls || Queries.LS.mem (dummyFunDec.svar, `NoOffset) ls ->
+      D.empty ()
+    | ls when Queries.LS.exists (fun (v, _) -> not (D.mem v local) && (v.vglob || ThreadEscape.has_escaped ask v)) ls ->
+      D.empty ()
+    | _ ->
+      local
+
+  let assign ctx lval rval =
+    assign_lval (Analyses.ask_of_ctx ctx) lval ctx.local
+
+  let combine ctx lval f fd args context f_local =
+    match lval with
+    | None -> f_local
+    | Some lval -> assign_lval (Analyses.ask_of_ctx ctx) lval f_local
+
+  let special ctx lval f args =
+    match LibraryFunctions.classify f.vname args with
+    | `Malloc _
+    | `Calloc _
+    | `Realloc _ ->
+      begin match ctx.ask HeapVar with
+        | `Lifted var -> D.add var ctx.local
+        | _ -> ctx.local
+      end
+    | _ ->
+      match lval with
+      | None -> ctx.local
+      | Some lval -> assign_lval (Analyses.ask_of_ctx ctx) lval ctx.local
+
+  let threadenter ctx lval f args =
+    [D.empty ()]
+
+  let threadspawn ctx lval f args fctx =
+    D.empty ()
+
+  module A =
+  struct
+    include BoolDomain.Bool
+    let name () = "fresh"
+    let may_race f1 f2 = not (f1 || f2)
+    let should_print f = f
+  end
+  let access ctx (a: Queries.access) =
+    match a with
+    | Memory {var_opt = Some v; _} ->
+      D.mem v ctx.local
+    | _ ->
+      false
+end
+
+let _ =
+  MCP.register_analysis ~dep:["mallocWrapper"] (module Spec : MCPSpec)

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -80,6 +80,8 @@ struct
       D.add (Analyses.ask_of_ctx ctx) (List.hd arglist) ctx.local
     | `Unlock ->
       D.remove (Analyses.ask_of_ctx ctx) (List.hd arglist) ctx.local
+    | `Unknown "ZSTD_customFree" -> (* only used with extraspecials *)
+      ctx.local
     | `Unknown fn when VarEq.safe_fn fn ->
       Messages.warn "Assume that %s does not change lockset." fn;
       ctx.local

--- a/tests/regression/03-practical/25-zstd-customMem.c
+++ b/tests/regression/03-practical/25-zstd-customMem.c
@@ -1,0 +1,32 @@
+// Extracted from zstd
+#include <stddef.h>
+#include <assert.h>
+
+typedef void* (*ZSTD_allocFunction) (void* opaque, size_t size);
+typedef void  (*ZSTD_freeFunction) (void* opaque, void* address);
+typedef struct { ZSTD_allocFunction customAlloc; ZSTD_freeFunction customFree; void* opaque; } ZSTD_customMem;
+
+ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };
+
+#define ZSTD_malloc(s) malloc(s)
+
+void* ZSTD_customMalloc(size_t size, ZSTD_customMem customMem)
+{
+    if (customMem.customAlloc) // WARN (dead branch)
+        return customMem.customAlloc(customMem.opaque, size);
+    return ZSTD_malloc(size);
+}
+
+int* ZSTD_createCCtx_advanced(ZSTD_customMem customMem)
+{
+  if ((!customMem.customAlloc) ^ (!customMem.customFree)) // WARN (dead branch)
+    return NULL;
+
+  return ZSTD_customMalloc(sizeof(int), customMem);
+}
+
+int main() {
+  int *p = ZSTD_createCCtx_advanced(ZSTD_defaultCMem);
+  assert(p != NULL);
+  return 0;
+}

--- a/tests/regression/06-symbeq/35-zstd-thread-pool-multi.c
+++ b/tests/regression/06-symbeq/35-zstd-thread-pool-multi.c
@@ -1,0 +1,265 @@
+// PARAM: --set ana.activated[+] symb_locks --set ana.activated[+] mallocFresh
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) Facebook, Inc.
+ * All rights reserved.
+ *
+ * This code is a challenging example for race detection extracted from zstd.
+ * Copyright (c) The Goblint Contributors
+ */
+
+#include<stdlib.h>
+#include<pthread.h>
+#define ZSTD_pthread_mutex_t            pthread_mutex_t
+#define ZSTD_pthread_mutex_init(a, b)   pthread_mutex_init((a), (b))
+#define ZSTD_pthread_mutex_destroy(a)   pthread_mutex_destroy((a))
+#define ZSTD_pthread_mutex_lock(a)      pthread_mutex_lock((a))
+#define ZSTD_pthread_mutex_unlock(a)    pthread_mutex_unlock((a))
+
+#define ZSTD_pthread_cond_t             pthread_cond_t
+#define ZSTD_pthread_cond_init(a, b)    pthread_cond_init((a), (b))
+#define ZSTD_pthread_cond_destroy(a)    pthread_cond_destroy((a))
+#define ZSTD_pthread_cond_wait(a, b)    pthread_cond_wait((a), (b))
+#define ZSTD_pthread_cond_signal(a)     pthread_cond_signal((a))
+#define ZSTD_pthread_cond_broadcast(a)  pthread_cond_broadcast((a))
+
+#define ZSTD_pthread_t                  pthread_t
+#define ZSTD_pthread_create(a, b, c, d) pthread_create((a), (b), (c), (d))
+#define ZSTD_pthread_join(a, b)         pthread_join((a),(b))
+
+#define ZSTD_malloc(s) malloc(s)
+#define ZSTD_calloc(n,s) calloc((n), (s))
+#define ZSTD_free(p) free((p))
+#define ZSTD_memset(d,s,n) __builtin_memset((d),(s),(n))
+
+typedef struct POOL_ctx_s POOL_ctx;
+
+typedef void* (*ZSTD_allocFunction) (void* opaque, size_t size);
+typedef void  (*ZSTD_freeFunction) (void* opaque, void* address);
+typedef struct { ZSTD_allocFunction customAlloc; ZSTD_freeFunction customFree; void* opaque; } ZSTD_customMem;
+typedef struct POOL_ctx_s ZSTD_threadPool;
+
+
+void* ZSTD_customMalloc(size_t size, ZSTD_customMem customMem)
+{
+    if (customMem.customAlloc)
+        return customMem.customAlloc(customMem.opaque, size);
+    return ZSTD_malloc(size);
+}
+
+void* ZSTD_customCalloc(size_t size, ZSTD_customMem customMem)
+{
+    if (customMem.customAlloc) {
+        /* calloc implemented as malloc+memset;
+         * not as efficient as calloc, but next best guess for custom malloc */
+        void* const ptr = customMem.customAlloc(customMem.opaque, size);
+        ZSTD_memset(ptr, 0, size);
+        return ptr;
+    }
+    return ZSTD_calloc(1, size);
+}
+
+void ZSTD_customFree(void* ptr, ZSTD_customMem customMem)
+{
+    if (ptr!=NULL) {
+        if (customMem.customFree)
+            customMem.customFree(customMem.opaque, ptr);
+        else
+            ZSTD_free(ptr);
+    }
+}
+
+
+
+/*! POOL_create() :
+ *  Create a thread pool with at most `numThreads` threads.
+ * `numThreads` must be at least 1.
+ *  The maximum number of queued jobs before blocking is `queueSize`.
+ * @return : POOL_ctx pointer on success, else NULL.
+*/
+POOL_ctx* POOL_create(size_t numThreads, size_t queueSize);
+
+POOL_ctx* POOL_create_advanced(size_t numThreads, size_t queueSize, ZSTD_customMem customMem);
+
+/*! POOL_free() :
+ *  Free a thread pool returned by POOL_create().
+ */
+void POOL_free(POOL_ctx* ctx);
+
+
+/*! POOL_function :
+ *  The function type that can be added to a thread pool.
+ */
+typedef void (*POOL_function)(void*);
+
+
+static
+#ifdef __GNUC__
+__attribute__((__unused__))
+#endif
+ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  /**< this constant defers to stdlib's functions */
+
+
+/* A job is a function and an opaque argument */
+typedef struct POOL_job_s {
+    POOL_function function;
+    void *opaque;
+} POOL_job;
+
+struct POOL_ctx_s {
+    ZSTD_customMem customMem;
+    /* Keep track of the threads */
+    ZSTD_pthread_t* threads;
+    size_t threadCapacity;
+    size_t threadLimit;
+
+    /* The queue is a circular buffer */
+    POOL_job *queue;
+    size_t queueHead;
+    size_t queueTail;
+    size_t queueSize;
+
+    /* The number of threads working on jobs */
+    size_t numThreadsBusy;
+    /* Indicates if the queue is empty */
+    int queueEmpty;
+
+    /* The mutex protects the queue */
+    ZSTD_pthread_mutex_t queueMutex;
+    /* Condition variable for pushers to wait on when the queue is full */
+    ZSTD_pthread_cond_t queuePushCond;
+    /* Condition variables for poppers to wait on when the queue is empty */
+    ZSTD_pthread_cond_t queuePopCond;
+    /* Indicates if the queue is shutting down */
+    int shutdown;
+};
+
+/* POOL_thread() :
+ * Work thread for the thread pool.
+ * Waits for jobs and executes them.
+ * @returns : NULL on failure else non-null.
+ */
+static void* POOL_thread(void* opaque) {
+    POOL_ctx* const ctx = (POOL_ctx*)opaque;
+    if (!ctx) { return NULL; }
+    for (;;) {
+        /* Lock the mutex and wait for a non-empty queue or until shutdown */
+        ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+
+        while ( ctx->queueEmpty // RACE! (threadLimit)
+            || (ctx->numThreadsBusy >= ctx->threadLimit) ) {
+            if (ctx->shutdown) {
+                /* even if !queueEmpty, (possible if numThreadsBusy >= threadLimit),
+                 * a few threads will be shutdown while !queueEmpty,
+                 * but enough threads will remain active to finish the queue */
+                ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+                return opaque;
+            }
+            ZSTD_pthread_cond_wait(&ctx->queuePopCond, &ctx->queueMutex);
+        }
+        /* Pop a job off the queue */
+        {   POOL_job const job = ctx->queue[ctx->queueHead]; //NORACE
+            ctx->queueHead = (ctx->queueHead + 1) % ctx->queueSize; //NORACE
+            ctx->numThreadsBusy++; //NORACE
+            ctx->queueEmpty = (ctx->queueHead == ctx->queueTail); //NORACE
+            /* Unlock the mutex, signal a pusher, and run the job */
+            ZSTD_pthread_cond_signal(&ctx->queuePushCond);
+            ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+
+            job.function(job.opaque);
+
+            /* If the intended queue size was 0, signal after finishing job */
+            ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+            ctx->numThreadsBusy--; //NORACE
+            ZSTD_pthread_cond_signal(&ctx->queuePushCond);
+            ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+        }
+    }  /* for (;;) */
+    assert(0);  //NOWARN (unreachable)
+}
+
+POOL_ctx* POOL_create(size_t numThreads, size_t queueSize) {
+    return POOL_create_advanced(numThreads, queueSize, ZSTD_defaultCMem);
+}
+
+POOL_ctx* POOL_create_advanced(size_t numThreads, size_t queueSize,
+                               ZSTD_customMem customMem)
+{
+    POOL_ctx* ctx;
+    /* Check parameters */
+    if (!numThreads) { return NULL; }
+    /* Allocate the context and zero initialize */
+    ctx = (POOL_ctx*)ZSTD_customCalloc(sizeof(POOL_ctx), customMem);
+    if (!ctx) { return NULL; }
+    /* Initialize the job queue.
+     * It needs one extra space since one space is wasted to differentiate
+     * empty and full queues.
+     */
+    ctx->queueSize = queueSize + 1; // NORACE
+    ctx->queue = (POOL_job*)ZSTD_customMalloc(ctx->queueSize * sizeof(POOL_job), customMem); // NORACE
+    ctx->queueHead = 0; // NORACE
+    ctx->queueTail = 0; // NORACE
+    ctx->numThreadsBusy = 0; // NORACE
+    ctx->queueEmpty = 1; // NORACE
+    {
+        int error = 0;
+        error |= ZSTD_pthread_mutex_init(&ctx->queueMutex, NULL); // NORACE
+        error |= ZSTD_pthread_cond_init(&ctx->queuePushCond, NULL); // NORACE
+        error |= ZSTD_pthread_cond_init(&ctx->queuePopCond, NULL); // NORACE
+        if (error) { POOL_free(ctx); return NULL; }
+    }
+    ctx->shutdown = 0; // NORACE
+    /* Allocate space for the thread handles */
+    ctx->threads = (ZSTD_pthread_t*)ZSTD_customMalloc(numThreads * sizeof(ZSTD_pthread_t), customMem); // NORACE
+    ctx->threadCapacity = 0; // NORACE
+    ctx->customMem = customMem; // NORACE
+    /* Check for errors */
+    if (!ctx->threads || !ctx->queue) { POOL_free(ctx); return NULL; } // NORACE
+    /* Initialize the threads */
+    {   size_t i;
+        for (i = 0; i < numThreads; ++i) {
+            if (ZSTD_pthread_create(&ctx->threads[i], NULL, &POOL_thread, ctx)) {
+                ctx->threadCapacity = i;
+                POOL_free(ctx);
+                return NULL;
+        }   }
+        ctx->threadCapacity = numThreads;
+        ctx->threadLimit = numThreads; // RACE!
+    }
+    return ctx;
+}
+
+/*! POOL_join() :
+    Shutdown the queue, wake any sleeping threads, and join all of the threads.
+*/
+static void POOL_join(POOL_ctx* ctx) {
+    /* Shut down the queue */
+    ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+    ctx->shutdown = 1; //NORACE
+    ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+    /* Wake up sleeping threads */
+    ZSTD_pthread_cond_broadcast(&ctx->queuePushCond);
+    ZSTD_pthread_cond_broadcast(&ctx->queuePopCond);
+    /* Join all of the threads */
+    {   size_t i;
+        for (i = 0; i < ctx->threadCapacity; ++i) {
+            ZSTD_pthread_join(ctx->threads[i], NULL);  /* note : could fail */
+    }   }
+}
+
+void POOL_free(POOL_ctx *ctx) {
+    if (!ctx) { return; }
+    POOL_join(ctx);
+    ZSTD_pthread_mutex_destroy(&ctx->queueMutex);
+    ZSTD_pthread_cond_destroy(&ctx->queuePushCond);
+    ZSTD_pthread_cond_destroy(&ctx->queuePopCond);
+    ZSTD_customFree(ctx->queue, ctx->customMem);
+    ZSTD_customFree(ctx->threads, ctx->customMem);
+    ZSTD_customFree(ctx, ctx->customMem);
+}
+
+int main() {
+    while (1) {
+        POOL_ctx* const ctx = POOL_create(20, 10);
+    }
+}

--- a/tests/regression/45-escape/50-fresh-malloc.c
+++ b/tests/regression/45-escape/50-fresh-malloc.c
@@ -1,0 +1,27 @@
+// PARAM: --set ana.activated[+] mallocFresh --set ana.activated[-] mhp --set ana.thread.domain plain
+#include <pthread.h>
+#include <stdlib.h>
+
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun2(void *arg) {
+  int *i = arg;
+  pthread_mutex_lock(&A);
+  *i = 10; // NORACE
+  pthread_mutex_unlock(&A);
+  return NULL;
+}
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+int main() {
+  pthread_t id, id2;
+  pthread_create(&id, NULL, t_fun, NULL); // enter multithreaded
+
+  int *i = malloc(sizeof(int));
+  *i = 5; // NORACE (fresh)
+  pthread_create(&id2, NULL, t_fun2, i);
+  return 0;
+}

--- a/tests/regression/45-escape/51-fresh-global.c
+++ b/tests/regression/45-escape/51-fresh-global.c
@@ -1,0 +1,30 @@
+// PARAM: --set ana.activated[+] mallocFresh --set ana.activated[-] mhp --set ana.thread.domain plain
+#include <pthread.h>
+#include <stdlib.h>
+
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun2(void *arg) {
+  int *i = arg;
+  pthread_mutex_lock(&A);
+  *i = 10; // RACE!
+  pthread_mutex_unlock(&A);
+  return NULL;
+}
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+int *g;
+
+int main() {
+  pthread_t id, id2;
+  pthread_create(&id, NULL, t_fun, NULL); // enter multithreaded
+
+  int *i = malloc(sizeof(int));
+  g = i;
+  *i = 5; // RACE! (not fresh)
+  pthread_create(&id2, NULL, t_fun2, i);
+  return 0;
+}


### PR DESCRIPTION
This is a very primitive malloc freshness analysis that should be sufficient for the initializations in zstd and chrony.

### Changes
1. Add mallocFresh analysis, which keeps a must-set of fresh alloc variables, which are used for excluding races. The set is very easily forgotten to hopefully ensure soundness.
2. Add zstd custom allocation functions to `LibraryFunctions`. This is necessary because due to some invalidation somewhere, unknown pointer gets added to possible values, despite the program only ever using custom allocators with `NULL`. These are only used when added to `exp.extraspecials`.
3. (Add conf for analyzing zstd races such that all spurious races are now gone!) To be readded to `interactive`.
4. Handle address set result in base `branch`.
5. Handle address set in base logical not expression.

### TODO
- [x] Figure out why doesn't work on full zstd. Due to custom allocator? _Yes._
- [x] Check if works on chrony. @vesalvojdani 
- [x] Rebase to `master`.
- [ ] Readd zstd-race conf when merging to `interactive`.