### PR TITLE
Add general expression threshold widening to Apron

### DIFF
--- a/src/util/wideningThresholds.ml
+++ b/src/util/wideningThresholds.ml
@@ -31,5 +31,43 @@ let thresholds () =
 let thresholds_incl_mul2 () =
   snd @@ ResettableLazy.force widening_thresholds
 
+module EH = BatHashtbl.Make (CilType.Exp)
+
+class extractInvariantsVisitor (exps) = object
+  inherit nopCilVisitor
+
+  method! vinst (i: instr) =
+    match i with
+    | Call (_, Lval (Var f, NoOffset), args, _, _) ->
+      (* TODO: dependency cycle with LibraryFunctions somehow... *)
+      (* begin match LibraryFunctions.classify f.vname args with
+        | `Assert e ->
+          EH.replace exps e ();
+          DoChildren
+        | _ ->
+          DoChildren
+      end *)
+      begin match f.vname, args with
+        | "assert", [e] ->
+          EH.replace exps e ();
+          DoChildren
+        | _, _ ->
+          DoChildren
+      end
+    | _ ->
+      DoChildren
+
+  method! vstmt (s: stmt) =
+    DoChildren
+end
+
+let exps = ResettableLazy.from_fun (fun () ->
+    let exps = EH.create 100 in
+    let visitor = new extractInvariantsVisitor exps in
+    visitCilFileSameGlobals visitor !Cilfacade.current_file;
+    EH.keys exps |> BatList.of_enum
+  )
+
 let reset_lazy () =
-  ResettableLazy.reset widening_thresholds
+  ResettableLazy.reset widening_thresholds;
+  ResettableLazy.reset exps

--- a/src/util/wideningThresholds.ml
+++ b/src/util/wideningThresholds.ml
@@ -58,7 +58,13 @@ class extractInvariantsVisitor (exps) = object
       DoChildren
 
   method! vstmt (s: stmt) =
-    DoChildren
+    match s.skind with
+    | If (e, _, _, _, _)
+    | Switch (e, _, _, _, _) ->
+      EH.replace exps e ();
+      DoChildren
+    | _ ->
+      DoChildren
 end
 
 let exps = ResettableLazy.from_fun (fun () ->

--- a/src/util/wideningThresholds.mli
+++ b/src/util/wideningThresholds.mli
@@ -1,3 +1,6 @@
 val thresholds : unit -> Z.t list
 val thresholds_incl_mul2 : unit -> Z.t list
+
+val exps: Cil.exp list ResettableLazy.t
+
 val reset_lazy : unit -> unit

--- a/tests/regression/36-apron/57-vectorsize-lazy-downsize.c
+++ b/tests/regression/36-apron/57-vectorsize-lazy-downsize.c
@@ -1,5 +1,5 @@
-// SKIP PARAM: --set ana.activated[+] apron --enable ana.sv-comp.functions --set ana.apron.privatization mutex-meet-tid --set ana.path_sens[+] threadflag --set ana.apron.domain polyhedra
-// TODO: this requires "used >= capacity - used - 1" as widening threshold to succeed, otherwise that extra lazy downsize branch causes additional widening that loses the constraint
+// SKIP PARAM: --set ana.activated[+] apron --enable ana.sv-comp.functions --set ana.apron.privatization mutex-meet-tid --set ana.path_sens[+] threadflag --set ana.apron.domain polyhedra --enable ana.apron.threshold_widening
+// this requires "used >= capacity - used - 1" as widening threshold to succeed, otherwise that extra lazy downsize branch causes additional widening that loses the constraint
 #include <pthread.h>
 #include <assert.h>
 #include <limits.h>
@@ -22,9 +22,9 @@ void remove() {
     pthread_mutex_lock(&C);
     assert(used >= 0);
     assert(capacity >= 1);
-    assert(capacity <= MAX_CAPACITY); // TODO
+    assert(capacity <= MAX_CAPACITY);
     assert(used <= capacity);
-    assert(used >= capacity - used - 1); // TODO: 2 * used >= capacity - 1, but without overflow in *
+    assert(used >= capacity - used - 1); // 2 * used >= capacity - 1, but without overflow in *
 
     if (amount <= used) {
       used -= amount;
@@ -42,9 +42,9 @@ void remove() {
 
     assert(used >= 0);
     assert(capacity >= 1);
-    assert(capacity <= MAX_CAPACITY); // TODO
+    assert(capacity <= MAX_CAPACITY);
     assert(used <= capacity);
-    assert(used >= capacity - used - 1); // TODO: 2 * used >= capacity - 1, but without overflow in *
+    assert(used >= capacity - used - 1); // 2 * used >= capacity - 1, but without overflow in *
     pthread_mutex_unlock(&C);
     pthread_mutex_unlock(&U);
   }
@@ -58,9 +58,9 @@ void append() {
     pthread_mutex_lock(&C);
     assert(used >= 0);
     assert(capacity >= 1);
-    assert(capacity <= MAX_CAPACITY); // TODO
+    assert(capacity <= MAX_CAPACITY);
     assert(used <= capacity);
-    assert(used >= capacity - used - 1); // TODO: 2 * used >= capacity - 1, but without overflow in *
+    assert(used >= capacity - used - 1); // 2 * used >= capacity - 1, but without overflow in *
 
     if (used <= MAX_CAPACITY - amount) { // used + amount <= MAX_CAPACITY, but without overflow in +
       int new_used = used + amount;
@@ -73,9 +73,9 @@ void append() {
 
     assert(used >= 0);
     assert(capacity >= 1);
-    assert(capacity <= MAX_CAPACITY); // TODO
+    assert(capacity <= MAX_CAPACITY);
     assert(used <= capacity);
-    assert(used >= capacity - used - 1); // TODO: 2 * used >= capacity - 1, but without overflow in *
+    assert(used >= capacity - used - 1); // 2 * used >= capacity - 1, but without overflow in *
     pthread_mutex_unlock(&C);
     pthread_mutex_unlock(&U);
   }
@@ -108,9 +108,9 @@ int main() {
     pthread_mutex_lock(&C);
     assert(used >= 0);
     assert(capacity >= 1);
-    assert(capacity <= MAX_CAPACITY); // TODO
+    assert(capacity <= MAX_CAPACITY);
     assert(used <= capacity);
-    assert(used >= capacity - used - 1); // TODO: 2 * used >= capacity - 1, but without overflow in *
+    assert(used >= capacity - used - 1); // 2 * used >= capacity - 1, but without overflow in *
     pthread_mutex_unlock(&C);
     pthread_mutex_unlock(&U);
   }


### PR DESCRIPTION
Initially the idea was to use `Abstract1.widening_threshold` and provide a list on threshold constraints if a non-octagon domain is used and widening thresholds are desired. That function requires `Lincons1`-s, while we can convert CIL expressions to `Tcons1`-s and Apron doesn't expose to OCaml any function to do linearization.
Hence this now implements the generic algorithm behind `widening_threshold` but on `Tcons1` instead: every threshold constraint, which holds in the second argument of `widen`, is re-asserted in the `widen` result.

The candidate threshold expression collecting is as naïve as for octagon threshold values: every expression in `if` conditions and `assert` arguments is collected.
Since in 36-apron/57-vectorsize-lazy-downsize the widening happens on global program variables in the global constraint variable, any function-scoped candidate threshold collecting doesn't suffice.