### PR TITLE
Add `LOr` eval to base for address and enum set validation

### DIFF
--- a/scripts/update_suite.rb
+++ b/scripts/update_suite.rb
@@ -156,8 +156,12 @@ class Tests
                     when /Assertion .* will fail/    then "fail"
                     when /Assertion .* will succeed/ then "success"
                     when /Assertion .* is unknown/   then "unknown"
+                    when /invariant confirmed/       then "success"
+                    when /invariant unconfirmed/     then "unknown"
+                    when /invariant refuted/         then "fail"
                     when /^\[Warning\]/              then "warn"
                     when /^\[Error\]/                then "warn"
+                    when /^\[Success\]/              then "success"
                     when /\[Debug\]/                 then next # debug "warnings" shouldn't count as other warnings (against NOWARN)
                     when /^  on line \d+ $/          then next # dead line warnings shouldn't count (used for unreachability with NOWARN)
                     when /^  on lines \d+..\d+ $/    then next # dead line warnings shouldn't count (used for unreachability with NOWARN)
@@ -192,7 +196,7 @@ class Tests
         check.call warnings[idx] == type
       when "nowarn"
         check.call warnings[idx].nil?
-      when "assert"
+      when "assert", "success"
         check.call warnings[idx] == "success"
       when "norace"
         check.call warnings[idx] != "race"
@@ -285,6 +289,12 @@ class Project
         tests[i] = if obj =~ /NODEADLOCK/ then "nodeadlock" else "deadlock" end
       elsif obj =~ /WARN/ then
         tests[i] = if obj =~ /NOWARN/ then "nowarn" else "warn" end
+      elsif obj =~ /SUCCESS/ then
+        tests[i] = "success"
+      elsif obj =~ /FAIL/ then
+        tests[i] = "fail"
+      elsif obj =~ /UNKNOWN/ then
+        tests[i] = "unknown"
       elsif obj =~ /assert.*\(/ then
         if obj =~ /FAIL/ then
           tests[i] = "fail"

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -828,8 +828,7 @@ struct
             let definite_ad = to_definite_ad vs in
             if AD.leq a definite_ad then (* other sides cover common address *)
               Some (`Int (ID.of_bool ik true))
-            else if AD.is_empty (AD.meet a definite_ad) then
-              Some (`Int (ID.of_bool ik false))
+            (* TODO: detect disjoint cases using may *)
             else
               None
           | `Int i ->
@@ -848,8 +847,7 @@ struct
             let int_set = to_int_set vs in
             if BISet.leq incl_set int_set then (* other sides cover common int *)
               Some (`Int (ID.of_bool ik true))
-            else if BISet.disjoint incl_set int_set then
-              Some (`Int (ID.of_bool ik false))
+            (* TODO: detect disjoint cases using may *)
             else
               None
           | _ ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -828,8 +828,7 @@ struct
             let definite_ad = to_definite_ad vs in
             if AD.leq a definite_ad then (* other sides cover common address *)
               Some (`Int (ID.of_bool ik true))
-            (* TODO: detect disjoint cases using may *)
-            else
+            else (* TODO: detect disjoint cases using may: https://github.com/goblint/analyzer/pull/757#discussion_r898105918 *)
               None
           | `Int i ->
             let module BISet = IntDomain.BISet in
@@ -847,8 +846,7 @@ struct
             let int_set = to_int_set vs in
             if BISet.leq incl_set int_set then (* other sides cover common int *)
               Some (`Int (ID.of_bool ik true))
