### PR TITLE
Incremental: (Cheap!) Full Reachability to Prune 

### DIFF
--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -797,13 +797,14 @@ module EqIncrSolverFromEqSolver (Sol: GenericEqBoxSolver): GenericEqBoxIncrSolve
   functor (Arg: IncrSolverArg) (S: EqConstrSys) (VH: Hashtbl.S with type key = S.v) ->
   struct
     module Sol = Sol (S) (VH)
-    module Post = PostSolver.MakeList (PostSolver.ListArgFromStdArg (S) (VH) (Arg))
+    module VS = BatSet.Make(S.Var)
+    module Post = PostSolver.MakeList (PostSolver.ListArgFromStdArg (S) (VH) (VS) (Arg))
 
     type marshal = unit
 
     let solve box xs vs =
       let vh = Sol.solve box xs vs in
-      Post.post xs vs vh;
+      Post.post xs vs vh None;
       (vh, ())
   end
 

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -797,14 +797,13 @@ module EqIncrSolverFromEqSolver (Sol: GenericEqBoxSolver): GenericEqBoxIncrSolve
   functor (Arg: IncrSolverArg) (S: EqConstrSys) (VH: Hashtbl.S with type key = S.v) ->
   struct
     module Sol = Sol (S) (VH)
-    module VS = BatSet.Make(S.Var)
-    module Post = PostSolver.MakeList (PostSolver.ListArgFromStdArg (S) (VH) (VS) (Arg))
+    module Post = PostSolver.MakeList (PostSolver.ListArgFromStdArg (S) (VH) (Arg))
 
     type marshal = unit
 
     let solve box xs vs =
       let vh = Sol.solve box xs vs in
-      Post.post xs vs vh None;
+      Post.post xs vs vh;
       (vh, ())
   end
 

--- a/src/solvers/postSolver.ml
+++ b/src/solvers/postSolver.ml
@@ -211,7 +211,7 @@ struct
       if M.tracing then M.trace "postsolver" "one_constraint %a %a\n" S.Var.pretty_trace x S.Dom.pretty rhs;
       PS.one_constraint ~vh ~x ~rhs
     in
-    (Stats.time "potentially_incremental_reach" (List.iter one_var)) vs;
+    (Stats.time "postsolver_iter" (List.iter one_var)) vs;
 
     PS.finalize ~vh ~reachable;
     Goblintutil.postsolving := false

--- a/src/solvers/postSolver.ml
+++ b/src/solvers/postSolver.ml
@@ -98,7 +98,7 @@ module Verify: F =
 
 (** Postsolver for enabling messages (warnings) output. *)
 module Warn: F =
-  functor (S: EqConstrSys) (VH: Hashtbl.S with type key = S.v)  ->
+  functor (S: EqConstrSys) (VH: Hashtbl.S with type key = S.v) ->
   struct
     include Unit (S) (VH)
 
@@ -114,7 +114,7 @@ module Warn: F =
 
 (** Postsolver for save_run option. *)
 module SaveRun: F =
-  functor (S: EqConstrSys) (VH: Hashtbl.S with type key = S.v)  ->
+  functor (S: EqConstrSys) (VH: Hashtbl.S with type key = S.v) ->
   struct
     include Unit (S) (VH)
 
@@ -213,7 +213,7 @@ struct
     in
     (Stats.time "potentially_incremental_reach" (List.iter one_var)) vs;
 
-    PS.finalize ~vh ~reachable:reachable;
+    PS.finalize ~vh ~reachable;
     Goblintutil.postsolving := false
 
   let post xs vs vh =

--- a/src/solvers/postSolver.ml
+++ b/src/solvers/postSolver.ml
@@ -217,24 +217,7 @@ struct
     in
     (Stats.time "potentially_incremental_reach" (List.iter one_var)) vs;
 
