### PR TITLE
Invalidate variables based on annotations of asm statements

### DIFF
--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -423,7 +423,7 @@ struct
     let d = do_emits ctx !emits d in
     if q then raise Deadcode else d
 
-  let asm (ctx:(D.t, G.t, C.t, V.t) ctx) =
+  let asm (ctx:(D.t, G.t, C.t, V.t) ctx) t an =
     let spawns = ref [] in
     let splits = ref [] in
     let sides  = ref [] in
@@ -431,7 +431,7 @@ struct
     let ctx'' = outer_ctx "asm" ~spawns ~sides ~emits ctx in
     let f post_all (n,(module S:MCPSpec),d) =
       let ctx' : (S.D.t, S.G.t, S.C.t, S.V.t) ctx = inner_ctx "asm" ~splits ~post_all ctx'' n d in
-      n, repr @@ S.asm ctx'
+      n, repr @@ S.asm ctx' t an
     in
     let d, q = map_deadcode f @@ spec_list ctx.local in
     do_sideg ctx !sides;

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -9,6 +9,7 @@ type t =
   | AssignSpawnedThread of lval * ThreadIdDomain.Thread.t (** Assign spawned thread's ID to lval. *)
   | Access of {var_opt: CilType.Varinfo.t option; write: bool} (** Access varinfo (unknown if None). *)
   | Assign of {lval: CilType.Lval.t; exp: CilType.Exp.t} (** Used to simulate old [ctx.assign]. *)
+  | Invalidate of {addr_list: PreValueDomain.AD.bucket BatMap.Int.t list}
 
 let pretty () = function
   | Lock m -> dprintf "Lock %a" LockDomain.Lockset.Lock.pretty m
@@ -19,3 +20,4 @@ let pretty () = function
   | AssignSpawnedThread (lval, tid) -> dprintf "AssignSpawnedThread (%a, %a)" d_lval lval ThreadIdDomain.Thread.pretty tid
   | Access {var_opt; write} -> dprintf "Access {var_opt=%a, write=%B}" (docOpt (CilType.Varinfo.pretty ())) var_opt write
   | Assign {lval; exp} -> dprintf "Assugn {lval=%a, exp=%a}" CilType.Lval.pretty lval CilType.Exp.pretty exp
+  | Invalidate{addr_list} -> dprintf "Invalidate {addr_list=%a}" (docList (PreValueDomain.AD.pretty ())) addr_list

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -361,7 +361,7 @@ sig
   val body  : (D.t, G.t, C.t, V.t) ctx -> fundec -> D.t
   val return: (D.t, G.t, C.t, V.t) ctx -> exp option  -> fundec -> D.t
   val intrpt: (D.t, G.t, C.t, V.t) ctx -> D.t
-  val asm   : (D.t, G.t, C.t, V.t) ctx -> D.t
+  val asm   : (D.t, G.t, C.t, V.t) ctx -> string list -> (Edge.asm_out * Edge.asm_in * string list) option -> D.t
   val skip  : (D.t, G.t, C.t, V.t) ctx -> D.t
 
 
@@ -546,7 +546,7 @@ struct
 
   let vdecl ctx _ = ctx.local
 
-  let asm x =
+  let asm x t an =
     ignore (M.info ~category:Unsound "ASM statement ignored.");
     x.local (* Just ignore. *)
 

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -291,7 +291,8 @@ let createCFG (file: file) =
             let edge_of_instr = function
               | Set (lval,exp,loc,eloc) -> eloc, Assign (lval, exp) (* TODO: eloc loc fallback if unknown here and If *)
               | Call (lval,func,args,loc,eloc) -> eloc, Proc (lval,func,args)
-              | Asm (attr,tmpl,out,inp,regs,loc) -> loc, ASM (tmpl,out,inp)
+              | Asm (attr, tmpl, Some (out, inp, regs, gotos), loc) -> loc, ASM (tmpl, Some(out, inp, regs))
+              | Asm (attr, tmpl, None, loc) -> loc, ASM (tmpl, None)
               | VarDecl (v, loc) -> loc, VDecl(v)
             in
             let edges = List.map edge_of_instr instrs in

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -675,7 +675,7 @@ struct
       | Entry f        -> tf_entry var edge prev_node f
       | Ret (r,fd)     -> tf_ret var edge prev_node r fd
       | Test (p,b)     -> tf_test var edge prev_node p b
-      | ASM (_, _, _)  -> tf_asm var edge prev_node (* TODO: use ASM fields for something? *)
+      | ASM _          -> tf_asm var edge prev_node (* TODO: use ASM fields for something? *)
       | Skip           -> tf_skip var edge prev_node
       | SelfLoop       -> tf_loop var edge prev_node
     end getl sidel getg sideg d

--- a/src/framework/edge.ml
+++ b/src/framework/edge.ml
@@ -18,9 +18,9 @@ type t =
     * transferred to the function node! *)
   | Test of CilType.Exp.t * bool
   (** The true-branch or false-branch of a conditional exp *)
