### PR TITLE
Improve `memset` analysis

### DIFF
--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -35,6 +35,12 @@ struct
     unsafe := 0
 
   let side_access ctx ty lv_opt (conf, w, loc, e, a) =
+    let ty =
+      if Option.is_some lv_opt then
+        `Type Cil.voidType (* avoid unsound type split for alloc variables *)
+      else
+        ty
+    in
     let d =
       if !GU.should_warn then
         Access.AS.singleton (conf, w, loc, e, a)

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -181,7 +181,7 @@ struct
       (* TODO: per-argument reach *)
       let reach =
         match f.vname with
-        | "memset" -> false
+        | "memset" | "__builtin_memset" -> false
         | _ -> true
       in
       List.iter (access_one_top ctx false reach) (arg_acc `Read);

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -172,8 +172,14 @@ struct
         | Some fnc -> (fnc act arglist)
         | _ -> arglist
       in
-      List.iter (access_one_top ctx false true) (arg_acc `Read);
-      List.iter (access_one_top ctx true  true ) (arg_acc `Write);
+      (* TODO: per-argument reach *)
+      let reach =
+        match f.vname with
+        | "memset" -> false
+        | _ -> true
+      in
+      List.iter (access_one_top ctx false reach) (arg_acc `Read);
+      List.iter (access_one_top ctx true  reach) (arg_acc `Write);
       (match lv with
        | Some x -> access_one_top ctx true false (AddrOf x)
        | None -> ());

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2112,6 +2112,25 @@ struct
     let st: store = ctx.local in
     let gs = ctx.global in
     match LF.classify f.vname args with
