### PR TITLE
Fix incremental warnings with reluctant destabilization

### DIFF
--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -540,6 +540,9 @@ module WP =
 
       start_event ();
 
+      (* reluctantly unchanged return nodes to additionally query for postsolving to get warnings, etc. *)
+      let reluctant_vs: S.Var.t list ref = ref [] in
+
       if GobConfig.get_bool "incremental.load" then (
         let c = S.increment.changes in
         List.(Printf.printf "change_info = { unchanged = %d; changed = %d; added = %d; removed = %d }\n" (length c.unchanged) (length c.changed) (length c.added) (length c.removed));
@@ -854,6 +857,7 @@ module WP =
               )
               else (
                 print_endline "Destabilization not required...";
+                reluctant_vs := x :: !reluctant_vs
               )
             ) old_ret;
 
@@ -1111,7 +1115,7 @@ module WP =
 
       let module Post = PostSolver.MakeIncrList (MakeIncrListArg) in
 
-      Post.post st vs rho;
+      Post.post st (!reluctant_vs @ vs) rho;
 
       print_data data "Data after postsolve";
 

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -852,6 +852,9 @@ module WP =
                 destabilize x;
                 HM.replace stable x ()
               )
+              else (
+                print_endline "Destabilization not required...";
+              )
             ) old_ret;
 
           print_endline "Final solve..."

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -737,7 +737,7 @@ module WP =
         print_endline "Removing data for changed and removed functions...";
         let delete_marked s = HM.iter (fun k _ -> HM.remove s k) marked_for_deletion in
         delete_marked rho;
-        delete_marked infl;
+        delete_marked infl; (* TODO: delete from inner sets? *)
         delete_marked wpoint;
 
         (* destabilize_with_side doesn't have all infl to follow anymore, so should somewhat work with reluctant *)
@@ -826,8 +826,15 @@ module WP =
         );
 
         delete_marked stable;
-        delete_marked side_dep;
-        delete_marked side_infl;
+        delete_marked side_dep; (* TODO: delete from inner sets? *)
+        delete_marked side_infl; (* TODO: delete from inner sets? *)
+
+        (* delete from incremental postsolving/warning structures to remove spurious warnings *)
+        delete_marked superstable;
+        delete_marked var_messages;
+        delete_marked rho_write;
+        HM.iter (fun x w -> delete_marked w) rho_write;
+
         print_data data "Data after clean-up";
 
         (* TODO: reluctant doesn't call destabilize on removed functions or old copies of modified functions (e.g. after removing write), so those globals don't get restarted *)

--- a/tests/incremental/13-restart-write/06-mutex-simple-reluctant.c
+++ b/tests/incremental/13-restart-write/06-mutex-simple-reluctant.c
@@ -1,0 +1,23 @@
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  myglobal=myglobal+1; // RACE!
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex2);
+  myglobal=myglobal+1; // RACE!
+  pthread_mutex_unlock(&mutex2);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/incremental/13-restart-write/06-mutex-simple-reluctant.json
+++ b/tests/incremental/13-restart-write/06-mutex-simple-reluctant.json
@@ -1,0 +1,12 @@
+{
+    "incremental": {
+        "restart": {
+            "sided": {
+                "enabled": false
+            }
+        },
+        "reluctant": {
+            "on": true
+        }
+    }
+}

