### PR TITLE
Fix unsound var_eq unknown function invalidation

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -809,6 +809,8 @@ struct
     match ofs with
     | NoOffset -> `NoOffset
     | Field (fld, ofs) -> `Field (fld, convert_offset a gs st ofs)
+    | Index (CastE (TInt(IInt,[]), Const (CStr ("unknown",No_encoding))), ofs) -> (* special offset added by convertToQueryLval *)
+      `Index (IdxDom.top (), convert_offset a gs st ofs)
     | Index (exp, ofs) ->
       let exp_rv = eval_rv a gs st exp in
       match exp_rv with

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -491,15 +491,8 @@ struct
     match reachables (Analyses.ask_of_ctx ctx) es with
     | None -> D.top ()
     | Some rs ->
-      let remove_reachable1 es st =
-        let remove_reachable2 e st =
-          if reachable_from rs e && not (isConstant e) then remove_exp (Analyses.ask_of_ctx ctx) e st else st
-        in
-        D.B.fold remove_reachable2 es st
-      in
-      (* TODO: do something like this instead to be sound? *)
-      (* List.fold_left (fun st e -> remove_exp (Analyses.ask_of_ctx ctx) e st) ctx.local (Queries.LS.fold (fun lval acc -> mkAddrOf (Lval.CilLval.to_lval lval) :: acc) rs []) *)
-      D.fold remove_reachable1 ctx.local ctx.local
+      (* TODO: avoid intermediate list *)
+      List.fold_left (fun st e -> remove_exp (Analyses.ask_of_ctx ctx) e st) ctx.local (Queries.LS.fold (fun lval acc -> mkAddrOf (Lval.CilLval.to_lval lval) :: acc) rs [])
 
   let unknown_fn ctx lval f args =
     let args =

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -193,6 +193,7 @@ struct
     let bt =
       match unrollTypeDeep (Cilfacade.typeOf b) with
       | TPtr (t,_) -> t
+      | exception Cilfacade.TypeOfError _
       | _ -> voidType
     in (* type of thing that changed: typeof( *b ) *)
     let rec type_may_change_apt a =

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -409,40 +409,6 @@ struct
     in
     List.fold_right reachable es (Some (Queries.LS.empty ()))
 
-  let rec reachable_from (r:Queries.LS.t) e =
-    if Queries.LS.is_top r then true else
-      let rec is_prefix x1 x2 =
-        match x1, x2 with
-        | _, `NoOffset -> true
-        | Field (f1,o1), `Field (f2,o2) when CilType.Fieldinfo.equal f1 f2 -> is_prefix o1 o2
-        | Index (_,o1), `Index (_,o2) -> is_prefix o1 o2
-        | _ -> false
-      in
-      let has_reachable_prefix v1 ofs =
-        let suitable_prefix (v2,ofs2) =
-          CilType.Varinfo.equal v1 v2
-          && is_prefix ofs ofs2
-        in
-        Queries.LS.exists suitable_prefix r
-      in
-      match e with
-      | SizeOf _
-      | SizeOfE _
-      | SizeOfStr _
-      | AlignOf _
-      | Const _
-      | AlignOfE _
-      | UnOp  _
-      | BinOp _ -> true
-      | AddrOf  (Var v2,ofs)
-      | StartOf (Var v2,ofs)
-      | Lval    (Var v2,ofs) -> has_reachable_prefix v2 ofs
-      | AddrOf  (Mem e,_)
-      | StartOf (Mem e,_)
-      | Lval    (Mem e,_)
-      | CastE (_,e)           -> reachable_from r e
-      | Question _ -> failwith "Logical operations should be compiled away by CIL."
-      | _ -> failwith "Unmatched pattern."
 
   (* Probably ok as is. *)
   let body ctx f = ctx.local
@@ -493,6 +459,9 @@ struct
     match reachables ask es with
     | None -> D.top ()
     | Some rs ->
+      (* Prior to https://github.com/goblint/analyzer/pull/694 checks were done "in the other direction":
+         each expression in ctx.local was checked for reachability from es/rs using very conservative but also unsound reachable_from.
+         It is unknown, why that was necessary. *)
       Queries.LS.fold (fun lval st ->
           remove ask (Lval.CilLval.to_lval lval) st
         ) rs ctx.local

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -489,11 +489,13 @@ struct
       | None -> st2
 
   let remove_reachable ctx es =
-    match reachables (Analyses.ask_of_ctx ctx) es with
+    let ask = Analyses.ask_of_ctx ctx in
+    match reachables ask es with
     | None -> D.top ()
     | Some rs ->
-      (* TODO: avoid intermediate list *)
-      List.fold_left (fun st e -> remove_exp (Analyses.ask_of_ctx ctx) e st) ctx.local (Queries.LS.fold (fun lval acc -> mkAddrOf (Lval.CilLval.to_lval lval) :: acc) rs [])
+      Queries.LS.fold (fun lval st ->
+          remove ask (Lval.CilLval.to_lval lval) st
+        ) rs ctx.local
 
   let unknown_fn ctx lval f args =
     let args =

--- a/tests/regression/06-symbeq/32-var_eq-unknown-invalidate.c
+++ b/tests/regression/06-symbeq/32-var_eq-unknown-invalidate.c
@@ -19,7 +19,7 @@ int main() {
   if (res == (struct resource *)0)
     assert(1); // reachable
   else
-    assert(1); // TODO reachable
+    assert(1); // reachable
 
   return 0;
 }


### PR DESCRIPTION
Initially this came up in #618, where a TODO test and commented out possible fix were added. Since those benchmarks ended up not being relevant, we put off fixing the issue.

While analyzing zstd with var_eq I found that the same unsoundness occurs there, making all locking in files other than `pool.c` dead. This applies the commented out fix from #618 and a couple of others where zstd caused crashes due to the change.

This changes the unknown function invalidation to just use `remove` like all the other var_eq invalidation. The old algorithm did something weirder: it checked each expression in the local state whether it's reachable from the lvalues reachable from the invalidated variables. I don't recall any more why it was done so, but the change doesn't cause any regressions.
Or is the new invalidation unsound in some different untested way? The extreme solution would be to apply both invalidations in sequence to ensure removal by both, but I'm not sure if we have to go that far.