### PR TITLE
Remove `inthack` and fix i-lock star display

### DIFF
--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -1,4 +1,6 @@
-(** Symbolic lock-sets for use in per-element patterns. *)
+(** Symbolic lock-sets for use in per-element patterns.
+
+    See Section 5 and 6 in https://dl.acm.org/doi/10.1145/2970276.2970337 for more details. *)
 
 module LF = LibraryFunctions
 module LP = SymbLocksDomain.LockingPattern

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -105,6 +105,16 @@ struct
     | _ ->
       ctx.local
 
+  module ILock =
+  struct
+    module Idx =
+    struct
+      include ValueDomain.IndexDomain
+    end
+
+    include Lval.Normal (Idx)
+  end
+
 
   let rec conv_const_offset x =
     match x with
@@ -117,11 +127,11 @@ struct
   module A =
   struct
     module E = struct
-      include Printable.Either (CilType.Offset) (ValueDomain.Addr)
+      include Printable.Either (CilType.Offset) (ILock)
 
       let pretty () = function
         | `Left o -> Pretty.dprintf "p-lock:%a" (d_offset (text "*")) o
-        | `Right addr -> Pretty.dprintf "i-lock:%a" ValueDomain.Addr.pretty addr
+        | `Right addr -> Pretty.dprintf "i-lock:%a" ILock.pretty addr
 
       include Printable.SimplePretty (
         struct
@@ -164,7 +174,7 @@ struct
     let one_lockstep (_,a,m) xs =
       match m with
       | AddrOf (Var v,o) ->
-        let lock = ValueDomain.Addr.from_var_offset (v, conv_const_offset o) in
+        let lock = ILock.from_var_offset (v, conv_const_offset o) in
         A.add (`Right lock) xs
       | _ ->
         Messages.warn "Internal error: found a strange lockstep pattern.";

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -138,7 +138,7 @@ struct
   let rec conv_const_offset x =
     match x with
     | NoOffset    -> `NoOffset
-    | Index (Const  (CInt (i,ikind,s)),o) when Z.to_int64 i = GU.inthack -> `Index (ILock.Idx.Star, conv_const_offset o)
+    | Index (i,o) when Exp.(equal i star) -> `Index (ILock.Idx.Star, conv_const_offset o)
     | Index (_,o) -> `Index (ILock.Idx.Unknown, conv_const_offset o)
     | Field (f,o) -> `Field (f, conv_const_offset o)
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -930,7 +930,7 @@ struct
   let bot () = raise Error
   let top_of ik = top ()
   let bot_of ik = bot ()
-  let show (x: Ints_t.t) = if (Ints_t.to_int64 x) = GU.inthack then "*" else Ints_t.to_string x
+  let show (x: Ints_t.t) = Ints_t.to_string x
 
   include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
   (* is_top and is_bot are never called, but if they were, the Std impl would raise their exception, so we overwrite them: *)

--- a/src/cdomains/symbLocksDomain.ml
+++ b/src/cdomains/symbLocksDomain.ml
@@ -274,14 +274,17 @@ struct
   let printXml f (x,y,z) = BatPrintf.fprintf f "<value>\n<map>\n<key>1</key>\n%a<key>2</key>\n%a<key>3</key>\n%a</map>\n</value>\n" Exp.printXml x Exp.printXml y Exp.printXml z
 end
 
+(** Index-based symbolic lock *)
 module ILock =
 struct
+
+  (** Index in index-based symbolic lock *)
   module Idx =
   struct
     include Printable.Std
     type t =
-      | Unknown
-      | Star
+      | Unknown (** Unknown index. Mutex index not synchronized with access index. *)
+      | Star (** Star index. Mutex index synchronized with access index. Corresponds to star_0 in ASE16 paper, multiple star indices not supported in this implementation. *)
     [@@deriving eq, ord, hash]
     let name () = "i-lock index"
 

--- a/src/cdomains/symbLocksDomain.ml
+++ b/src/cdomains/symbLocksDomain.ml
@@ -111,6 +111,8 @@ struct
     | Index (i,o) -> isConstant i && conc o
     | Field (_,o) -> conc o
 
+  let star = Lval (Cil.var (Goblintutil.create_var (makeGlobalVar "*" intType)))
+
   let rec one_unknown_array_index exp =
     let rec separate_fields_index o =
       match o with
@@ -121,7 +123,6 @@ struct
         | Some (osf, ie,o) -> Some ((fun o -> Field (f,o)), ie, o)
         | x -> x
     in
-    let star = kinteger64 IInt Goblintutil.inthack in
     match exp with
     | Lval (Mem (Lval (Var v, io)),o) when conc o ->
       begin match separate_fields_index io with

--- a/src/util/goblintutil.ml
+++ b/src/util/goblintutil.ml
@@ -14,9 +14,6 @@ let should_warn = ref false
 (** Whether signed overflow or underflow happened *)
 let svcomp_may_overflow = ref false
 
-(** hack to use a special integer to denote synchronized array-based locking *)
-let inthack = Int64.of_int (-19012009) (* TODO do we still need this? *)
-
 (** The file where everything is output *)
 let out = ref stdout
 


### PR DESCRIPTION
For a long while now, the i-lock star (denoting symbolic index-based locking) hasn't been nicely printed. For example, the warning for the website example shows `def_exc:-19012009` as the index:
```
[Warning][Race] Memory location data[?]@tests/regression/05-lval_ls/18-website.c:4:5-4:13 (race with conf. 110):
  write with [symblock:{i-lock:mutexes[def_exc:-19012009]}, mhp:{tid=[main, t_fun@tests/regression/05-lval_ls/18-website.c:25:3-25:40]}, lock:{mutexes[def_exc:3]}, thread:[main, t_fun@tests/regression/05-lval_ls/18-website.c:25:3-25:40]] (conf. 110)  (exp: & data[i]) (tests/regression/05-lval_ls/18-website.c:9:3-9:12)
```
After this PR, this is fixed to display the indented and more user-friendly `*` in its place, as it was originally intended:
```
[Warning][Race] Memory location data[?]@tests/regression/05-lval_ls/18-website.c:4:5-4:13 (race with conf. 110):
  write with [symblock:{i-lock:mutexes[*]}, mhp:{tid=[main, t_fun@tests/regression/05-lval_ls/18-website.c:25:3-25:40]}, lock:{mutexes[def_exc:3]}, thread:[main, t_fun@tests/regression/05-lval_ls/18-website.c:25:3-25:40]] (conf. 110)  (exp: & data[i]) (tests/regression/05-lval_ls/18-website.c:9:3-9:12)
```

This removes the global `inthack` altogether and changes the `Printable` used for those i-lock accesses to use a custom implementation that explicitly only has unknown and star indices in offsets. During the expression transformation, `star` is no longer an integer constant with `inthack` value, but rather has a special `varinfo`, which only exists in expressions very locally in the symb_locks analysis.