### PR TITLE
Modify Library Function Specification for assert to not dereference its argument

### DIFF
--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -15,7 +15,7 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("realloc", special [__ "ptr" [r; f]; __ "size" []] @@ fun ptr size -> Realloc { ptr; size });
     ("abort", special [] Abort);
     ("exit", special [drop "exit_code" []] Abort);
-    ("assert", special [__ "cond" [r]] @@ fun cond -> Assert cond);
+    ("assert", special [__ "cond" []] @@ fun cond -> Assert cond);
   ]
 
 (** C POSIX library functions.

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -18,4 +18,4 @@ let pretty () = function
   | SplitBranch (exp, tv) -> dprintf "SplitBranch (%a, %B)" d_exp exp tv
   | AssignSpawnedThread (lval, tid) -> dprintf "AssignSpawnedThread (%a, %a)" d_lval lval ThreadIdDomain.Thread.pretty tid
   | Access {var_opt; kind} -> dprintf "Access {var_opt=%a, kind=%a}" (docOpt (CilType.Varinfo.pretty ())) var_opt AccessKind.pretty kind
-  | Assign {lval; exp} -> dprintf "Assugn {lval=%a, exp=%a}" CilType.Lval.pretty lval CilType.Exp.pretty exp
+  | Assign {lval; exp} -> dprintf "Assign {lval=%a, exp=%a}" CilType.Lval.pretty lval CilType.Exp.pretty exp

--- a/tests/regression/02-base/86-spurious.c
+++ b/tests/regression/02-base/86-spurious.c
@@ -1,0 +1,24 @@
+#include<pthread.h>
+#include<assert.h>
+int counter = 0;
+pthread_mutex_t lock1;
+
+void* producer(void* param) {
+    pthread_mutex_lock(&lock1);
+    counter = 0;
+    pthread_mutex_unlock(&lock1);
+}
+
+void* consumer(void* param) {
+    pthread_mutex_lock(&lock1);
+    assert(counter >= 0); //NOWARN
+    pthread_mutex_unlock(&lock1);
+}
+
+
+int main() {
+    pthread_t thread;
+    pthread_t thread2;
+    pthread_create(&thread,NULL,producer,NULL);
+    pthread_create(&thread2,NULL,consumer,NULL);
+}

--- a/tests/regression/02-base/86-spurious.c
+++ b/tests/regression/02-base/86-spurious.c
@@ -11,7 +11,9 @@ void* producer(void* param) {
 
 void* consumer(void* param) {
     pthread_mutex_lock(&lock1);
-    assert(counter >= 0); //NOWARN
+    int bla = counter >= 0;
+    // This should not produce a warning about the privatization being unsound
+    assert(counter >= 0);
     pthread_mutex_unlock(&lock1);
 }
 

--- a/tests/regression/02-base/86-spurious.c
+++ b/tests/regression/02-base/86-spurious.c
@@ -1,3 +1,4 @@
+//PARAM: --disable warn.assert
 #include<pthread.h>
 #include<assert.h>
 int counter = 0;
@@ -13,7 +14,7 @@ void* consumer(void* param) {
     pthread_mutex_lock(&lock1);
     int bla = counter >= 0;
     // This should not produce a warning about the privatization being unsound
-    assert(counter >= 0);
+    assert(counter >= 0); //NOWARN
     pthread_mutex_unlock(&lock1);
 }
 


### PR DESCRIPTION
It seems like there was a mistake in the specification of the library function for `assert` as it was marked to dereference its argument. This caused the warnings in #765.

@sim642 does this fix makes sense like this? Are there other library functions that need to be fixed as well?

Closes #765 