### PR TITLE
Interactive: improvements for chrony story

### DIFF
--- a/docs/user-guide/annotating.md
+++ b/docs/user-guide/annotating.md
@@ -25,3 +25,11 @@ The following string arguments are supported:
 3. `base.non-ptr`/`base.no-non-ptr` to override the `ana.base.context.non-ptr` option.
 4. `apron.context`/`apron.no-context` to override the `ana.apron.context` option.
 5. `widen`/`no-widen` to override the `ana.context.widen` option.
+
+
+## Functions
+Goblint-specific functions can be called in the code, where they assist the analyzer but have no runtime effect.
+
+* `__goblint_assume_join(id)` is like `pthread_join(id)`, but considers the given thread IDs must-joined even if Goblint cannot, e.g. due to non-uniqueness.
+  Notably, this annotation can be used after a threads joining loop to make the assumption that the loop correctly joined all those threads.
+  _Misuse of this annotation can cause unsoundness._

--- a/scripts/update_suite.rb
+++ b/scripts/update_suite.rb
@@ -159,6 +159,7 @@ class Tests
                     when /Assertion .* is unknown/   then "unknown"
                     when /^\[Warning\]/              then "warn"
                     when /^\[Error\]/                then "warn"
+                    when /^\[Info\]/                 then "warn"
                     when /\[Debug\]/                 then next # debug "warnings" shouldn't count as other warnings (against NOWARN)
                     when /^  on line \d+ $/          then next # dead line warnings shouldn't count (used for unreachability with NOWARN)
                     when /^  on lines \d+..\d+ $/    then next # dead line warnings shouldn't count (used for unreachability with NOWARN)

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -220,6 +220,7 @@ struct
         | "memset" | "__builtin_memset" | "__builtin___memset_chk" -> false
         | "bzero" | "__builtin_bzero" | "explicit_bzero" | "__explicit_bzero_chk" -> false
         | "__builtin_object_size" -> false
+        | "realloc" -> false
         | _ -> true
       in
       List.iter (access_one_top ctx `Read reach) (arg_acc `Read);

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -207,7 +207,11 @@ struct
       let arg_acc act =
         match act, LF.get_threadsafe_inv_ac x with
         | _, Some fnc -> (fnc act arglist)
-        | `Read, None -> arglist
+        | `Read, None ->
+          if get_bool "sem.unknown_function.read.args" then
+            arglist
+          else
+            []
         | (`Write | `Free), None ->
           if get_bool "sem.unknown_function.invalidate.args" then
             arglist

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -323,6 +323,9 @@ struct
         | Some lv -> invalidate_one st' lv
         | None -> st'
       )