-    match dep with
-    | None -> PS.finalize ~vh ~reachable:reachable;
-    | Some dep -> (
-        (* Perform reachability on whole constraint system, but cheaply by using logged dependencies *)
-        (* This only works if the other reachability has been performed before, so dependencies created only during postsolve are recorded *)
-        let reachable' = VH.create (VH.length vh) in
-        let rec one_var' x =
-          if not (VH.mem reachable' x) then (
-            VH.replace reachable' x ();
-            match VH.find_option dep x with
-            | Some vs -> VS.iter one_var' vs
-            | None -> ()
-          )
-        in
-        (Stats.time "cheap_full_reach" (List.iter one_var')) vs;
-        PS.finalize ~vh ~reachable:reachable';
-      )
-      ;
+    PS.finalize ~vh ~reachable:reachable;
     Goblintutil.postsolving := false
 
   let post xs vs vh dep =

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -1003,10 +1003,10 @@ module WP =
           (* Perform reachability on whole constraint system, but cheaply by using logged dependencies *)
           (* This only works if the other reachability has been performed before, so dependencies created only during postsolve are recorded *)
           let reachable' = HM.create (HM.length rho) in
-          let rechable_and_superstable = HM.create (HM.length rho) in
+          let reachable_and_superstable = HM.create (HM.length rho) in
           let rec one_var' x =
             if (not (HM.mem reachable' x)) then (
-              if HM.mem superstable x then HM.replace rechable_and_superstable x ();
+              if HM.mem superstable x then HM.replace reachable_and_superstable x ();
               HM.replace reachable' x ();
               Option.may (VS.iter one_var') (HM.find_option dep x);
               Option.may (VS.iter one_var') (HM.find_option side_infl x)
@@ -1014,7 +1014,7 @@ module WP =
           in
           (Stats.time "cheap_full_reach" (List.iter one_var')) vs;
 
-          rechable_and_superstable (* consider superstable reached if it is still reachable: stop recursion (evaluation) and keep from being pruned *)
+          reachable_and_superstable (* consider superstable reached if it is still reachable: stop recursion (evaluation) and keep from being pruned *)
         else
           HM.create 0 (* doesn't matter, not used *)
       in

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -56,7 +56,7 @@ module WP =
 
     let print_data data str =
       if GobConfig.get_bool "dbg.verbose" then
-        Printf.printf "%s:\n|rho|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|side_dep|=%d\n|side_infl|=%d|dep|=%d\n"
+        Printf.printf "%s:\n|rho|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|side_dep|=%d\n|side_infl|=%d\n|dep|=%d\n"
           str (HM.length data.rho) (HM.length data.stable) (HM.length data.infl) (HM.length data.wpoint) (HM.length data.side_dep) (HM.length data.side_infl) (HM.length data.dep)
 
     let verify_data data =

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -1056,7 +1056,7 @@ module WP =
 
           (* replay superstable messages from unknowns that are still reachable *)
           if incr_verify then (
-            HM.iter (fun (l:S.v) m ->
+            HM.iter (fun _ m ->
                 Messages.add m
               ) var_messages;
           );

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -140,7 +140,7 @@ module WP =
       let restart_once = GobConfig.get_bool "solvers.td3.restart.wpoint.once" in
       let restarted_wpoint = HM.create 10 in
 
-      let incr_verify = GobConfig.get_bool "incremental.verify" in
+      let incr_verify = GobConfig.get_bool "incremental.postsolver.enabled" in
       (* In incremental load, initially stable nodes, which are never destabilized.
          These don't have to be re-verified and warnings can be reused. *)
       let superstable = HM.copy stable in

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -141,6 +141,7 @@ module WP =
       let restarted_wpoint = HM.create 10 in
 
       let incr_verify = GobConfig.get_bool "incremental.postsolver.enabled" in
+      let consider_superstable_reached = GobConfig.get_bool "incremental.postsolver.superstable-reached" in
       (* In incremental load, initially stable nodes, which are never destabilized.
          These don't have to be re-verified and warnings can be reused. *)
       let superstable = HM.copy stable in
@@ -1015,7 +1016,7 @@ module WP =
       in
 
       let reachable_and_superstable =
-        if incr_verify then
+        if incr_verify && not consider_superstable_reached then
           (* Perform reachability on whole constraint system, but cheaply by using logged dependencies *)
           (* This only works if the other reachability has been performed before, so dependencies created only during postsolve are recorded *)
           let reachable' = HM.create (HM.length rho) in
@@ -1031,6 +1032,8 @@ module WP =
           (Stats.time "cheap_full_reach" (List.iter one_var')) (vs @ !reluctant_vs);
 
           reachable_and_superstable (* consider superstable reached if it is still reachable: stop recursion (evaluation) and keep from being pruned *)
+        else if incr_verify then
+          superstable
         else
           HM.create 0 (* doesn't matter, not used *)
       in

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -956,9 +956,9 @@ module WP =
 
       (* Prune other data structures than rho with reachable.
          These matter for the incremental data. *)
-      let module IncrPrune: PostSolver.S with module S = S and module VH = HM and module VS = VS =
+      let module IncrPrune: PostSolver.S with module S = S and module VH = HM =
       struct
-        include PostSolver.Unit (S) (HM) (VS)
+        include PostSolver.Unit (S) (HM)
 
         let finalize ~vh ~reachable =
           VH.filteri_inplace (fun x _ ->
@@ -995,9 +995,9 @@ module WP =
       in
 
       (* postsolver also populates side_dep, side_infl, and dep *)
-      let module SideInfl: PostSolver.S with module S = S and module VH = HM  and module VS = VS=
+      let module SideInfl: PostSolver.S with module S = S and module VH = HM =
       struct
-        include PostSolver.Unit (S) (HM) (VS)
+        include PostSolver.Unit (S) (HM)
 
         let one_side ~vh ~x ~y ~d =
           (* Also record side-effects caused by post-solver *)
@@ -1047,9 +1047,9 @@ module WP =
 
       let init_reachable = reachable_and_superstable in
 
-      let module IncrWarn: PostSolver.S with module S = S and module VH = HM and module VS = VS =
+      let module IncrWarn: PostSolver.S with module S = S and module VH = HM =
       struct
-        include PostSolver.Warn (S) (HM) (VS)
+        include PostSolver.Warn (S) (HM)
 
         let init () =
           init (); (* enable warning like standard Warn *)
@@ -1078,9 +1078,9 @@ module WP =
 
       (** Incremental write-only side effect restart handling:
           retriggers superstable ones (after restarting above) and collects new (non-superstable) ones. *)
-      let module IncrWrite: PostSolver.S with module S = S and module VH = HM and module VS = VS =
+      let module IncrWrite: PostSolver.S with module S = S and module VH = HM =
       struct
-        include PostSolver.Unit (S) (HM) (VS)
+        include PostSolver.Unit (S) (HM)
 
         let init () = ()
 
@@ -1123,7 +1123,7 @@ module WP =
           include Arg
           let should_warn = false (* disable standard Warn in favor of IncrWarn *)
         end
-        include PostSolver.ListArgFromStdArg (S) (HM) (VS) (Arg)
+        include PostSolver.ListArgFromStdArg (S) (HM) (Arg)
 
         let postsolvers = (module IncrPrune: M) :: (module SideInfl: M) :: (module IncrWrite: M) :: (module IncrWarn: M) :: postsolvers
 
@@ -1137,7 +1137,7 @@ module WP =
 
       let module Post = PostSolver.MakeIncrList (MakeIncrListArg) in
 
-      Post.post st vs rho (Some dep);
+      Post.post st vs rho;
 
       print_data data "Data after postsolve";
 

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -1201,7 +1201,7 @@ module WP =
           data.rho_write <- rho_write';
           let dep' = HM.create (HM.length data.dep) in
           HM.iter (fun k v ->
-              HM.replace dep' (S.Var.relift k) v
+              HM.replace dep' (S.Var.relift k) (VS.map S.Var.relift v)
             ) data.dep;
           data.dep <- dep';
         );

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -1017,9 +1017,7 @@ module WP =
             if (not (HM.mem reachable' x)) then (
               if HM.mem superstable x then HM.replace rechable_and_superstable x ();
               HM.replace reachable' x ();
-              match HM.find_option dep x with
-              | Some vs -> VS.iter one_var' vs
-              | None -> ()
+              Option.may (VS.iter one_var') (HM.find_option dep x)
             )
           in
           (Stats.time "cheap_full_reach" (List.iter one_var')) vs;

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -160,9 +160,9 @@ module WP =
       let dep = data.dep in
 
       let () = print_solver_stats := fun () ->
-        Printf.printf "|rho|=%d\n|called|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|side_dep|=%d\n|side_infl|=%d\n"
-          (HM.length rho) (HM.length called) (HM.length stable) (HM.length infl) (HM.length wpoint) (HM.length side_dep) (HM.length side_infl);
-        print_context_stats rho
+          Printf.printf "|rho|=%d\n|called|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|side_dep|=%d\n|side_infl|=%d\n|dep|=%d\n"
+            (HM.length rho) (HM.length called) (HM.length stable) (HM.length infl) (HM.length wpoint) (HM.length side_dep) (HM.length side_infl) (HM.length dep);
+          print_context_stats rho
       in
 
       if GobConfig.get_bool "incremental.load" then (

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -1005,6 +1005,8 @@ module WP =
       struct
         include PostSolver.Unit (S) (HM)
 
+        (* TODO: We should be able to reset side_infl before executing the RHS, as all relevant side-effects should happen here again *)
+        (* However, this currently breaks some tests https://github.com/goblint/analyzer/pull/713#issuecomment-1114764937 *)
         let one_side ~vh ~x ~y ~d =
           (* Also record side-effects caused by post-solver *)
           HM.replace side_dep y (VS.add x (try HM.find side_dep y with Not_found -> VS.empty));

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1053,11 +1053,24 @@
           },
           "additionalProperties": false
         },
-        "verify": {
-          "title": "incremental.verify",
-          "description": "TODO",
-          "type": "boolean",
-          "default": true
+        "postsolver": {
+          "title": "incremental.postsolver",
+          "type" : "object",
+          "properties": {
+            "enabled": {
+              "title": "incremental.postsolver.enabled",
+              "description": "Use incremental postsolver",
+              "type": "boolean",
+              "default": true
+            },
+            "superstable-reached" : {
+              "title":  "incremental.postsolver.superstable-reached",
+              "description": "Consider superstable set reached",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1065,7 +1065,7 @@
             },
             "superstable-reached" : {
               "title":  "incremental.postsolver.superstable-reached",
-              "description": "Consider superstable set reached",
+              "description": "Consider superstable set reached, may be faster but can lead to spurious warnings",
               "type": "boolean",
               "default": false
             }

--- a/tests/incremental/00-basic/09-unreach.c
+++ b/tests/incremental/00-basic/09-unreach.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+void foo() {
+  int x = 2;
+  assert(x == 3); //FAIL
+}
+
+int main() {
+  int a = 1;
+
+  foo();
+
+  return 0;
+}

--- a/tests/incremental/00-basic/09-unreach.json
+++ b/tests/incremental/00-basic/09-unreach.json
@@ -3,6 +3,8 @@
         "debug": true
     },
     "incremental" : {
-        "verify": true
+        "postsolver": {
+            "enabled":  true
+        }
     }
 }

--- a/tests/incremental/00-basic/09-unreach.json
+++ b/tests/incremental/00-basic/09-unreach.json
@@ -1,0 +1,8 @@
+{
+    "dbg": {
+        "debug": true
+    },
+    "incremental" : {
+        "verify": true
+    }
+}

--- a/tests/incremental/00-basic/09-unreach.patch
+++ b/tests/incremental/00-basic/09-unreach.patch
@@ -1,0 +1,17 @@
+--- tests/incremental/00-basic/09-unreach.c
++++ tests/incremental/00-basic/09-unreach.c
+@@ -2,13 +2,12 @@
+
+ void foo() {
+   int x = 2;
+-  assert(x == 3); //FAIL
++  assert(x == 3); //NOWARN
+ }
+
+ int main() {
+   int a = 1;
+
+-  foo();
+
+   return 0;
+ }

--- a/tests/incremental/00-basic/10-reach.c
+++ b/tests/incremental/00-basic/10-reach.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include<pthread.h>
+
+void foo() {
+  int x = 2;
+  assert(x == 2);
+}
+
+int main() {
+    pthread_t id;
+    pthread_create(&id, NULL, foo, NULL); // just go multithreaded
+
+  return 0;
+}

--- a/tests/incremental/00-basic/10-reach.json
+++ b/tests/incremental/00-basic/10-reach.json
@@ -3,6 +3,8 @@
         "debug": true
     },
     "incremental" : {
-        "verify": true
+        "postsolver": {
+            "enabled":  true
+        }
     }
 }

--- a/tests/incremental/00-basic/10-reach.json
+++ b/tests/incremental/00-basic/10-reach.json
@@ -1,0 +1,8 @@
+{
+    "dbg": {
+        "debug": true
+    },
+    "incremental" : {
+        "verify": true
+    }
+}

--- a/tests/incremental/00-basic/11-unreach-reusesuper.c
+++ b/tests/incremental/00-basic/11-unreach-reusesuper.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+void foo() {
+  int x = 2;
+  assert(x == 3); //FAIL
+}
+
+int main() {
+  int a = 1;
+
+  foo();
+
+  return 0;
+}

--- a/tests/incremental/00-basic/11-unreach-reusesuper.json
+++ b/tests/incremental/00-basic/11-unreach-reusesuper.json
@@ -1,0 +1,11 @@
+{
+    "dbg": {
+        "debug": true
+    },
+    "incremental" : {
+        "postsolver": {
+            "enabled":  true,
+            "superstable-reached" : true
+        }
+    }
+}

--- a/tests/incremental/00-basic/11-unreach-reusesuper.patch
+++ b/tests/incremental/00-basic/11-unreach-reusesuper.patch
@@ -1,0 +1,17 @@
+--- tests/incremental/00-basic/11-unreach-reusesuper.c
++++ tests/incremental/00-basic/11-unreach-reusesuper.c
+@@ -2,13 +2,12 @@
+
+ void foo() {
+   int x = 2;
+-  assert(x == 3); //FAIL
++  assert(x == 3); //TODO (considered rechable without cheap from scratch re-analysis)
+ }
+
+ int main() {
+   int a = 1;
+
+-  foo();
+
+   return 0;
+ }

--- a/tests/incremental/01-force-reanalyze/01-int-reluctant.json
+++ b/tests/incremental/01-force-reanalyze/01-int-reluctant.json
@@ -17,6 +17,8 @@
         "reluctant" : {
             "on": true
         },
-        "verify": false
+        "postsolver": {
+            "enabled": false
+        }
     }
 }

--- a/tests/incremental/03-precision-annotation/02-reluctant-int-annotation.json
+++ b/tests/incremental/03-precision-annotation/02-reluctant-int-annotation.json
@@ -14,6 +14,8 @@
         "reluctant": {
             "on": true
         },
-        "verify": false
+        "postsolver": {
+            "enabled":  false
+        }
     }
 }

--- a/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.json
+++ b/tests/incremental/03-precision-annotation/03-reluctant-int-annotation-dyn.json
@@ -14,6 +14,8 @@
         "reluctant": {
             "on": true
         },
-        "verify": false
+        "postsolver": {
+            "enabled":  false
+        }
     }
 }

--- a/tests/incremental/13-restart-write/05-race-call-remove.c
+++ b/tests/incremental/13-restart-write/05-race-call-remove.c
@@ -1,0 +1,20 @@
+#include <pthread.h>
+#include <assert.h>
+
+int g;
+
+void *t_fun(void *arg) {
+  g++; // RACE!
+  return NULL;
+}
+
+void foo() {
+  g++; // RACE!
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  foo();
+  return 0;
+}

--- a/tests/incremental/13-restart-write/05-race-call-remove.json
+++ b/tests/incremental/13-restart-write/05-race-call-remove.json
@@ -1,0 +1,14 @@
+{
+    "incremental": {
+        "restart": {
+            "sided": {
+                "enabled": false
+            }
+        }
+    },
+    "ana": {
+        "thread": {
+            "include-node": false
+        }
+    }
+}

--- a/tests/incremental/13-restart-write/05-race-call-remove.patch
+++ b/tests/incremental/13-restart-write/05-race-call-remove.patch
@@ -1,0 +1,25 @@
+diff --git tests/incremental/13-restart-write/05-race-call-remove.c tests/incremental/13-restart-write/05-race-call-remove.c
+index cf9f5c713..20e09db1a 100644
+--- tests/incremental/13-restart-write/05-race-call-remove.c
++++ tests/incremental/13-restart-write/05-race-call-remove.c
+@@ -4,17 +4,16 @@
+ int g;
+ 
+ void *t_fun(void *arg) {
+-  g++; // RACE!
++  g++; // NORACE (unique thread)
+   return NULL;
+ }
+ 
+ void foo() {
+-  g++; // RACE!
++  g++; // NORACE
+ }
+ 
+ int main() {
+   pthread_t id;
+   pthread_create(&id, NULL, t_fun, NULL);
+-  foo();
+   return 0;
+ }
+\ No newline at end of file


### PR DESCRIPTION
This implements a cheap form of reachability that works on a set of `dep` collected during solving (and heavy-weight reachability).

Something that is a bit odd:
- If a side-effect occurs from `x` to `y`, it still is necessary to record that `x` depends on `y`, to avoid those globals that only receive side-effects but are never read from being pruned. This has the effect that globals that are only side-effected to do not depend on anything, which I am not quite sure is the right thing here.

This stronger form of reachability can then be used to additionally filter warnings and accesses to replay: Only those that are superstable and still reachable need to be replayed.

I tested the performance impact on a small program, and this cheap reachability seems to be a lot cheaper than full reachability, meaning that it hopefully is not too expensive also for larger programs:

~~~
TOTAL                           0.676 s
  parse                           0.016 s
  convert to CIL                  0.010 s
  mergeCIL                        0.008 s
  analysis                        0.642 s
    createCFG                       0.007 s
      handle                          0.003 s
      iter_connect                    0.003 s
        computeSCCs                     0.002 s
    global_inits                    0.013 s
    solving                         0.612 s
      S.Dom.equal                     0.004 s
      postsolver                      0.183 s
        potentially_incremental_reach       0.176 s
        cheap_full_reach                0.001 s
    warn_global                     0.002 s
      access                          0.001 s
Timing used
~~~

There are still three incremental tests that fail, all of which use restarting. I'll try to have a look, but I am not so familiar with it: maybe @sim642 has an idea what could go wrong there?

Closes #710 