### PR TITLE
Add static module for top-level Control Spec context

### DIFF
--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -567,6 +567,31 @@ struct
 end
 
 
+module type FailwithMessage =
+sig
+  val message: string
+end
+
+module Failwith (Message: FailwithMessage): S =
+struct
+  type t = |
+
+  let name () = "failwith"
+  let equal _ _ = failwith Message.message
+  let compare _ _ = failwith Message.message
+  let hash _ = failwith Message.message
+  let tag _ = failwith Message.message
+
+  let show _ = failwith Message.message
+  let pretty _ _ = failwith Message.message
+  let printXml _ _ = failwith Message.message
+  let to_yojson _ = failwith Message.message
+
+  let arbitrary _ = failwith Message.message
+  let relift _ = failwith Message.message
+end
+
+
 (** Concatenates a list of strings that
     fit in the given character constraint *)
 let get_short_list begin_str end_str list =

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -269,8 +269,15 @@ struct
 end
 
 
-let control_spec_c: (module Printable.S) ref = ref (module Printable.Unit: Printable.S) (* TODO: some failing printable instead *)
 (** Reference to top-level Control Spec context first-class module. *)
+let control_spec_c: (module Printable.S) ref =
+  let module Failwith = Printable.Failwith (
+    struct
+      let message = "uninitialized control_spec_c"
+    end
+    )
+  in
+  ref (module Failwith: Printable.S)
 
 (** Top-level Control Spec context as static module, which delegates to {!control_spec_c}.
     This allows using top-level context values inside individual analyses. *)

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -576,3 +576,47 @@ struct
   let threadenter ctx lval f args = [ctx.local]
   let threadspawn ctx lval f args fctx = ctx.local
 end
+
+let control_c: (module Printable.S) ref = ref (module Printable.Unit: Printable.S) (* TODO: some failing printable instead *)
+
+module ControlC: Printable.S =
+struct
+  type t = Obj.t (** represents [(val !control_c).t] *)
+
+  let name () =
+    let module C = (val !control_c) in
+    C.name ()
+
+  let equal x y =
+    let module C = (val !control_c) in
+    C.equal (Obj.obj x) (Obj.obj y)
+  let compare x y =
+    let module C = (val !control_c) in
+    C.compare (Obj.obj x) (Obj.obj y)
+  let hash x =
+    let module C = (val !control_c) in
+    C.hash (Obj.obj x)
+  let tag x =
+    let module C = (val !control_c) in
+    C.tag (Obj.obj x)
+
+  let show x =
+    let module C = (val !control_c) in
+    C.show (Obj.obj x)
+  let pretty () x =
+    let module C = (val !control_c) in
+    C.pretty () (Obj.obj x)
+  let printXml f x =
+    let module C = (val !control_c) in
+    C.printXml f (Obj.obj x)
+  let to_yojson x =
+    let module C = (val !control_c) in
+    C.to_yojson (Obj.obj x)
+
+  let arbitrary () =
+    let module C = (val !control_c) in
+    QCheck.map ~rev:Obj.obj Obj.repr (C.arbitrary ())
+  let relift x =
+    let module C = (val !control_c) in
+    Obj.repr (C.relift (Obj.obj x))
+end

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -269,6 +269,51 @@ struct
 end
 
 
