### PR TITLE
Hide mutex structure contents and standard globals in base analysis

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -429,6 +429,7 @@ struct
     | `Struct s -> ValueDomain.Structs.fold (fun k v acc -> AD.join (reachable_from_value ask gs st v t description) acc) s empty
     | `Int _ -> empty
     | `Thread _ -> empty (* thread IDs are abstract and nothing known can be reached from them *)
+    | `Mutex -> empty (* mutexes are abstract and nothing known can be reached from them *)
 
   (* Get the list of addresses accessable immediately from a given address, thus
    * all pointers within a structure should be considered, but we don't follow
@@ -567,6 +568,7 @@ struct
           ValueDomain.Structs.fold f s (empty, TS.bot (), false)
         | `Int _ -> (empty, TS.bot (), false)
         | `Thread _ -> (empty, TS.bot (), false) (* TODO: is this right? *)
+        | `Mutex -> (empty, TS.bot (), false) (* TODO: is this right? *)
       in
       reachable_from_value (get (Analyses.ask_of_ctx ctx) ctx.global ctx.local adr None)
     in

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -854,6 +854,7 @@ struct
       let mu = function `Blob (`Blob (y, s', orig), s, orig2) -> `Blob (y, ID.join s s',orig) | x -> x in
       let r =
       match x, offs with
+      | _, _ when is_mutex_type t -> `Top (* hide mutex structure contents, not updated anyway *)
       | `Blob (x,s,orig), `Index (_,ofs) ->
         begin
           let l', o' = shift_one_over l o in

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -133,7 +133,7 @@ struct
 
   let rec init_value (t: typ): t = (* top_value is not used here because structs, blob etc will not contain the right members *)
     match t with
-    | t when is_mutex_type t -> `Top
+    | t when is_mutex_type t -> `Bot (* use `Bot instead of `Top to avoid unknown value escape warnings *)
     | TInt (ik,_) -> `Int (ID.top_of ik)
     | TPtr _ -> `Address AD.top_ptr
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> init_value fd.ftype) ci)
@@ -854,7 +854,8 @@ struct
       let mu = function `Blob (`Blob (y, s', orig), s, orig2) -> `Blob (y, ID.join s s',orig) | x -> x in
       let r =
       match x, offs with
-      | _, _ when is_mutex_type t -> `Top (* hide mutex structure contents, not updated anyway *)
+      | _, _ when is_mutex_type t -> (* hide mutex structure contents, not updated anyway *)
+        `Bot (* use `Bot instead of `Top to avoid unknown value escape warnings *)
       | `Blob (x,s,orig), `Index (_,ofs) ->
         begin
           let l', o' = shift_one_over l o in

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -131,7 +131,7 @@ struct
     | `Array x -> CArrays.is_bot x
     | `Blob x -> Blobs.is_bot x
     | `Thread x -> Threads.is_bot x
-    | `Mutex -> false
+    | `Mutex -> true
     | `Bot -> true
     | `Top -> false
 
@@ -175,7 +175,7 @@ struct
     | `Array x -> CArrays.is_top x
     | `Blob x -> Blobs.is_top x
     | `Thread x -> Threads.is_top x
-    | `Mutex -> false
+    | `Mutex -> true
     | `Top -> true
     | `Bot -> false
 

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1367,7 +1367,7 @@
         },
         "hide-std-globals": {
           "title": "exp.hide-std-globals",
-          "description": "Hide standard extern globals from cluttering local states, e.g. stdout.",
+          "description": "Hide standard extern globals (e.g. `stdout`) from cluttering local states.",
           "type": "boolean",
           "default": true
         }

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1364,6 +1364,12 @@
             "Sets the unrolling factor for the loopUnrollingVisitor.",
           "type": "integer",
           "default": 0
+        },
+        "hide-std-globals": {
+          "title": "exp.hide-std-globals",
+          "description": "Hide standard extern globals from cluttering local states, e.g. stdout.",
+          "type": "boolean",
+          "default": true
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Split off from https://github.com/goblint/analyzer/pull/745#discussion_r883347346.

@michael-schwarz:
> I'm a bit worried about having `Bot` here, as it might make some comparisons of the struct members return false, potentially making both branches unreachable.

@sim642:
> Maybe a safer alternative would be like a `Struct` with no fields? Of course introducing a new `Mutex` variant to the value domain would be the safest, but I suspect it requires similar hacks as for `Thread` since there's some unknown structure still being manipulated (and that structure probably is different for OSX).

---

This is to avoid large amounts of invariants about `pthread_mutex_t` contents, which are actually all incorrect, since base analysis never updates them from their initialized values. Hiding them from elsewhere (e.g. g2html) would improve readability as well, but so far such mutex type ignoring was only done for accesses, not base.

Additionally, it (optionally) hides unknown globals from standard headers, e.g. `__tzname`, etc, such that they wouldn't always clutter local states.