### PR TITLE
Make `mutex-meet-tid` Sound for Threads Exited by `pthread_exit(...)` & Improve Precision of `threadJoins` Analysis

### DIFF
--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -421,6 +421,8 @@ struct
     | ThreadExit _, _ ->
       begin match ThreadId.get_current ask with
         | `Lifted tid ->
+          (* value returned from the thread is not used in thread_join or any Priv.thread_join, *)
+          (* thus no handling like for returning from functions required *)
           ignore @@ Priv.thread_return ask ctx.global ctx.sideg tid st;
           raise Deadcode
         | _ ->

--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -418,6 +418,14 @@ struct
         | Some lv -> invalidate_one ask ctx st' lv
         | None -> st'
       )
+    | ThreadExit _, _ ->
+      begin match ThreadId.get_current ask with
+        | `Lifted tid ->
+          ignore @@ Priv.thread_return ask ctx.global ctx.sideg tid st;
+          raise Deadcode
+        | _ ->
+          raise Deadcode
+      end
     | _, _ ->
       let lvallist e =
         let s = ask.f (Queries.MayPointTo e) in

--- a/tests/regression/46-apron2/19-tid-toy-10-exit.c
+++ b/tests/regression/46-apron2/19-tid-toy-10-exit.c
@@ -1,0 +1,45 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// Copy of 80-tid-toy10 making use of pthread_exit
+#include <pthread.h>
+#include <assert.h>
+
+int g = 10;
+int h = 10;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_benign(void *arg) {
+  int top;
+
+  if(top) {
+    pthread_mutex_lock(&A);
+    g = 10;
+    h = 10;
+    pthread_mutex_unlock(&A);
+
+    // If the analysis does unsoundly not account for pthread_exit, these writes are lost
+    pthread_exit(NULL);
+  }
+
+  return NULL;
+}
+
+int main(void) {
+  int t;
+
+  // Force multi-threaded handling
+  pthread_t id2;
+  pthread_create(&id2, NULL, t_benign, NULL);
+
+  pthread_mutex_lock(&A);
+  g = 12;
+  h = 14;
+  pthread_mutex_unlock(&A);
+
+  pthread_join(id2, NULL);
+
+  pthread_mutex_lock(&A);
+  assert(g == 12); //UNKNOWN!
+  pthread_mutex_unlock(&A);
+
+  return 0;
+}

--- a/tests/regression/46-apron2/20-inprecise-returns.c
+++ b/tests/regression/46-apron2/20-inprecise-returns.c
@@ -1,0 +1,57 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// Based on 80-tid-toy10
+#include <pthread.h>
+#include <assert.h>
+
+int g = 10;
+int h = 10;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+int imInnocent() {
+    // If all returns side-effect the set of must-joined threads, this leads to imprecision
+    // https://github.com/goblint/analyzer/issues/793
+    return 8;
+}
+
+void *t_evil(void *arg) {
+  pthread_mutex_lock(&A);
+  g = 8;
+  h = 20;
+  pthread_mutex_unlock(&A);
+}
+
+void *t_benign(void *arg) {
+  pthread_t id2;
+  pthread_create(&id2, NULL, t_evil, NULL);
+
+  imInnocent();
+  pthread_join(id2, NULL);
+
+  pthread_mutex_lock(&A);
+  g = 10;
+  h = 10;
+  pthread_mutex_unlock(&A);
+
+  return NULL;
+}
+
+int main(void) {
+  int t;
+
+  // Force multi-threaded handling
+  pthread_t id2;
+  pthread_create(&id2, NULL, t_benign, NULL);
+
+  pthread_mutex_lock(&A);
+  g = 10;
+  h = 10;
+  pthread_mutex_unlock(&A);
+
+  pthread_join(id2, NULL);
+
+  pthread_mutex_lock(&A);
+  assert(g == h);
+  pthread_mutex_unlock(&A);
+
+  return 0;
+}

--- a/tests/regression/46-apron2/21-tid-toy-10-exit-othert.c
+++ b/tests/regression/46-apron2/21-tid-toy-10-exit-othert.c
@@ -1,0 +1,60 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// Modification of 19 that would fail if pthread_exit was only handled for the top-level thread
+#include <pthread.h>
+#include <assert.h>
+
+int g = 10;
+int h = 10;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void cheeky() { pthread_exit(NULL); }
+
+void *t_evil(void *arg) {
+  pthread_mutex_lock(&A);
+  g = 8;
+  h = 20;
+  pthread_mutex_unlock(&A);
+}
+
+void *t_benign(void *arg) {
+  pthread_t id2;
+  pthread_create(&id2, NULL, t_evil, NULL);
+
+  int top;
+
+  if(top) {
+    // If the analysis does unsoundly not account for pthread_exit called from another function, these writes are lost
+    cheeky();
+  }
+
+  pthread_join(id2, NULL);
+
+  pthread_mutex_lock(&A);
+  g = 10;
+  h = 10;
+  pthread_mutex_unlock(&A);
+
+
+  return NULL;
+}
+
+int main(void) {
+  int t;
+
+  // Force multi-threaded handling
+  pthread_t id2;
+  pthread_create(&id2, NULL, t_benign, NULL);
+
+  pthread_mutex_lock(&A);
+  g = 10;
+  h = 10;
+  pthread_mutex_unlock(&A);
+
+  pthread_join(id2, NULL);
+
+  pthread_mutex_lock(&A);
+  assert(g == 10); //UNKNOWN!
+  pthread_mutex_unlock(&A);
+
+  return 0;
+}


### PR DESCRIPTION
- Consider `pthread_exit` in `mutex-meet-tid` for soundness
- Improve `threadJoins` by only side-effecting set of must-joined TIDs on return from a thread, not just any random **return**

Closes #793 