--- a/tests/incremental/13-restart-write/06-mutex-simple-reluctant.patch
+++ b/tests/incremental/13-restart-write/06-mutex-simple-reluctant.patch
@@ -1,0 +1,24 @@
+--- tests/incremental/13-restart-write/06-mutex-simple-reluctant.c
++++ tests/incremental/13-restart-write/06-mutex-simple-reluctant.c
+@@ -7,7 +7,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+ void *t_fun(void *arg) {
+   pthread_mutex_lock(&mutex1);
+-  myglobal=myglobal+1; // RACE!
++  myglobal=myglobal+1; // NORACE
+   pthread_mutex_unlock(&mutex1);
+   return NULL;
+ }
+@@ -15,9 +15,9 @@ void *t_fun(void *arg) {
+ int main(void) {
+   pthread_t id;
+   pthread_create(&id, NULL, t_fun, NULL);
+-  pthread_mutex_lock(&mutex2);
+-  myglobal=myglobal+1; // RACE!
+-  pthread_mutex_unlock(&mutex2);
++  pthread_mutex_lock(&mutex1);
++  myglobal=myglobal+1; // NORACE
++  pthread_mutex_unlock(&mutex1);
+   pthread_join (id, NULL);
+   return 0;
+ }

--- a/tests/incremental/13-restart-write/07-mutex-simple-reluctant2.c
+++ b/tests/incremental/13-restart-write/07-mutex-simple-reluctant2.c
@@ -1,0 +1,23 @@
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  myglobal=myglobal+1; // RACE!
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex2);
+  myglobal=myglobal+1; // RACE!
+  pthread_mutex_unlock(&mutex2);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/incremental/13-restart-write/07-mutex-simple-reluctant2.json
+++ b/tests/incremental/13-restart-write/07-mutex-simple-reluctant2.json
@@ -1,0 +1,12 @@
+{
+    "incremental": {
+        "restart": {
+            "sided": {
+                "enabled": false
+            }
+        },
+        "reluctant": {
+            "on": true
+        }
+    }
+}

--- a/tests/incremental/13-restart-write/07-mutex-simple-reluctant2.patch
+++ b/tests/incremental/13-restart-write/07-mutex-simple-reluctant2.patch
@@ -1,0 +1,11 @@
+--- tests/incremental/13-restart-write/07-mutex-simple-reluctant2.c
++++ tests/incremental/13-restart-write/07-mutex-simple-reluctant2.c
+@@ -7,7 +7,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+ void *t_fun(void *arg) {
+   pthread_mutex_lock(&mutex1);
+-  myglobal=myglobal+1; // RACE!
++  myglobal=myglobal+2; // RACE!
+   pthread_mutex_unlock(&mutex1);
+   return NULL;
+ }

--- a/tests/incremental/13-restart-write/08-mutex-simple-reluctant3.c
+++ b/tests/incremental/13-restart-write/08-mutex-simple-reluctant3.c
@@ -1,0 +1,22 @@
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex2);
+  myglobal=myglobal+1; // NORACE
+  pthread_mutex_unlock(&mutex2);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/incremental/13-restart-write/08-mutex-simple-reluctant3.json
+++ b/tests/incremental/13-restart-write/08-mutex-simple-reluctant3.json
@@ -1,0 +1,12 @@
+{
+    "incremental": {
+        "restart": {
+            "sided": {
+                "enabled": false
+            }
+        },
+        "reluctant": {
+            "on": true
+        }
+    }
+}

--- a/tests/incremental/13-restart-write/08-mutex-simple-reluctant3.patch
+++ b/tests/incremental/13-restart-write/08-mutex-simple-reluctant3.patch
@@ -1,0 +1,19 @@
+--- tests/incremental/13-restart-write/08-mutex-simple-reluctant3.c
++++ tests/incremental/13-restart-write/08-mutex-simple-reluctant3.c
+@@ -7,6 +7,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+ void *t_fun(void *arg) {
+   pthread_mutex_lock(&mutex1);
++  myglobal=myglobal+1; // RACE!
+   pthread_mutex_unlock(&mutex1);
+   return NULL;
+ }
+@@ -15,7 +16,7 @@ int main(void) {
+   pthread_t id;
+   pthread_create(&id, NULL, t_fun, NULL);
+   pthread_mutex_lock(&mutex2);
+-  myglobal=myglobal+1; // NORACE
++  myglobal=myglobal+1; // RACE!
+   pthread_mutex_unlock(&mutex2);
+   pthread_join (id, NULL);
+   return 0;


### PR DESCRIPTION
Closes #708.

I tried the fix on the one test I added to confirm it works, but didn't experiment on more incremental tests with reluctant destabilization enabled.

### Changes
1. Fix old warnings not being removed by additionally deleting old nodes from superstable.
2. Fix new warnings not being added for reluctantly unchanged functions by additionally querying those unknowns from postsolver.