### PR TITLE
Add template for Taint Analysis Tutorial

### DIFF
--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -68,14 +68,7 @@ debug Goblint.
 
 Install the [`hackwaly.ocamlearlybird` extension](https://marketplace.visualstudio.com/items?itemName=hackwaly.ocamlearlybird) in your installation of Visual Studio Code.
 To be able to use this extension, you additionally need to install `ocamlearlybird` on the opam switch you use for Goblint.
-Running:
-
-```console
-make dev
-```
-
-will install `ocamlearlybird` along with some other useful development tools.
-In case you do not want to install all of these and only want to install `ocamlearlybird` by itself, run the following command in the `analyzer` directory:
+To do so, run the following command in the `analyzer` directory:
 
 ```console
 opam install earlybird

--- a/docs/developer-guide/firstanalysis.md
+++ b/docs/developer-guide/firstanalysis.md
@@ -44,7 +44,7 @@ Goblint could verify that this assertion does hold using interval analysis (`--e
 ## Starting point
 
 We begin with the flawed implementation in **`src/analyses/tutorials/signs.ml`**.
-If you immediately try to run Goblint with the new analysis enabled: `--set "ana.activated[+]" signs`. The result will still be that nothing is verified, so you need to fix all the problems in the code.
+If you immediately try to run Goblint with the new analysis enabled: `--set ana.activated[+] signs`. The result will still be that nothing is verified, so you need to fix all the problems in the code.
 
 It may still be useful to use Goblint's HTML output to [see the result](../user-guide/inspecting.md) of the analysis. This will also include Goblint's base analysis, which is needed to deal with function calls.
 
@@ -55,7 +55,7 @@ We first need to design the abstract domain. It may help if you have read some t
 1. `of_int i` should abstract integers to their best representation in our abstract domain. Our sign domain can distinguish positive, negative and zero values, so do it right!
 2. `gt x y` should answer true if the value represented by `x` is definitely greater than the value represented by `y`. There seems to be a crucial case missing here in the otherwise excellent implementation...
 
-We will represent tha abstract state of the program as a map from variables to the newly created sign domain.
+We will represent the abstract state of the program as a map from variables to the newly created sign domain.
 
 ```ocaml
 module D = MapDomain.MapBot (Basetype.Variables) (SL)

--- a/docs/developer-guide/firstanalysis.md
+++ b/docs/developer-guide/firstanalysis.md
@@ -44,7 +44,7 @@ Goblint could verify that this assertion does hold using interval analysis (`--e
 ## Starting point
 
 We begin with the flawed implementation in **`src/analyses/tutorials/signs.ml`**.
-If you immediately try to run Goblint with the new analysis enabled: `--set ana.activated[+] signs`. The result will still be that nothing is verified, so you need to fix all the problems in the code.
+If you immediately try to run Goblint with the new analysis enabled: `--set "ana.activated[+]" signs`. The result will still be that nothing is verified, so you need to fix all the problems in the code.
 
 It may still be useful to use Goblint's HTML output to [see the result](../user-guide/inspecting.md) of the analysis. This will also include Goblint's base analysis, which is needed to deal with function calls.
 

--- a/docs/developer-guide/firstanalysis.md
+++ b/docs/developer-guide/firstanalysis.md
@@ -79,4 +79,4 @@ For example, have a look at the following program: `tests/regression/99-tutorial
 _Hint:_
 The easiest way to do this is to use the powerset lattice of `{-, 0, +}`.
 For example, "non-negative" is represented by `{0, +}`, while negative is represented by `{-}`.
-To do this, modify `SL` by using `SetDomain.Make` instead of `Lattice.Flat` and reimplementing the two functions using `singleton` and `for_all`.
+To do this, modify `SL` by using `SetDomain.FiniteSet` (takes a `struct` with a list of finite elements as second parameter) instead of `Lattice.Flat` and reimplementing the two functions using `singleton` and `for_all`.

--- a/make.sh
+++ b/make.sh
@@ -80,7 +80,7 @@ rule() {
     ;; dev)
       eval $(opam env)
       echo "Installing opam packages for development..."
-      opam install -y utop ocaml-lsp-server ocp-indent ocamlformat ounit2 earlybird
+      opam install -y utop ocaml-lsp-server ocp-indent ocamlformat ounit2
       # ocaml-lsp-server is needed for https://github.com/ocamllabs/vscode-ocaml-platform
       echo "Be sure to adjust your vim/emacs config!"
       echo "Installing Pre-commit hook..."

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -361,6 +361,7 @@ let invalidate_actions = [
     "putc", readsAll;(*safe*)
     "putw", readsAll;(*safe*)
     "putchar", readsAll;(*safe*)
+    "getchar", readsAll;(*safe*)
     "feof", readsAll;(*safe*)
     "__getdelim", writes [3];(*keep [3]*)
     "vsyslog", readsAll;(*safe*)

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -57,7 +57,7 @@ struct
     let state = ctx.local in
     match lval with
     | Var v,_ ->
-      (* TODO: Handle assignment to v *)
+      (* TODO: Check whether lval is tainted, handle assignment to v accordingly *)
       state
     | _ -> state
 
@@ -75,9 +75,12 @@ struct
   (** Handles the [return] statement, i.e. "return exp" or "return", in function [f]. *)
   let return ctx (exp:exp option) (f:fundec) : D.t =
     let state = ctx.local in
-    (* TODO: If a tainted value is returned, this has to be recorded. *)
-    (* Hint: Use [return_varinfo] in place of a variable. *)
-    state
+    match exp with
+    | Some e ->
+      (* TODO: Record whether a tainted value was returned. *)
+      (* Hint: You may use return_varinfo in place of a variable. *)
+      state
+    | None -> state
 
   (** For a function call "lval = f(args)" or "f(args)",
       [enter] returns a caller state, and the inital state of the callee.
@@ -102,7 +105,7 @@ struct
       Argument [callee_local] is the state of [f] at its return node. *)
   let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (callee_local:D.t) : D.t =
     let caller_state = ctx.local in
-    (* TODO: Record whether [lval] was tainted. *)
+    (* TODO: Record whether lval was tainted. *)
     caller_state
 
   (** For a call to a _special_ function f "lval = f(args)" or "f(args)",

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -29,7 +29,7 @@ struct
 
   (** Determines whether an expression [e] is tainted, given a [state]. *)
   let rec is_exp_tainted (state:D.t) (e:Cil.exp) = match e with
-    (* Recurse over the structure in the expression, retruning true if any varinfo appearing in the expression is tainted *)
+    (* Recurse over the structure in the expression, returning true if any varinfo appearing in the expression is tainted *)
     | AddrOf v
     | StartOf v
     | Lval v -> is_lval_tainted state v
@@ -57,7 +57,7 @@ struct
     let state = ctx.local in
     match lval with
     | Var v,_ ->
-      (* TODO: Check whether lval is tainted, handle assignment to v accordingly *)
+      (* TODO: Check whether rval is tainted, handle assignment to v accordingly *)
       state
     | _ -> state
 

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -1,0 +1,122 @@
+(** An analysis specification for didactic purposes. *)
+(* Helpful link on CIL: https://goblint.in.tum.de/assets/goblint-cil/ *)
+(* Goblint documentation: https://goblint.readthedocs.io/en/latest/ *)
+(* You may test your analysis on our toy examples by running `ruby scripts/update_suite.rb group tutorials` *)
+
+open Prelude.Ana
+open Analyses
+
+module VarinfoSet = SetDomain.Make(CilType.Varinfo)
+
+(* Use to check if a specific function is a sink / source *)
+let is_sink varinfo = Cil.hasAttribute "taint_sink" varinfo.vattr
+let is_source varinfo = Cil.hasAttribute "taint_source" varinfo.vattr
+
+
+(** "Fake" variable to handle returning from a function *)
+let return_varinfo = dummyFunDec.svar
+
+module Spec : Analyses.MCPSpec with module D = Lattice.Unit and module C = Lattice.Unit =
+struct
+  include Analyses.DefaultSpec
+
+  let name () = "taint"
+  module D = Lattice.Unit (* TODO: Change such that you have a fitting local domain; also update in the signature above *)
+  module C = Lattice.Unit
+
+  (* We are context insensitive in this analysis *)
+  let context _ _ = ()
+
+  (** Determines whether an expression [e] is tainted, given a [state]. *)
+  let rec is_exp_tainted (state:D.t) (e:Cil.exp) = match e with
+    (* Recurse over the structure in the expression, retruning true if any varinfo appearing in the expression is tainted *)
+    | AddrOf v
+    | StartOf v
+    | Lval v -> is_lval_tainted state v
+    | BinOp (_,e1,e2,_) -> is_exp_tainted state e1 || is_exp_tainted state e2
+    | Real e
+    | Imag e
+    | SizeOfE e
+    | AlignOfE e
+    | CastE (_,e)
+    | UnOp (_,e,_) -> is_exp_tainted state e
+    | SizeOf _ | SizeOfStr _ | Const _  | AlignOf _ | AddrOfLabel _ -> false
+    | Question _ -> failwith "should be optimized away by CIL"
+  and is_lval_tainted state = function
+    | (Var v, _) ->
+      (* TODO: Check whether variable v is tainted *)
+      failwith "TODO"
+    | _ ->
+      (* We assume using a tainted offset does not taint the expression, and that our language has no pointers *)
+      false
+
+  (* transfer functions *)
+
+  (** Handles assignment of [rval] to [lval]. *)
+  let assign ctx (lval:lval) (rval:exp) : D.t =
+    match lval with
+    | Var v,_ ->
+      (* TODO: Handle assignment to v *)
+      failwith "TODO"
+    | _ -> ctx.local
+
+  (** Handles conditional branching yielding truth value [tv]. *)
+  let branch ctx (exp:exp) (tv:bool) : D.t =
+    (* Nothing needs to be done *)
+    ctx.local
+
+  (** Handles going from start node of function [f] into the function body of [f].
+      Meant to handle e.g. initializiation of local variables. *)
+  let body ctx (f:fundec) : D.t =
+    (* Nothing needs to be done here, as the (non-formals) locals are initally untainted *)
+    ctx.local
+
+  (** Handles the [return] statement, i.e. "return exp" or "return", in function [f]. *)
+  let return ctx (exp:exp option) (f:fundec) : D.t =
+    (* TODO: If a tainted value is returned, this has to be recorded. *)
+    (* Hint: Use [return_varinfo] in place of a variable. *)
+    failwith "TODO"
+
+  (** For a function call "lval = f(args)" or "f(args)",
+      [enter] returns a caller state, and the inital state of the callee.
+      In [enter], the caller state can ususally be return unchanged, as [combine] (below)
+      will compute the caller state after the function call, given the return state of the callee. *)
+  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
+    let caller_local = ctx.local in
+    (* Create list of (formal, actual_exp)*)
+    let zipped = List.combine f.sformals args in
+    (* TODO: Collect formal parameters where the actual is tainted. *)
+    let callee_state = List.fold_left (fun ts (f,a) ->
+                                        if is_exp_tainted caller_local a
+                                          then failwith "TODO"
+                                          else ts)
+                                      (D.bot ())
+                                      zipped in
+    (* first component is state of caller, second component is state of callee *)
+    [caller_local, callee_state]
+
+  (** For a function call "lval = f(args)" or "f(args)",
+      computes the state of the caller after the call.
+      Argument [callee_local] is the state at the return node of [f]. *)
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (callee_local:D.t) : D.t =
+    let caller_local = ctx.local in
+    (* TODO: Record whether [lval] was tainted. *)
+    failwith "TODO"
+
+  (** For a call to a _special_ function f "lval = f(args)" or "f(args)",
+      computes the caller state after the function call.
+      For this analysis, source and sink functions will be considered _special_ and have to be treated here. *)
+  let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
+    (* TODO: Check if f is a sink / source and handle it appropriately *)
+    (* To warn about a potential issue in the code, use M.warn. *)
+    failwith "TODO"
+
+  (* You may leave these alone *)
+  let startstate v = D.bot ()
+  let threadenter ctx lval f args = [D.top ()]
+  let threadspawn ctx lval f args fctx = ctx.local
+  let exitstate  v = D.top ()
+end
+
+let _ =
+  MCP.register_analysis (module Spec : MCPSpec)

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -81,7 +81,7 @@ struct
 
   (** For a function call "lval = f(args)" or "f(args)",
       [enter] returns a caller state, and the inital state of the callee.
-      In [enter], the caller state can ususally be return unchanged, as [combine] (below)
+      In [enter], the caller state can usually be returned unchanged, as [combine] (below)
       will compute the caller state after the function call, given the return state of the callee. *)
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     let caller_state = ctx.local in
@@ -99,7 +99,7 @@ struct
 
   (** For a function call "lval = f(args)" or "f(args)",
       computes the state of the caller after the call.
-      Argument [callee_local] is the state at the return node of [f]. *)
+      Argument [callee_local] is the state of [f] at its return node. *)
   let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (callee_local:D.t) : D.t =
     let caller_state = ctx.local in
     (* TODO: Record whether [lval] was tainted. *)

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -2,6 +2,7 @@
 (* Helpful link on CIL: https://goblint.in.tum.de/assets/goblint-cil/ *)
 (* Goblint documentation: https://goblint.readthedocs.io/en/latest/ *)
 (* You may test your analysis on our toy examples by running `ruby scripts/update_suite.rb group tutorials` *)
+(* after removing the `SKIP` from the beginning of the tests in tests/regression/99-tutorials/{03-taint_simple.c,04-taint_inter.c} *)
 
 open Prelude.Ana
 open Analyses
@@ -83,7 +84,7 @@ struct
     | None -> state
 
   (** For a function call "lval = f(args)" or "f(args)",
-      [enter] returns a caller state, and the inital state of the callee.
+      [enter] returns a caller state, and the initial state of the callee.
       In [enter], the caller state can usually be returned unchanged, as [combine] (below)
       will compute the caller state after the function call, given the return state of the callee. *)
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
@@ -93,7 +94,7 @@ struct
     (* TODO: For the initial callee_state, collect formal parameters where the actual is tainted. *)
     let callee_state = List.fold_left (fun ts (f,a) ->
         if is_exp_tainted caller_state a
-        then ts (* TODO: Change accumulater ts here? *)
+        then ts (* TODO: Change accumulator ts here? *)
         else ts)
         (D.bot ())
         zipped in

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -45,7 +45,7 @@ struct
   and is_lval_tainted state = function
     | (Var v, _) ->
       (* TODO: Check whether variable v is tainted *)
-      failwith "TODO"
+      false
     | _ ->
       (* We assume using a tainted offset does not taint the expression, and that our language has no pointers *)
       false
@@ -54,11 +54,12 @@ struct
 
   (** Handles assignment of [rval] to [lval]. *)
   let assign ctx (lval:lval) (rval:exp) : D.t =
+    let state = ctx.local in
     match lval with
     | Var v,_ ->
       (* TODO: Handle assignment to v *)
-      failwith "TODO"
-    | _ -> ctx.local
+      state
+    | _ -> state
 
   (** Handles conditional branching yielding truth value [tv]. *)
   let branch ctx (exp:exp) (tv:bool) : D.t =
@@ -73,43 +74,45 @@ struct
 
   (** Handles the [return] statement, i.e. "return exp" or "return", in function [f]. *)
   let return ctx (exp:exp option) (f:fundec) : D.t =
+    let state = ctx.local in
     (* TODO: If a tainted value is returned, this has to be recorded. *)
     (* Hint: Use [return_varinfo] in place of a variable. *)
-    failwith "TODO"
+    state
 
   (** For a function call "lval = f(args)" or "f(args)",
       [enter] returns a caller state, and the inital state of the callee.
       In [enter], the caller state can ususally be return unchanged, as [combine] (below)
       will compute the caller state after the function call, given the return state of the callee. *)
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
-    let caller_local = ctx.local in
+    let caller_state = ctx.local in
     (* Create list of (formal, actual_exp)*)
     let zipped = List.combine f.sformals args in
-    (* TODO: Collect formal parameters where the actual is tainted. *)
+    (* TODO: For the initial callee_state, collect formal parameters where the actual is tainted. *)
     let callee_state = List.fold_left (fun ts (f,a) ->
-                                        if is_exp_tainted caller_local a
-                                          then failwith "TODO"
-                                          else ts)
-                                      (D.bot ())
-                                      zipped in
+        if is_exp_tainted caller_state a
+        then ts (* TODO: Change accumulater ts here? *)
+        else ts)
+        (D.bot ())
+        zipped in
     (* first component is state of caller, second component is state of callee *)
-    [caller_local, callee_state]
+    [caller_state, callee_state]
 
   (** For a function call "lval = f(args)" or "f(args)",
       computes the state of the caller after the call.
       Argument [callee_local] is the state at the return node of [f]. *)
   let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (callee_local:D.t) : D.t =
-    let caller_local = ctx.local in
+    let caller_state = ctx.local in
     (* TODO: Record whether [lval] was tainted. *)
-    failwith "TODO"
+    caller_state
 
   (** For a call to a _special_ function f "lval = f(args)" or "f(args)",
       computes the caller state after the function call.
       For this analysis, source and sink functions will be considered _special_ and have to be treated here. *)
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
+    let caller_state = ctx.local in
     (* TODO: Check if f is a sink / source and handle it appropriately *)
     (* To warn about a potential issue in the code, use M.warn. *)
-    failwith "TODO"
+    caller_state
 
   (* You may leave these alone *)
   let startstate v = D.bot ()

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -17,12 +17,12 @@ let is_source varinfo = Cil.hasAttribute "taint_source" varinfo.vattr
 (** "Fake" variable to handle returning from a function *)
 let return_varinfo = dummyFunDec.svar
 
-module Spec : Analyses.MCPSpec with module D = Lattice.Unit and module C = Lattice.Unit =
+module Spec : Analyses.MCPSpec =
 struct
   include Analyses.DefaultSpec
 
   let name () = "taint"
-  module D = Lattice.Unit (* TODO: Change such that you have a fitting local domain; also update in the signature above *)
+  module D = Lattice.Unit (* TODO: Change such that you have a fitting local domain *)
   module C = Lattice.Unit
 
   (* We are context insensitive in this analysis *)

--- a/src/domains/setDomain.ml
+++ b/src/domains/setDomain.ml
@@ -375,3 +375,22 @@ struct
   include Base
   include Lattice.Reverse (Base)
 end
+
+module type FiniteSetElems =
+sig
+  type t
+  val elems: t list
+end
+
+module FiniteSet (E:Printable.S) (Elems:FiniteSetElems with type t = E.t) =
+struct
+  module E =
+  struct
+    include E
+    let arbitrary () = QCheck.oneofl Elems.elems
+  end
+
+  include Make (E)
+  let top () = of_list Elems.elems
+  let is_top x = equal x (top ())
+end

--- a/tests/regression/99-tutorials/03-taint_simple.c
+++ b/tests/regression/99-tutorials/03-taint_simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set "ana.activated[+]" taint --disable warn.imprecise --set "exp.extraspecials[+]" getchar --set "exp.extraspecials[+]" putchar --set "exp.extraspecials[+]" printInt
+// SKIP PARAM: --set "ana.activated[+]" taint --disable warn.imprecise --set "exp.extraspecials[+]" printInt
 
 // getchar from the standard library is marked as a source
 int getchar() __attribute__((__taint_source__));

--- a/tests/regression/99-tutorials/03-taint_simple.c
+++ b/tests/regression/99-tutorials/03-taint_simple.c
@@ -1,0 +1,40 @@
+// PARAM: --set "ana.activated[+]" taint --set "exp.extraspecials[+]" readInt --set "exp.extraspecials[+]" printInt  --disable warn.imprecise
+
+int readInt() __attribute__((__taint_source__));
+void printInt(int x,int y ,int z) __attribute__((__taint_sink__));
+
+
+int main(void) {
+    int x = readInt();
+    int y;
+    int tmp;
+
+    printInt(1,2,3); //NOWARN
+    printInt(x,x,x); //WARN
+    printInt(x+7,2,3); //WARN
+    printInt(0,x-2*x,3); //WARN
+
+    x = x+7;
+    printInt(x,x,x); //WARN
+
+    x = 8;
+    printInt(x,x,x); //NOWARN
+
+    y = x+17;
+    y = y/readInt();
+    printInt(y,y,y); //WARN
+
+
+    // Trivial example showing how the analysis you just wrote benefits from other analyses
+    // If we wanted to write a real analysis, we would also aks other analyses questions, to e.g. handle pointers
+    int z;
+    if(z == 0) {
+        z = 5;
+    }
+
+    if(z == 0) {
+        z = readInt();
+    }
+
+    printInt(z,z,z); //NOWARN
+}

--- a/tests/regression/99-tutorials/03-taint_simple.c
+++ b/tests/regression/99-tutorials/03-taint_simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set "ana.activated[+]" taint --set "exp.extraspecials[+]" readInt --set "exp.extraspecials[+]" printInt  --disable warn.imprecise
+// SKIP PARAM: --set "ana.activated[+]" taint --disable warn.imprecise
 
 int readInt() __attribute__((__taint_source__));
 void printInt(int x,int y ,int z) __attribute__((__taint_sink__));

--- a/tests/regression/99-tutorials/03-taint_simple.c
+++ b/tests/regression/99-tutorials/03-taint_simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set "ana.activated[+]" taint --set "exp.extraspecials[+]" readInt --set "exp.extraspecials[+]" printInt  --disable warn.imprecise
+// SKIP PARAM: --set "ana.activated[+]" taint --set "exp.extraspecials[+]" readInt --set "exp.extraspecials[+]" printInt  --disable warn.imprecise
 
 int readInt() __attribute__((__taint_source__));
 void printInt(int x,int y ,int z) __attribute__((__taint_sink__));

--- a/tests/regression/99-tutorials/03-taint_simple.c
+++ b/tests/regression/99-tutorials/03-taint_simple.c
@@ -1,11 +1,16 @@
-// SKIP PARAM: --set "ana.activated[+]" taint --disable warn.imprecise
+// SKIP PARAM: --set "ana.activated[+]" taint --disable warn.imprecise --set "exp.extraspecials[+]" getchar --set "exp.extraspecials[+]" putchar --set "exp.extraspecials[+]" printInt
 
-int readInt() __attribute__((__taint_source__));
+// getchar from the standard library is marked as a source
+int getchar() __attribute__((__taint_source__));
+
+// putchar from the standard library is marked as a sink
+int putchar(int c)  __attribute__((__taint_sink__));
+
+// we can also declare our own functions to be sources / sinks
 void printInt(int x,int y ,int z) __attribute__((__taint_sink__));
 
-
 int main(void) {
-    int x = readInt();
+    int x = getchar();
     int y;
     int tmp;
 
@@ -21,7 +26,7 @@ int main(void) {
     printInt(x,x,x); //NOWARN
 
     y = x+17;
-    y = y/readInt();
+    y = y/getchar();
     printInt(y,y,y); //WARN
 
 
@@ -33,7 +38,7 @@ int main(void) {
     }
 
     if(z == 0) {
-        z = readInt();
+        z = getchar();
     }
 
     printInt(z,z,z); //NOWARN

--- a/tests/regression/99-tutorials/04-taint_inter.c
+++ b/tests/regression/99-tutorials/04-taint_inter.c
@@ -4,7 +4,7 @@ int readInt() __attribute__((__taint_source__));
 void printInt(int x,int y ,int z) __attribute__((__taint_sink__));
 
 int id(int x) {
-    return id;
+    return x;
 }
 
 int benign(int x) {

--- a/tests/regression/99-tutorials/04-taint_inter.c
+++ b/tests/regression/99-tutorials/04-taint_inter.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set "ana.activated[+]" taint --disable warn.imprecise --set "exp.extraspecials[+]" getchar --set "exp.extraspecials[+]" putchar --set "exp.extraspecials[+]" printInt
+// SKIP PARAM: --set "ana.activated[+]" taint --disable warn.imprecise --set "exp.extraspecials[+]" printInt
 
 // getchar from the standard library is marked as a source
 int getchar() __attribute__((__taint_source__));

--- a/tests/regression/99-tutorials/04-taint_inter.c
+++ b/tests/regression/99-tutorials/04-taint_inter.c
@@ -1,6 +1,12 @@
-// SKIP PARAM: --set "ana.activated[+]" taint --disable warn.imprecise
+// SKIP PARAM: --set "ana.activated[+]" taint --disable warn.imprecise --set "exp.extraspecials[+]" getchar --set "exp.extraspecials[+]" putchar --set "exp.extraspecials[+]" printInt
 
-int readInt() __attribute__((__taint_source__));
+// getchar from the standard library is marked as a source
+int getchar() __attribute__((__taint_source__));
+
+// putchar from the standard library is marked as a sink
+int putchar(int c)  __attribute__((__taint_sink__));
+
+// we can also declare our own functions to be sources / sinks
 void printInt(int x,int y ,int z) __attribute__((__taint_sink__));
 
 int id(int x) {
@@ -30,8 +36,8 @@ int contextNotSufficient() {
 
     int r = fun(x,y);
     printInt(r,r,r); // Here, we would hope for no warn, but we actually get a spurious warning, as we are not using enough context in the example
-    x = readInt();
-    y = readInt();
+    x = getchar();
+    y = getchar();
 
     r = fun(x,y);
     printInt(r,r,r); //WARN
@@ -39,7 +45,7 @@ int contextNotSufficient() {
 
 
 int main(void) {
-    int x = readInt();
+    int x = getchar();
     int y;
 
     x = id(x);

--- a/tests/regression/99-tutorials/04-taint_inter.c
+++ b/tests/regression/99-tutorials/04-taint_inter.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set "ana.activated[+]" taint --set "exp.extraspecials[+]" readInt --set "exp.extraspecials[+]" printInt  --disable warn.imprecise
+// SKIP PARAM: --set "ana.activated[+]" taint --disable warn.imprecise
 
 int readInt() __attribute__((__taint_source__));
 void printInt(int x,int y ,int z) __attribute__((__taint_sink__));

--- a/tests/regression/99-tutorials/04-taint_inter.c
+++ b/tests/regression/99-tutorials/04-taint_inter.c
@@ -1,4 +1,4 @@
-// PARAM: --set "ana.activated[+]" taint --set "exp.extraspecials[+]" readInt --set "exp.extraspecials[+]" printInt  --disable warn.imprecise
+// SKIP PARAM: --set "ana.activated[+]" taint --set "exp.extraspecials[+]" readInt --set "exp.extraspecials[+]" printInt  --disable warn.imprecise
 
 int readInt() __attribute__((__taint_source__));
 void printInt(int x,int y ,int z) __attribute__((__taint_sink__));

--- a/tests/regression/99-tutorials/04-taint_inter.c
+++ b/tests/regression/99-tutorials/04-taint_inter.c
@@ -1,0 +1,60 @@
+// PARAM: --set "ana.activated[+]" taint --set "exp.extraspecials[+]" readInt --set "exp.extraspecials[+]" printInt  --disable warn.imprecise
+
+int readInt() __attribute__((__taint_source__));
+void printInt(int x,int y ,int z) __attribute__((__taint_sink__));
+
+int id(int x) {
+    return id;
+}
+
+int benign(int x) {
+    return 0;
+}
+
+int fun(int x,int y) {
+    if(x == 5) {
+        return x+y;
+    } else {
+        return x;
+    }
+}
+
+int contextNotSufficient() {
+    // This is an advanced example that shows that our analysis still has surprising false positives
+    // To fix these, more context would be required
+    // If you are adventurous, you might try to modify the analysis such that it is context-sensitive
+    // and succeeds here as well
+
+    int x;
+    int y;
+
+    int r = fun(x,y);
+    printInt(r,r,r); // Here, we would hope for no warn, but we actually get a spurious warning, as we are not using enough context in the example
+    x = readInt();
+    y = readInt();
+
+    r = fun(x,y);
+    printInt(r,r,r); //WARN
+}
+
+
+int main(void) {
+    int x = readInt();
+    int y;
+
+    x = id(x);
+    printInt(x,x,x); //WARN
+
+    int r = fun(8,fun(6,id(x)));
+    printInt(r,r,r); //NOWARN
+
+    r = fun(x,x);
+    printInt(r,r,r); //WARN
+
+    // Another example of the analysis benefitting from base
+    r = y==5 ? fun(8,x) : fun(y,x);
+    printInt(r,r,r); //NOWARN
+
+
+    contextNotSufficient();
+}

--- a/unittest/maindomaintest.ml
+++ b/unittest/maindomaintest.ml
@@ -1,24 +1,5 @@
 (* open! Defaults (* Enums / ... need initialized conf *) *)
 
-module type FiniteSetElems =
-sig
-  type t
-  val elems: t list
-end
-
-module FiniteSet (E:Printable.S) (Elems:FiniteSetElems with type t = E.t) =
-struct
-  module E =
-  struct
-    include E
-    let arbitrary () = QCheck.oneofl Elems.elems
-  end
-
-  include SetDomain.Make (E)
-  let top () = of_list Elems.elems
-  let is_top x = equal x (top ())
-end
-
 module PrintableChar =
 struct
   include Printable.Std
@@ -34,7 +15,7 @@ struct
   include Printable.SimpleShow (P)
 end
 
-module ArbitraryLattice = FiniteSet (PrintableChar) (
+module ArbitraryLattice = SetDomain.FiniteSet (PrintableChar) (
   struct
     type t = char
     let elems = ['a'; 'b'; 'c'; 'd']


### PR DESCRIPTION
This is a second tutorial (which @stilscher and I gave at the 2022 Venice Retreat on Continuous Verification of Cyber-Physical System) that provides a template for a simple taint analysis, describing what needs to be done where.

As part of this PR, we remove `earlybird` from the `make dev` dependencies, as it is once again lagging behind and also is not really used much by us Goblint developers currently. 

A solution is in the following branch: https://github.com/goblint/analyzer/tree/convey_retreat_venice_topsecret, I also attached a set of [slides](https://github.com/goblint/analyzer/files/8569680/slides_Schwarz_Tilscher_Erhard_GoblintWorkshop.pdf) one may refer people to.