+    | `Unknown "__goblint_assume_join" ->
+      let id = List.hd args in
+      Priv.thread_join ~force:true ask ctx.global id st
     | _ ->
       let ask = Analyses.ask_of_ctx ctx in
       let invalidate_one st lv =

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -988,7 +988,7 @@ struct
     let tids = ask.f (Q.EvalThread exp) in
     if force then (
       if ConcDomain.ThreadSet.is_top tids then
-        failwith "TODO"
+        st (* don't consider anything more joined, matches threadJoins analysis *)
       else (
         (* fold throws if the thread set is top *)
         let (lmust', l') = ConcDomain.ThreadSet.fold (fun tid (lmust, l) ->

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -987,11 +987,13 @@ struct
     let w,lmust,l = st.priv in
     let tids = ask.f (Q.EvalThread exp) in
     if force then (
-      if ConcDomain.ThreadSet.is_top tids then
-        st (* don't consider anything more joined, matches threadJoins analysis *)
+      if ConcDomain.ThreadSet.is_top tids then (
+        M.info ~category:Unsound "Unknown thread ID assume-joined, Apron privatization unsound"; (* TODO: something more sound *)
+        st (* cannot find all thread IDs to join them all *)
+      )
       else (
         (* fold throws if the thread set is top *)
-        let tids' = ConcDomain.ThreadSet.diff tids (ask.f Q.MustJoinedThreads) in (* avoid unnecessary imprecision by force joining already must-joined threas, e.g. 46-apron2/04-other-assume-inprec *)
+        let tids' = ConcDomain.ThreadSet.diff tids (ask.f Q.MustJoinedThreads) in (* avoid unnecessary imprecision by force joining already must-joined threads, e.g. 46-apron2/04-other-assume-inprec *)
         let (lmust', l') = ConcDomain.ThreadSet.fold (fun tid (lmust, l) ->
             let lmust',l' = G.thread (getg (V.thread tid)) in
             (LMust.union lmust' lmust, L.join l l')

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -991,10 +991,11 @@ struct
         st (* don't consider anything more joined, matches threadJoins analysis *)
       else (
         (* fold throws if the thread set is top *)
+        let tids' = ConcDomain.ThreadSet.diff tids (ask.f Q.MustJoinedThreads) in (* avoid unnecessary imprecision by force joining already must-joined threas, e.g. 46-apron2/04-other-assume-inprec *)
         let (lmust', l') = ConcDomain.ThreadSet.fold (fun tid (lmust, l) ->
             let lmust',l' = G.thread (getg (V.thread tid)) in
             (LMust.union lmust' lmust, L.join l l')
-          ) tids (lmust, l)
+          ) tids' (lmust, l)
         in
         {st with priv = (w, lmust', l')}
       )

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -37,7 +37,7 @@ module type S =
     val enter_multithreaded: Q.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> apron_components_t -> apron_components_t
     val threadenter: Q.ask -> (V.t -> G.t) -> apron_components_t -> apron_components_t
 
-    val thread_join: Q.ask -> (V.t -> G.t) -> Cil.exp -> apron_components_t -> apron_components_t
+    val thread_join: ?force:bool -> Q.ask -> (V.t -> G.t) -> Cil.exp -> apron_components_t -> apron_components_t
     val thread_return: Q.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> ThreadIdDomain.Thread.t -> apron_components_t -> apron_components_t
     val iter_sys_vars: (V.t -> G.t) -> VarQuery.t -> V.t VarQuery.f -> unit (** [Queries.IterSysVars] for apron. *)
 
@@ -62,7 +62,7 @@ struct
   let lock ask getg st m = st
   let unlock ask getg sideg st m = st
 
-  let thread_join ask getg exp st = st
+  let thread_join ?(force=false) ask getg exp st = st
   let thread_return ask getg sideg tid st = st
 
   let sync ask getg sideg st reason = st
@@ -270,7 +270,7 @@ struct
     {apr = apr_local'; priv = (p', w')}
 
 
-  let thread_join ask getg exp st = st
+  let thread_join ?(force=false) ask getg exp st = st
   let thread_return ask getg sideg tid st = st
 
   let sync ask getg sideg (st: apron_components_t) reason =
@@ -461,7 +461,7 @@ struct
     let apr_local = remove_globals_unprotected_after_unlock ask m apr in
     {st with apr = apr_local}
 
-  let thread_join ask getg exp st = st
+  let thread_join ?(force=false) ask getg exp st = st
   let thread_return ask getg sideg tid st = st
 
   let sync ask getg sideg (st: apron_components_t) reason =
@@ -983,22 +983,37 @@ struct
       let l' = L.add lm apr_side l in
       {apr = apr_local; priv = (w',LMust.add lm lmust,l')}
 
-  let thread_join (ask:Q.ask) getg exp (st: apron_components_t) =
+  let thread_join ?(force=false) (ask:Q.ask) getg exp (st: apron_components_t) =
     let w,lmust,l = st.priv in
     let tids = ask.f (Q.EvalThread exp) in
-    if ConcDomain.ThreadSet.is_top tids then
-      st (* TODO: why needed? *)
+    if force then (
+      if ConcDomain.ThreadSet.is_top tids then
+        failwith "TODO"
+      else (
+        (* fold throws if the thread set is top *)
+        let (lmust', l') = ConcDomain.ThreadSet.fold (fun tid (lmust, l) ->
+            let lmust',l' = G.thread (getg (V.thread tid)) in
+            (LMust.union lmust' lmust, L.join l l')
+          ) tids (lmust, l)
+        in
+        {st with priv = (w, lmust', l')}
+      )
+    )
     else (
-      (* elements throws if the thread set is top *)
-      let tids = ConcDomain.ThreadSet.elements tids in
-      match tids with
-      | [tid] ->
-        let lmust',l' = G.thread (getg (V.thread tid)) in
-        {st with priv = (w, LMust.union lmust' lmust, L.join l l')}
-      | _ ->
-        (* To match the paper more closely, one would have to join in the non-definite case too *)
-        (* Given how we handle lmust (for initialization), doing this might actually be beneficial given that it grows lmust *)
-        st
+      if ConcDomain.ThreadSet.is_top tids then
+        st (* TODO: why needed? *)
+      else (
+        (* elements throws if the thread set is top *)
+        let tids = ConcDomain.ThreadSet.elements tids in
+        match tids with
+        | [tid] ->
+          let lmust',l' = G.thread (getg (V.thread tid)) in
+          {st with priv = (w, LMust.union lmust' lmust, L.join l l')}
+        | _ ->
+          (* To match the paper more closely, one would have to join in the non-definite case too *)
+          (* Given how we handle lmust (for initialization), doing this might actually be beneficial given that it grows lmust *)
+          st
+      )
     )
 
   let thread_return ask getg sideg tid (st: apron_components_t) =

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -521,6 +521,7 @@ let invalidate_actions = [
     "down_trylock", readsAll;
     "up", readsAll;
     "ZSTD_customFree", frees [1]; (* only used with extraspecials *)
+    "__goblint_assume_join", readsAll;
   ]
 
 (* used by get_invalidate_action to make sure

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -59,8 +59,12 @@ struct
       | a when not (Queries.ES.is_bot a) -> Queries.ES.add e a
       | _ -> Queries.ES.singleton e
     in
+    if M.tracing then M.tracel "symb_locks" "get_all_locks exps %a = %a\n" d_plainexp e Queries.ES.pretty exps;
+    if M.tracing then M.tracel "symb_locks" "get_all_locks st = %a\n" D.pretty st;
     let add_locks x xs = PS.union (get_locks x st) xs in
-    Queries.ES.fold add_locks exps (PS.empty ())
+    let r = Queries.ES.fold add_locks exps (PS.empty ()) in
+    if M.tracing then M.tracel "symb_locks" "get_all_locks %a = %a\n" d_plainexp e PS.pretty r;
+    r
 
   let same_unknown_index (ask: Queries.ask) exp slocks =
     let uk_index_equal i1 i2 = ask.f (Queries.MustBeEqual (i1, i2)) in
@@ -148,6 +152,7 @@ struct
     *)
     let one_perelem (e,a,l) xs =
       (* ignore (printf "one_perelem (%a,%a,%a)\n" Exp.pretty e Exp.pretty a Exp.pretty l); *)
+      if M.tracing then M.tracel "symb_locks" "one_perelem (%a,%a,%a)\n" Exp.pretty e Exp.pretty a Exp.pretty l;
       match Exp.fold_offs (Exp.replace_base (dummyFunDec.svar,`NoOffset) e l) with
       | Some (v, o) ->
         (* ignore (printf "adding lock %s\n" l); *)