-  | ASM of string list * asm_out * asm_in
+  | ASM of string list * (asm_out * asm_in * string list) option
   (** Inline assembly statements, and the annotations for output and input
-    * variables. *)
+    * variables and clobbers or None if it is an unannotated basic asm statement. *)
   | VDecl of CilType.Varinfo.t
   (** VDecl edge for the variable in varinfo. Whether such an edge is there for all
     * local variables or only when it is not possible to pull the declaration up, is
@@ -42,7 +42,7 @@ let pretty () = function
   | Entry (f) -> Pretty.text "(body)"
   | Ret (Some e,f) -> Pretty.dprintf "return %a" dn_exp e
   | Ret (None,f) -> Pretty.dprintf "return"
-  | ASM (_,_,_) -> Pretty.text "ASM ..."
+  | ASM _ -> Pretty.text "ASM ..."
   | Skip -> Pretty.text "skip"
   | VDecl v -> Cil.defaultCilPrinter#pVDecl () v
   | SelfLoop -> Pretty.text "SelfLoop"

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -15,7 +15,7 @@ type edge = Edge.t =
   | Entry of CilType.Fundec.t
   | Ret of CilType.Exp.t option * CilType.Fundec.t
   | Test of CilType.Exp.t * bool
-  | ASM of string list * Edge.asm_out * Edge.asm_in
+  | ASM of string list * (Edge.asm_out * Edge.asm_in * string list) option
   | VDecl of CilType.Varinfo.t
   | Skip
   | SelfLoop

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -160,7 +160,8 @@ let eq_instr (a: instr) (b: instr) = match a, b with
   | Set (lv1, exp1, _l1, _el1), Set (lv2, exp2, _l2, _el2) -> eq_lval lv1 lv2 && eq_exp exp1 exp2
   | Call (Some lv1, f1, args1, _l1, _el1), Call (Some lv2, f2, args2, _l2, _el2) -> eq_lval lv1 lv2 && eq_exp f1 f2 && GobList.equal eq_exp args1 args2
   | Call (None, f1, args1, _l1, _el1), Call (None, f2, args2, _l2, _el2) -> eq_exp f1 f2 && GobList.equal eq_exp args1 args2
-  | Asm (attr1, tmp1, ci1, dj1, rk1, l1), Asm (attr2, tmp2, ci2, dj2, rk2, l2) -> GobList.equal String.equal tmp1 tmp2 && GobList.equal(fun (x1,y1,z1) (x2,y2,z2)-> x1 = x2 && y1 = y2 && eq_lval z1 z2) ci1 ci2 && GobList.equal(fun (x1,y1,z1) (x2,y2,z2)-> x1 = x2 && y1 = y2 && eq_exp z1 z2) dj1 dj2 && GobList.equal String.equal rk1 rk2(* ignore attributes and locations *)
+  | Asm (_, tmp1, None, _), Asm (_, tmp2, None, _) -> GobList.equal String.equal tmp1 tmp2 (* ignore attributes and locations *)
+  | Asm (_, tmp1, Some (ci1, dj1, rk1, gt1), _), Asm (_, tmp2, Some (ci2, dj2, rk2, gt2), _) -> GobList.equal String.equal tmp1 tmp2 && GobList.equal(fun (x1,y1,z1) (x2,y2,z2)-> x1 = x2 && y1 = y2 && eq_lval z1 z2) ci1 ci2 && GobList.equal(fun (x1,y1,z1) (x2,y2,z2)-> x1 = x2 && y1 = y2 && eq_exp z1 z2) dj1 dj2 && GobList.equal String.equal rk1 rk2 && GobList.equal String.equal gt1 gt2
   | VarDecl (v1, _l1), VarDecl (v2, _l2) -> eq_varinfo v1 v2
   | _, _ -> false
 

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -478,7 +478,7 @@ class countFnVisitor = object
     method! vinst = function
       | Set (_,_,loc,_)
       | Call (_,_,_,loc,_)
-      | Asm (_,_,_,_,_,loc)
+      | Asm (_,_,_,loc)
         -> Hashtbl.replace locs loc.line (); SkipChildren
       | _ -> SkipChildren
 

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1108,6 +1108,38 @@
             }
           },
           "additionalProperties": false
