### PR TITLE
Add option to compile and run regression tests to sanity check assertions

### DIFF
--- a/scripts/include/assert.h
+++ b/scripts/include/assert.h
@@ -1,0 +1,7 @@
+#define _ASSERT_H 1
+#include <stdio.h>
+
+#define assert(expr)                                                                           \
+      ((expr)                                                                                  \
+           ? printf("%s:%i: %s: Assertion `%s' passed\n", __FILE__, __LINE__, __func__, #expr) \
+           : printf("%s:%i: %s: Assertion `%s' failed\n", __FILE__, __LINE__, __func__, #expr))


### PR DESCRIPTION
Adds the new options `-e` and `-eq` to the regression tests that compiles and run the regression tests and then use the actual results of executing the assertions to check the annotations.

This of course has the issue that actually running the assertions generally doesn't result in an unknown result and some annotations are just never actually reached which results in a bunch of useless errors in `-e` mode which are suppressed in `-eq` which only shows issues that indicate definite errors.

This requires that the tests `#include <assert.h>` instead of relying on a global `assert` as done in #645.

With that only one assertion `malloc_array:10` actually falls because it asserts that an uninitialized value is 4, there is a comment explaining it, so that is probably fine.

Beyond that there are 285 tests that either fail to compile, segfault when running or otherwise don't exit with code 0.

I am not sure how useful this is in general, but i think there is merit to using it at least when writing new tests.