+    | `Unknown "memset" ->
+      begin match args with
+        | [dest; ch; count] ->
+          (* TODO: check count *)
+          let eval_ch = eval_rv (Analyses.ask_of_ctx ctx) gs st ch in
+          let dest_lval = mkMem ~addr:(Cil.stripCasts dest) ~off:NoOffset in
+          let dest_a = eval_lv (Analyses.ask_of_ctx ctx) gs st dest_lval in
+          (* let dest_typ = Cilfacade.typeOfLval dest_lval in *)
+          let dest_typ = AD.get_type dest_a in (* TODO: what is the right way? *)
+          let value =
+            match eval_ch with
+            | `Int i when ID.to_int i = Some Z.zero ->
+              VD.zero_init_value dest_typ
+            | _ ->
+              VD.top_value dest_typ
+          in
+          set ~ctx:(Some ctx) (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ value
+        | _ -> failwith "strange memset arguments"
+      end
     | `Unknown "F59" (* strcpy *)
     | `Unknown "F60" (* strncpy *)
     | `Unknown "F63" (* memcpy *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2112,7 +2112,7 @@ struct
     let st: store = ctx.local in
     let gs = ctx.global in
     match LF.classify f.vname args with
-    | `Unknown "memset" ->
+    | `Unknown ("memset" | "__builtin_memset") ->
       begin match args with
         | [dest; ch; count] ->
           (* TODO: check count *)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -208,7 +208,7 @@ let invalidate_actions = [
     "__builtin___memcpy_chk", writes [1];
     "__builtin___mempcpy_chk", writes [1];
     "memset", writes [1];(*unsafe*)
-    "__builtin_memset", writesAll;(*unsafe*)
+    "__builtin_memset", writes [1];(*unsafe*)
     "__builtin___memset_chk", writesAll;
     "printf", readsAll;(*safe*)
     "__printf_chk", readsAll;(*safe*)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -207,7 +207,7 @@ let invalidate_actions = [
     "mempcpy", writes [1];(*keep [1]*)
     "__builtin___memcpy_chk", writes [1];
     "__builtin___mempcpy_chk", writes [1];
-    "memset", writesAll;(*unsafe*)
+    "memset", writes [1];(*unsafe*)
     "__builtin_memset", writesAll;(*unsafe*)
     "__builtin___memset_chk", writesAll;
     "printf", readsAll;(*safe*)

--- a/tests/regression/02-base/75-memset.c
+++ b/tests/regression/02-base/75-memset.c
@@ -1,0 +1,27 @@
+#include <string.h>
+#include <assert.h>
+
+struct s {
+  int x;
+  int *p;
+};
+
+int main() {
+  int x;
+  memset(&x, 0, sizeof(int));
+  assert(x == 0);
+  memset(&x, x, sizeof(int));
+  assert(x == 0);
+  memset(&x, 1, sizeof(int));
+  assert(x == 0); // UNKNOWN
+
+  int *p;
+  memset(&p, 0, sizeof(int*));
+  assert(p == NULL);
+
+  struct s s;
+  memset(&s, 0, sizeof(struct s));
+  assert(s.x == 0);
+  assert(s.p == NULL);
+  return 0;
+}

--- a/tests/regression/04-mutex/70-memset_indirect_nr.c
+++ b/tests/regression/04-mutex/70-memset_indirect_nr.c
@@ -1,0 +1,30 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+
+int g;
+
+struct s {
+  int *p;
+} s = {&g};
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  int *p;
+  pthread_mutex_lock(&mutex);
+  p = s.p; // NORACE
+  pthread_mutex_unlock(&mutex);
+  (*p)++; // NORACE
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex);
+  memset(&s, 0, sizeof(s)); // NORACE
+  pthread_mutex_unlock(&mutex);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/04-mutex/71-memset_direct_rc.c
+++ b/tests/regression/04-mutex/71-memset_direct_rc.c
@@ -1,0 +1,20 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+
+int g;
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  g++; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  memset(&g, 0, sizeof(int)); // RACE!
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/06-symbeq/31-zstd-thread-pool.c
+++ b/tests/regression/06-symbeq/31-zstd-thread-pool.c
@@ -158,7 +158,7 @@ static void* POOL_thread(void* opaque) {
             ZSTD_pthread_cond_wait(&ctx->queuePopCond, &ctx->queueMutex);
         }
         /* Pop a job off the queue */
-        {   POOL_job const job = ctx->queue[ctx->queueHead]; //NORACE
+        {   POOL_job const job = ctx->queue[ctx->queueHead]; // TODO NORACE
             ctx->queueHead = (ctx->queueHead + 1) % ctx->queueSize; //NORACE
             ctx->numThreadsBusy++; //NORACE
             ctx->queueEmpty = (ctx->queueHead == ctx->queueTail); //NORACE

--- a/tests/regression/06-symbeq/35-zstd-thread-pool-multi.c
+++ b/tests/regression/06-symbeq/35-zstd-thread-pool-multi.c
@@ -158,7 +158,7 @@ static void* POOL_thread(void* opaque) {
             ZSTD_pthread_cond_wait(&ctx->queuePopCond, &ctx->queueMutex);
         }
         /* Pop a job off the queue */
-        {   POOL_job const job = ctx->queue[ctx->queueHead]; //NORACE
+        {   POOL_job const job = ctx->queue[ctx->queueHead]; // TODO NORACE
             ctx->queueHead = (ctx->queueHead + 1) % ctx->queueSize; //NORACE
             ctx->numThreadsBusy++; //NORACE
             ctx->queueEmpty = (ctx->queueHead == ctx->queueTail); //NORACE


### PR DESCRIPTION
This contains additional attempts to improve race detection precision on zstd after the soundness fixes.

I noticed that certain `memset` calls are accessing an unreasonably large number of memory locations and causing write races there. As a special function, the access analysis calculates the set of _reachable_ addresses from its argument(s) and emits writes to all of them. Notably, if a memset struct contains a pointer to something else (another struct), then a write to the latter is also added. But this is unnecessarily imprecise, because `memset` only changes/writes what it immediately points to and doesn't dereference any pointers inside. In general special functions may do that, but `memset` (and probably many others) don't as generic functions, so instead of _reachable_ addresses it suffices to just emit accesses to _may point to_ addresses (i.e. not go transitive).

Additionally, I tried to fix #691, i.e. add explicit `memset` handling to base analysis as well. My hope is that this avoids introducing at least some unknown pointers whose calls later cause spurious races.

### Changes
1. Hack access analysis to not use reachability for `memset`. This is very ad-hoc for the time being. Ideally each invalidation argument would also specify whether it may access transitively or not.
2. Cherry-pick access analysis type-partitioning unsoundness fix from #695 because a similar (but not the same) issue appears here (no alloc variables in the failing test). Instead, the access analysis incorrectly calculates the type of the `memset` argument as `void` because it's implicitly cast to `void*` by CIL for `memset`. Considering how stupidly the type-partitioning fails, I have serious doubts about fixing it.
3. Implement `memset` handling in base analysis to write a zero value of the corresponding type if `memset` argument is 0 (closes #691).
4. Together with the previous, the special handling in other cases (non-zero argument), only writes top values to direct addresses, not all indirect ones via reachability (analogously to access analysis). Therefore it should also improve `memset` precision on non-zero arguments as well by avoiding all reachable invalidation.

### TODO
- [x] Add special `__builtin_memset` handling as well, because zstd's macro calls it directly.
- [x] Check if this helps on zstd.
- [ ] Apply same improvement to `free` instead of #695?