### PR TITLE
Mutex-Meet-TID Privatization for Base

### DIFF
--- a/src/analyses/basePriv.mli
+++ b/src/analyses/basePriv.mli
@@ -22,6 +22,9 @@ sig
   val enter_multithreaded: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t
   val threadenter: Queries.ask -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t
 
+  val thread_join: Queries.ask -> (V.t -> G.t) -> Cil.exp -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t
+  val thread_return: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> ThreadIdDomain.Thread.t -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t
+
   val init: unit -> unit
   val finalize: unit -> unit
 end

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -6,6 +6,36 @@ module Q = Queries
 module IdxDom = ValueDomain.IndexDomain
 module VD     = BaseDomain.VD
 
+module ConfCheck =
+struct
+  module RequireMutexActivatedInit =
+  struct
+    let init () =
+      let analyses = GobConfig.get_string_list "ana.activated" in
+      let mutex_active = List.mem "mutex" analyses || not (List.mem "base" analyses) in
+      if not mutex_active then failwith "Privatization (to be useful) requires the 'mutex' analysis to be enabled (it is currently disabled)"
+  end
+
+  module RequireMutexPathSensInit =
+  struct
+    let init () =
+      RequireMutexActivatedInit.init ();
+      let mutex_path_sens = List.mem "mutex" (GobConfig.get_string_list "ana.path_sens") in
+      if not mutex_path_sens then failwith "The activated privatization requires the 'mutex' analysis to be enabled & path sensitive (it is currently enabled, but not path sensitive)";
+      ()
+  end
+
+  module RequireThreadFlagPathSensInit =
+  struct
+    let init () =
+      let threadflag_active = List.mem "threadflag" (GobConfig.get_string_list "ana.activated") in
+      if threadflag_active then
+        let threadflag_path_sens = List.mem "threadflag" (GobConfig.get_string_list "ana.path_sens") in
+        if not threadflag_path_sens then failwith "The activated privatization requires the 'threadflag' analysis to be path sensitive if it is enabled (it is currently enabled, but not path sensitive)";
+        ()
+  end
+end
+
 module ProtectionLogging =
 struct
   module GM = Hashtbl.Make(ValueDomain.Addr)
@@ -155,33 +185,89 @@ struct
   end
 end
 
-module ConfCheck =
+module PerMutexTidG (LAD:Lattice.S) =
 struct
-  module RequireMutexActivatedInit =
+  include ConfCheck.RequireThreadFlagPathSensInit
+
+  module TID = ThreadIdDomain.Thread
+
+  (** May written variables. *)
+  module W =
   struct
-    let init () =
-      let analyses = GobConfig.get_string_list "ana.activated" in
-      let mutex_active = List.mem "mutex" analyses || not (List.mem "base" analyses) in
-      if not mutex_active then failwith "Privatization (to be useful) requires the 'mutex' analysis to be enabled (it is currently disabled)"
+    include MayVars
+    let name () = "W"
   end
 
-  module RequireMutexPathSensInit =
+  module V =
   struct
-    let init () =
-      RequireMutexActivatedInit.init ();
-      let mutex_path_sens = List.mem "mutex" (GobConfig.get_string_list "ana.path_sens") in
-      if not mutex_path_sens then failwith "The activated privatization requires the 'mutex' analysis to be enabled & path sensitive (it is currently enabled, but not path sensitive)";
-      ()
+    include Printable.Either (MutexGlobals.V) (TID)
+    let mutex x = `Left (MutexGlobals.V.mutex x)
+    let mutex_inits = `Left MutexGlobals.V.mutex_inits
+    let global x = `Left (MutexGlobals.V.global x)
+    let thread x = `Right x
   end
 
-  module RequireThreadFlagPathSensInit =
+  module LLock =
   struct
-    let init () =
-      let threadflag_active = List.mem "threadflag" (GobConfig.get_string_list "ana.activated") in
-      if threadflag_active then
-        let threadflag_path_sens = List.mem "threadflag" (GobConfig.get_string_list "ana.path_sens") in
-        if not threadflag_path_sens then failwith "The activated privatization requires the 'threadflag' analysis to be path sensitive if it is enabled (it is currently enabled, but not path sensitive)";
-        ()
+    include Printable.Either (Locksets.Lock) (CilType.Varinfo)
+    let mutex m = `Left m
+    let global x = `Right x
   end
 
+  module LMust = struct
+    include SetDomain.Reverse (SetDomain.ToppedSet (LLock) (struct let topname = "All locks" end))
+    let name () = "LMust"
+  end
+
+  (* Map from locks to last written values thread-locally *)
+  module L = MapDomain.MapBot_LiftTop (LLock) (LAD)
+  module GMutex = MapDomain.MapBot_LiftTop (ThreadIdDomain.ThreadLifted) (LAD)
+  module GThread = Lattice.Prod (LMust) (L)
+
+  module G =
+  struct
+    include Lattice.Lift2 (GMutex) (GThread) (Printable.DefaultNames)
+
+    let mutex = function
+      | `Bot -> GMutex.bot ()
+      | `Lifted1 x -> x
+      | _ -> failwith "PerMutexMeetPrivTID.mutex"
+    let thread = function
+      | `Bot -> GThread.bot ()
+      | `Lifted2 x -> x
+      | _ -> failwith "PerMutexMeetPrivTID.thread"
+    let create_mutex mutex = `Lifted1 mutex
+    let create_global global = `Lifted1 global
+    let create_thread thread = `Lifted2 thread
+  end
+
+  module D = Lattice.Prod3 (W) (LMust) (L)
+
+  let compatible (ask:Q.ask) current must_joined other =
+    match current, other with
+    | `Lifted current, `Lifted other ->
+      if (TID.is_unique current) && (TID.equal current other) then
+        false (* self-read *)
+      else if GobConfig.get_bool "ana.apron.priv.not-started" && MHP.definitely_not_started (current, ask.f Q.CreatedThreads) other then
+        false (* other is not started yet *)
+      else if GobConfig.get_bool "ana.apron.priv.must-joined" && MHP.must_be_joined other must_joined then
+        false (* accounted for in local information *)
+      else
+        true
+    | _ -> true
+
+  let get_relevant_writes_nofilter (ask:Q.ask) v =
+    let current = ThreadId.get_current ask in
+    let must_joined = ask.f Queries.MustJoinedThreads in
+    GMutex.fold (fun k v acc ->
+        if compatible ask current must_joined k then
+          LAD.join acc v
+        else
+          acc
+      ) v (LAD.bot ())
+
+  let merge_all v =
+    GMutex.fold (fun _ v acc -> LAD.join acc v) v (LAD.bot ())
+
+  let startstate () = W.bot (), LMust.top (), L.bot ()
 end


### PR DESCRIPTION
This adds a Mutex-Meet-TID based privatization for Base.

TODO:
- [ ] Tests
- [ ] See if more duplication can be avoided between the relational and non-relational analysis


During the process, it became clear that enhancing protection based with MHP should also be fairly trivial and may also pay off, so we should also take a look at that.

Closes #631 