### PR TITLE
Add `setjmp` Analysis

### DIFF
--- a/src/analyses/libraryDesc.ml
+++ b/src/analyses/libraryDesc.ml
@@ -25,6 +25,8 @@ type special =
   | Memset of { dest: Cil.exp; ch: Cil.exp; count: Cil.exp; }
   | Bzero of { dest: Cil.exp; count: Cil.exp; }
   | Abort
+  | Setjmp of { env: Cil.exp }
+  | Longjmp of { env: Cil.exp; value: Cil.exp; }
   | Unknown (** Anything not belonging to other types. *) (* TODO: rename to Other? *)
 
 

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -16,6 +16,11 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("abort", special [] Abort);
     ("exit", special [drop "exit_code" []] Abort);
     ("assert", special [__ "cond" [r]] @@ fun cond -> Assert cond);
+
+    ("setjmp", special [__ "env" []] @@ fun env -> Setjmp { env } );
+    ("_setjmp", special [__ "env" []] @@ fun env -> Setjmp { env } );
+    ("longjmp", special [__ "env" []; __ "value" [r]] @@ fun env value -> Longjmp { env; value } );
+    ("_longjmp", special [__ "env" []; __ "value" [r]] @@ fun env value -> Longjmp { env; value } );
   ]
 
 (** C POSIX library functions.

--- a/src/analyses/setjmpAnalysis.ml
+++ b/src/analyses/setjmpAnalysis.ml
@@ -1,0 +1,91 @@
+(** [setjmp]/[longjmp] analysis.
+
+    This analysis doesn't really do anything by itself, it only makes it really easy for other analysis to support analyzing [setjmp] and [longjmp] calls.
+
+    To do this heterogeneous maps are used to be able to collect and manage state from other analysis without putting restrictions on the format of that data.
+    An analysis must use HM.token to register 3 tokens for tracking:
+    1. The return value of the [setjmp] call. The provided default value for this must be 0.
+    2. The values of volatile locals. This could also contain the value of non-volatile locals as changing them between a setjmp and longjmp is undefined behaviour, but it must not contain any privatized globals as they are tracked separately.
+    3. The values of privatized globals (if any).
+
+    The setjmp analysis then uses 2 queries to retrieve state at the appropriate points:
+    1. [Queries.Longjmp] is used whenever a longjmp is performed.
+       In this query a map should be returned containing token 1 with the value of the provided expresssion and 3 with the values of any privatized globals or otherwise any state that should be transfered from the [longjmp] to the [setjmp] call.
+    2. [Queries.VolatileLocals] is used for every call in a function after [setjmp] was called.
+       Here a map with token 2 containg the values of volatile locals or otherwise any intra-function state that needs to be preserved from [longjmp] to [setjmp].
+
+    Finally the [Events.Setjmp] event is called for every [setjmp]. It should take the value of token 1 and write it to the provided lval and also apply the state saved in token 2 and 3.
+
+*)
+
+open Prelude.Ana
+open Analyses
+module LF = LibraryFunctions
+module HM = MapDomainHeterogeneous.MapSetJmp
+
+module Spec =
+struct
+  include IdentitySpec
+
+  let name () = "setjmp"
+
+  module D = Queries.LS (* if the local method has performed a setjmp *)
+  module C = D
+  module G = HM
+  module V = Basetype.Variables
+
+  let startstate v = D.bot ()
+  let exitstate = startstate
+
+  (** write [data] into all the variables in [vars] *)
+  let sideg (ctx : (D.t, G.t, C.t, V.t) ctx) (vars : D.t) data =
+    D.elements vars 
+    |> List.map fst
+    |> List.iter (fun var ->
+        (** explicit join with the old value is required or 0 can be lost from the possible setjmp return values. *)
+        let getg = (ctx.global var) in
+        let g = (HM.join data getg) in
+        if M.tracing then M.tracel "setjmp" "Longjmp: %a\n+ %a\n-> %a\n" HM.pretty data HM.pretty getg HM.pretty g;
+        ctx.sideg var g)
+
+  let collect_volatiles ctx =
+    if D.is_empty ctx.local then begin
+      if M.tracing then M.tracel "setjmp" "Enter - no setjump\n";
+    end else begin
+      let locals = ctx.ask Queries.VolatileLocals in
+      if M.tracing then M.tracel "setjmp" "Enter: %a\n" HM.pretty locals;
+      sideg ctx ctx.local locals
+    end
+
+  let special (ctx : (D.t, G.t, C.t, V.t) ctx) result f args =
+    match (LF.find f).special args with
+    | Setjmp { env } ->
+      (* join the state from all the setjump buffers, env may refer to (generally just one global) *)
+      let vars = ctx.ask (Queries.MayPointTo env) in
+      if M.tracing then M.traceli "setjmp" "Setjmp vars: [%a]\n" D.pretty vars;
+      let data = List.fold HM.join (HM.top ()) (List.map ctx.global (D.elements vars |> List.map fst)) in
+      if M.tracing then M.tracel "setjmp" "Setjmp: %a\n" HM.pretty data;
+      if M.tracing then M.traceOutdent();
+      (* and use it to call the event *)
+      ctx.emit (Events.Setjmp (result, data));
+      (* track the buffers that will need to receive volatiles *)
+      D.join ctx.local vars
+    | Longjmp { env; value } ->
+      let data = ctx.ask (Queries.Longjmp value) in
+      (* collect the state for all setjmp in the dummy var in case we try to setjmp with an unknown buffer *)
+      let vars = D.add (dummyFunDec.svar, `NoOffset) (ctx.ask (Queries.MayPointTo env)) in
+      if M.tracing then M.traceli "setjmp" "Longjmp vars: [%a]\n" D.pretty vars;
+      sideg ctx vars data;
+      collect_volatiles ctx;
+      if M.tracing then M.traceOutdent();
+      (* longjmp never returns directly it will return from the setjmp instead *)
+      raise Deadcode
+    | _ -> ctx.local
+
+  let enter ctx lval fn args =
+    collect_volatiles ctx;
+    [ctx.local, startstate()]
+end
+
+let _ =
+  MCP.register_analysis (module Spec : MCPSpec)

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -9,6 +9,7 @@ type t =
   | AssignSpawnedThread of lval * ThreadIdDomain.Thread.t (** Assign spawned thread's ID to lval. *)
   | Access of {var_opt: CilType.Varinfo.t option; kind: AccessKind.t} (** Access varinfo (unknown if None). *)
   | Assign of {lval: CilType.Lval.t; exp: CilType.Exp.t} (** Used to simulate old [ctx.assign]. *)
+  | Setjmp of CilType.Lval.t option * MapDomainHeterogeneous.MapSetJmp.t
 
 let pretty () = function
   | Lock m -> dprintf "Lock %a" LockDomain.Lockset.Lock.pretty m
@@ -18,4 +19,5 @@ let pretty () = function
   | SplitBranch (exp, tv) -> dprintf "SplitBranch (%a, %B)" d_exp exp tv
   | AssignSpawnedThread (lval, tid) -> dprintf "AssignSpawnedThread (%a, %a)" d_lval lval ThreadIdDomain.Thread.pretty tid
   | Access {var_opt; kind} -> dprintf "Access {var_opt=%a, kind=%a}" (docOpt (CilType.Varinfo.pretty ())) var_opt AccessKind.pretty kind
-  | Assign {lval; exp} -> dprintf "Assugn {lval=%a, exp=%a}" CilType.Lval.pretty lval CilType.Exp.pretty exp
+  | Assign {lval; exp} -> dprintf "Assign {lval=%a, exp=%a}" CilType.Lval.pretty lval CilType.Exp.pretty exp
+  | Setjmp (lval, map) -> dprintf "Setjmp (%a, %a)" (docOpt (CilType.Lval.pretty())) lval MapDomainHeterogeneous.MapSetJmp.pretty map

--- a/src/domains/mapDomainHeterogeneous.ml
+++ b/src/domains/mapDomainHeterogeneous.ml
@@ -1,0 +1,241 @@
+(** Specification and functors for maps. *)
+
+open Pretty
+module ME = Messages
+module GU = Goblintutil
+
+type 'a mt = (module Lattice.S with type t = 'a)
+
+module type PS =
+sig
+  include Printable.S
+  type 'a key
+  (** The type of the map keys. *)
+
+  type 'a value
+  (** The type of the values. *)
+
+  type binding
+  type mapper = { map : 'a. 'a key -> 'a value -> 'a value }
+  type mapper2 = { map2 : 'a. 'a key -> 'a value -> 'a value -> 'a value }
+  type merger = { merge : 'a. 'a key -> 'a value option -> 'a value option -> 'a value option }
+
+  val add: 'a key -> 'a value -> t -> t
+  val remove: 'a key -> t -> t
+  val find: 'a key -> t -> 'a value
+  val find_opt: 'a key -> t -> 'a value option
+  val mem: 'a key -> t -> bool
+  val iter: (binding -> unit) -> t -> unit
+  val map: mapper -> t -> t
+  val filter: (binding -> bool) -> t -> t
+  val fold: (binding -> 'a -> 'a) -> t -> 'a -> 'a
+
+  val add_list: binding list -> t -> t
+  val add_list_set: 'a key list -> 'a value -> t -> t
+
+  val for_all: (binding -> bool) -> t -> bool
+  val map2: mapper2 -> t -> t -> t
+  val long_map2: mapper2 -> t -> t -> t
+  val merge : merger -> t -> t -> t
+
+  val cardinal: t -> int
+  val choose: t -> binding
+  val singleton: 'a key -> 'a value -> t
+  val empty: unit -> t
+  val is_empty: t -> bool
+  val exists: (binding -> bool) -> t -> bool
+  val bindings: t -> binding list
+end
+
+module type S =
+sig
+  include PS
+  include Lattice.S with type t := t
+
+  type equality_comparer = { equal : 'a. 'a key -> 'a value -> 'a value -> bool }
+
+  val widen_with_fct: mapper2 -> t -> t -> t
+  (* Widen using a custom widening function for value rather than the default one for value *)
+  val join_with_fct: mapper2 -> t -> t -> t
+  (* Join using a custom join function for value rather than the default one for value *)
+  val leq_with_fct: equality_comparer -> t -> t -> bool
+  (* Leq test using a custom leq function for value rather than the default one provided for value *)
+end
+
+module Map
+  (* : sig
+     include PS' with type 'a value = 'a
+
+     val token : (module Lattice.S with type t = 'a) -> 'a key
+     end *)
+=
+struct
+  module M = Hmap.Make(struct type 'a t = 'a mt * string end)
+
+  include Printable.Std
+  type 'a key = 'a M.key
+  type 'a value = 'a
+  type binding = M.binding = B : 'a key * 'a value -> binding
+  type mapper = M.mapper = { map : 'a. 'a key -> 'a value -> 'a value }
+  type mapper2 = { map2 : 'a. 'a key -> 'a value -> 'a value -> 'a value }
+  type merger = M.merger = { merge : 'a. 'a key -> 'a value option -> 'a value option -> 'a value option }
+  type t = M.t (* key -> value  mapping *)
+
+  let token (m : (module Lattice.S with type t = 'a)) id = (M.Key.create (m, id))
+
+  (* And some braindead definitions, because I would want to do
+   * include Map.Make (Domain) with type t = Range.t t *)
+  let add = M.add
+  let remove = M.rem
+  let find_opt = M.find
+  let find k m = match find_opt k m with Some x -> x | _ -> raise Not_found
+  let mem = M.mem
+  let iter = M.iter
+  let map = M.map
+  let fold = M.fold
+  let filter = M.filter
+  (* And one less brainy definition *)
+  let for_all2 = M.equal
+  let equal x y = x == y || for_all2 { equal = fun (type a) k a b -> let module R = (val (fst (M.Key.info k) : a mt)) in R.equal a b } x y
+  let compare x y = if equal x y then 0 else M.compare { compare = fun (type a) k a b -> let module R = (val (fst (M.Key.info k) : a mt)) in R.compare a b } x y
+  let merge = M.merge
+  let for_all = M.for_all
+  let hash xs = fold (fun (B(k,v)) a -> let module R = (val (fst (M.Key.info k))) in a + (Hashtbl.hash k * R.hash v)) xs 0
+
+  let cardinal = M.cardinal
+  let choose = M.get_any_binding
+  let singleton = M.singleton
+  let empty () = M.empty
+  let is_empty = M.is_empty
+  let exists = M.exists
+  let bindings = M.bindings
+
+
+  let add_list keyvalues m =
+    List.fold_left (fun acc (B(key,value)) -> add key value acc) m keyvalues
+
+  let add_list_set keys value m =
+    List.fold_left (fun acc key -> add key value acc) m keys
+
+  let add_list_fun keys f m =
+    List.fold_left (fun acc key -> add key (f key) acc) m keys
+
+  let long_map2 op =
+    let f (type a) k (v1 : a option) v2 =
+      match v1, v2 with
+      | Some v1, Some v2 -> Some (op.map2 k v1 v2)
+      | Some _, _ -> v1
+      | _, Some _ -> v2
+      | _ -> None
+    in
+    M.merge { merge = f }
+
+  let map2 op =
+    (* Similar to the previous, except we ignore elements that only occur in one
+     * of the mappings, so we start from an empty map *)
+    let f k v1 v2 =
+      match v1, v2 with
+      | Some v1, Some v2 -> Some (op.map2 k v1 v2)
+      | _ -> None
+    in
+    M.merge { merge = f }
+
+  let show x = "mapping"
+
+  let pretty () mapping =
+    let text () = Pretty.text in
+    let f (B(key, value) : binding) dok =
+      if ME.tracing && trace_enabled && !ME.tracevars <> [] &&
+         not (List.mem (snd (M.Key.info key)) !ME.tracevars) then
+        dok
+      else
+        dok ++ dprintf "%a ->@?  @[%a@]\n" text (snd (M.Key.info key)) (let module R = (val (fst (M.Key.info key))) in R.pretty) value
+    in
+    let pretty_group () map = fold f map nil in
+    let content () = pretty_group () mapping in
+    dprintf "@[%s {\n  @[%t@]}@]" (show mapping) content
+  let printXml _ = failwith "not supported; keys cannot be serialized xml"
+  let to_yojson _ = failwith "not supported; keys cannot be serialized json"
+
+  let printXml f xs =
+    let print_one (B (k, v)) =
+      BatPrintf.fprintf f "<key>\n%s</key>\n%a" (XmlUtil.escape (snd (M.Key.info k))) (let module R = (val (fst (M.Key.info k))) in R.printXml) v
+    in
+    BatPrintf.fprintf f "<value>\n<map>\n";
+    iter print_one xs;
+    BatPrintf.fprintf f "</map>\n</value>\n"
+
+  let to_yojson xs =
+    let f (B (k, v)) = (snd (M.Key.info k), (let module R = (val (fst (M.Key.info k))) in R.to_yojson v)) in
+    `Assoc (xs |> M.bindings |> List.map f)
+
+  let arbitrary () = QCheck.always M.empty (* S TODO: non-empty map *)
+end
+
+
+module MapSetJmp = struct
+  include Map
+
+  let bot_map = ref (empty ())
+
+  let token (m : (module Lattice.S with type t = 'a)) bot id =
+    let token = token m id in
+    bot_map := add token bot !bot_map;
+    token
+
+  type equality_comparer = M.equality_comparer = { equal: 'a. 'a key -> 'a value -> 'a value -> bool }
+
+  let leq_with_fct f m1 m2 = (* TODO use merge or sth faster? *)
+    (* For each key-value in m1, the same key must be in m2 with a geq value: *)
+    let p (B(key, value)) =
+      try f.equal key value (find key m2) with Not_found -> false
+    in
+    m1 == m2 || for_all p m1
+
+  let leq a b =
+    let result = leq_with_fct { equal = (fun (type a) k a b -> let module R = (val (fst (M.Key.info k) : a mt)) in R.leq a b) } a b in
+    if Messages.tracing && not (M.is_empty a && M.is_empty b) then Messages.tracel "hetmap" "%s\n%a\n%a\n%b\n" "leq" pretty a pretty b result;
+    result
+
+
+  let find (type a) k m = try find k m with | Not_found -> let module R = (val (fst (M.Key.info k) : a mt)) in R.top ()
+  let top () = empty ()
+  let bot () = !bot_map
+  let is_top _ = Lattice.unsupported "MapSetJmp.is_top"
+  let is_bot _ = Lattice.unsupported "MapSetJmp.is_bot"
+
+  (* let cleanup m = fold (fun k v m -> if Range.is_top v then remove k m else m) m m *)
+
+  let logable str f a b =
+    let result = f a b in
+    if Messages.tracing && not (M.is_empty a && M.is_empty b) then Messages.tracel "hetmap" "%s\n%a\n%a\n%a\n" str pretty a pretty b pretty result;
+    result
+
+  let meet = logable "meet" (fun m1 m2 -> if m1 == m2 then m1 else long_map2 { map2 = fun (type a) k a b -> let module R = (val (fst (M.Key.info k) : a mt)) in R.meet a b } m1 m2)
+
+  let join_with_fct f = logable "join" (fun m1 m2 -> if m1 == m2 then m1 else long_map2 f m1 m2)
+  let join = join_with_fct { map2 = fun (type a) k a b -> let module R = (val (fst (M.Key.info k) : a mt)) in R.join a b }
+
+  let widen_with_fct f = logable "widen" (long_map2 f)
+  let widen = widen_with_fct { map2 = fun (type a) k a b -> let module R = (val (fst (M.Key.info k) : a mt)) in R.widen a b }
+  let narrow = logable "narrow" (long_map2 { map2 = fun (type a) k a b -> let module R = (val (fst (M.Key.info k) : a mt)) in R.narrow a b })
+
+  let pretty_diff () ((m1:t),(m2:t)): Pretty.doc =
+    let p (type a) key value =
+      let module R = (val (fst (M.Key.info key) : a mt)) in
+      not (try R.leq value (find key m2) with Not_found -> false)
+    in
+    let report (type a) key v1 v2 =
+      let module R = (val (fst (M.Key.info key) : a mt)) in
+      Pretty.dprintf "Map: %a =@?@[%a@]"
+        (fun () -> text) (snd (M.Key.info key)) R.pretty_diff (v1,v2)
+    in
+    let diff_key (B(k, v)) = function
+      | None   when p k v -> Some (report k v (find k m2))
+      | Some w when p k v -> Some (w++Pretty.line++report k v (find k m2))
+      | x -> x
+    in
+    match fold diff_key m1 None with
+    | Some w -> w
+    | None -> Pretty.dprintf "No binding grew."
+end

--- a/src/util/hmap.ml
+++ b/src/util/hmap.ml
@@ -1,0 +1,230 @@
+(*---------------------------------------------------------------------------
+   Copyright (c) 2016 Daniel C. Bünzli. All rights reserved.
+   Distributed under the ISC license, see terms at the end of the file.
+   %%NAME%% %%VERSION%%
+  ---------------------------------------------------------------------------*)
+
+(* Type identifiers.
+   See http://alan.petitepomme.net/cwn/2015.03.24.html#1 *)
+
+module Tid = struct type _ t = .. end
+module type Tid = sig
+  type t
+  type _  Tid.t += Tid : t Tid.t
+end
+
+type 'a tid = (module Tid with type t = 'a)
+
+let tid () (type s) =
+  let module M = struct
+    type t = s
+    type _ Tid.t += Tid : t Tid.t
+  end
+  in
+  (module M : Tid with type t = s)
+
+type ('a, 'b) teq = Teq : ('a, 'a) teq
+
+let eq : type r s. r tid -> s tid -> (r, s) teq option =
+  fun r s ->
+  let module R = (val r : Tid with type t = r) in
+  let module S = (val s : Tid with type t = s) in
+  match R.Tid with
+  | S.Tid -> Some Teq
+  | _ -> None
+
+(* Heterogeneous maps *)
+
+module type KEY_INFO = sig
+  type 'a t
+end
+
+module type S = sig
+
+  type 'a key
+
+  module Key : sig
+    type 'a info
+    val create : 'a info -> 'a key
+    val info : 'a key -> 'a info
+
+    type t
+    val hide_type : 'a key -> t
+    val equal : t -> t -> bool
+    val compare : t -> t -> int
+  end
+
+  type t
+  val empty : t
+  val is_empty : t -> bool
+  val mem : 'a key -> t -> bool
+  val add : 'a key -> 'a -> t -> t
+  val singleton : 'a key -> 'a -> t
+  val rem : 'a key -> t -> t
+  val find : 'a key -> t -> 'a option
+  val get : 'a key -> t -> 'a
+
+  type binding = B : 'a key * 'a -> binding
+  val iter : (binding -> unit) -> t -> unit
+  val fold : (binding -> 'a -> 'a) -> t -> 'a -> 'a
+  val for_all : (binding -> bool) -> t -> bool
+  val exists : (binding -> bool) -> t -> bool
+  val filter : (binding -> bool) -> t -> t
+  val cardinal : t -> int
+  val bindings : t -> binding list
+  val any_binding : t -> binding option
+  val get_any_binding : t -> binding
+
+  type mapper = { map: 'a. 'a key -> 'a -> 'a }
+  val map : mapper -> t -> t
+
+  type merger = { merge: 'a. 'a key -> 'a option -> 'a option -> 'a option }
+  val merge : merger -> t -> t -> t
+
+  type equality_comparer = { equal : 'a. 'a key -> 'a -> 'a -> bool }
+  val equal : equality_comparer -> t -> t -> bool
+
+  type comparer = { compare : 'a. 'a key -> 'a -> 'a -> int }
+  val compare : comparer -> t -> t -> int
+end
+
+
+module Make (Key_info : KEY_INFO) : S
+  with type 'a Key.info = 'a Key_info.t = struct
+
+  (* Keys *)
+
+  module Key = struct
+
+    type 'a info = 'a Key_info.t
+    type 'a key = { uid : int; tid : 'a tid; info : 'a Key_info.t }
+
+    let uid =
+      let id = ref (-1) in
+      fun () -> incr id; !id
+
+    let create info =
+      let uid = uid () in
+      let tid = tid () in
+      { uid; tid; info }
+
+    let info k = k.info
+
+    type t = V : 'a key -> t
+    let hide_type k = V k
+    let equal (V k0) (V k1) = (compare : int -> int -> int) k0.uid k1.uid = 0
+    let compare (V k0) (V k1) = (compare : int -> int -> int) k0.uid k1.uid
+  end
+
+  type 'a key = 'a Key.key
+
+  (* Maps *)
+
+  module M = Map.Make (Key)
+  type binding = B : 'a key * 'a -> binding
+  type t = binding M.t
+
+  let empty = M.empty
+  let is_empty = M.is_empty
+  let mem k m = M.mem (Key.V k) m
+  let add k v m = M.add (Key.V k) (B (k, v)) m
+  let singleton k v = M.singleton (Key.V k) (B (k, v))
+  let rem k m = M.remove (Key.V k) m
+  let find : type a. a key -> t -> a option =
+    fun k s ->
+    try match M.find (Key.V k) s with
+      | B (k', v) ->
+        match eq k.Key.tid k'.Key.tid with
+        | None -> None
+        | Some Teq -> Some v
+    with Not_found -> None
+
+  let get k s = match find k s with
+    | None -> invalid_arg "key not found in map"
+    | Some v -> v
+
+  let iter f m = M.iter (fun _ b -> f b) m
+  let fold f m acc = M.fold (fun _ b acc -> f b acc) m acc
+  let for_all p m = M.for_all (fun _ b -> p b) m
+  let exists p m = M.exists (fun _ b -> p b) m
+  let filter p m = M.filter (fun _ b -> p b) m
+  let cardinal m = M.cardinal m
+  let bindings m = M.bindings m |> List.map snd
+  let any_binding m = try Some (snd (M.choose m)) with
+    | Not_found -> None
+
+  let get_any_binding m = try snd (M.choose m) with
+    | Not_found -> invalid_arg "empty map"
+
+  type mapper = { map: 'a. 'a key -> 'a -> 'a }
+
+  let map f a =
+    M.mapi
+      (fun (Key.V k) (B(k',v) as b) ->
+         match eq k.Key.tid k'.Key.tid with
+         | None -> b
+         | Some Teq -> B(k', f.map k' v)
+      ) a
+
+  type merger = { merge: 'a. 'a key -> 'a option -> 'a option -> 'a option }
+
+  let merge f a b =
+    let do_merge : type a b.
+      a key -> a option -> b key -> b option -> binding option =
+      fun k v k' v' ->
+        match eq k.Key.tid k'.Key.tid with
+        | None -> None
+        | Some Teq ->
+          match f.merge k v v' with
+          | None -> None
+          | Some r -> Some (B(k,r))
+    in
+    M.merge
+      (fun (Key.V k) ua ub ->
+         match ua, ub with
+         | None, None -> None
+         | Some(B(ka,va)), None -> do_merge ka (Some va) ka None
+         | None, Some(B(kb,vb)) -> do_merge kb None kb (Some vb)
+         | Some(B(ka,va)), Some(B(kb,vb)) -> do_merge ka (Some va) kb (Some vb)
+      ) a b
+
+  type equality_comparer = { equal: 'a. 'a key -> 'a -> 'a -> bool }
+
+  let equal f a b =
+    let do_equal : type a b.
+      a key -> a -> b key -> b -> bool =
+      fun k v k' v' ->
+        match eq k.Key.tid k'.Key.tid with
+        | None -> false
+        | Some Teq -> f.equal k v v'
+    in
+    M.equal (fun ua ub -> match ua, ub with B(ka,va), B(kb,vb) -> do_equal ka va kb vb) a b
+
+  type comparer = { compare: 'a. 'a key -> 'a -> 'a -> int }
+
+  let compare f a b =
+    let do_compare : type a b.
+      a key -> a -> b key -> b -> int =
+      fun k v k' v' ->
+        match eq k.Key.tid k'.Key.tid with
+        | None -> 0
+        | Some Teq -> f.compare k v v'
+    in
+    M.compare (fun ua ub -> match ua, ub with B(ka,va), B(kb,vb) -> do_compare ka va kb vb) a b
+end
+
+include Make (struct type 'a t = unit end)
+
+(*---------------------------------------------------------------------------
+  Copyright (c) 2016 Daniel C. Bünzli
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  ---------------------------------------------------------------------------*)

--- a/src/util/hmap.mli
+++ b/src/util/hmap.mli
@@ -1,0 +1,168 @@
+(*---------------------------------------------------------------------------
+   Copyright (c) 2016 Daniel C. Bünzli. All rights reserved.
+   Distributed under the ISC license, see terms at the end of the file.
+   %%NAME%% %%VERSION%%
+  ---------------------------------------------------------------------------*)
+
+(** Heterogeneous value maps.
+    {e %%VERSION%% - {{:%%PKG_HOMEPAGE%% }homepage}} *)
+
+(** {1:func Functorial interface}
+    The functorial interface allows to associate more information to the
+    keys. For example a key name or a key value pretty-printer. *)
+
+(** The type for key information. *)
+module type KEY_INFO = sig
+  type 'a t
+  (** The type for key information. *)
+end
+
+(** Output signature of the functor {!Make} *)
+module type S = sig
+
+  (** {1:keys Keys} *)
+
+  type 'a key
+  (** The type for keys whose lookup value is of type ['a]. *)
+
+  (** Keys. *)
+  module Key : sig
+
+    (** {1:keys Keys} *)
+
+    type 'a info
+    (** The type for key information. *)
+
+    val create : 'a info -> 'a key
+    (** [create i] is a new key with information [i]. *)
+
+    val info : 'a key -> 'a info
+    (** [info k] is [k]'s information. *)
+
+    (** {1:exists Existential keys}
+        Exisential keys allow to compare keys. This can be useful for
+        functions like {!filter}. *)
+
+    type t
+    (** The type for existential keys. *)
+
+    val hide_type : 'a key -> t
+    (** [hide_type k] is an existential key for [k]. *)
+
+    val equal : t -> t -> bool
+    (** [equal k k'] is [true] iff [k] and [k'] are the same key. *)
+
+    val compare : t -> t -> int
+    (** [compare k k'] is a total order on keys compatible with {!equal}. *)
+  end
+
+  (** {1:maps Maps} *)
+
+  type t
+  (** The type for heterogeneous value maps. *)
+
+  val empty : t
+  (** [empty] is the empty map. *)
+
+  val is_empty : t -> bool
+  (** [is_empty m] is [true] iff [m] is empty. *)
+
+  val mem : 'a key -> t -> bool
+  (** [mem k m] is [true] iff [k] is bound in [m]. *)
+
+  val add : 'a key -> 'a -> t -> t
+  (** [add k v m] is [m] with [k] bound to [v]. *)
+
+  val singleton : 'a key -> 'a -> t
+  (** [singleton k v] is [add k v empty]. *)
+
+  val rem : 'a key -> t -> t
+  (** [rem k m] is [m] with [k] unbound. *)
+
+  val find : 'a key -> t -> 'a option
+  (** [find k m] is the value of [k]'s binding in [m], if any. *)
+
+  val get : 'a key -> t -> 'a
+  (** [get k m] is the value of [k]'s binding in [m].
+      @raise Invalid_argument if [k] is not bound in [m]. *)
+
+  (** The type for bindings. *)
+  type binding = B : 'a key * 'a -> binding
+
+  val iter : (binding -> unit) -> t -> unit
+  (** [iter f m] applies [f] to all bindings of [m]. *)
+
+  val fold : (binding -> 'a -> 'a) -> t -> 'a -> 'a
+  (** [fold f m acc] folds over the bindings of [m] with [f], starting with
+      [acc] *)
+
+  val for_all : (binding -> bool) -> t -> bool
+  (** [for_all p m] is [true] iff all bindings of [m] satisfy [p]. *)
+
+  val exists : (binding -> bool) -> t -> bool
+  (** [exists p m] is [true] iff there exists a bindings of [m] that
+      satisfies [p]. *)
+
+  val filter : (binding -> bool) -> t -> t
+  (** [filter p m] are the bindings of [m] that satisfy [p]. *)
+
+  val cardinal : t -> int
+  (** [cardinal m] is the number of bindings in [m]. *)
+
+  val bindings : t -> binding list
+  (** [bindings m] is the list of all bindings in [m] *)
+
+  val any_binding : t -> binding option
+  (** [any_binding m] is a binding of [m] (if not empty). *)
+
+  val get_any_binding : t -> binding
+  (** [get_any_binding m] is a binding of [m].
+      @raise Invalid_argument if [m] is empty. *)
+
+  type mapper = { map: 'a. 'a key -> 'a -> 'a }
+  (** The type for map operation. *)
+
+  val map : mapper -> t -> t
+  (** [map f m] applies [f.map] to all bindings of [m]. *)
+
+  type merger = { merge: 'a. 'a key -> 'a option -> 'a option -> 'a option }
+  (** The type for merge operation. *)
+
+  val merge : merger -> t -> t -> t
+  (** [merge f a b] applies [f.merge] to all pair of (optional)
+      bindings in [a] and [b]. *)
+
+  type equality_comparer = { equal : 'a. 'a key -> 'a -> 'a -> bool }
+  (** The type for equals operation. *)
+
+  val equal : equality_comparer -> t -> t -> bool
+  (** [equal f a b] applies [f.equal] to all pair of bindings in [a] and [b].
+      Returns true, if all keys exists exists in both maps and the comparition of all keys is true *)
+
+  type comparer = { compare : 'a. 'a key -> 'a -> 'a -> int }
+  (** The type for compare operation. *)
+
+  val compare : comparer -> t -> t -> int
+  (** Total ordering between maps. The first argument is a total ordering used to compare data associated with equal keys in the two maps. *)
+end
+
+(** Functor for heterogeneous maps whose keys hold information
+    of type [Key_info.t] *)
+module Make :
+  functor (Key_info : KEY_INFO) -> S with type 'a Key.info = 'a Key_info.t
+
+include module type of Make(struct type 'a t = unit end)
+
+(*---------------------------------------------------------------------------
+   Copyright (c) 2016 Daniel C. Bünzli
+   Permission to use, copy, modify, and/or distribute this software for any
+   purpose with or without fee is hereby granted, provided that the above
+   copyright notice and this permission notice appear in all copies.
+   THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+   WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+   ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+   WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+   ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  ---------------------------------------------------------------------------*)

--- a/tests/regression/57-setjmp/01-setjmp-return.c
+++ b/tests/regression/57-setjmp/01-setjmp-return.c
@@ -1,0 +1,30 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp --set solvers.td3.side_widen never
+#include <setjmp.h>
+#include <assert.h>
+
+int main(void)
+{
+    jmp_buf jmp_buf;
+
+    assert(1);
+    switch (setjmp(jmp_buf))
+    {
+    case 0:
+        assert(1);
+        longjmp(jmp_buf, 1);
+        assert(0); // NOWARN
+        break;
+    case 1:
+        assert(1);
+        break;
+    case 2:
+        assert(0); // NOWARN
+        break;
+    default:
+        assert(0); // NOWARN
+        break;
+    }
+    assert(1);
+
+    return 0;
+}

--- a/tests/regression/57-setjmp/02-setjmp-global.c
+++ b/tests/regression/57-setjmp/02-setjmp-global.c
@@ -1,0 +1,34 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp --set solvers.td3.side_widen never
+#include <setjmp.h>
+#include <assert.h>
+
+int global = 0;
+
+int main(void)
+{
+    jmp_buf jmp_buf;
+
+    assert(1);
+    setjmp(jmp_buf);
+    switch (global)
+    {
+    case 0:
+        assert(1);
+        global = 1;
+        longjmp(jmp_buf, 1);
+        assert(0); // NOWARN
+        break;
+    case 1:
+        assert(1);
+        break;
+    case 2:
+        assert(0); // NOWARN
+        break;
+    default:
+        assert(0); // NOWARN
+        break;
+    }
+    assert(1);
+
+    return 0;
+}

--- a/tests/regression/57-setjmp/03-setjmp-local.c
+++ b/tests/regression/57-setjmp/03-setjmp-local.c
@@ -1,0 +1,34 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp --set solvers.td3.side_widen never --disable exp.volatiles_are_top
+#include <setjmp.h>
+#include <assert.h>
+
+
+int main(void)
+{
+    jmp_buf jmp_buf;
+    volatile int local = 0;
+
+    assert(1);
+    setjmp(jmp_buf);
+    switch (local)
+    {
+    case 0:
+        assert(1);
+        local = 1;
+        longjmp(jmp_buf, 1);
+        assert(0); // NOWARN
+        break;
+    case 1:
+        assert(1);
+        break;
+    case 2:
+        assert(0); // NOWARN
+        break;
+    default:
+        assert(0); // NOWARN
+        break;
+    }
+    assert(1);
+
+    return 0;
+}

--- a/tests/regression/57-setjmp/04-counting-local.c
+++ b/tests/regression/57-setjmp/04-counting-local.c
@@ -1,0 +1,25 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp
+#include <assert.h>
+#include <setjmp.h>
+
+jmp_buf my_jump_buffer;
+
+void foo(int count)
+{
+    assert(count >= 0 && count <= 5);
+    longjmp(my_jump_buffer, 1);
+    assert(0); // NOWARN
+}
+
+int main(void)
+{
+    volatile int count = 0;
+    setjmp(my_jump_buffer);
+    assert(count == 0); // UNKNOWN!
+    if (count < 5) {
+        count++;
+        foo(count);
+        assert(0); // NOWARN
+    }
+    assert(count == 5);
+}

--- a/tests/regression/57-setjmp/05-counting-return-one-method.c
+++ b/tests/regression/57-setjmp/05-counting-return-one-method.c
@@ -1,0 +1,17 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp --enable exp.earlyglobs
+#include <assert.h>
+#include <setjmp.h>
+
+jmp_buf my_jump_buffer;
+
+int main(void)
+{
+    int count = setjmp(my_jump_buffer);
+    assert(count == 0); // UNKNOWN!
+    if (count < 5) {
+        assert(count >= 0 && count < 5);
+        longjmp(my_jump_buffer, count + 1);
+        assert(0); // NOWARN
+    }
+    assert(count == 5);
+}

--- a/tests/regression/57-setjmp/11-counting-return.c
+++ b/tests/regression/57-setjmp/11-counting-return.c
@@ -1,0 +1,23 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp --set solvers.td3.side_widen never
+#include <assert.h>
+#include <setjmp.h>
+
+jmp_buf my_jump_buffer;
+ 
+void foo(int count) 
+{
+    assert(count >= 0 && count < 5);
+    longjmp(my_jump_buffer, count + 1);
+    assert(0); // NOWARN
+}
+
+int main(void)
+{
+    int count = setjmp(my_jump_buffer);
+    assert(count == 0); // UNKNOWN!
+    if (count < 5) {
+        foo(count);
+        assert(0); // NOWARN
+    }
+    assert(count == 5);
+}

--- a/tests/regression/57-setjmp/12-counting-global.c
+++ b/tests/regression/57-setjmp/12-counting-global.c
@@ -1,0 +1,25 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp --set solvers.td3.side_widen never
+#include <assert.h>
+#include <setjmp.h>
+
+jmp_buf my_jump_buffer;
+int count = 0;
+
+void foo()
+{
+    assert(count >= 0 && count < 5);
+    count++;
+    longjmp(my_jump_buffer, 1);
+    assert(0); // NOWARN
+}
+
+int main(void)
+{
+    setjmp(my_jump_buffer);
+    assert(count == 0); // UNKNOWN!
+    if (count < 5) {
+        foo();
+        assert(0); // NOWARN
+    }
+    assert(count == 5);
+}

--- a/tests/regression/57-setjmp/13-counting-local.c
+++ b/tests/regression/57-setjmp/13-counting-local.c
@@ -1,0 +1,25 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp --set solvers.td3.side_widen never --disable exp.volatiles_are_top
+#include <assert.h>
+#include <setjmp.h>
+
+jmp_buf my_jump_buffer;
+
+void foo(int count)
+{
+    assert(count >= 0 && count <= 5);
+    longjmp(my_jump_buffer, 1);
+    assert(0); // NOWARN
+}
+
+int main(void)
+{
+    volatile int count = 0;
+    setjmp(my_jump_buffer);
+    assert(count == 0); // UNKNOWN!
+    if (count < 5) {
+        count++;
+        foo(count);
+        assert(0); // NOWARN
+    }
+    assert(count == 5);
+}

--- a/tests/regression/57-setjmp/14-counting-return-one-method.c
+++ b/tests/regression/57-setjmp/14-counting-return-one-method.c
@@ -1,0 +1,17 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp --set solvers.td3.side_widen never
+#include <assert.h>
+#include <setjmp.h>
+
+jmp_buf my_jump_buffer;
+
+int main(void)
+{
+    int count = setjmp(my_jump_buffer);
+    assert(count == 0); // UNKNOWN!
+    if (count < 5) {
+        assert(count >= 0 && count < 5);
+        longjmp(my_jump_buffer, count + 1);
+        assert(0); // NOWARN
+    }
+    assert(count == 5);
+}

--- a/tests/regression/57-setjmp/15-counting-global-one-method.c
+++ b/tests/regression/57-setjmp/15-counting-global-one-method.c
@@ -1,0 +1,19 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp --set solvers.td3.side_widen never
+#include <assert.h>
+#include <setjmp.h>
+
+jmp_buf my_jump_buffer;
+int count = 0;
+
+int main(void)
+{
+    setjmp(my_jump_buffer);
+    assert(count == 0); // UNKNOWN!
+    if (count < 5) {
+        assert(count >= 0 && count < 5);
+        count++;
+        longjmp(my_jump_buffer, 1);
+        assert(0); // NOWARN
+    }
+    assert(count == 5);
+}

--- a/tests/regression/57-setjmp/16-counting-local-one-method.c
+++ b/tests/regression/57-setjmp/16-counting-local-one-method.c
@@ -1,0 +1,19 @@
+// PARAM: --enable ana.int.interval --enable ana.int.enums --set "ana.activated[+]" setjmp --set solvers.td3.side_widen never --disable exp.volatiles_are_top
+#include <assert.h>
+#include <setjmp.h>
+
+jmp_buf my_jump_buffer;
+
+int main(void)
+{
+    volatile int count = 0;
+    setjmp(my_jump_buffer);
+    assert(count == 0); // UNKNOWN!
+    if (count < 5) {
+        count++;
+        assert(count >= 0 && count <= 5);
+        longjmp(my_jump_buffer, 1);
+        assert(0); // NOWARN
+    }
+    assert(count == 5);
+}


### PR DESCRIPTION
Adds an analysis to handle the [`setjmp`](https://en.cppreference.com/w/c/program/setjmp) and [`longjmp`](https://en.cppreference.com/w/c/program/longjmp) functions.

The setjmp analysis collects local state of the other analyses with the `Longjmp` and `VolatileLocals` query and then returns it when required with the `Setjmp` event. Due to the path insensitive nature of analysis globals it is not necessary to touch them.

The setjump analysis is able to collect arbitrary data from all analyses by using a heterogeneous map, but this also means it is not able to affect any specific state and can only perform domain operations on the whole map. This map domain is based on the [hmap](https://github.com/dbuenzli/hmap) library, but included directly as it is pretty abandoned and it needed to add various functions to be able to implement a domain based on it.

This is currently only used by base, and i am not exactly sure which other analyses also benefit from support for it.