### PR TITLE
Add `realloc` support

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -715,7 +715,9 @@ struct
           let cast_ok = function
             | Addr (x, o) ->
               begin
-                match Cil.getInteger (sizeOf t), Cil.getInteger (sizeOf (get_type_addr (x, o))) with
+                let at = get_type_addr (x, o) in
+                if M.tracing then M.tracel "evalint" "cast_ok %a %a %a\n" Addr.pretty (Addr (x, o)) CilType.Typ.pretty (Cil.unrollType x.vtype) CilType.Typ.pretty at;
+                match Cil.getInteger (sizeOf t), Cil.getInteger (sizeOf at) with
                 | Some i1, Some i2 -> Cilint.compare_cilint i1 i2 <= 0
                 | _ ->
                   if contains_vla t || contains_vla (get_type_addr (x, o)) then

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -717,17 +717,20 @@ struct
               begin
                 let at = get_type_addr (x, o) in
                 if M.tracing then M.tracel "evalint" "cast_ok %a %a %a\n" Addr.pretty (Addr (x, o)) CilType.Typ.pretty (Cil.unrollType x.vtype) CilType.Typ.pretty at;
-                match Cil.getInteger (sizeOf t), Cil.getInteger (sizeOf at) with
-                | Some i1, Some i2 -> Cilint.compare_cilint i1 i2 <= 0
-                | _ ->
-                  if contains_vla t || contains_vla (get_type_addr (x, o)) then
-                    begin
-                      (* TODO: Is this ok? *)
-                      M.warn "Casting involving a VLA is assumed to work";
-                      true
-                    end
-                  else
-                    false
+                if at = TVoid [] then
+                  true
+                else
+                  match Cil.getInteger (sizeOf t), Cil.getInteger (sizeOf at) with
+                  | Some i1, Some i2 -> Cilint.compare_cilint i1 i2 <= 0
+                  | _ ->
+                    if contains_vla t || contains_vla (get_type_addr (x, o)) then
+                      begin
+                        (* TODO: Is this ok? *)
+                        M.warn "Casting involving a VLA is assumed to work";
+                        true
+                      end
+                    else
+                      false
               end
             | NullPtr | UnknownPtr -> true (* TODO: are these sound? *)
             | _ -> false

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2321,7 +2321,7 @@ struct
             (* TODO: don't we already have logic for this? *)
             | `Int i when ID.to_int i = Some BI.zero -> AD.null_ptr
             | `Int i -> AD.top_ptr
-            | _ -> failwith "realloc p_addr"
+            | _ -> AD.top_ptr (* TODO: why does this ever happen? *)
           in
           let p_addr' = AD.remove NullPtr p_addr in (* realloc with NULL is same as malloc, remove to avoid unknown value from NullPtr access *)
           let p_addr_get = get ask gs st p_addr' None in (* implicitly includes join of malloc value (VD.bot) *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -239,6 +239,22 @@ struct
         | Mod -> `Int (ID.top_of (Cilfacade.ptrdiff_ikind ())) (* we assume that address is actually casted to int first*)
         | _ -> `Address AD.top_ptr
       end
+    | `Address p, `Top  -> begin
+        (* copy of above with Unknown instead of int *)
+        (* TODO: why does this even happen in zstd-thread-pool-add? *)
+        let n = ID.top_of (Cilfacade.ptrdiff_ikind ()) in (* pretend to have unknown ptrdiff int instead *)
+        match op with
+        (* For array indexing e[i] and pointer addition e + i we have: *)
+        | IndexPI | PlusPI ->
+          `Address (AD.map (addToAddr n) p)
+        (* Pointer subtracted by a value (e-i) is very similar *)
+        (* Cast n to the (signed) ptrdiff_ikind, then add the its negated value. *)
+        | MinusPI ->
+          let n = ID.neg (ID.cast_to (Cilfacade.ptrdiff_ikind ()) n) in
+          `Address (AD.map (addToAddr n) p)
+        | Mod -> `Int (ID.top_of (Cilfacade.ptrdiff_ikind ())) (* we assume that address is actually casted to int first*)
+        | _ -> `Address AD.top_ptr
+      end
     (* If both are pointer values, we can subtract them and well, we don't
      * bother to find the result in most cases, but it's an integer. *)
     | `Address p1, `Address p2 -> begin

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -153,6 +153,12 @@ struct
     | `Read  -> o
     | `Free  -> i
 
+  let readsFrees rs fs a x =
+    match a with
+    | `Write -> []
+    | `Read  -> keep rs x
+    | `Free  -> keep fs x
+
   let onlyReads ns a x =
     match a with
     | `Write -> []
@@ -452,7 +458,7 @@ let invalidate_actions = [
     "rand", readsAll; (*safe*)
     "gethostname", writesAll; (*unsafe*)
     "fork", readsAll; (*safe*)
-    "realloc", writes [1];(*unsafe*) (* TODO: replace write with free+read *)
+    "realloc", readsFrees [0; 1] [0]; (* read+free first argument, read second argument *)
     "setrlimit", readsAll; (*safe*)
     "getrlimit", writes [2]; (*keep [2]*)
     "sem_init", readsAll; (*safe*)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -437,7 +437,7 @@ let invalidate_actions = [
     "rand", readsAll; (*safe*)
     "gethostname", writesAll; (*unsafe*)
     "fork", readsAll; (*safe*)
-    "realloc", writesAll;(*unsafe*)
+    "realloc", writes [1];(*unsafe*) (* TODO: replace write with free+read *)
     "setrlimit", readsAll; (*safe*)
     "getrlimit", writes [2]; (*keep [2]*)
     "sem_init", readsAll; (*safe*)

--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -151,10 +151,11 @@ struct
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     match LibraryFunctions.classify f.vname arglist with
-    | `Malloc _ | `Calloc _ -> begin
+    | `Malloc _ | `Calloc _ | `Realloc _ -> begin
         match ctx.local, lval with
         | `Lifted reg, Some lv ->
           let old_regpart = ctx.global () in
+          (* TODO: should realloc use arg region if failed/in-place? *)
           let regpart, reg = Reg.assign_bullet lv (old_regpart, reg) in
           if not (RegPart.leq regpart old_regpart) then
             ctx.sideg () regpart;

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -329,7 +329,7 @@ struct
           end
     in
     let one_addr = let open Addr in function
-        | Addr ({ vtype = TVoid _; _} as v, offs) -> (* we had no information about the type (e.g. malloc), so we add it *)
+        | Addr ({ vtype = TVoid _; _} as v, offs) when false -> (* we had no information about the type (e.g. malloc), so we add it *)
           Addr ({ v with vtype = t }, offs)
         | Addr (v, o) as a ->
           begin try Addr (v, (adjust_offs v o None)) (* cast of one address by adjusting the abstract offset *)

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -329,8 +329,8 @@ struct
           end
     in
     let one_addr = let open Addr in function
-        | Addr ({ vtype = TVoid _; _} as v, offs) when false -> (* we had no information about the type (e.g. malloc), so we add it *)
-          Addr ({ v with vtype = t }, offs)
+        | Addr ({ vtype = TVoid _; _} as v, offs) when not (Cilfacade.isCharType t) -> (* we had no information about the type (e.g. malloc), so we add it; ignore for casts to char* since they're special conversions (N1570 6.3.2.3.7) *)
+          Addr ({ v with vtype = t }, offs) (* HACK: equal varinfo with different type, causes inconsistencies down the line, when we again assume vtype being "right", but joining etc gives no consideration to which type version to keep *)
         | Addr (v, o) as a ->
           begin try Addr (v, (adjust_offs v o None)) (* cast of one address by adjusting the abstract offset *)
             with CastError s -> (* don't know how to handle this cast :( *)

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -690,6 +690,7 @@ struct
     |                 t , `Blob n       -> `Blob (Blobs.invalidate_value ask t n)
     |                 _ , `List n       -> `Top
     |                 _ , `Thread _     -> state (* TODO: no top thread ID set! *)
+    | _, `Bot -> `Bot (* Leave uninitialized value (from malloc) alone in free to avoid trashing everything. TODO: sound? *)
     |                 t , _             -> top_value t
 
 

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -31,6 +31,11 @@ let get_stmtLoc stmt =
     get_labelsLoc stmt.labels
   | _ -> get_stmtkindLoc stmt.skind
 
+(** Is character type (N1570 6.2.5.15)? *)
+let isCharType = function
+  | TInt ((IChar | ISChar | IUChar), _) -> true
+  | _ -> false
+
 
 let init () =
   initCIL ();

--- a/tests/regression/02-base/76-realloc.c
+++ b/tests/regression/02-base/76-realloc.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <assert.h>
+#include <pthread.h>
 
 void test1_f() {
   assert(1); // reachable
@@ -16,7 +17,21 @@ void test1() {
   fp(); // should call test1_f
 }
 
+void* test2_f(void *arg) {
+  int *p = arg;
+  *p = 1; // RACE!
+  return NULL;
+}
+
+void test2() {
+  int *p = malloc(sizeof(int));
+  pthread_t id;
+  pthread_create(&id, NULL, test2_f, p);
+  realloc(p, sizeof(int)); // RACE!
+}
+
 int main() {
   test1();
+  test2();
   return 0;
 }

--- a/tests/regression/02-base/76-realloc.c
+++ b/tests/regression/02-base/76-realloc.c
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+#include <assert.h>
+
+void test1_f() {
+  assert(1); // reachable
+}
+
+void test1() {
+  void (**fpp)(void) = malloc(sizeof(void(**)(void)));
+  *fpp = &test1_f;
+
+  fpp = realloc(fpp, sizeof(void(**)(void))); // same size
+
+  // (*fpp)();
+  void (*fp)(void) = *fpp;
+  fp(); // should call test1_f
+}
+
+int main() {
+  test1();
+  return 0;
+}

--- a/tests/regression/02-base/77-chrony-sched-array.c
+++ b/tests/regression/02-base/77-chrony-sched-array.c
@@ -1,0 +1,189 @@
+// PARAM: --set ana.malloc.wrappers '["Malloc", "Realloc", "Malloc2", "Realloc2", "ARR_CreateInstance", "realloc_array", "ARR_GetNewElement"]' --disable sem.unknown_function.spawn --disable sem.unknown_function.invalidate.globals
+// extracted from chrony
+#include <stdlib.h>
+#include <assert.h>
+
+// memory.c
+
+void *
+Malloc(size_t size)
+{
+  void *r;
+
+  r = malloc(size);
+
+  return r;
+}
+
+void *
+Realloc(void *ptr, size_t size)
+{
+  void *r;
+
+  r = realloc(ptr, size);
+
+  return r;
+}
+
+static size_t
+get_array_size(size_t nmemb, size_t size)
+{
+  size_t array_size;
+
+  array_size = nmemb * size;
+
+  return array_size;
+}
+
+void *
+Realloc2(void *ptr, size_t nmemb, size_t size)
+{
+  return Realloc(ptr, get_array_size(nmemb, size));
+}
+
+#define MallocNew(T) ((T *) Malloc(sizeof(T)))
+#define MallocArray(T, n) ((T *) Malloc2(n, sizeof(T)))
+#define ReallocArray(T, n, x) ((T *) Realloc2((void *)(x), n, sizeof(T)))
+#define Free(x) free(x)
+
+// array.c
+
+struct ARR_Instance_Record {
+  void *data;
+  unsigned int elem_size;
+  unsigned int used;
+  unsigned int allocated;
+};
+
+typedef struct ARR_Instance_Record *ARR_Instance;
+
+ARR_Instance
+ARR_CreateInstance(unsigned int elem_size)
+{
+  ARR_Instance array;
+
+  assert(elem_size > 0);
+
+  array = MallocNew(struct ARR_Instance_Record);
+
+  array->data = NULL;
+  array->elem_size = elem_size;
+  array->used = 0;
+  array->allocated = 0;
+
+  return array;
+}
+
+void *
+ARR_GetElement(ARR_Instance array, unsigned int index)
+{
+  assert(index < array->used); // UNKNOWN
+  return (void *)((char *)array->data + (size_t)index * array->elem_size);
+}
+
+static void
+realloc_array(ARR_Instance array, unsigned int min_size)
+{
+  assert(min_size <= 2 * min_size); // UNKNOWN
+  if (array->allocated >= min_size && array->allocated <= 2 * min_size)
+    return;
+
+  if (array->allocated < min_size) {
+    while (array->allocated < min_size)
+      array->allocated = array->allocated ? 2 * array->allocated : 1;
+  } else {
+    array->allocated = min_size;
+  }
+
+  array->data = Realloc2(array->data, array->allocated, array->elem_size);
+}
+
+void *
+ARR_GetNewElement(ARR_Instance array)
+{
+  array->used++;
+  realloc_array(array, array->used);
+  return ARR_GetElement(array, array->used - 1);
+}
+
+unsigned int
+ARR_GetSize(ARR_Instance array)
+{
+  return array->used;
+}
+
+// sched.c
+
+typedef void* SCH_ArbitraryArgument;
+typedef void (*SCH_FileHandler)(SCH_ArbitraryArgument);
+
+typedef struct {
+  SCH_FileHandler       handler;
+  SCH_ArbitraryArgument arg;
+} FileHandlerEntry;
+
+static ARR_Instance file_handlers;
+
+void
+SCH_Initialise(void)
+{
+  file_handlers = ARR_CreateInstance(sizeof (FileHandlerEntry));
+}
+
+void
+SCH_AddFileHandler
+(SCH_FileHandler handler, SCH_ArbitraryArgument arg)
+{
+  int fd; // rand
+  FileHandlerEntry *ptr;
+
+  while (ARR_GetSize(file_handlers) <= fd) {
+    ptr = ARR_GetNewElement(file_handlers);
+    ptr->handler = NULL;
+    ptr->arg = NULL;
+  }
+
+  ptr = ARR_GetElement(file_handlers, fd);
+
+  /* Don't want to allow the same fd to register a handler more than
+     once without deleting a previous association - this suggests
+     a bug somewhere else in the program. */
+  assert(!ptr->handler); // UNKNOWN
+
+  ptr->handler = handler;
+  ptr->arg = arg;
+}
+
+static void
+dispatch_filehandlers()
+{
+  FileHandlerEntry *ptr;
+  int fd; // rand
+
+  ptr = (FileHandlerEntry *)ARR_GetElement(file_handlers, fd);
+  SCH_FileHandler stuff = *(ptr->handler);
+  if (ptr->handler)
+    (ptr->handler)(ptr->arg);
+}
+
+// stub
+
+void foo(void *arg) {
+  assert(1); // reachable
+}
+
+void bar(void *arg) {
+  int *p = arg;
+  int y = *p;
+  assert(1); // reachable
+  assert(y); // TODO
+}
+
+int main() {
+  SCH_Initialise();
+  SCH_AddFileHandler(foo, NULL);
+  int x = 1;
+  SCH_AddFileHandler(bar, &x);
+  dispatch_filehandlers();
+  return 0;
+}

--- a/tests/regression/02-base/78-realloc-free.c
+++ b/tests/regression/02-base/78-realloc-free.c
@@ -1,4 +1,5 @@
-// PARAM: --enable ana.race.free
+// PARAM: --disable ana.race.free
+// copy of 02-base/76-realloc with different PARAM
 #include <stdlib.h>
 #include <assert.h>
 #include <pthread.h>
@@ -33,7 +34,7 @@ void test2() {
 
 void* test3_f(void *arg) {
   int *p = arg;
-  int x = *p; // RACE!
+  int x = *p; // NORACE
   return NULL;
 }
 
@@ -41,7 +42,7 @@ void test3() {
   int *p = malloc(sizeof(int));
   pthread_t id;
   pthread_create(&id, NULL, test3_f, p);
-  realloc(p, sizeof(int)); // RACE!
+  realloc(p, sizeof(int)); // NORACE
 }
 
 int main() {


### PR DESCRIPTION
Closes #701.

Also includes a couple of blob and pointer casting changes that were necessary to get chrony's `array.c` to work soundly (i.e. not going to `VD.top`) while not breaking any other tests (particularly with `calloc`).

### TODO
- [x] Tasks from #701.
- [x] Figure out what to do about `cast_addr` changing alloc variable type from `void`. Had to disable to get chrony `array.c` to work (otherwise a cast to `char*` screwed up the type and any following casts to a larger struct type were considered not ok, so supertop got introduced).
- [x] Adapt `realloc` accesses to `free` type after #695 merge.