+let control_c: (module Printable.S) ref = ref (module Printable.Unit: Printable.S) (* TODO: some failing printable instead *)
+
+module ControlC: Printable.S =
+struct
+  type t = Obj.t (** represents [(val !control_c).t] *)
+
+  let name () =
+    let module C = (val !control_c) in
+    C.name ()
+
+  let equal x y =
+    let module C = (val !control_c) in
+    C.equal (Obj.obj x) (Obj.obj y)
+  let compare x y =
+    let module C = (val !control_c) in
+    C.compare (Obj.obj x) (Obj.obj y)
+  let hash x =
+    let module C = (val !control_c) in
+    C.hash (Obj.obj x)
+  let tag x =
+    let module C = (val !control_c) in
+    C.tag (Obj.obj x)
+
+  let show x =
+    let module C = (val !control_c) in
+    C.show (Obj.obj x)
+  let pretty () x =
+    let module C = (val !control_c) in
+    C.pretty () (Obj.obj x)
+  let printXml f x =
+    let module C = (val !control_c) in
+    C.printXml f (Obj.obj x)
+  let to_yojson x =
+    let module C = (val !control_c) in
+    C.to_yojson (Obj.obj x)
+
+  let arbitrary () =
+    let module C = (val !control_c) in
+    QCheck.map ~rev:Obj.obj Obj.repr (C.arbitrary ())
+  let relift x =
+    let module C = (val !control_c) in
+    Obj.repr (C.relift (Obj.obj x))
+end
+
+
 (* Experiment to reduce the number of arguments on transfer functions and allow
    sub-analyses. The list sub contains the current local states of analyses in
    the same order as written in the dependencies list (in MCP).
@@ -284,7 +329,7 @@ type ('d,'g,'c,'v) ctx =
   ; emit     : Events.t -> unit
   ; node     : MyCFG.node
   ; prev_node: MyCFG.node
-  ; control_context : Obj.t (** (Control.get_spec ()) context, represented type: unit -> (Control.get_spec ()).C.t *)
+  ; control_context : unit -> ControlC.t (** (Control.get_spec ()) context *)
   ; context  : unit -> 'c (** current Spec context *)
   ; edge     : MyCFG.edge
   ; local    : 'd
@@ -575,48 +620,4 @@ struct
 
   let threadenter ctx lval f args = [ctx.local]
   let threadspawn ctx lval f args fctx = ctx.local
-end
-
-let control_c: (module Printable.S) ref = ref (module Printable.Unit: Printable.S) (* TODO: some failing printable instead *)
-
-module ControlC: Printable.S =
-struct
-  type t = Obj.t (** represents [(val !control_c).t] *)
-
-  let name () =
-    let module C = (val !control_c) in
-    C.name ()
-
-  let equal x y =
-    let module C = (val !control_c) in
-    C.equal (Obj.obj x) (Obj.obj y)
-  let compare x y =
-    let module C = (val !control_c) in
-    C.compare (Obj.obj x) (Obj.obj y)
-  let hash x =
-    let module C = (val !control_c) in
-    C.hash (Obj.obj x)
-  let tag x =
-    let module C = (val !control_c) in
-    C.tag (Obj.obj x)
-
-  let show x =
-    let module C = (val !control_c) in
-    C.show (Obj.obj x)
-  let pretty () x =
-    let module C = (val !control_c) in
-    C.pretty () (Obj.obj x)
-  let printXml f x =
-    let module C = (val !control_c) in
-    C.printXml f (Obj.obj x)
-  let to_yojson x =
-    let module C = (val !control_c) in
-    C.to_yojson (Obj.obj x)
-
-  let arbitrary () =
-    let module C = (val !control_c) in
-    QCheck.map ~rev:Obj.obj Obj.repr (C.arbitrary ())
-  let relift x =
-    let module C = (val !control_c) in
-    Obj.repr (C.relift (Obj.obj x))
 end

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -478,7 +478,7 @@ struct
       ; emit    = (fun _ -> failwith "emit outside MCP")
       ; node    = fst var
       ; prev_node = prev_node
-      ; control_context = snd var
+      ; control_context = snd var |> Obj.obj
       ; context = snd var |> Obj.obj
       ; edge    = edge
       ; local   = pval

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -255,7 +255,7 @@ struct
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in global initializer context.")
         ; node    = MyCFG.dummy_node
         ; prev_node = MyCFG.dummy_node
-        ; control_context = Obj.repr (fun () -> ctx_failwith "Global initializers have no context.")
+        ; control_context = (fun () -> ctx_failwith "Global initializers have no context.")
         ; context = (fun () -> ctx_failwith "Global initializers have no context.")
         ; edge    = MyCFG.Skip
         ; local   = Spec.D.top ()
@@ -355,7 +355,7 @@ struct
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in enter_with context.")
         ; node    = MyCFG.dummy_node
         ; prev_node = MyCFG.dummy_node
-        ; control_context = Obj.repr (fun () -> ctx_failwith "enter_func has no context.")
+        ; control_context = (fun () -> ctx_failwith "enter_func has no context.")
         ; context = (fun () -> ctx_failwith "enter_func has no context.")
         ; edge    = MyCFG.Skip
         ; local   = st
@@ -388,7 +388,7 @@ struct
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in otherstate context.")
         ; node    = MyCFG.dummy_node
         ; prev_node = MyCFG.dummy_node
-        ; control_context = Obj.repr (fun () -> ctx_failwith "enter_func has no context.")
+        ; control_context = (fun () -> ctx_failwith "enter_func has no context.")
         ; context = (fun () -> ctx_failwith "enter_func has no context.")
         ; edge    = MyCFG.Skip
         ; local   = st
@@ -589,7 +589,7 @@ struct
                 ; emit   = (fun _ -> failwith "Cannot \"emit\" in query context.")
                 ; node   = MyCFG.dummy_node (* TODO maybe ask should take a node (which could be used here) instead of a location *)
                 ; prev_node = MyCFG.dummy_node
-                ; control_context = Obj.repr (fun () -> ctx_failwith "No context in query context.")
+                ; control_context = (fun () -> ctx_failwith "No context in query context.")
                 ; context = (fun () -> ctx_failwith "No context in query context.")
                 ; edge    = MyCFG.Skip
                 ; local  = local
@@ -643,7 +643,7 @@ struct
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in query context.")
         ; node   = MyCFG.dummy_node (* TODO maybe ask should take a node (which could be used here) instead of a location *)
         ; prev_node = MyCFG.dummy_node
-        ; control_context = Obj.repr (fun () -> ctx_failwith "No context in query context.")
+        ; control_context = (fun () -> ctx_failwith "No context in query context.")
         ; context = (fun () -> ctx_failwith "No context in query context.")
         ; edge    = MyCFG.Skip
         ; local  = snd (List.hd startvars) (* bot and top both silently raise and catch Deadcode in DeadcodeLifter *)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -31,7 +31,7 @@ let spec_module: (module Spec) Lazy.t = lazy (
             |> lift (get_bool "ana.opt.hashcons") (module HashconsLifter)
           ) in
   GobConfig.building_spec := false;
-  Analyses.control_c := (module S1.C);
+  Analyses.control_spec_c := (module S1.C);
   (module S1)
 )
 

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -31,6 +31,7 @@ let spec_module: (module Spec) Lazy.t = lazy (
             |> lift (get_bool "ana.opt.hashcons") (module HashconsLifter)
           ) in
   GobConfig.building_spec := false;