--- a/src/analyses/threadJoins.ml
+++ b/src/analyses/threadJoins.ml
@@ -49,7 +49,7 @@ struct
       let id = List.hd arglist in
       let threads = ctx.ask (Queries.EvalThread id) in
       if TIDs.is_top threads then
-        D.bot () (* consider everything joined, D is reversed so bot is All threads *)
+        ctx.local (* don't consider everything joined, because would be confusing to have All threads unsoundly joined due to imprecision *)
       else (
         (* elements throws if the thread set is top *)
         let threads = TIDs.elements threads in

--- a/src/analyses/threadJoins.ml
+++ b/src/analyses/threadJoins.ml
@@ -60,6 +60,13 @@ struct
       )
     | _ -> ctx.local
 
+  let threadspawn ctx lval f args fctx =
+    match ThreadId.get_current (Analyses.ask_of_ctx fctx) with
+    | `Lifted tid ->
+      D.remove tid ctx.local
+    | _ ->
+      ctx.local
+
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     match q with
     | Queries.MustJoinedThreads -> (ctx.local:ConcDomain.MustThreadSet.t) (* type annotation needed to avoid "would escape the scope of its equation" *)

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -521,6 +521,8 @@ struct
   let rec eq_set_clos e s =
     if M.tracing then M.traceli "var_eq" "eq_set_clos %a\n" d_plainexp e;
     let r = match e with
+    | BinOp ((PlusPI | IndexPI), e1, e2, _) ->
+      eq_set_clos e1 s (* TODO: what about e2? add to some Index offset to all? *)
     | SizeOf _
     | SizeOfE _
     | SizeOfStr _

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -315,7 +315,8 @@ struct
            | _ -> failwith "Unmatched pattern."
     in
     let r =
-      if Queries.LS.is_top bls || Queries.LS.mem (dummyFunDec.svar, `NoOffset) bls
+      if Cil.isConstant b then false
+      else if Queries.LS.is_top bls || Queries.LS.mem (dummyFunDec.svar, `NoOffset) bls
       then ((*Messages.warn "No PT-set: switching to types ";*) type_may_change_apt a )
       else Queries.LS.exists (lval_may_change_pt a) bls
     in
@@ -323,7 +324,9 @@ struct
           then (Messages.warn ~msg:("Kill " ^sprint 80 (Exp.pretty () a)^" because of "^sprint 80 (Exp.pretty () b)) (); r)
           else (Messages.warn ~msg:("Keep " ^sprint 80 (Exp.pretty () a)^" because of "^sprint 80 (Exp.pretty () b)) (); r)
           Messages.warn ~msg:(sprint 80 (Exp.pretty () b) ^" changed lvalues: "^sprint 80 (Queries.LS.pretty () bls)) ();
-    *)    r
+    *)
+    if M.tracing then M.tracel "var_eq" "may_change %a %a = %B\n" CilType.Exp.pretty b CilType.Exp.pretty a r;
+    r
 
   (* Remove elements, that would change if the given lval would change.*)
   let remove_exp ask (e:exp) (st:D.t) : D.t =

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -379,6 +379,12 @@ struct
           let st =
     *)  let lvt = unrollType @@ Cilfacade.typeOfLval lv in
     (*     Messages.warn ~msg:(sprint 80 (d_type () lvt)) (); *)
+    if M.tracing then (
+      M.tracel "var_eq" "add_eq is_global_var %a = %B\n" d_plainlval lv (is_global_var ask (Lval lv) = Some false);
+      M.tracel "var_eq" "add_eq interesting %a = %B\n" d_plainexp rv (Exp.interesting rv);
+      M.tracel "var_eq" "add_eq is_global_var %a = %B\n" d_plainexp rv (is_global_var ask rv = Some false);
+      M.tracel "var_eq" "add_eq type %a = %B\n" d_plainlval lv ((isArithmeticType lvt && match lvt with | TFloat _ -> false | _ -> true ) || isPointerType lvt);
+    );
     if is_global_var ask (Lval lv) = Some false
     && Exp.interesting rv
     && is_global_var ask rv = Some false

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -519,7 +519,8 @@ struct
       D.B.fold add es (Queries.ES.empty ())
 
   let rec eq_set_clos e s =
-    match e with
+    if M.tracing then M.traceli "var_eq" "eq_set_clos %a\n" d_plainexp e;
+    let r = match e with
     | SizeOf _
     | SizeOfE _
     | SizeOfStr _
@@ -541,6 +542,9 @@ struct
       Queries.ES.map (fun e -> CastE (t,e)) (eq_set_clos e s)
     | Question _ -> failwith "Logical operations should be compiled away by CIL."
     | _ -> failwith "Unmatched pattern."
+    in
+    if M.tracing then M.traceu "var_eq" "eq_set_clos %a = %a\n" d_plainexp e Queries.ES.pretty r;
+    r
 
 
   let query ctx (type a) (x: a Queries.t): a Queries.result =
@@ -550,6 +554,7 @@ struct
     | Queries.EqualSet e ->
       let r = eq_set_clos e ctx.local in
       (*          Messages.warn ~msg:("equset of "^(sprint 80 (d_exp () e))^" is "^(Queries.ES.short 80 r)) ();  *)
+      if M.tracing then M.tracel "var_eq" "equalset %a = %a\n" d_plainexp e Queries.ES.pretty r;
       r
     | _ -> Queries.Result.top x
 

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -12,6 +12,8 @@ struct
   (* TODO: what does interesting mean? *)
   let rec interesting x =
     match x with
+    | BinOp ((PlusPI | IndexPI), e1, e2, _) ->
+    interesting e1 (* TODO: what about e2? *)
     | SizeOf _
     | SizeOfE _
     | SizeOfStr _

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -12,7 +12,8 @@ struct
   (* TODO: what does interesting mean? *)
   let rec interesting x =
     match x with
-    (* TODO: handle IndexPI like var_eq eq_set_clos? *)
+    | AddrOf (Mem (BinOp (IndexPI, a, _i, _)), _os) ->
+      interesting a
     | SizeOf _
     | SizeOfE _
     | SizeOfStr _

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -1,6 +1,8 @@
 open Pretty
 open Cil
 
+module M = Messages
+
 module Exp =
 struct
   include CilType.Exp
@@ -331,6 +333,7 @@ struct
     List.rev el, fs
 
   let from_exps a l : t option =
+    if M.tracing then M.tracel "symb_locks" "from_exps %a (%s) %a (%s)\n" d_plainexp a (ees_to_str (toEl a)) d_plainexp l (ees_to_str (toEl l));
     let a, l = toEl a, toEl l in
     (* ignore (printf "from_exps:\n %s\n %s\n" (ees_to_str a) (ees_to_str l)); *)
     (*let rec fold_left2 f a xs ys =

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -301,12 +301,13 @@ struct
       | AlignOfE _
       | UnOp _
       | BinOp _
-      | StartOf _
       | Const _ -> raise NotSimpleEnough
       | Lval (Var v, os) -> EVar v :: conv_o os
       | Lval (Mem e, os) -> helper e @ [EDeref] @ conv_o os
       | AddrOf (Var v, os) -> EVar v :: conv_o os @ [EAddr]
       | AddrOf (Mem e, os) -> helper e @ [EDeref] @ conv_o os @ [EAddr]
+      | StartOf (Var v, os) -> EVar v :: conv_o os @ [EAddr]
+      | StartOf (Mem e, os) -> helper e @ [EDeref] @ conv_o os @ [EAddr]
       | CastE (_,e) -> helper e
       | Question _ -> failwith "Logical operations should be compiled away by CIL."
       | _ -> failwith "Unmatched pattern."

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -292,6 +292,8 @@ struct
     in
     let rec helper exp =
       match exp with
+      | BinOp ((PlusPI | IndexPI), e1, e2, _) ->
+        helper e1 (* TODO: what about e2? add to some Index offset to all? *)
       | SizeOf _
       | SizeOfE _
       | SizeOfStr _

--- a/src/cdomains/exp.ml
+++ b/src/cdomains/exp.ml
@@ -12,8 +12,7 @@ struct
   (* TODO: what does interesting mean? *)
   let rec interesting x =
     match x with
-    | BinOp ((PlusPI | IndexPI), e1, e2, _) ->
-    interesting e1 (* TODO: what about e2? *)
+    (* TODO: handle IndexPI like var_eq eq_set_clos? *)
     | SizeOf _
     | SizeOfE _
     | SizeOfStr _
@@ -294,8 +293,7 @@ struct
     in
     let rec helper exp =
       match exp with
-      | BinOp ((PlusPI | IndexPI), e1, e2, _) ->
-        helper e1 (* TODO: what about e2? add to some Index offset to all? *)
+      (* TODO: handle IndexPI like var_eq eq_set_clos? *)
       | SizeOf _
       | SizeOfE _
       | SizeOfStr _

--- a/src/cdomains/mHP.ml
+++ b/src/cdomains/mHP.ml
@@ -54,7 +54,7 @@ let exists_definitely_not_started_in_joined (current,created) other_joined =
 (** Must the thread with thread id other be already joined  *)
 let must_be_joined other joined =
   if ConcDomain.ThreadSet.is_top joined then
-    false
+    true (* top means all threads are joined, so [other] must be as well *)
   else
     List.mem other (ConcDomain.ThreadSet.elements joined)
 

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1136,6 +1136,20 @@
                 }
               },
               "additionalProperties": false
+            },
+            "read": {
+              "title": "sem.unknown_function.read",
+              "type": "object",
+              "properties": {
+                "args": {
+                  "title": "sem.unknown_function.read.args",
+                  "description":
+                    "Unknown function call reads arguments passed to it",
+                  "type": "boolean",
+                  "default": true
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/tests/regression/02-base/78-realloc-free.c
+++ b/tests/regression/02-base/78-realloc-free.c
@@ -21,7 +21,7 @@ void test1() {
 
 void* test2_f(void *arg) {
   int *p = arg;
-  *p = 1; // RACE!
+  *p = 1; // NORACE
   return NULL;
 }
 
@@ -29,7 +29,7 @@ void test2() {
   int *p = malloc(sizeof(int));
   pthread_t id;
   pthread_create(&id, NULL, test2_f, p);
-  realloc(p, sizeof(int)); // RACE!
+  realloc(p, sizeof(int)); // NORACE
 }
 
 void* test3_f(void *arg) {

--- a/tests/regression/06-symbeq/37-funloop_index.c
+++ b/tests/regression/06-symbeq/37-funloop_index.c
@@ -1,0 +1,36 @@
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+// copy of 06/02 with additional index accesses
+#include<pthread.h>
+#include<stdio.h>
+
+struct cache_entry {
+  int refs;
+  pthread_mutex_t refs_mutex;
+} cache[10];
+
+void cache_entry_addref(struct cache_entry *entry) {
+  pthread_mutex_lock(&entry->refs_mutex);
+  entry->refs++; // NORACE
+  (*entry).refs++; // NORACE
+  entry[0].refs++; // NORACE
+  pthread_mutex_unlock(&entry->refs_mutex);
+}
+
+void *t_fun(void *arg) {
+  int i;
+  for(i=0; i<10; i++)
+    cache_entry_addref(&cache[i]); // NORACE
+  return NULL;
+}
+
+int main () {
+  for (int i = 0; i < 10; i++)
+    pthread_mutex_init(&cache[i].refs_mutex, NULL);
+
+  int i;
+  pthread_t t1;
+  pthread_create(&t1, NULL, t_fun, NULL);
+  for(i=0; i<10; i++)
+    cache_entry_addref(&cache[i]); // NORACE
+  return 0;
+}

--- a/tests/regression/06-symbeq/37-funloop_index.c
+++ b/tests/regression/06-symbeq/37-funloop_index.c
@@ -10,9 +10,9 @@ struct cache_entry {
 
 void cache_entry_addref(struct cache_entry *entry) {
   pthread_mutex_lock(&entry->refs_mutex);
-  entry->refs++; // NORACE
-  (*entry).refs++; // NORACE
-  entry[0].refs++; // NORACE
+  entry->refs++; // TODO NORACE
+  (*entry).refs++; // TODO NORACE
+  entry[0].refs++; // TODO NORACE
   pthread_mutex_unlock(&entry->refs_mutex);
 }
 

--- a/tests/regression/06-symbeq/38-chrony-name2ipaddress.c
+++ b/tests/regression/06-symbeq/38-chrony-name2ipaddress.c
@@ -1,10 +1,11 @@
-// PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'" --set ana.activated[+] "'mallocFresh'" --set ana.malloc.wrappers '["Malloc"]' --disable sem.unknown_function.spawn --disable sem.unknown_function.invalidate.globals
+// PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'" --set ana.activated[+] "'mallocFresh'" --set ana.malloc.wrappers '["Malloc"]' --disable sem.unknown_function.spawn --disable sem.unknown_function.invalidate.globals --set pre.cppflags[+] -D_FORTIFY_SOURCE=2 --set pre.cppflags[+] -O3
 #include <stddef.h>
 #include <stdint.h>
 // #include <sys/types.h>
 // #include <sys/socket.h>
 #include <netdb.h>
 #include <pthread.h>
+#include <string.h>
 
 void *
 Malloc(size_t size)
@@ -39,6 +40,8 @@ typedef struct {
 #define IPADDR_INET4 1
 #define IPADDR_INET6 2
 #define IPADDR_ID 3
+
+#define FEAT_IPV6 1
 
 static int address_family = IPADDR_UNSPEC;
 

--- a/tests/regression/06-symbeq/38-chrony-name2ipaddress.c
+++ b/tests/regression/06-symbeq/38-chrony-name2ipaddress.c
@@ -1,0 +1,219 @@
+// PARAM: --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'" --set ana.activated[+] "'mallocFresh'" --set ana.malloc.wrappers '["Malloc"]' --disable sem.unknown_function.spawn --disable sem.unknown_function.invalidate.globals
+#include <stddef.h>
+#include <stdint.h>
+// #include <sys/types.h>
+// #include <sys/socket.h>
+#include <netdb.h>
+#include <pthread.h>
+
+void *
+Malloc(size_t size)
+{
+  void *r;
+
+  r = malloc(size);
+  // if (!r && size)
+  //   LOG_FATAL("Could not allocate memory");
+
+  return r;
+}
+
+typedef enum {
+  DNS_Success,
+  DNS_TryAgain,
+  DNS_Failure
+} DNS_Status;
+
+typedef struct {
+  union {
+    uint32_t in4;
+    uint8_t in6[16];
+    uint32_t id;
+  } addr;
+  uint16_t family;
+  uint16_t _pad;
+} IPAddr;
+
+#define DNS_MAX_ADDRESSES 16
+#define IPADDR_UNSPEC 0
+#define IPADDR_INET4 1
+#define IPADDR_INET6 2
+#define IPADDR_ID 3
+
+static int address_family = IPADDR_UNSPEC;
+
+int
+UTI_StringToIP(const char *addr, IPAddr *ip)
+{
+  struct in_addr in4;
+#ifdef FEAT_IPV6
+  struct in6_addr in6;
+#endif
+
+  if (inet_pton(AF_INET, addr, &in4) > 0) {
+    ip->family = IPADDR_INET4;
+    ip->_pad = 0;
+    ip->addr.in4 = ntohl(in4.s_addr);
+    return 1;
+  }
+
+#ifdef FEAT_IPV6
+  if (inet_pton(AF_INET6, addr, &in6) > 0) {
+    ip->family = IPADDR_INET6;
+    ip->_pad = 0;
+    memcpy(ip->addr.in6, in6.s6_addr, sizeof (ip->addr.in6));
+    return 1;
+  }
+#endif
+
+  return 0;
+}
+
+
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+
+DNS_Status
+DNS_Name2IPAddress(const char *name, IPAddr *ip_addrs, int max_addrs)
+{
+  struct addrinfo hints, *res, *ai;
+  int i, result;
+  IPAddr ip;
+
+  max_addrs = MIN(max_addrs, DNS_MAX_ADDRESSES);
+
+  for (i = 0; i < max_addrs; i++)
+    ip_addrs[i].family = IPADDR_UNSPEC;
+
+// #if 0
+  /* Avoid calling getaddrinfo() if the name is an IP address */
+  if (UTI_StringToIP(name, &ip)) {
+    if (address_family != IPADDR_UNSPEC && ip.family != address_family)
+      return DNS_Failure;
+    if (max_addrs >= 1)
+      ip_addrs[0] = ip;
+    return DNS_Success;
+  }
+
+  memset(&hints, 0, sizeof (hints));
+
+  switch (address_family) {
+    case IPADDR_INET4:
+      hints.ai_family = AF_INET;
+      break;
+#ifdef FEAT_IPV6
+    case IPADDR_INET6:
+      hints.ai_family = AF_INET6;
+      break;
+#endif
+    default:
+      hints.ai_family = AF_UNSPEC;
+  }
+  hints.ai_socktype = SOCK_DGRAM;
+
+  result = getaddrinfo(name, NULL, &hints, &res);
+
+  if (result) {
+#ifdef FORCE_DNSRETRY
+    return DNS_TryAgain;
+#else
+    return result == EAI_AGAIN ? DNS_TryAgain : DNS_Failure;
+#endif
+  }
+
+  for (ai = res, i = 0; i < max_addrs && ai != NULL; ai = ai->ai_next) {
+    switch (ai->ai_family) {
+      case AF_INET:
+        if (address_family != IPADDR_UNSPEC && address_family != IPADDR_INET4)
+          continue;
+        ip_addrs[i].family = IPADDR_INET4;
+        ip_addrs[i].addr.in4 = ntohl(((struct sockaddr_in *)ai->ai_addr)->sin_addr.s_addr);
+        i++;
+        break;
+#ifdef FEAT_IPV6
+      case AF_INET6:
+        if (address_family != IPADDR_UNSPEC && address_family != IPADDR_INET6)
+          continue;
+        /* Don't return an address that would lose a scope ID */
+        if (((struct sockaddr_in6 *)ai->ai_addr)->sin6_scope_id != 0)
+          continue;
+        ip_addrs[i].family = IPADDR_INET6;
+        memcpy(&ip_addrs[i].addr.in6, &((struct sockaddr_in6 *)ai->ai_addr)->sin6_addr.s6_addr,
+               sizeof (ip_addrs->addr.in6));
+        i++;
+        break;
+#endif
+    }
+  }
+
+  freeaddrinfo(res);
+// #endif
+
+  return !max_addrs || ip_addrs[0].family != IPADDR_UNSPEC ? DNS_Success : DNS_Failure;
+}
+
+struct DNS_Async_Instance {
+  const char *name;
+  DNS_Status status;
+  IPAddr addresses[DNS_MAX_ADDRESSES];
+  // DNS_NameResolveHandler handler;
+  // void *arg;
+  pthread_mutex_t mutex;
+
+  pthread_t thread;
+  // int pipe[2];
+};
+
+static pthread_mutex_t privops_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/* ================================================== */
+
+static void *
+start_resolving(void *anything)
+{
+  struct DNS_Async_Instance *inst = (struct DNS_Async_Instance *)anything;
+
+  pthread_mutex_lock(&inst->mutex);
+  inst->status = DNS_Name2IPAddress(inst->name, inst->addresses, DNS_MAX_ADDRESSES);
+  pthread_mutex_unlock(&inst->mutex);
+
+  /* Notify the main thread that the result is ready */
+  // if (write(inst->pipe[1], "", 1) < 0)
+  //   ;
+
+  return NULL;
+}
+
+
+#define MallocNew(T) ((T *) Malloc(sizeof(T)))
+
+void
+DNS_Name2IPAddressAsync(const char *name)
+{
+  struct DNS_Async_Instance *inst;
+
+  inst = MallocNew(struct DNS_Async_Instance);
+  inst->name = name;
+  // inst->handler = handler;
+  // inst->arg = anything;
+  inst->status = DNS_Failure;
+  pthread_mutex_init(&inst->mutex, NULL);
+
+  // if (pipe(inst->pipe)) {
+  //   LOG_FATAL("pipe() failed");
+  // }
+
+  // UTI_FdSetCloexec(inst->pipe[0]);
+  // UTI_FdSetCloexec(inst->pipe[1]);
+
+  if (pthread_create(&inst->thread, NULL, start_resolving, inst)) {
+    // LOG_FATAL("pthread_create() failed");
+  }
+
+  // SCH_AddFileHandler(inst->pipe[0], SCH_FILE_INPUT, end_resolving, inst);
+}
+
+int main() {
+  DNS_Name2IPAddressAsync("foo");
+  DNS_Name2IPAddressAsync("bar");
+  return 0;
+}

--- a/tests/regression/06-symbeq/39-funloop_index_bad.c
+++ b/tests/regression/06-symbeq/39-funloop_index_bad.c
@@ -10,9 +10,9 @@ struct cache_entry {
 
 void cache_entry_addref(struct cache_entry *entry) {
   pthread_mutex_lock(&entry->refs_mutex);
-  entry->refs++; // NORACE
-  (*entry).refs++; // NORACE
-  entry[1].refs++; // RACE
+  entry->refs++; // RACE!
+  (*entry).refs++; // RACE!
+  entry[1].refs++; // RACE!
   pthread_mutex_unlock(&entry->refs_mutex);
 }
 

--- a/tests/regression/06-symbeq/39-funloop_index_bad.c
+++ b/tests/regression/06-symbeq/39-funloop_index_bad.c
@@ -1,0 +1,36 @@
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
+// copy of 06/02 with additional index accesses (that are wrong)
+#include<pthread.h>
+#include<stdio.h>
+
+struct cache_entry {
+  int refs;
+  pthread_mutex_t refs_mutex;
+} cache[10];
+
+void cache_entry_addref(struct cache_entry *entry) {
+  pthread_mutex_lock(&entry->refs_mutex);
+  entry->refs++; // NORACE
+  (*entry).refs++; // NORACE
+  entry[1].refs++; // RACE
+  pthread_mutex_unlock(&entry->refs_mutex);
+}
+
+void *t_fun(void *arg) {
+  int i;
+  for(i=0; i<9; i++)
+    cache_entry_addref(&cache[i]); // NORACE
+  return NULL;
+}
+
+int main () {
+  for (int i = 0; i < 10; i++)
+    pthread_mutex_init(&cache[i].refs_mutex, NULL);
+
+  int i;
+  pthread_t t1;
+  pthread_create(&t1, NULL, t_fun, NULL);
+  for(i=0; i<9; i++)
+    cache_entry_addref(&cache[i]); // NORACE
+  return 0;
+}

--- a/tests/regression/46-apron2/03-other-assume.c
+++ b/tests/regression/46-apron2/03-other-assume.c
@@ -1,0 +1,38 @@
+//PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+#include <pthread.h>
+#include <assert.h>
+
+int g = 10;
+int h = 10;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+void *t_benign(void *arg) {
+  pthread_t id2;
+  pthread_create(&id2, NULL, t_fun, NULL);
+  __goblint_assume_join(id2, NULL);
+  // t_fun should be in here
+
+  g = 7;
+
+  return NULL;
+}
+
+int main(void) {
+  int t;
+
+  pthread_t id2[10];
+  for(int i =0; i < 10;i++) {
+    pthread_create(&id2[i], NULL, t_benign, NULL);
+  }
+
+  __goblint_assume_join(id2[2]);
+  // t_benign and t_fun should be in here
+
+  assert(g==h); //FAIL
+
+  return 0;
+}

--- a/tests/regression/46-apron2/03-other-assume.c
+++ b/tests/regression/46-apron2/03-other-assume.c
@@ -1,4 +1,4 @@
-//PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/46-apron2/04-other-assume-inprec.c
+++ b/tests/regression/46-apron2/04-other-assume-inprec.c
@@ -1,0 +1,30 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+#include <pthread.h>
+#include <assert.h>
+
+int g = 10;
+int h = 10;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  g = 7;
+  return NULL;
+}
+
+int main(void) {
+  int t;
+
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_join(id,NULL);
+
+  g = h;
+  assert(g == h);
+
+  // __goblint_assume_join for something Goblint knows is joined should not worsen precision
+  __goblint_assume_join(id);
+
+  assert(g == h);
+
+  return 0;
+}

--- a/tests/regression/51-threadjoins/03-other-assume.c
+++ b/tests/regression/51-threadjoins/03-other-assume.c
@@ -1,0 +1,34 @@
+//PARAM: --set ana.activated[+] threadJoins
+#include <pthread.h>
+#include <assert.h>
+
+int g = 10;
+int h = 10;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+void *t_benign(void *arg) {
+  pthread_t id2;
+  pthread_create(&id2, NULL, t_fun, NULL);
+  __goblint_assume_join(id2, NULL);
+  // t_fun should be in here
+  return NULL;
+}
+
+int main(void) {
+  int t;
+
+  pthread_t id2[10];
+  for(int i =0; i < 10;i++) {
+  pthread_create(&id2[i], NULL, t_benign, NULL);
+  }
+
+  __goblint_assume_join(id2[2]);
+
+  // t_benign and t_fun should be in here
+
+  return 0;
+}

--- a/tests/regression/51-threadjoins/04-assume-recreate.c
+++ b/tests/regression/51-threadjoins/04-assume-recreate.c
@@ -1,0 +1,23 @@
+//PARAM: --set ana.activated[+] threadJoins --disable ana.thread.include-node --set ana.thread.domain plain
+#include <pthread.h>
+#include <assert.h>
+
+int g = 0;
+
+void *t_fun(void *arg) {
+  g++; // RACE!
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  __goblint_assume_join(id); // should add to must-joined
+
+  pthread_create(&id, NULL, t_fun, NULL); // should remove from must-joined again
+
+  g++; // RACE!
+
+  return 0;
+}

--- a/tests/regression/51-threadjoins/05-assume-unknown.c
+++ b/tests/regression/51-threadjoins/05-assume-unknown.c
@@ -13,8 +13,11 @@ int main() {
   pthread_t id, id2;
   pthread_create(&id, NULL, t_fun, NULL);
 
-  __goblint_assume_join(id2); // joining unknown thread ID, shouldn't make joined set All threads
+  __goblint_assume_join(id2); // WARN joining unknown thread ID, make joined set All threads
 
+  g++; // NORACE
+
+  pthread_create(&id, NULL, t_fun, NULL); // WARN make joined set different from All threads
   g++; // RACE!
 
   return 0;

--- a/tests/regression/51-threadjoins/05-assume-unknown.c
+++ b/tests/regression/51-threadjoins/05-assume-unknown.c
@@ -1,0 +1,21 @@
+//PARAM: --set ana.activated[+] threadJoins
+#include <pthread.h>
+#include <assert.h>
+
+int g = 0;
+
+void *t_fun(void *arg) {
+  g++; // RACE!
+  return NULL;
+}
+
+int main() {
+  pthread_t id, id2;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  __goblint_assume_join(id2); // joining unknown thread ID, shouldn't make joined set All threads
+
+  g++; // RACE!
+
+  return 0;
+}


### PR DESCRIPTION
### Changes
1. Fix var_eq and symb_locks such that they are not confused about `IndexPI` expressions.
2. Add `__goblint_assume_join` special Goblint builtin to threadJoins analysis to annotate thread being joined even if Goblint doesn't consider it unique. This can be used as an annotation after a `pthread_join` loop.
3. Make `realloc` argument read and free accesses non-transitive (we really need #719).
4. Add option `sem.unknown_function.read.args` for also ignoring read accesses from unknown function arguments (`sem.unknown_function.invalidate.args` from #707 only concerns invalidation, i.e. writing).