### PR TITLE
Optimize TD3 in server mode by avoiding relifting

### DIFF
--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -405,7 +405,7 @@ type increment_data = {
   changes: CompareCIL.change_info
 }
 
-let empty_increment_data ~server file = {
+let empty_increment_data ?(server=false) file = {
   server;
   old_data = None;
   new_file = file;

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -398,12 +398,15 @@ type analyzed_data = {
 }
 
 type increment_data = {
+  server: bool;
+
   old_data: analyzed_data option;
   new_file: Cil.file;
   changes: CompareCIL.change_info
 }
 
-let empty_increment_data file = {
+let empty_increment_data ~server file = {
+  server;
   old_data = None;
   new_file = file;
   changes = CompareCIL.empty_change_info ()

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -11,6 +11,7 @@ module type S2S = functor (X : Spec) -> Spec
 
 (* spec is lazy, so HConsed table in Hashcons lifters is preserved between analyses in server mode *)
 let spec_module: (module Spec) Lazy.t = lazy (
+  GobConfig.building_spec := true;
   let open Batteries in
   (* apply functor F on module X if opt is true *)
   let lift opt (module F : S2S) (module X : Spec) = (module (val if opt then (module F (X)) else (module X) : Spec) : Spec) in
@@ -29,6 +30,7 @@ let spec_module: (module Spec) Lazy.t = lazy (
             |> lift (get_bool "ana.opt.equal" && not (get_bool "ana.opt.hashcons")) (module OptEqual)
             |> lift (get_bool "ana.opt.hashcons") (module HashconsLifter)
           ) in
+  GobConfig.building_spec := false;
   (module S1)
 )
 

--- a/src/goblint.ml
+++ b/src/goblint.ml
@@ -25,7 +25,7 @@ let main () =
     );
     let file = Fun.protect ~finally:GoblintDir.finalize preprocess_and_merge in
     if get_bool "server.enabled" then Server.start file else (
-      let changeInfo = if GobConfig.get_bool "incremental.load" || GobConfig.get_bool "incremental.save" then diff_and_rename file else Analyses.empty_increment_data file in
+      let changeInfo = if GobConfig.get_bool "incremental.load" || GobConfig.get_bool "incremental.save" then diff_and_rename ~server:false file else Analyses.empty_increment_data ~server:false file in
       file|> do_analyze changeInfo;
       do_stats ();
       do_html_output ();

--- a/src/goblint.ml
+++ b/src/goblint.ml
@@ -25,7 +25,7 @@ let main () =
     );
     let file = Fun.protect ~finally:GoblintDir.finalize preprocess_and_merge in
     if get_bool "server.enabled" then Server.start file else (
-      let changeInfo = if GobConfig.get_bool "incremental.load" || GobConfig.get_bool "incremental.save" then diff_and_rename ~server:false file else Analyses.empty_increment_data ~server:false file in
+      let changeInfo = if GobConfig.get_bool "incremental.load" || GobConfig.get_bool "incremental.save" then diff_and_rename file else Analyses.empty_increment_data file in
       file|> do_analyze changeInfo;
       do_stats ();
       do_html_output ();

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -515,7 +515,7 @@ let handle_extraspecials () =
   LibraryFunctions.add_lib_funs funs
 
 (* Detects changes and renames vids and sids. *)
-let diff_and_rename ~server current_file =
+let diff_and_rename current_file =
   (* Create change info, either from old results, or from scratch if there are no previous results. *)
   let change_info: Analyses.increment_data =
     if GobConfig.get_bool "incremental.load" && not (Serialize.results_exist ()) then begin
@@ -546,7 +546,7 @@ let diff_and_rename ~server current_file =
       | Some cil_file, Some solver_data -> Some ({cil_file; solver_data}: Analyses.analyzed_data)
       | _, _ -> None
     in
-    {server; Analyses.changes = changes; old_data; new_file = current_file}
+    {server = false; Analyses.changes = changes; old_data; new_file = current_file}
   in change_info
 
 let () = (* signal for printing backtrace; other signals in Generic.SolverStats and Timeout *)

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -515,7 +515,7 @@ let handle_extraspecials () =
   LibraryFunctions.add_lib_funs funs
 
 (* Detects changes and renames vids and sids. *)
-let diff_and_rename current_file =
+let diff_and_rename ~server current_file =
   (* Create change info, either from old results, or from scratch if there are no previous results. *)
   let change_info: Analyses.increment_data =
     if GobConfig.get_bool "incremental.load" && not (Serialize.results_exist ()) then begin
@@ -546,7 +546,7 @@ let diff_and_rename current_file =
       | Some cil_file, Some solver_data -> Some ({cil_file; solver_data}: Analyses.analyzed_data)
       | _, _ -> None
     in
-    {Analyses.changes = changes; old_data; new_file = current_file}
+    {server; Analyses.changes = changes; old_data; new_file = current_file}
   in change_info
 
 let () = (* signal for printing backtrace; other signals in Generic.SolverStats and Timeout *)

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -477,7 +477,14 @@ module WP =
          * - If we destabilized a node with a call, we will also destabilize all vars of the called function. However, if we end up with the same state at the caller node, without hashcons we would only need to go over all vars in the function once to restabilize them since we have
          *   the old values, whereas with hashcons, we would get a context with a different tag, could not find the old value for that var, and have to recompute all vars in the function (without access to old values).
          *)
-        if loaded && GobConfig.get_bool "ana.opt.hashcons" then (
+        if loaded && S.increment.server then (
+          data.rho <- HM.copy data.rho;
+          data.stable <- HM.copy data.stable;
+          data.wpoint <- HM.copy data.wpoint;
+          data.infl <- HM.copy data.infl;
+          (* data.st <- data.st; *)
+        )
+        else if loaded && GobConfig.get_bool "ana.opt.hashcons" then (
           let rho' = HM.create (HM.length data.rho) in
           HM.iter (fun k v ->
             (* call hashcons on contexts and abstract values; results in new tags *)

--- a/src/util/gobConfig.ml
+++ b/src/util/gobConfig.ml
@@ -28,6 +28,8 @@ exception ConfigError of string
 (* Phase of the analysis (moved from GoblintUtil b/c of circular build...) *)
 let phase = ref 0
 
+let building_spec = ref false
+
 
 module Validator = JsonSchema.Validator (struct let schema = Options.schema end)
 module ValidatorRequireAll = JsonSchema.Validator (struct let schema = Options.require_all end)
@@ -303,10 +305,16 @@ struct
     in
     drop memo_int; drop memo_bool; drop memo_string; drop memo_list
 
-  let get_int    = memo_int.get
-  let get_bool   = memo_bool.get
-  let get_string = memo_string.get
-  let get_list   = memo_list.get
+  let wrap_get f x =
+    (* self-observe options, which Spec construction depends on *)
+    (* if !building_spec then
+      Printf.printf "GET during spec building: %s\n" x; *)
+    f x
+
+  let get_int    = wrap_get memo_int.get
+  let get_bool   = wrap_get memo_bool.get
+  let get_string = wrap_get memo_string.get
+  let get_list   = wrap_get memo_list.get
   let get_string_list = List.map Yojson.Safe.Util.to_string % get_list
 
   (** Helper functions for writing values. *)

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -171,7 +171,6 @@ let () =
         analyze serve ~reset;
         {status = if !Goblintutil.verified = Some false then VerifyError else Success}
       with Sys.Break ->
-        assert (GobConfig.get_bool "ana.opt.hashcons"); (* TODO: TD3 doesn't copy input solver data, so will modify it in place and screw up Serialize.server_solver_data accidentally *)
         {status = Aborted}
   end);
 

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -125,12 +125,12 @@ let increment_data (s: t) file reparsed = match !Serialize.server_solver_data wi
     let changes = CompareCIL.compareCilFiles s.file file in
     let old_data = Some { Analyses.cil_file = s.file; solver_data } in
     s.max_ids <- UpdateCil.update_ids s.file s.max_ids file changes;
-    { Analyses.changes; old_data; new_file = file }, false
+    { server = true; Analyses.changes; old_data; new_file = file }, false
   | Some solver_data ->
     let changes = virtual_changes file in
     let old_data = Some { Analyses.cil_file = file; solver_data } in
-    { Analyses.changes; old_data; new_file = file }, false
-  | _ -> Analyses.empty_increment_data file, true
+    { server = true; Analyses.changes; old_data; new_file = file }, false
+  | _ -> Analyses.empty_increment_data ~server:true file, true
 
 let analyze ?(reset=false) (s: t) =
   Messages.Table.(MH.clear messages_table);


### PR DESCRIPTION
Since in server mode the solver data isn't unmarshaled from a file but stays in memory the entire time, it is unnecessary for TD3 to relift the entire solution, which can be time-consuming since the hashtables are semi-deeply copied by `relift`.
Instead it suffices to just shallowly copy the solver hashtables themselves, which is still necessary to allow analysis abort in server mode to revert back to previous data without the aborted run having mutated the same data structures.

Surprisingly, this didn't initially work and always caused complete reanalysis in server mode. This was because each reanalysis calls `get_spec ()` and reconstructs the `Spec`, including reinitializing the hashconsing functor and its table.
Since we have to forbid changes to the data structure anyway, we can assume the `Spec` to be constant throughout (by using `lazy`). This ensures that the hashconsing table is reused properly without the need for relifting.

Additionally, I added a bit of debug printing to identify options on which the `Spec` construction itself depends (by self-observation). In the future we could forbid these options from being modified in server mode/incrementally without manually having to maintain a list of these (which could go out of date).