### PR TITLE
IntDomain logcal operation short-circuiting

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1605,8 +1605,20 @@ struct
   let shift_right =
     shift BigInt.shift_right
   (* TODO: lift does not treat Not {0} as true. *)
-  let logand = lift2 BigInt.logand
-  let logor  = lift2 BigInt.logor
+  let logand ik x y =
+    match to_bool x, to_bool y with
+    | Some false, _
+    | _, Some false ->
+      of_bool ik false
+    | _, _ ->
+      lift2 BigInt.logand ik x y
+  let logor ik x y =
+    match to_bool x, to_bool y with
+    | Some true, _
+    | _, Some true ->
+      of_bool ik true
+    | _, _ ->
+      lift2 BigInt.logor ik x y
   let lognot ik = eq ik (of_int ik BigInt.zero)
 
   let invariant_ikind e ik (x:t) =

--- a/tests/regression/56-witness/03-int-log-short.c
+++ b/tests/regression/56-witness/03-int-log-short.c
@@ -1,0 +1,11 @@
+// PARAM: --set witness.yaml.validate 03-int-log-short.yml
+
+int main() {
+  int r;
+  int x, y;
+  x = 1;
+  y = 0;
+  ; // SUCCESS (witness)
+  ; // SUCCESS (witness)
+  return 0;
+}

--- a/tests/regression/56-witness/03-int-log-short.yml
+++ b/tests/regression/56-witness/03-int-log-short.yml
@@ -1,0 +1,58 @@
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: 872fc896-7029-4d06-b733-6ecc2d3f8074
+    creation_time: 2022-06-29T09:18:35Z
+    producer:
+      name: Goblint
+      version: heads/int-log-0-g5f8473450-dirty
+      command_line: '''/home/simmo/dev/goblint/sv-comp/goblint/goblint'' ''03-int-log-short.c''
+        ''--enable'' ''witness.yaml.enabled'' ''--set'' ''dbg.debug'' ''true'' ''--set''
+        ''printstats'' ''true'' ''--enable'' ''dbg.print_dead_code'' ''--set'' ''goblint-dir''
+        ''.goblint-56-03'''
+    task:
+      input_files:
+      - 03-int-log-short.c
+      input_file_hashes:
+        03-int-log-short.c: 055e8b0b611a6bbe2b072f5c92f094e63fa339ac53190660ac3e54f2fd40d379
+      data_model: LP64
+      language: C
+  location:
+    file_name: 03-int-log-short.c
+    file_hash: 055e8b0b611a6bbe2b072f5c92f094e63fa339ac53190660ac3e54f2fd40d379
+    line: 8
+    column: 2
+    function: main
+  loop_invariant:
+    string: r || x
+    type: assertion
+    format: C
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: f42797cf-479e-469f-b378-3bf9ab3f79a9
+    creation_time: 2022-06-29T09:18:35Z
+    producer:
+      name: Goblint
+      version: heads/int-log-0-g5f8473450-dirty
+      command_line: '''/home/simmo/dev/goblint/sv-comp/goblint/goblint'' ''03-int-log-short.c''
+        ''--enable'' ''witness.yaml.enabled'' ''--set'' ''dbg.debug'' ''true'' ''--set''
+        ''printstats'' ''true'' ''--enable'' ''dbg.print_dead_code'' ''--set'' ''goblint-dir''
+        ''.goblint-56-03'''
+    task:
+      input_files:
+      - 03-int-log-short.c
+      input_file_hashes:
+        03-int-log-short.c: 055e8b0b611a6bbe2b072f5c92f094e63fa339ac53190660ac3e54f2fd40d379
+      data_model: LP64
+      language: C
+  location:
+    file_name: 03-int-log-short.c
+    file_hash: 055e8b0b611a6bbe2b072f5c92f094e63fa339ac53190660ac3e54f2fd40d379
+    line: 9
+    column: 2
+    function: main
+  loop_invariant:
+    string: '!(r && y)'
+    type: assertion
+    format: C


### PR DESCRIPTION
When invariants are generated (witness or assert) for path-sensitive abstract values, the path invariants are joined syntactically with `||`. So far we have been unable to reprove these invariants.

In light of #757, I thought reproving path disjunctions would also require something involved or inefficient (e.g. finding a permutation to match disjuncts with paths that they succeed in). But actually the reason we couldn't reprove them is embarrasingly stupid: `logor` in `IntDomain`s is always just default-lifted to work with both definite booleans and doesn't handle short-circuiting. That is, `top || true` was `top`, not `true`, and analogously for `top && false`.

Hence, this PR implements the required short-circuiting `logor` and `logand` in `DefExc`. This allows disjunctive path invariants to be automagically reproven: `EvalInt` on a set of paths requires the expression to be true on all paths, but individually each path just needs one disjunct to be true, not all of them.

An open point is whether short-circuiting should also be implemented in other `IntDomain`s.

**EDIT:** This fix, applied to https://github.com/goblint/bench/pull/31, reproves all the invariants there. And applied to https://github.com/goblint/bench/pull/30, reproves more (but not all) invariants.