+        },
+        "asm": {
+          "title": "sem.asm",
+          "description": "Inline Assembly Analysis options",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "sem.asm.enabled",
+              "description": "",
+              "type": "boolean",
+              "default": true
+            },
+            "basic-preserve-globals": {
+              "title": "sem.asm.basic-preserve-globals",
+              "description": "If enabled, do preserve globals across basic asm statements",
+              "type": "boolean",
+              "default": false
+            },
+            "memory-preserve-globals": {
+              "title": "sem.asm.memory-preserve-globals",
+              "description": "If enabled, do preserve globals across advanced asm statements with memory clobber annotation",
+              "type": "boolean",
+              "default": false
+            },
+            "readonly-inputs": {
+              "title": "sem.asm.readonly-inputs",
+              "description": "If enabled, do not consider changes through pointers given as inputs",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -230,7 +230,7 @@ struct
   let return ctx e f    = map ctx Spec.return  (fun h -> h e f )
   let branch ctx e tv   = map ctx Spec.branch  (fun h -> h e tv)
   let intrpt ctx        = map ctx Spec.intrpt  identity
-  let asm ctx           = map ctx Spec.asm     identity
+  let asm ctx t an      = map ctx Spec.asm     (fun h -> h t an)
   let skip ctx          = map ctx Spec.skip    identity
   let special ctx l f a = map ctx Spec.special (fun h -> h l f a)
 

--- a/tests/regression/56-asm/01-parsing.c
+++ b/tests/regression/56-asm/01-parsing.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+int main()
+{
+  int x;
+
+  asm("nop");
+
+  asm volatile("");
+
+  assert(1);
+
+  return 0;
+}

--- a/tests/regression/56-asm/02-basic-discard-local.c
+++ b/tests/regression/56-asm/02-basic-discard-local.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+
+  asm("nop");
+
+  assert(x == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/03-basic-discard-global.c
+++ b/tests/regression/56-asm/03-basic-discard-global.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+int x = 0;
+
+int main()
+{
+  asm("nop");
+
+  assert(x == 0); // UNKNOWN
+
+  return 0;
+}

--- a/tests/regression/56-asm/04-memory-clobber.c
+++ b/tests/regression/56-asm/04-memory-clobber.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+int x = 0;
+
+int main()
+{
+  asm("movl $1, x" : : : "memory");
+
+  assert(x == 1); // UNKNOWN
+
+  return 0;
+}

--- a/tests/regression/56-asm/10-advanced-discard-local.c
+++ b/tests/regression/56-asm/10-advanced-discard-local.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  int y = 0;
+
+  asm("nop"
+      : "=r"(x));
+
+  assert(x == 0); // UNKNOWN
+  assert(y == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/11-advanced-discard-global.c
+++ b/tests/regression/56-asm/11-advanced-discard-global.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+int x = 0;
+int y = 0;
+
+int main()
+{
+  asm("nop"
+      : "=r"(x));
+
+  assert(x == 0); // UNKNOWN
+  assert(y == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/12-advanced-discard-mixed.c
+++ b/tests/regression/56-asm/12-advanced-discard-mixed.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+
+int gx = 0;
+int gy = 0;
+
+int main()
+{
+  int x = 0;
+  int y = 0;
+
+  asm("nop"
+      : "=r"(x), "=r"(gx));
+
+  assert(x == 0); // UNKNOWN
+  assert(y == 0);
+  assert(gx == 0); // UNKNOWN
+  assert(gy == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/13-advanced-discard-local-multi.c
+++ b/tests/regression/56-asm/13-advanced-discard-local-multi.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  int y = 0;
+  int z = 0;
+
+  asm("nop"
+      : "=r"(x), "=r"(y));
+
+  assert(x == 0); // UNKNOWN
+  assert(y == 0); // UNKNOWN
+  assert(z == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/14-advanced-discard-global-multi.c
+++ b/tests/regression/56-asm/14-advanced-discard-global-multi.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+int x = 0;
+int y = 0;
+int z = 0;
+
+int main()
+{
+  asm("nop"
+      : "=r"(x), "=r"(y));
+
+  assert(x == 0); // UNKNOWN
+  assert(y == 0); // UNKNOWN
+  assert(z == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/15-advanced-discard-mixed-multi.c
+++ b/tests/regression/56-asm/15-advanced-discard-mixed-multi.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+int gx = 0;
+int gy = 0;
+int gz = 0;
+
+int main()
+{
+  int x = 0;
+  int y = 0;
+  int z = 0;
+
+  asm("nop"
+      : "=r"(x), "=r"(y), "=r"(gx), "=r"(gy));
+
+  assert(x == 0); // UNKNOWN
+  assert(y == 0); // UNKNOWN
+  assert(z == 0);
+  assert(gx == 0); // UNKNOWN
+  assert(gy == 0); // UNKNOWN
+  assert(gz == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/20-advanced-read-local.c
+++ b/tests/regression/56-asm/20-advanced-read-local.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  int y = 0;
+
+  asm("nop"
+      :
+      : "r"(x));
+
+  assert(x == 0);
+  assert(y == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/21-advanced-read-global.c
+++ b/tests/regression/56-asm/21-advanced-read-global.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int x = 0;
+int y = 0;
+
+int main()
+{
+  asm("nop"
+      :
+      : "r"(x));
+
+  assert(x == 0);
+  assert(y == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/22-advanced-read-mixed.c
+++ b/tests/regression/56-asm/22-advanced-read-mixed.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+int gx = 0;
+int gy = 0;
+
+int main()
+{
+  int x = 0;
+  int y = 0;
+
+  asm("nop"
+      :
+      : "r"(x), "r"(gx));
+
+  assert(x == 0);
+  assert(y == 0);
+  assert(gx == 0);
+  assert(gy == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/23-advanced-read-local-multi.c
+++ b/tests/regression/56-asm/23-advanced-read-local-multi.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  int y = 0;
+  int z = 0;
+
+  asm("nop"
+      :
+      : "r"(x), "r"(y));
+
+  assert(x == 0);
+  assert(y == 0);
+  assert(z == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/24-advanced-read-global-multi.c
+++ b/tests/regression/56-asm/24-advanced-read-global-multi.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+int x = 0;
+int y = 0;
+int z = 0;
+
+int main()
+{
+  asm("nop"
+      :
+      : "r"(x), "r"(y));
+
+  assert(x == 0);
+  assert(y == 0);
+  assert(z == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/25-advanced-read-mixed-multi.c
+++ b/tests/regression/56-asm/25-advanced-read-mixed-multi.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+
+int gx = 0;
+int gy = 0;
+int gz = 0;
+
+int main()
+{
+  int x = 0;
+  int y = 0;
+  int z = 0;
+
+  asm("nop"
+      :
+      : "r"(x), "r"(y), "r"(gx), "r"(gy));
+
+  assert(x == 0);
+  assert(y == 0);
+  assert(z == 0);
+  assert(gx == 0);
+  assert(gy == 0);
+  assert(gz == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/30-simple-branch.c
+++ b/tests/regression/56-asm/30-simple-branch.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  int y;
+
+  if (!y)
+  {
+    asm("movl $1, %0"
+        : "=r"(x));
+  }
+
+  assert(x == 1); // UNKNOWN
+
+  return 0;
+}

--- a/tests/regression/56-asm/31-struct-value.c
+++ b/tests/regression/56-asm/31-struct-value.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+
+int main()
+{
+  struct test
+  {
+    int a;
+    int b;
+  } x = {0, 0};
+  int y;
+
+  asm("movl $1, %0"
+      : "=r"(x.a));
+
+  assert(x.a == 1); // UNKNOWN
+  assert(x.b == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/32-struct-value-branch.c
+++ b/tests/regression/56-asm/32-struct-value-branch.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+
+int main()
+{
+  struct test
+  {
+    int a;
+    int b;
+  } x = {0, 0};
+  int y;
+
+  if (!y)
+  {
+    asm("movl $1, %0"
+        : "=r"(x.a));
+  }
+
+  assert(x.a == 1); // UNKNOWN
+  assert(x.b == 0);
+
+  return 0;
+}

--- a/tests/regression/56-asm/33-struct-ptr.c
+++ b/tests/regression/56-asm/33-struct-ptr.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+
+int main()
+{
+  struct test
+  {
+    int a;
+    int b;
+  };
+
+  struct test v = {0, 0};
+  struct test *x = &v;
+  int y;
+
+  asm("nop"
+      :
+      : "r"(x));
+
+  assert(x->a == 0); // UNKNOWN
+  assert(x->b == 0); // UNKNOWN
+
+  assert(v.a == 0); // UNKNOWN
+  assert(v.b == 0); // UNKNOWN
+
+  return 0;
+}

--- a/tests/regression/56-asm/34-struct-pr-branch.c
+++ b/tests/regression/56-asm/34-struct-pr-branch.c
@@ -1,0 +1,29 @@
+#include <assert.h>
+
+int main()
+{
+  struct test
+  {
+    int a;
+    int b;
+  };
+
+  struct test v = {0, 0};
+  struct test *x = &v;
+  int y;
+
+  if (!y)
+  {
+    asm("nop"
+        :
+        : "r"(x));
+  }
+
+  assert(x->a == 0); // UNKNOWN
+  assert(x->b == 0); // UNKNOWN
+
+  assert(v.a == 0); // UNKNOWN
+  assert(v.b == 0); // UNKNOWN
+
+  return 0;
+}

--- a/tests/regression/56-asm/60-goto-issue.c
+++ b/tests/regression/56-asm/60-goto-issue.c
@@ -1,0 +1,45 @@
+// see https://github.com/goblint/cil/issues/81
+
+#define __stringify_1(x...) #x
+#define __stringify(x...) __stringify_1(x)
+
+#define __ASM_FORM(x, ...) " " __stringify(x, ##__VA_ARGS__) " "
+#define __ASM_SEL(a, b) __ASM_FORM(b)
+
+#define _ASM_PTR __ASM_SEL(.long, .quad)
+#define _ASM_ALIGN __ASM_SEL(.balign 4, .balign 8)
+
+#define JUMP_TABLE_ENTRY                                      \
+	".pushsection __jump_table,  \"aw\" \n\t" _ASM_ALIGN "\n\t" \
+	".long 1b - . \n\t"                                         \
+	".long %l[l_yes] - . \n\t" _ASM_PTR "%c0 + %c1 - .\n\t"     \
+	".popsection \n\t"
+
+#define __stringify_1(x...) #x
+#define __stringify(x...) __stringify_1(x)
+
+#define asm_volatile_goto(x...) \
+	do                            \
+	{                             \
+		asm goto(x);                \
+		asm("");                    \
+	} while (0)
+
+static int arch_static_branch(const int key, const int branch)
+{
+	asm_volatile_goto("1:"
+										".byte " __stringify(BYTES_NOP5) "\n\t" JUMP_TABLE_ENTRY
+										:
+										: "i"(key), "i"(branch)
+										:
+										: l_yes);
+
+	return 0;
+l_yes:
+	return 1;
+}
+
+int main()
+{
+	return 0;
+}


### PR DESCRIPTION
Instead of simply ignoring `asm` statements use their annotations to invalidate variables that are potentially modified by them.

- https://github.com/goblint/analyzer/commit/e3af268163594212468a490abf9318c10ee9a803 are the changes required to make this compile after the changes in https://github.com/goblint/cil/pull/92 that are required for this analysis. This commit will have to be replace in the future after i get to properly creating the CFG for `asm goto` statements.
- https://github.com/goblint/analyzer/commit/92b89d58d9652272bb5bb99d6fda4a1b494286d4 introduces an event to invalidate variables and makes the two existing invalidates in base use it.
- https://github.com/goblint/analyzer/commit/e3af268163594212468a490abf9318c10ee9a803 the actual code to collect which variables to invalidate for an asm

### TODO
- [ ] use the invalidate event outside of base
- [ ] proper handling of `asm goto`
- [ ] more tests
- [ ] Update goblint-cil opam pin to https://github.com/goblint/cil/pull/92
- ???