+  Analyses.control_c := (module S1.C);
   (module S1)
 )
 

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -290,7 +290,7 @@ struct
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in witness context.")
         ; node   = fst lvar
         ; prev_node = MyCFG.dummy_node
-        ; control_context = (fun () -> Obj.magic (snd lvar))
+        ; control_context = (fun () -> Obj.magic (snd lvar)) (* magic is fine because Spec is top-level Control Spec *)
         ; context = (fun () -> snd lvar)
         ; edge    = MyCFG.Skip
         ; local  = local

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -290,7 +290,7 @@ struct
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in witness context.")
         ; node   = fst lvar
         ; prev_node = MyCFG.dummy_node
-        ; control_context = Obj.repr (fun () -> snd lvar)
+        ; control_context = (fun () -> Obj.magic (snd lvar))
         ; context = (fun () -> snd lvar)
         ; edge    = MyCFG.Skip
         ; local  = local

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -137,7 +137,7 @@ struct
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in witness context.")
         ; node   = n
         ; prev_node = MyCFG.dummy_node
-        ; control_context = Obj.repr (fun () -> ctx_failwith "No context in witness context.")
+        ; control_context = (fun () -> ctx_failwith "No context in witness context.")
         ; context = (fun () -> ctx_failwith "No context in witness context.")
         ; edge    = MyCFG.Skip
         ; local  = local
@@ -240,7 +240,7 @@ struct
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in witness context.")
         ; node   = fst lvar
         ; prev_node = MyCFG.dummy_node
-        ; control_context = Obj.repr (fun () -> snd lvar)
+        ; control_context = (fun () -> Obj.magic (snd lvar))
         ; context = (fun () -> snd lvar)
         ; edge    = MyCFG.Skip
         ; local  = local

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -240,7 +240,7 @@ struct
         ; emit   = (fun _ -> failwith "Cannot \"emit\" in witness context.")
         ; node   = fst lvar
         ; prev_node = MyCFG.dummy_node
-        ; control_context = (fun () -> Obj.magic (snd lvar))
+        ; control_context = (fun () -> Obj.magic (snd lvar)) (* magic is fine because Spec is top-level Control Spec *)
         ; context = (fun () -> snd lvar)
         ; edge    = MyCFG.Skip
         ; local  = local


### PR DESCRIPTION
This adds the static `Analyses.ControlSpecC` module, which corresponds to the context of the entire top-level `Spec`. This allows individual analyses to actually use `ctx.control_context`, get a result of meaningful type and use them (opaquely) inside its own domains and global constraint variables.

Previously this was problematic in multiple ways:
1. ARINC analysis (and its extraction) unsafely get (or really reconstruct) the corresponding base analysis context and use its hash to identify the context:
    https://github.com/goblint/analyzer/blob/1dcd96761ff4a457c5f86e74285dd78e675e8fb4/src/analyses/arinc.ml#L253-L255
    This in itself is prone to two problems:
    1. Hashes may collide.
    3. Other analyses other than base may also have context components.
2. To avoid the aforementioned problems, a safe way is to implement a `Spec` functor instead, which wraps the entire combined analysis and can thus directly access its `C` module. The GraphML witness generation takes this route.
    Implementing such an analysis as a functor is inconvenient and composes poorly with other analyses.