-            (* TODO: detect disjoint cases using may *)
-            else
+            else (* TODO: detect disjoint cases using may: https://github.com/goblint/analyzer/pull/757#discussion_r898105918 *)
               None
           | _ ->
             None

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -338,6 +338,8 @@ module Size : sig
   val bits            : Cil.ikind -> int * int
 end
 
+module BISet: SetDomain.S with type elt = Z.t
+
 exception ArithmeticOnIntegerBot of string
 
 exception Unknown

--- a/tests/regression/01-cpa/33-asserts.c
+++ b/tests/regression/01-cpa/33-asserts.c
@@ -10,30 +10,30 @@ extern void __goblint_unknown(void*);
 
 int main(){
   int i, j, k, n;
-  
+
   n=0;
   assert(n==0); // SUCCESS
-  
-  unknown(&i);   
-  assert(i==8); // UNKNOWN 
+
+  unknown(&i);
+  assert(i==8); // UNKNOWN
   assert(i==8); // SUCCESS
-  
+
   j=3;
   check(j==3); // assert
 
-  unknown(&j);   
+  unknown(&j);
   check(j==6); // assert UNKNOWN
   check(j==6); // assert UNKNOWN
-  
+
   unknown(&k);
-  commit(k==4); // assert SUCCESS
+  commit(k==4); // TODO? assert SUCCESS
   check(k==4);  // assert SUCCESS
-  
+
   unknown(&k);
-  commit(k+1==n); // FAIL
-  
-  commit(n==5);  // NOWARN
+  commit(k+1==n); // TODO? FAIL
+
+  commit(n==5);  // TODO? NOWARN
   assert(0);     // NOWARN
-  
+
   return 0;
 }

--- a/tests/regression/56-witness/01-base-lor-enums.c
+++ b/tests/regression/56-witness/01-base-lor-enums.c
@@ -1,0 +1,33 @@
+// PARAM: --enable ana.int.enums --set witness.yaml.validate 01-base-lor-enums.yml
+
+int main() {
+  int r; // rand
+  int x;
+  switch (r) {
+    case 0:
+      x = 1;
+      break;
+    case 1:
+      x = 3;
+      break;
+    default:
+      x = 6;
+      break;
+  }
+  ; // SUCCESS (witness)
+  ; // UNKNOWN (witness)
+
+  int y;
+  switch (r) {
+    case 0:
+      y = 11;
+      break;
+    default:
+      y = x;
+      break;
+  }
+  ; // UNKNOWN (witness)
+  ; // SUCCESS (witness)
+  ; // UNKNOWN (witness)
+  return 0;
+}

--- a/tests/regression/56-witness/01-base-lor-enums.c
+++ b/tests/regression/56-witness/01-base-lor-enums.c
@@ -15,7 +15,7 @@ int main() {
       break;
   }
   ; // SUCCESS (witness)
-  ; // UNKNOWN (witness)
+  ; // UNKNOWN! (witness)
 
   int y;
   switch (r) {
@@ -28,6 +28,6 @@ int main() {
   }
   ; // UNKNOWN (witness)
   ; // SUCCESS (witness)
-  ; // UNKNOWN (witness)
+  ; // UNKNOWN! (witness)
   return 0;
 }

--- a/tests/regression/56-witness/01-base-lor-enums.yml
+++ b/tests/regression/56-witness/01-base-lor-enums.yml
@@ -1,0 +1,140 @@
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: e5802c77-d0ac-4f91-a0ac-c97ba97697d5
+    creation_time: 2022-06-16T06:37:52Z
+    producer:
+      name: Goblint
+      version: heads/base-eval-lor-0-g5a1ac0905-dirty
+      command_line: '''./goblint'' ''--enable'' ''dbg.debug'' ''--enable'' ''dbg.regression''
+        ''--html'' ''--enable'' ''ana.int.enums'' ''--enable'' ''witness.yaml.enabled''
+        ''tests/regression/56-witness/01-base-lor-enums.c'''
+    task:
+      input_files:
+      - tests/regression/56-witness/01-base-lor-enums.c
+      input_file_hashes:
+        tests/regression/56-witness/01-base-lor-enums.c: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+      data_model: LP64
+      language: C
+  location:
+    file_name: 01-base-lor-enums.c
+    file_hash: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+    line: 17
+    column: 2
+    function: main
+  loop_invariant:
+    string: (x == 1 || x == 3) || x == 6
+    type: assertion
+    format: C
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: e5802c77-d0ac-4f91-a0ac-c97ba97697d5
+    creation_time: 2022-06-16T06:37:52Z
+    producer:
+      name: Goblint
+      version: heads/base-eval-lor-0-g5a1ac0905-dirty
+      command_line: '''./goblint'' ''--enable'' ''dbg.debug'' ''--enable'' ''dbg.regression''
+        ''--html'' ''--enable'' ''ana.int.enums'' ''--enable'' ''witness.yaml.enabled''
+        ''tests/regression/56-witness/01-base-lor-enums.c'''
+    task:
+      input_files:
+      - tests/regression/56-witness/01-base-lor-enums.c
+      input_file_hashes:
+        tests/regression/56-witness/01-base-lor-enums.c: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+      data_model: LP64
+      language: C
+  location:
+    file_name: 01-base-lor-enums.c
+    file_hash: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+    line: 18
+    column: 2
+    function: main
+  loop_invariant:
+    string: (x == 1 || x == 3) || x == 7
+    type: assertion
+    format: C
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: e5802c77-d0ac-4f91-a0ac-c97ba97697d5
+    creation_time: 2022-06-16T06:37:52Z
+    producer:
+      name: Goblint
+      version: heads/base-eval-lor-0-g5a1ac0905-dirty
+      command_line: '''./goblint'' ''--enable'' ''dbg.debug'' ''--enable'' ''dbg.regression''
+        ''--html'' ''--enable'' ''ana.int.enums'' ''--enable'' ''witness.yaml.enabled''
+        ''tests/regression/56-witness/01-base-lor-enums.c'''
+    task:
+      input_files:
+      - tests/regression/56-witness/01-base-lor-enums.c
+      input_file_hashes:
+        tests/regression/56-witness/01-base-lor-enums.c: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+      data_model: LP64
+      language: C
+  location:
+    file_name: 01-base-lor-enums.c
+    file_hash: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+    line: 29
+    column: 2
+    function: main
+  loop_invariant:
+    string: y == 11 || y == x
+    type: assertion
+    format: C
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: e5802c77-d0ac-4f91-a0ac-c97ba97697d5
+    creation_time: 2022-06-16T06:37:52Z
+    producer:
+      name: Goblint
+      version: heads/base-eval-lor-0-g5a1ac0905-dirty
+      command_line: '''./goblint'' ''--enable'' ''dbg.debug'' ''--enable'' ''dbg.regression''
+        ''--html'' ''--enable'' ''ana.int.enums'' ''--enable'' ''witness.yaml.enabled''
+        ''tests/regression/56-witness/01-base-lor-enums.c'''
+    task:
+      input_files:
+      - tests/regression/56-witness/01-base-lor-enums.c
+      input_file_hashes:
+        tests/regression/56-witness/01-base-lor-enums.c: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+      data_model: LP64
+      language: C
+  location:
+    file_name: 01-base-lor-enums.c
+    file_hash: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+    line: 30
+    column: 2
+    function: main
+  loop_invariant:
+    string: (y == 1 || y == 3) || y == 6 || y == 11
+    type: assertion
+    format: C
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: e5802c77-d0ac-4f91-a0ac-c97ba97697d5
+    creation_time: 2022-06-16T06:37:52Z
+    producer:
+      name: Goblint
+      version: heads/base-eval-lor-0-g5a1ac0905-dirty
+      command_line: '''./goblint'' ''--enable'' ''dbg.debug'' ''--enable'' ''dbg.regression''
+        ''--html'' ''--enable'' ''ana.int.enums'' ''--enable'' ''witness.yaml.enabled''
+        ''tests/regression/56-witness/01-base-lor-enums.c'''
+    task:
+      input_files:
+      - tests/regression/56-witness/01-base-lor-enums.c
+      input_file_hashes:
+        tests/regression/56-witness/01-base-lor-enums.c: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+      data_model: LP64
+      language: C
+  location:
+    file_name: 01-base-lor-enums.c
+    file_hash: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+    line: 31
+    column: 2
+    function: main
+  loop_invariant:
+    string: y == 42 || y == x
+    type: assertion
+    format: C

--- a/tests/regression/56-witness/02-base-lor-addr.c
+++ b/tests/regression/56-witness/02-base-lor-addr.c
@@ -15,7 +15,7 @@ int main() {
       break;
   }
   ; // SUCCESS (witness)
-  ; // UNKNOWN (witness)
+  ; // UNKNOWN! (witness)
 
   int *y;
   switch (r) {
@@ -28,6 +28,6 @@ int main() {
   }
   ; // UNKNOWN (witness)
   ; // SUCCESS (witness)
-  ; // UNKNOWN (witness)
+  ; // UNKNOWN! (witness)
   return 0;
 }

--- a/tests/regression/56-witness/02-base-lor-addr.c
+++ b/tests/regression/56-witness/02-base-lor-addr.c
@@ -1,0 +1,33 @@
+// PARAM: --set witness.yaml.validate 02-base-lor-addr.yml
+
+int main() {
+  int r; // rand
+  int *x, a, b, c, d, e;
+  switch (r) {
+    case 0:
+      x = &a;
+      break;
+    case 1:
+      x = &b;
+      break;
+    default:
+      x = &c;
+      break;
+  }
+  ; // SUCCESS (witness)
+  ; // UNKNOWN (witness)
+
+  int *y;
+  switch (r) {
+    case 0:
+      y = &e;
+      break;
+    default:
+      y = x;
+      break;
+  }
+  ; // UNKNOWN (witness)
+  ; // SUCCESS (witness)
+  ; // UNKNOWN (witness)
+  return 0;
+}

--- a/tests/regression/56-witness/02-base-lor-addr.yml
+++ b/tests/regression/56-witness/02-base-lor-addr.yml
@@ -1,0 +1,140 @@
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: e5802c77-d0ac-4f91-a0ac-c97ba97697d5
+    creation_time: 2022-06-16T06:37:52Z
+    producer:
+      name: Goblint
+      version: heads/base-eval-lor-0-g5a1ac0905-dirty
+      command_line: '''./goblint'' ''--enable'' ''dbg.debug'' ''--enable'' ''dbg.regression''
+        ''--html'' ''--enable'' ''ana.int.enums'' ''--enable'' ''witness.yaml.enabled''
+        ''tests/regression/56-witness/02-base-lor-addr.c'''
+    task:
+      input_files:
+      - tests/regression/56-witness/02-base-lor-addr.c
+      input_file_hashes:
+        tests/regression/56-witness/02-base-lor-addr.c: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+      data_model: LP64
+      language: C
+  location:
+    file_name: 02-base-lor-addr.c
+    file_hash: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+    line: 17
+    column: 2
+    function: main
+  loop_invariant:
+    string: (x == &a || x == &b) || x == &c
+    type: assertion
+    format: C
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: e5802c77-d0ac-4f91-a0ac-c97ba97697d5
+    creation_time: 2022-06-16T06:37:52Z
+    producer:
+      name: Goblint
+      version: heads/base-eval-lor-0-g5a1ac0905-dirty
+      command_line: '''./goblint'' ''--enable'' ''dbg.debug'' ''--enable'' ''dbg.regression''
+        ''--html'' ''--enable'' ''ana.int.enums'' ''--enable'' ''witness.yaml.enabled''
+        ''tests/regression/56-witness/02-base-lor-addr.c'''
+    task:
+      input_files:
+      - tests/regression/56-witness/02-base-lor-addr.c
+      input_file_hashes:
+        tests/regression/56-witness/02-base-lor-addr.c: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+      data_model: LP64
+      language: C
+  location:
+    file_name: 02-base-lor-addr.c
+    file_hash: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+    line: 18
+    column: 2
+    function: main
+  loop_invariant:
+    string: (x == &a || x == &b) || x == &d
+    type: assertion
+    format: C
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: e5802c77-d0ac-4f91-a0ac-c97ba97697d5
+    creation_time: 2022-06-16T06:37:52Z
+    producer:
+      name: Goblint
+      version: heads/base-eval-lor-0-g5a1ac0905-dirty
+      command_line: '''./goblint'' ''--enable'' ''dbg.debug'' ''--enable'' ''dbg.regression''
+        ''--html'' ''--enable'' ''ana.int.enums'' ''--enable'' ''witness.yaml.enabled''
+        ''tests/regression/56-witness/02-base-lor-addr.c'''
+    task:
+      input_files:
+      - tests/regression/56-witness/02-base-lor-addr.c
+      input_file_hashes:
+        tests/regression/56-witness/02-base-lor-addr.c: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+      data_model: LP64
+      language: C
+  location:
+    file_name: 02-base-lor-addr.c
+    file_hash: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+    line: 29
+    column: 2
+    function: main
+  loop_invariant:
+    string: y == &e || y == x
+    type: assertion
+    format: C
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: e5802c77-d0ac-4f91-a0ac-c97ba97697d5
+    creation_time: 2022-06-16T06:37:52Z
+    producer:
+      name: Goblint
+      version: heads/base-eval-lor-0-g5a1ac0905-dirty
+      command_line: '''./goblint'' ''--enable'' ''dbg.debug'' ''--enable'' ''dbg.regression''
+        ''--html'' ''--enable'' ''ana.int.enums'' ''--enable'' ''witness.yaml.enabled''
+        ''tests/regression/56-witness/02-base-lor-addr.c'''
+    task:
+      input_files:
+      - tests/regression/56-witness/02-base-lor-addr.c
+      input_file_hashes:
+        tests/regression/56-witness/02-base-lor-addr.c: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+      data_model: LP64
+      language: C
+  location:
+    file_name: 02-base-lor-addr.c
+    file_hash: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+    line: 30
+    column: 2
+    function: main
+  loop_invariant:
+    string: (y == &a || y == &b) || y == &c || y == &e
+    type: assertion
+    format: C
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: e5802c77-d0ac-4f91-a0ac-c97ba97697d5
+    creation_time: 2022-06-16T06:37:52Z
+    producer:
+      name: Goblint
+      version: heads/base-eval-lor-0-g5a1ac0905-dirty
+      command_line: '''./goblint'' ''--enable'' ''dbg.debug'' ''--enable'' ''dbg.regression''
+        ''--html'' ''--enable'' ''ana.int.enums'' ''--enable'' ''witness.yaml.enabled''
+        ''tests/regression/56-witness/02-base-lor-addr.c'''
+    task:
+      input_files:
+      - tests/regression/56-witness/02-base-lor-addr.c
+      input_file_hashes:
+        tests/regression/56-witness/02-base-lor-addr.c: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+      data_model: LP64
+      language: C
+  location:
+    file_name: 02-base-lor-addr.c
+    file_hash: 5f686f726d140fbb7f3052f778e99aa09e3807cc6972a4d4905df2f6ed0c3e01
+    line: 31
+    column: 2
+    function: main
+  loop_invariant:
+    string: y == &d || y == x
+    type: assertion
+    format: C


### PR DESCRIPTION
When generating witness invariants for enums inclusion set or known address set, the resulting expression is a disjunction of all the possible values. But when trying to validate our own witness, we couldn't confirm such invariant, because evaluating each equality in the disjunction separately gives unknown and so does their `LOr`.

This adds special logic to base analysis `eval_rv` to collect disjunctions of equalities together. If there's a common expression in all the sides of the equalities and all the other sides evaluate to definite addresses/ints, then a set-based subset/disjoint check can be used to evaluate such disjunction as a whole. It allows us to confirm some of our own disjunctive invariants.

This isn't complete though, because we generate, but still cannot validate `(p == & i && *p == 8) || (p == & j && *p == 7)`.
