### PR TITLE
Add Apron box product lifter

### DIFF
--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -433,7 +433,13 @@ struct
     (* After the solver is finished, store the results (for later comparison) *)
     if !GU.postsolving then begin
       let old_value = RH.find_default results ctx.node (AD.bot ()) in
-      let new_value = AD.join old_value ctx.local.apr in
+      let st = AD.keep_filter ctx.local.apr (fun v ->
+          match V.find_metadata v with
+          | Some (Global _) -> true
+          | _ -> false
+        )
+      in
+      let new_value = AD.join old_value st in
       RH.replace results ctx.node new_value;
     end;
     Priv.sync (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg ctx.local (reason :> [`Normal | `Join | `Return | `Init | `Thread])

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -481,6 +481,7 @@ let spec_module: (module MCPSpec) Lazy.t =
   lazy (
     let module Man = (val ApronDomain.get_manager ()) in
     let module AD = ApronDomain.D3 (Man) in
+    let module AD = ApronDomain.BoxProd (AD) in
     let module Priv = (val ApronPriv.get_priv ()) in
     let module Spec = SpecFunctor (AD) (Priv) in
     (module Spec)

--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -12,7 +12,7 @@ open CommonPriv
 
 
 module type S =
-  functor (AD: ApronDomain.S2) ->
+  functor (AD: ApronDomain.S3) ->
   sig
     module D: Lattice.S
     module G: Lattice.S
@@ -45,7 +45,7 @@ module type S =
   end
 
 
-module Dummy: S = functor (AD: ApronDomain.S2) ->
+module Dummy: S = functor (AD: ApronDomain.S3) ->
 struct
   module D = Lattice.Unit
   module G = Lattice.Unit
@@ -80,7 +80,7 @@ sig
 end
 
 (** Protection-Based Reading. *)
-module ProtectionBasedPriv (Param: ProtectionBasedPrivParam): S = functor (AD: ApronDomain.S2) ->
+module ProtectionBasedPriv (Param: ProtectionBasedPrivParam): S = functor (AD: ApronDomain.S3) ->
 struct
   include ConfCheck.RequireMutexActivatedInit
   open Protection
@@ -345,7 +345,7 @@ struct
   let finalize () = ()
 end
 
-module CommonPerMutex = functor(AD: ApronDomain.S2) ->
+module CommonPerMutex = functor(AD: ApronDomain.S3) ->
 struct
   include Protection
   module V = ApronDomain.V
@@ -368,7 +368,7 @@ struct
 end
 
 (** Per-mutex meet. *)
-module PerMutexMeetPriv : S = functor (AD: ApronDomain.S2) ->
+module PerMutexMeetPriv : S = functor (AD: ApronDomain.S3) ->
 struct
   open CommonPerMutex(AD)
   include MutexGlobals
@@ -523,7 +523,7 @@ struct
   let name () = "W"
 end
 
-module type ClusterArg = functor (AD: ApronDomain.S2) ->
+module type ClusterArg = functor (AD: ApronDomain.S3) ->
 sig
   module LAD: Lattice.S
 
@@ -537,7 +537,7 @@ sig
 end
 
 (** No clustering. *)
-module NoCluster:ClusterArg = functor (AD: ApronDomain.S2) ->
+module NoCluster:ClusterArg = functor (AD: ApronDomain.S3) ->
 struct
   module AD = AD
   open CommonPerMutex(AD)
@@ -620,7 +620,7 @@ end
 
 
 (** Clusters when clustering is downward-closed. *)
-module DownwardClosedCluster (ClusteringArg: ClusteringArg) =  functor (AD: ApronDomain.S2) ->
+module DownwardClosedCluster (ClusteringArg: ClusteringArg) =  functor (AD: ApronDomain.S3) ->
 struct
   module AD = AD
   open CommonPerMutex(AD)
@@ -685,7 +685,7 @@ struct
 end
 
 (** Clusters when clustering is arbitrary (not necessarily downward-closed). *)
-module ArbitraryCluster (ClusteringArg: ClusteringArg): ClusterArg = functor (AD: ApronDomain.S2) ->
+module ArbitraryCluster (ClusteringArg: ClusteringArg): ClusterArg = functor (AD: ApronDomain.S3) ->
 struct
   module AD = AD
   module DCCluster = (DownwardClosedCluster(ClusteringArg))(AD)
@@ -761,7 +761,7 @@ struct
 end
 
 (** Per-mutex meet with TIDs. *)
-module PerMutexMeetPrivTID (Cluster: ClusterArg): S  = functor (AD: ApronDomain.S2) ->
+module PerMutexMeetPrivTID (Cluster: ClusterArg): S  = functor (AD: ApronDomain.S3) ->
 struct
   open CommonPerMutex(AD)
   include MutexGlobals
@@ -1052,7 +1052,7 @@ struct
   let finalize () = finalize ()
 end
 
-module TracingPriv = functor (Priv: S) -> functor (AD: ApronDomain.S2) ->
+module TracingPriv = functor (Priv: S) -> functor (AD: ApronDomain.S3) ->
 struct
   module Priv = Priv (AD)
   include Priv

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -385,6 +385,7 @@ struct
   include CilOfApron
 end
 
+(** Pure environment and transfer functions. *)
 module type AOpsPure =
 sig
   type t
@@ -399,6 +400,7 @@ sig
   val substitute_exp : t -> Var.t -> exp -> t
 end
 
+(** Imperative in-place environment and transfer functions. *)
 module type AOpsImperative =
 sig
   type t
@@ -424,6 +426,7 @@ sig
   val copy : t -> t
 end
 
+(** Default implementations of pure functions from [copy] and imperative functions. *)
 module AOpsPureOfImperative (AOpsImperative: AOpsImperativeCopy): AOpsPure with type t = AOpsImperative.t =
 struct
   open AOpsImperative
@@ -467,6 +470,7 @@ struct
     nd
 end
 
+(** Extra functions that don't have the pure-imperative correspondence. *)
 module type AOpsExtra =
 sig
   type t
@@ -1194,6 +1198,9 @@ struct
       OctagonD2.of_lincons_array generator
 end
 
+(** Lift [D] to a non-reduced product with box.
+    Both are updated in parallel, but [D] answers to queries.
+    Box domain is used to filter out non-relational invariants for output. *)
 module BoxProd0 (D: S3) =
 struct
   module BoxD = D3 (IntervalManager)

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -328,21 +328,21 @@ struct
     let coeff_to_const consider_flip (c:Coeff.union_5) = match c with
       | Scalar c ->
         (match int_of_scalar c with
-        | Some i ->
-          let ci,truncation = truncateCilint ILongLong i in
-          if truncation = NoTruncation then
-            if not consider_flip || Z.compare i Z.zero >= 0 then
-              Const (CInt(i,ILongLong,None)), false
-            else
-              (* attempt to negate if that does not cause an overflow *)
-              let cneg, truncation = truncateCilint ILongLong (Z.neg i) in
-              if truncation = NoTruncation then
-                Const (CInt((Z.neg i),ILongLong,None)), true
-              else
-                Const (CInt(i,ILongLong,None)), false
-          else
-            (M.warn ~category:Analyzer "Invariant Apron: coefficient is not int: %s" (Scalar.to_string c); raise Unsupported_Linexpr1)
-        | None -> raise Unsupported_Linexpr1)
+         | Some i ->
+           let ci,truncation = truncateCilint ILongLong i in
+           if truncation = NoTruncation then
+             if not consider_flip || Z.compare i Z.zero >= 0 then
+               Const (CInt(i,ILongLong,None)), false
+             else
+               (* attempt to negate if that does not cause an overflow *)
+               let cneg, truncation = truncateCilint ILongLong (Z.neg i) in
+               if truncation = NoTruncation then
+                 Const (CInt((Z.neg i),ILongLong,None)), true
+               else
+                 Const (CInt(i,ILongLong,None)), false
+           else
+             (M.warn ~category:Analyzer "Invariant Apron: coefficient is not int: %s" (Scalar.to_string c); raise Unsupported_Linexpr1)
+         | None -> raise Unsupported_Linexpr1)
       | _ -> raise Unsupported_Linexpr1
     in
     let expr = ref (fst @@ coeff_to_const false (Linexpr1.get_cst linexpr1)) in

--- a/src/util/apron/apronPrecCompareUtil.apron.ml
+++ b/src/util/apron/apronPrecCompareUtil.apron.ml
@@ -10,11 +10,11 @@ struct
 end
 
 (* Currently serialization of Apron results only works for octagons. *)
-module OctagonD = ApronDomain.D2 (ApronDomain.OctagonManager)
+module OctagonD = ApronDomain.OctagonD2
 module Util =
 struct
   include Util (MyNode) (OctagonD)
-  type marshal = (OctagonManager.mt Apron.Abstract0.t * string array) RH.t
+  type marshal = OctagonD.marshal RH.t
   type dump = marshal dump_gen
   type result = Dom.t RH.t result_gen
 

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -782,6 +782,18 @@
                   "description": "Generate invariants with only one variable",
                   "type": "boolean",
                   "default": false
+                },
+                "local": {
+                  "title": "ana.apron.invariant.local",
+                  "description": "Keep local variables in invariants",
+                  "type": "boolean",
+                  "default": true
+                },
+                "global": {
+                  "title": "ana.apron.invariant.global",
+                  "description": "Keep global variables in invariants",
+                  "type": "boolean",
+                  "default": true
                 }
               },
               "additionalProperties": false

--- a/src/util/precCompare.ml
+++ b/src/util/precCompare.ml
@@ -101,7 +101,7 @@ struct
   module CompareDump = MakeHashtbl (Key) (Dom) (RH)
 
   let compare_dumps ({name = name1; results = lvh1}: result) ({name = name2; results = lvh2}: result) =
-    CompareDump.compare ~name1 lvh1 ~name2 lvh2
+    CompareDump.compare ~verbose:true ~name1 lvh1 ~name2 lvh2
 
   let count_locations (dumps: result list) =
     let module LH = Hashtbl.Make (CilType.Location) in


### PR DESCRIPTION
This adds the `BoxProd` lifter for Apron domains, which allows `invariant` to filter out all non-relational invariants (including trivially derived ones) by filtering out box constraints.
Some refactoring of the interfaces was necessary to abstract away `Man` since the `BoxProd` components use different domain managers.

Also adds options for deciding, which variables should be used in generated Apron invariants.