### PR TITLE
Remove erroneous call to `truncateCilint` in `min_for`

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -393,9 +393,6 @@ module Size = struct (* size in bits as int, range as int64 *)
   open Cil open Big_int_Z
   let sign x = if BI.compare x BI.zero < 0 then `Signed else `Unsigned
 
-  let max = function
-    | `Signed -> ILongLong
-    | `Unsigned -> IULongLong
   let top_typ = TInt (ILongLong, [])
   let min_for x = intKindForValue x (sign x = `Unsigned)
   let bit = function (* bits needed for representation *)

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -397,7 +397,7 @@ module Size = struct (* size in bits as int, range as int64 *)
     | `Signed -> ILongLong
     | `Unsigned -> IULongLong
   let top_typ = TInt (ILongLong, [])
-  let min_for x = intKindForValue (fst (truncateCilint (max (sign x)) x)) (sign x = `Unsigned)
+  let min_for x = intKindForValue x (sign x = `Unsigned)
   let bit = function (* bits needed for representation *)
     | IBool -> 1
     | ik -> bytesSizeOfInt ik * 8

--- a/tests/regression/38-int-refinements/02-strange-ulong.c
+++ b/tests/regression/38-int-refinements/02-strange-ulong.c
@@ -1,6 +1,8 @@
 // PARAM: --enable ana.int.interval --set ana.int.refinement once
 #include <assert.h>
 
+int main();
+
 int withint() {
   int i = 0;
   void* bla;

--- a/tests/regression/38-int-refinements/02-strange-ulong.c
+++ b/tests/regression/38-int-refinements/02-strange-ulong.c
@@ -1,25 +1,6 @@
 // PARAM: --enable ana.int.interval --set ana.int.refinement once
 #include <assert.h>
 
-int main() {
-  withint();
-  withuint();
-  withlong();
-  withlonglong();
-  withulonglong();
-
-  unsigned long i = 0;
-  void* bla;
-
-  while(i < 10000) {
-    i++;
-    bla = &main;
-  }
-
-  assert(1); // reachable
-  return 0;
-}
-
 int withint() {
   int i = 0;
   void* bla;
@@ -74,6 +55,25 @@ int withlonglong() {
 
 int withulonglong() {
   unsigned long long i = 0;
+  void* bla;
+
+  while(i < 10000) {
+    i++;
+    bla = &main;
+  }
+
+  assert(1); // reachable
+  return 0;
+}
+
+int main() {
+  withint();
+  withuint();
+  withlong();
+  withlonglong();
+  withulonglong();
+
+  unsigned long i = 0;
   void* bla;
 
   while(i < 10000) {

--- a/tests/regression/38-int-refinements/02-strange-ulong.c
+++ b/tests/regression/38-int-refinements/02-strange-ulong.c
@@ -1,0 +1,86 @@
+// PARAM: --enable ana.int.interval --set ana.int.refinement once
+#include <assert.h>
+
+int main() {
+  withint();
+  withuint();
+  withlong();
+  withlonglong();
+  withulonglong();
+
+  unsigned long i = 0;
+  void* bla;
+
+  while(i < 10000) {
+    i++;
+    bla = &main;
+  }
+
+  assert(1); // reachable
+  return 0;
+}
+
+int withint() {
+  int i = 0;
+  void* bla;
+
+  while(i < 10000) {
+    i++;
+    bla = &main;
+  }
+
+  assert(1); // reachable
+  return 0;
+}
+
+int withuint() {
+  unsigned int i = 0;
+  void* bla;
+
+  while(i < 10000) {
+    i++;
+    bla = &main;
+  }
+
+  assert(1); // reachable
+  return 0;
+}
+
+int withlong() {
+  long i = 0;
+  void* bla;
+
+  while(i < 10000) {
+    i++;
+    bla = &main;
+  }
+
+  assert(1); // reachable
+  return 0;
+}
+
+int withlonglong() {
+  long long i = 0;
+  void* bla;
+
+  while(i < 10000) {
+    i++;
+    bla = &main;
+  }
+
+  assert(1); // reachable
+  return 0;
+}
+
+int withulonglong() {
+  unsigned long long i = 0;
+  void* bla;
+
+  while(i < 10000) {
+    i++;
+    bla = &main;
+  }
+
+  assert(1); // reachable
+  return 0;
+}


### PR DESCRIPTION
Calling `truncateCilint` in `min_for` hides overflows that might happen, so it is incorrect to call it here.

Closes #769 