### PR TITLE
Clean up test `PARAM`s

### DIFF
--- a/scripts/test-param-activated.py
+++ b/scripts/test-param-activated.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+
+from pathlib import Path
+import re
+import shlex
+import json
+
+
+tests_root_path = Path("./tests/regression")
+
+# copied from options
+activated_default = set([
+    "expRelation", "base", "threadid", "threadflag", "threadreturn",
+    "escape", "mutexEvents", "mutex", "access", "mallocWrapper", "mhp",
+    "assert"
+])
+
+for test_path in tests_root_path.glob("*/*.c"):
+    # print(test_path)
+    with test_path.open() as test_file:
+        line = test_file.readline().strip()
+        # print(line)
+        m = re.match(r"^//.*PARAM.*:\s*(.*)$", line)
+        if m is not None:
+            param = m.group(1)
+            params = shlex.split(param)
+            if "ana.activated" in params:
+                activated_i = params.index("ana.activated")
+                activated_str = params[activated_i + 1]
+                activated_str = activated_str.replace("'","\"") # silly Goblint JSON
+                # print(activated)
+                activated = set(json.loads(activated_str))
+                added = activated - activated_default
+                removed = activated_default - activated
+                # print(added, removed)
+                if added or removed:
+                    print(test_path)
+                    if added:
+                        # print(f"  added: {added}")
+                        args_str = ""
+                        for analysis in added:
+                            args_str += f" --set ana.activated[+] {analysis}"
+                        print(f"  added:{args_str}")
+                    if removed:
+                        # print(f"  removed: {removed}")
+                        args_str = ""
+                        for analysis in removed:
+                            args_str += f" --set ana.activated[-] {analysis}"
+                        print(f"  removed:{args_str}")

--- a/tests/regression/00-sanity/13-sans_context.c
+++ b/tests/regression/00-sanity/13-sans_context.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['escape', 'base','threadid','threadflag','mallocWrapper','assert']" --set ana.ctx_insens[+] base --set ana.base.privatization none
+// PARAM: --set ana.ctx_insens[+] base --set ana.base.privatization none
 #include <assert.h>
 
 void f(int v, int i){

--- a/tests/regression/00-sanity/13-sans_context.c
+++ b/tests/regression/00-sanity/13-sans_context.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.ctx_insens[+] base --set ana.base.privatization none
+// PARAM: --set ana.ctx_insens[+] base
 #include <assert.h>
 
 void f(int v, int i){

--- a/tests/regression/00-sanity/26-strict-loop-enter.c
+++ b/tests/regression/00-sanity/26-strict-loop-enter.c
@@ -1,4 +1,4 @@
-//PARAM: --disable ana.int.def_exc --enable ana.int.interval --sets solver slr3tp
+//PARAM: --disable ana.int.def_exc --enable ana.int.interval --set solver slr3tp
 #include <assert.h>
 
 int g = 0;

--- a/tests/regression/00-sanity/26-strict-loop-enter.c
+++ b/tests/regression/00-sanity/26-strict-loop-enter.c
@@ -1,5 +1,4 @@
-//PARAM: --disable ana.int.def_exc --enable ana.int.interval --sets solver slr3tp --enable dbg.debug
-// dbg.debug manually enabled since update_suite only enables it when it sees normal assertion (without NOWARN)
+//PARAM: --disable ana.int.def_exc --enable ana.int.interval --sets solver slr3tp
 #include <assert.h>
 
 int g = 0;

--- a/tests/regression/00-sanity/30-both_branches.c
+++ b/tests/regression/00-sanity/30-both_branches.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.base.privatization none --enable exp.earlyglobs --disable exp.fast_global_inits
+// PARAM: --enable exp.earlyglobs --disable exp.fast_global_inits
 #include <assert.h>
 
 union bloirg {

--- a/tests/regression/01-cpa/28-interval.c
+++ b/tests/regression/01-cpa/28-interval.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver "'new'" --set ana.int.interval true
+// PARAM: --set ana.int.interval true
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/01-cpa/29-fun_struct_array.c
+++ b/tests/regression/01-cpa/29-fun_struct_array.c
@@ -1,4 +1,3 @@
-// PARAM: --set dbg.debug true
 #include <assert.h>
 
 void QQ(){

--- a/tests/regression/01-cpa/30-extern_var.c
+++ b/tests/regression/01-cpa/30-extern_var.c
@@ -1,4 +1,3 @@
-// PARAM: --set dbg.debug true
 #include <assert.h>
 
 extern int q;

--- a/tests/regression/01-cpa/31-unk-fn-ptrs.c
+++ b/tests/regression/01-cpa/31-unk-fn-ptrs.c
@@ -1,4 +1,3 @@
-// PARAM: --set ana.base.privatization none
 #include <assert.h>
 
 extern void f_everything_up();

--- a/tests/regression/01-cpa/31-unk-fn-ptrs.c
+++ b/tests/regression/01-cpa/31-unk-fn-ptrs.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set ana.base.privatization none
 #include <assert.h>
 
 extern void f_everything_up();

--- a/tests/regression/01-cpa/36-interval-branching.c
+++ b/tests/regression/01-cpa/36-interval-branching.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc
+// PARAM: --enable ana.int.interval --disable ana.int.def_exc
 #include <assert.h>
 #include <stdio.h>
 int main(){

--- a/tests/regression/01-cpa/45-float.c
+++ b/tests/regression/01-cpa/45-float.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --enable ana.int.def_exc --enable ana.sv-comp.functions --set ana.activated[+] var_eq --set ana.activated[+] region --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --enable ana.int.def_exc --enable ana.sv-comp.functions --set ana.activated[+] var_eq --set ana.activated[+] region
 #include <assert.h>
 
 int isNan(float arg) {

--- a/tests/regression/01-cpa/45-float.c
+++ b/tests/regression/01-cpa/45-float.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --enable ana.int.def_exc --enable ana.sv-comp.functions --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','var_eq','region','expRelation']" --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --enable ana.int.def_exc --enable ana.sv-comp.functions --set ana.activated[+] var_eq --set ana.activated[+] region --set ana.base.privatization none
 #include <assert.h>
 
 int isNan(float arg) {

--- a/tests/regression/01-cpa/49-earlyglobs-base.c
+++ b/tests/regression/01-cpa/49-earlyglobs-base.c
@@ -1,4 +1,5 @@
 // PARAM: --set ana.activated ["'base'","'mallocWrapper'","'assert'"]  --enable exp.earlyglobs --set ana.base.privatization none
+// intentional explicit ana.activated to have only base
 // same as 32-earlyglobs.c but only using the base analysis instead of all default analyses
 // earlyglobs was unsound without the threadflag analysis
 // https://github.com/goblint/analyzer/issues/177

--- a/tests/regression/01-cpa/51-marshal.c
+++ b/tests/regression/01-cpa/51-marshal.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval
 void callee(int j) {
   j++;
 }

--- a/tests/regression/01-cpa/51-marshal.c
+++ b/tests/regression/01-cpa/51-marshal.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 void callee(int j) {
   j++;
 }

--- a/tests/regression/01-cpa/51-marshal.c
+++ b/tests/regression/01-cpa/51-marshal.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 void callee(int j) {
   j++;
 }

--- a/tests/regression/01-cpa/51-marshal.c
+++ b/tests/regression/01-cpa/51-marshal.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 void callee(int j) {
   j++;
 }

--- a/tests/regression/01-cpa/53-escaping-recursion-varEq.c
+++ b/tests/regression/01-cpa/53-escaping-recursion-varEq.c
@@ -1,4 +1,4 @@
-// PARAM: --sets ana.activated[+] "var_eq"
+// PARAM: --set ana.activated[+] "var_eq"
 #include <assert.h>
 
 int rec(int i,int* ptr) {

--- a/tests/regression/02-base/06-side_effect1.c
+++ b/tests/regression/02-base/06-side_effect1.c
@@ -1,5 +1,3 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper','assert']"
-
 #include<pthread.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/07-side_effect2.c
+++ b/tests/regression/02-base/07-side_effect2.c
@@ -1,5 +1,3 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper','assert']"
-
 #include<pthread.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/08-glob_interval.c
+++ b/tests/regression/02-base/08-glob_interval.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver "'new'" --set ana.int.interval true
+// PARAM: --set ana.int.interval true
 #include<pthread.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/09-ambigpointer.c
+++ b/tests/regression/02-base/09-ambigpointer.c
@@ -1,4 +1,3 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper','assert']"
 #include<pthread.h>
 #include<assert.h>
 

--- a/tests/regression/02-base/10-init_allfuns.c
+++ b/tests/regression/02-base/10-init_allfuns.c
@@ -1,4 +1,4 @@
-// PARAM: --enable allfuns --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper','assert']"
+// PARAM: --enable allfuns
 #include <assert.h>
 
 int glob1 = 5;

--- a/tests/regression/02-base/12-init_otherfun.c
+++ b/tests/regression/02-base/12-init_otherfun.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set otherfun "['f']" --set ana.activated "['base','threadid','threadflag','escape','mallocWrapper','mutex','access','assert']"
+// SKIP PARAM: --set otherfun "['f']"
 
 int glob1 = 5;
 

--- a/tests/regression/02-base/23-malloc_globmt.c
+++ b/tests/regression/02-base/23-malloc_globmt.c
@@ -1,4 +1,3 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper','assert']"
 #include <stdlib.h>
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/02-base/30-escape_sound.c
+++ b/tests/regression/02-base/30-escape_sound.c
@@ -1,5 +1,3 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper','assert']"
-
 #include<pthread.h>
 #include<stdio.h>
 #include<assert.h>

--- a/tests/regression/02-base/33-assert-infinite-loop.c
+++ b/tests/regression/02-base/33-assert-infinite-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc
 // This is a pattern we saw in some examples for SVCOMP, where instead of the __goblint_check(0) there was a call to verifier error.
 // Because of the demand-driven nature of our solvers, we never looked at the code inside fail since there is no edge from the loop to the endpoint of f.
 // However, the __goblint_check(0) (verifier error) is still reachable from main.

--- a/tests/regression/02-base/33-assert-infinite-loop.c
+++ b/tests/regression/02-base/33-assert-infinite-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc
+// PARAM: --enable ana.int.interval --disable ana.int.def_exc
 // This is a pattern we saw in some examples for SVCOMP, where instead of the __goblint_check(0) there was a call to verifier error.
 // Because of the demand-driven nature of our solvers, we never looked at the code inside fail since there is no edge from the loop to the endpoint of f.
 // However, the __goblint_check(0) (verifier error) is still reachable from main.

--- a/tests/regression/02-base/33-assert-infinite-loop.c
+++ b/tests/regression/02-base/33-assert-infinite-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.privatization none
 // This is a pattern we saw in some examples for SVCOMP, where instead of the __goblint_check(0) there was a call to verifier error.
 // Because of the demand-driven nature of our solvers, we never looked at the code inside fail since there is no edge from the loop to the endpoint of f.
 // However, the __goblint_check(0) (verifier error) is still reachable from main.

--- a/tests/regression/02-base/41-calloc_globmt.c
+++ b/tests/regression/02-base/41-calloc_globmt.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper','assert']" --set ana.int.interval true --set ana.base.arrays.domain partitioned
+// PARAM: --set ana.int.interval true --set ana.base.arrays.domain partitioned
 #include <stdlib.h>
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/02-base/57-meet-def-exc.c
+++ b/tests/regression/02-base/57-meet-def-exc.c
@@ -1,4 +1,3 @@
-// PARAM: --set solver td3
 void main(void) {
     int x;
     int i = 41;

--- a/tests/regression/02-base/58-empty-not-dead.c
+++ b/tests/regression/02-base/58-empty-not-dead.c
@@ -1,4 +1,5 @@
 //PARAM: --set ana.activated '["base", "mallocWrapper", "assert"]'  --set ana.base.privatization none
+// intentional explicit ana.activated to have non-dead bot local state
 // Copied & modified from 33/04.
 #include <assert.h>
 

--- a/tests/regression/02-base/87-casts-dep-on-param.c
+++ b/tests/regression/02-base/87-casts-dep-on-param.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.ctx_insens[+] 'base'  --set ana.base.privatization none
+// PARAM: --set ana.ctx_insens[+] 'base'
 #include<stdlib.h>
 int f(int, void*);
 

--- a/tests/regression/02-base/87-casts-dep-on-param.c
+++ b/tests/regression/02-base/87-casts-dep-on-param.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base', 'mallocWrapper']" --set ana.ctx_insens[+] 'base'  --set ana.base.privatization none
+// PARAM: --set ana.ctx_insens[+] 'base'  --set ana.base.privatization none
 #include<stdlib.h>
 int f(int, void*);
 

--- a/tests/regression/02-base/87-casts-dep-on-param.c
+++ b/tests/regression/02-base/87-casts-dep-on-param.c
@@ -1,4 +1,5 @@
-// PARAM: --set ana.ctx_insens[+] 'base'
+// PARAM: --set ana.activated "['base', 'mallocWrapper']" --set ana.ctx_insens[+] 'base' --set ana.ctx_insens[+] 'mallocWrapper'
+// should be fully context-insensitive to activate minimal analyses
 #include<stdlib.h>
 int f(int, void*);
 

--- a/tests/regression/02-base/87-casts-dep-on-param.c
+++ b/tests/regression/02-base/87-casts-dep-on-param.c
@@ -1,5 +1,6 @@
-// PARAM: --set ana.activated "['base', 'mallocWrapper']" --set ana.ctx_insens[+] 'base' --set ana.ctx_insens[+] 'mallocWrapper'
+// PARAM: --set ana.activated "['base', 'mallocWrapper']" --set ana.ctx_insens[+] 'base' --set ana.ctx_insens[+] 'mallocWrapper' --set ana.base.privatization none
 // should be fully context-insensitive to activate minimal analyses
+// none privatization because mutex deactivated
 #include<stdlib.h>
 int f(int, void*);
 

--- a/tests/regression/03-practical/14-call_by_pointer.c
+++ b/tests/regression/03-practical/14-call_by_pointer.c
@@ -1,4 +1,3 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','mutexEvents','mutex','access','mallocWrapper','assert']"
 #include <assert.h>
 
 /**

--- a/tests/regression/03-practical/18-no_ctx_box.c
+++ b/tests/regression/03-practical/18-no_ctx_box.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[-] mutex --set solver "'new'" --set ana.ctx_insens[+] base --set ana.ctx_insens[+] escape --set ana.base.privatization none
+// SKIP PARAM: --set ana.activated[-] mutex --set solver "'new'" --set ana.ctx_insens[+] base --set ana.ctx_insens[+] escape
 void write(int **p){
   *p=1;
 }

--- a/tests/regression/04-mutex/48-assign_spawn.c
+++ b/tests/regression/04-mutex/48-assign_spawn.c
@@ -1,4 +1,4 @@
-// PARAM: --set kernel true --set dbg.debug true
+// PARAM: --set kernel true
 #include <linux/module.h>
 #include <linux/miscdevice.h>
 #include <linux/device.h>

--- a/tests/regression/06-symbeq/01-symbeq_ints.c
+++ b/tests/regression/06-symbeq/01-symbeq_ints.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set dbg.debug true --set ana.activated[+] "'var_eq'"
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/06-symbeq/18-symbeq_addrs.c
+++ b/tests/regression/06-symbeq/18-symbeq_addrs.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set dbg.debug true --set ana.activated[+] "'var_eq'"
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"
 #include<stdlib.h>
 #include <assert.h>
 

--- a/tests/regression/06-symbeq/19-symbeq_funcs.c
+++ b/tests/regression/06-symbeq/19-symbeq_funcs.c
@@ -1,4 +1,4 @@
-// PARAM: --disable ana.mutex.disjoint_types --set dbg.debug true --set ana.activated[+] "'var_eq'"
+// PARAM: --disable ana.mutex.disjoint_types --set ana.activated[+] "'var_eq'"
 #include <assert.h>
 
 void inc(int * a){

--- a/tests/regression/07-uninit/01-simple.c
+++ b/tests/regression/07-uninit/01-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 #include <stdio.h>
 
 int main() {

--- a/tests/regression/07-uninit/01-simple.c
+++ b/tests/regression/07-uninit/01-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 #include <stdio.h>
 
 int main() {

--- a/tests/regression/07-uninit/02-path_sense.c
+++ b/tests/regression/07-uninit/02-path_sense.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 #include <stdio.h>
 
 void f() {};

--- a/tests/regression/07-uninit/02-path_sense.c
+++ b/tests/regression/07-uninit/02-path_sense.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 #include <stdio.h>
 
 void f() {};

--- a/tests/regression/07-uninit/03-path_sense_bad.c
+++ b/tests/regression/07-uninit/03-path_sense_bad.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 #include<stdio.h>
 
 int main() {

--- a/tests/regression/07-uninit/03-path_sense_bad.c
+++ b/tests/regression/07-uninit/03-path_sense_bad.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 #include<stdio.h>
 
 int main() {

--- a/tests/regression/07-uninit/04-intent_out.c
+++ b/tests/regression/07-uninit/04-intent_out.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 void some_function(int* x){
 	*x = 0;
 }

--- a/tests/regression/07-uninit/04-intent_out.c
+++ b/tests/regression/07-uninit/04-intent_out.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 void some_function(int* x){
 	*x = 0;
 }

--- a/tests/regression/07-uninit/05-struct-bad.c
+++ b/tests/regression/07-uninit/05-struct-bad.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/05-struct-bad.c
+++ b/tests/regression/07-uninit/05-struct-bad.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/06-struct-good.c
+++ b/tests/regression/07-uninit/06-struct-good.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/06-struct-good.c
+++ b/tests/regression/07-uninit/06-struct-good.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/07-struct_return.c
+++ b/tests/regression/07-uninit/07-struct_return.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/07-struct_return.c
+++ b/tests/regression/07-uninit/07-struct_return.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/08-struct_intent_out.c
+++ b/tests/regression/07-uninit/08-struct_intent_out.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/08-struct_intent_out.c
+++ b/tests/regression/07-uninit/08-struct_intent_out.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/09-struct_deep_bad.c
+++ b/tests/regression/07-uninit/09-struct_deep_bad.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/09-struct_deep_bad.c
+++ b/tests/regression/07-uninit/09-struct_deep_bad.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/10-struct_deep_good.c
+++ b/tests/regression/07-uninit/10-struct_deep_good.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/10-struct_deep_good.c
+++ b/tests/regression/07-uninit/10-struct_deep_good.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef struct  {
 	int i;
 } S;

--- a/tests/regression/07-uninit/11-ptr_passtrough.c
+++ b/tests/regression/07-uninit/11-ptr_passtrough.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 int* some_function(int * x){
 	return x; //NOWARN
 }

--- a/tests/regression/07-uninit/11-ptr_passtrough.c
+++ b/tests/regression/07-uninit/11-ptr_passtrough.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 int* some_function(int * x){
 	return x; //NOWARN
 }

--- a/tests/regression/07-uninit/12-struct_return_warn.c
+++ b/tests/regression/07-uninit/12-struct_return_warn.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef struct  {
 	int i, j;
 } S;

--- a/tests/regression/07-uninit/12-struct_return_warn.c
+++ b/tests/regression/07-uninit/12-struct_return_warn.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef struct  {
 	int i, j;
 } S;

--- a/tests/regression/07-uninit/13-struct_param_warn.c
+++ b/tests/regression/07-uninit/13-struct_param_warn.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef struct  {
 	int i,j;
 } S;

--- a/tests/regression/07-uninit/13-struct_param_warn.c
+++ b/tests/regression/07-uninit/13-struct_param_warn.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef struct  {
 	int i,j;
 } S;

--- a/tests/regression/07-uninit/14-struct_in_struct.c
+++ b/tests/regression/07-uninit/14-struct_in_struct.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef struct {
 	int i;
 } S;

--- a/tests/regression/07-uninit/14-struct_in_struct.c
+++ b/tests/regression/07-uninit/14-struct_in_struct.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef struct {
 	int i;
 } S;

--- a/tests/regression/07-uninit/15-union_simple_good.c
+++ b/tests/regression/07-uninit/15-union_simple_good.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef union {
 	int i;
 	int j;

--- a/tests/regression/07-uninit/15-union_simple_good.c
+++ b/tests/regression/07-uninit/15-union_simple_good.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef union {
 	int i;
 	int j;

--- a/tests/regression/07-uninit/16-union_simple_bad.c
+++ b/tests/regression/07-uninit/16-union_simple_bad.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef union {
 	double i;
 	int j;

--- a/tests/regression/07-uninit/16-union_simple_bad.c
+++ b/tests/regression/07-uninit/16-union_simple_bad.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef union {
 	double i;
 	int j;

--- a/tests/regression/07-uninit/17-struct_in_union.c
+++ b/tests/regression/07-uninit/17-struct_in_union.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef union {
 	struct {
 		int a;

--- a/tests/regression/07-uninit/17-struct_in_union.c
+++ b/tests/regression/07-uninit/17-struct_in_union.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef union {
 	struct {
 		int a;

--- a/tests/regression/07-uninit/18-union_in_union.c
+++ b/tests/regression/07-uninit/18-union_in_union.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef union {
 	union {
 		struct {

--- a/tests/regression/07-uninit/18-union_in_union.c
+++ b/tests/regression/07-uninit/18-union_in_union.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef union {
 	union {
 		struct {

--- a/tests/regression/07-uninit/19-struct_in_union_bad.c
+++ b/tests/regression/07-uninit/19-struct_in_union_bad.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit
 typedef union {
 	struct {
 		short a;

--- a/tests/regression/07-uninit/19-struct_in_union_bad.c
+++ b/tests/regression/07-uninit/19-struct_in_union_bad.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper','assert']"  --set ana.base.privatization none
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none
 typedef union {
 	struct {
 		short a;

--- a/tests/regression/08-malloc_null/01-simple-malloc.c
+++ b/tests/regression/08-malloc_null/01-simple-malloc.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','malloc_null','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set ana.activated[+] malloc_null --set ana.base.privatization none
 #include <stdlib.h>
 #include <assert.h>
 

--- a/tests/regression/08-malloc_null/01-simple-malloc.c
+++ b/tests/regression/08-malloc_null/01-simple-malloc.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] malloc_null --set ana.base.privatization none
+// PARAM: --set ana.activated[+] malloc_null
 #include <stdlib.h>
 #include <assert.h>
 

--- a/tests/regression/08-malloc_null/02-paths-malloc.c
+++ b/tests/regression/08-malloc_null/02-paths-malloc.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','malloc_null','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set ana.activated[+] malloc_null --set ana.base.privatization none
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>

--- a/tests/regression/08-malloc_null/02-paths-malloc.c
+++ b/tests/regression/08-malloc_null/02-paths-malloc.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] malloc_null --set ana.base.privatization none
+// PARAM: --set ana.activated[+] malloc_null
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>

--- a/tests/regression/13-privatized/17-priv_interval.c
+++ b/tests/regression/13-privatized/17-priv_interval.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set solver "'td3'"
+// PARAM: --set ana.int.interval true
 #include<pthread.h>
 #include<assert.h>
 

--- a/tests/regression/13-privatized/18-first-reads.c
+++ b/tests/regression/13-privatized/18-first-reads.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set solver "'td3'"
+// PARAM: --set ana.int.interval true
 extern int __VERIFIER_nondet_int();
 
 #include<pthread.h>

--- a/tests/regression/13-privatized/19-publish-precision.c
+++ b/tests/regression/13-privatized/19-publish-precision.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set solver "'td3'"
+// PARAM: --set ana.int.interval true
 #include<pthread.h>
 #include<assert.h>
 

--- a/tests/regression/13-privatized/20-publish-regression.c
+++ b/tests/regression/13-privatized/20-publish-regression.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set solver "'td3'"
+// PARAM: --set ana.int.interval true
 
 #include<pthread.h>
 #include<assert.h>

--- a/tests/regression/13-privatized/21-publish-basic.c
+++ b/tests/regression/13-privatized/21-publish-basic.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.int.interval true --set solver "'td3'"
+// PARAM: --set ana.int.interval true
 #include<pthread.h>
 #include<assert.h>
 

--- a/tests/regression/13-privatized/70-mm-reentrant.c
+++ b/tests/regression/13-privatized/70-mm-reentrant.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --sets ana.base.privatization mutex-meet --disable sem.unknown_function.invalidate.globals --disable sem.unknown_function.spawn
+// PARAM: --enable ana.int.interval --set ana.base.privatization mutex-meet --disable sem.unknown_function.invalidate.globals --disable sem.unknown_function.spawn
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>

--- a/tests/regression/13-privatized/72-pthread_cond_wait_mutexoplus.c
+++ b/tests/regression/13-privatized/72-pthread_cond_wait_mutexoplus.c
@@ -1,4 +1,4 @@
-// PARAM: --sets ana.base.privatization mutex-oplus
+// PARAM: --set ana.base.privatization mutex-oplus
 #include<pthread.h>
 #include<stdio.h>
 #include<unistd.h>

--- a/tests/regression/17-arinc/05-term-simple.c
+++ b/tests/regression/17-arinc/05-term-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','term','mallocWrapper','assert']" --enable dbg.debug --enable ana.int.interval --set solver slr3 --set ana.base.privatization none
+// PARAM: --set ana.activated[+] term --enable dbg.debug --enable ana.int.interval --set solver slr3 --set ana.base.privatization none
 
 /*#include "stdio.h"*/
 

--- a/tests/regression/17-arinc/05-term-simple.c
+++ b/tests/regression/17-arinc/05-term-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] term --enable dbg.debug --enable ana.int.interval --set solver slr3 --set ana.base.privatization none
+// PARAM: --set ana.activated[+] term --enable dbg.debug --enable ana.int.interval --set solver slr3
 
 /*#include "stdio.h"*/
 

--- a/tests/regression/17-arinc/05-term-simple.c
+++ b/tests/regression/17-arinc/05-term-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] term --enable dbg.debug --enable ana.int.interval --set solver slr3
+// PARAM: --set ana.activated[+] term --enable ana.int.interval --set solver slr3
 
 /*#include "stdio.h"*/
 

--- a/tests/regression/17-arinc/06-term.c
+++ b/tests/regression/17-arinc/06-term.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] term --enable dbg.debug --enable ana.int.interval --set solver slr3 --set ana.base.privatization none
+// PARAM: --set ana.activated[+] term --enable dbg.debug --enable ana.int.interval --set solver slr3
 
 int main(){
     int i = 0;

--- a/tests/regression/17-arinc/06-term.c
+++ b/tests/regression/17-arinc/06-term.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] term --enable dbg.debug --enable ana.int.interval --set solver slr3
+// PARAM: --set ana.activated[+] term --enable ana.int.interval --set solver slr3
 
 int main(){
     int i = 0;

--- a/tests/regression/17-arinc/06-term.c
+++ b/tests/regression/17-arinc/06-term.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','term','mallocWrapper','assert']" --enable dbg.debug --enable ana.int.interval --set solver slr3 --set ana.base.privatization none
+// PARAM: --set ana.activated[+] term --enable dbg.debug --enable ana.int.interval --set solver slr3 --set ana.base.privatization none
 
 int main(){
     int i = 0;

--- a/tests/regression/20-slr_term/07-slr-interval.c
+++ b/tests/regression/20-slr_term/07-slr-interval.c
@@ -1,0 +1,73 @@
+// PARAM: --set ana.int.interval true --set solver new
+// https://github.com/goblint/analyzer/pull/805#discussion_r933230577
+#include<stdio.h>
+#include<assert.h>
+
+
+int main () {
+  int a = 1,b = 2,c = 3;
+  int x,y,z;
+  int w;
+  int false = 0;
+  int true = 42;
+
+  if (x){
+    __goblint_check(x != 0);
+  } else {
+    __goblint_check(x == 0);
+  }
+
+  __goblint_check(!! true);
+  __goblint_check(!  false);
+
+  if (a){
+    a = a;
+  } else
+    __goblint_check(0); // NOWARN
+
+
+  if (!a)
+    __goblint_check(0); // NOWARN
+  else
+    a = a;
+
+  if (z != 0){
+    a = 8;
+    b = 9;
+  } else {
+    a = 9;
+    b = 8;
+  }
+
+  __goblint_check(a);
+  __goblint_check(a!=b); //UNKNOWN
+  __goblint_check(a<10);
+  __goblint_check(a<=9);
+  __goblint_check(!(a<8));
+  __goblint_check(a==8); //UNKNOWN
+  __goblint_check(b>7);
+  __goblint_check(b>=8);
+  __goblint_check(!(a>9));
+  __goblint_check(b==8); //UNKNOWN
+
+  for(x = 0; x < 10; x++){
+    __goblint_check(x >= 0);
+    __goblint_check(x <= 9);
+  }
+  __goblint_check(x == 10);
+
+  if (0 <= w)
+  {
+  }
+  else
+  {
+      return 0;
+  }
+
+  if (w > 0)
+  {
+      __goblint_check(1);
+  }
+
+  return 0;
+}

--- a/tests/regression/20-slr_term/08-slr-glob_interval.c
+++ b/tests/regression/20-slr_term/08-slr-glob_interval.c
@@ -1,0 +1,37 @@
+// PARAM: --set ana.int.interval true --set solver new
+// https://github.com/goblint/analyzer/pull/805#discussion_r933232518
+#include<pthread.h>
+#include<assert.h>
+
+int glob = 0;
+pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mtx);
+  glob = 999;
+  pthread_mutex_unlock(&mtx);
+  return NULL;
+}
+
+int main() {
+  int i = 3;
+  pthread_t id;
+
+  __goblint_check(glob == 0);
+
+  // Create the thread
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  // Simple assignments to only locals
+  __goblint_check(i == 3);
+  i = 9;
+  __goblint_check(i == 9);
+
+  glob = 10;
+
+  i = glob;
+  __goblint_check(i >= 0);
+  __goblint_check(i > 100); // UNKNOWN
+
+  return 0;
+}

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 int global;

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int global;

--- a/tests/regression/22-partitioned_arrays/01-simple_array.c
+++ b/tests/regression/22-partitioned_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int global;

--- a/tests/regression/22-partitioned_arrays/02-pointers_array.c
+++ b/tests/regression/22-partitioned_arrays/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/02-pointers_array.c
+++ b/tests/regression/22-partitioned_arrays/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/02-pointers_array.c
+++ b/tests/regression/22-partitioned_arrays/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
+++ b/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
+++ b/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
+++ b/tests/regression/22-partitioned_arrays/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
+++ b/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
+++ b/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
+++ b/tests/regression/22-partitioned_arrays/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
+++ b/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
+++ b/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
+++ b/tests/regression/22-partitioned_arrays/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/22-partitioned_arrays/06-interprocedural.c
+++ b/tests/regression/22-partitioned_arrays/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/06-interprocedural.c
+++ b/tests/regression/22-partitioned_arrays/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/06-interprocedural.c
+++ b/tests/regression/22-partitioned_arrays/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/07-global_array.c
+++ b/tests/regression/22-partitioned_arrays/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int global_array[50];

--- a/tests/regression/22-partitioned_arrays/07-global_array.c
+++ b/tests/regression/22-partitioned_arrays/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int global_array[50];

--- a/tests/regression/22-partitioned_arrays/07-global_array.c
+++ b/tests/regression/22-partitioned_arrays/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 int global_array[50];

--- a/tests/regression/22-partitioned_arrays/08-unsupported.c
+++ b/tests/regression/22-partitioned_arrays/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned
 
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/08-unsupported.c
+++ b/tests/regression/22-partitioned_arrays/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/08-unsupported.c
+++ b/tests/regression/22-partitioned_arrays/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned
 
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/09-one_by_one.c
+++ b/tests/regression/22-partitioned_arrays/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/09-one_by_one.c
+++ b/tests/regression/22-partitioned_arrays/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/09-one_by_one.c
+++ b/tests/regression/22-partitioned_arrays/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/11-was_problematic.c
+++ b/tests/regression/22-partitioned_arrays/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(int argc, char **argv)

--- a/tests/regression/22-partitioned_arrays/11-was_problematic.c
+++ b/tests/regression/22-partitioned_arrays/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 int main(int argc, char **argv)

--- a/tests/regression/22-partitioned_arrays/11-was_problematic.c
+++ b/tests/regression/22-partitioned_arrays/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(int argc, char **argv)

--- a/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
+++ b/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned
 int main(void)
 {
   int arr[260];

--- a/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
+++ b/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval  --set ana.base.arrays.domain partitioned
 int main(void)
 {
   int arr[260];

--- a/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
+++ b/tests/regression/22-partitioned_arrays/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 int main(void)
 {
   int arr[260];

--- a/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
+++ b/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned
 struct some_struct
 {
     int dir[7];

--- a/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
+++ b/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval  --set ana.base.arrays.domain partitioned
 struct some_struct
 {
     int dir[7];

--- a/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
+++ b/tests/regression/22-partitioned_arrays/13-was_problematic_3.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 struct some_struct
 {
     int dir[7];

--- a/tests/regression/22-partitioned_arrays/14-with_def_exc.c
+++ b/tests/regression/22-partitioned_arrays/14-with_def_exc.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.def_exc  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.def_exc  --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/14-with_def_exc.c
+++ b/tests/regression/22-partitioned_arrays/14-with_def_exc.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.def_exc  --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.def_exc  --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/14-with_def_exc.c
+++ b/tests/regression/22-partitioned_arrays/14-with_def_exc.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.def_exc  --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.def_exc  --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/22-partitioned_arrays/15-var_eq.c
+++ b/tests/regression/22-partitioned_arrays/15-var_eq.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] var_eq
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] var_eq
 #include <assert.h>
 
 int global;

--- a/tests/regression/22-partitioned_arrays/15-var_eq.c
+++ b/tests/regression/22-partitioned_arrays/15-var_eq.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','mallocWrapper','var_eq','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] var_eq --set ana.base.privatization none
 #include <assert.h>
 
 int global;

--- a/tests/regression/22-partitioned_arrays/15-var_eq.c
+++ b/tests/regression/22-partitioned_arrays/15-var_eq.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] var_eq --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] var_eq
 #include <assert.h>
 
 int global;

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 #include <assert.h>
 
 int global;

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int global;

--- a/tests/regression/23-partitioned_arrays_last/01-simple_array.c
+++ b/tests/regression/23-partitioned_arrays_last/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int global;

--- a/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
+++ b/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
+++ b/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
+++ b/tests/regression/23-partitioned_arrays_last/02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
+++ b/tests/regression/23-partitioned_arrays_last/04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
+++ b/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
+++ b/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
+++ b/tests/regression/23-partitioned_arrays_last/05-adapted_from_01_09_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include<stdio.h>
 #include<assert.h>
 

--- a/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
+++ b/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
+++ b/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
+++ b/tests/regression/23-partitioned_arrays_last/06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/07-global_array.c
+++ b/tests/regression/23-partitioned_arrays_last/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 #include <assert.h>
 
 int global_array[50];

--- a/tests/regression/23-partitioned_arrays_last/07-global_array.c
+++ b/tests/regression/23-partitioned_arrays_last/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int global_array[50];

--- a/tests/regression/23-partitioned_arrays_last/07-global_array.c
+++ b/tests/regression/23-partitioned_arrays_last/07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int global_array[50];

--- a/tests/regression/23-partitioned_arrays_last/08-unsupported.c
+++ b/tests/regression/23-partitioned_arrays_last/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/08-unsupported.c
+++ b/tests/regression/23-partitioned_arrays_last/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/08-unsupported.c
+++ b/tests/regression/23-partitioned_arrays_last/08-unsupported.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval --disable exp.fast_global_inits --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 
 // This is just to test that the analysis does not cause problems for features that are not explicitly dealt with
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
+++ b/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
+++ b/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
+++ b/tests/regression/23-partitioned_arrays_last/09-one_by_one.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
+++ b/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 #include <assert.h>
 
 int main(int argc, char **argv)

--- a/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
+++ b/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int main(int argc, char **argv)

--- a/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
+++ b/tests/regression/23-partitioned_arrays_last/11-was_problematic.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last"
 #include <assert.h>
 
 int main(int argc, char **argv)

--- a/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
+++ b/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last"  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
 int main(void)
 {
   int arr[260];

--- a/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
+++ b/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last"
+// PARAM: --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last"
 int main(void)
 {
   int arr[260];

--- a/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
+++ b/tests/regression/23-partitioned_arrays_last/12-was_problematic_2.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last"
 int main(void)
 {
   int arr[260];

--- a/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
+++ b/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.partition-arrays.keep-expr last --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval  --set ana.base.partition-arrays.keep-expr last --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 void main(void) {

--- a/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
+++ b/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.partition-arrays.keep-expr last --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.partition-arrays.keep-expr last --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 void main(void) {

--- a/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
+++ b/tests/regression/23-partitioned_arrays_last/13-advantage_for_last.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.partition-arrays.keep-expr last --set ana.base.arrays.domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.partition-arrays.keep-expr last --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 void main(void) {

--- a/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
+++ b/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
+++ b/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
+++ b/tests/regression/23-partitioned_arrays_last/14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/24-octagon/01-octagon_simple.c
+++ b/tests/regression/24-octagon/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 #include <assert.h>
 

--- a/tests/regression/24-octagon/01-octagon_simple.c
+++ b/tests/regression/24-octagon/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 #include <assert.h>
 

--- a/tests/regression/24-octagon/01-octagon_simple.c
+++ b/tests/regression/24-octagon/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 #include <assert.h>
 

--- a/tests/regression/24-octagon/01-octagon_simple.c
+++ b/tests/regression/24-octagon/01-octagon_simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 #include <assert.h>
 

--- a/tests/regression/24-octagon/02-octagon_interprocedural.c
+++ b/tests/regression/24-octagon/02-octagon_interprocedural.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/24-octagon/02-octagon_interprocedural.c
+++ b/tests/regression/24-octagon/02-octagon_interprocedural.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/24-octagon/02-octagon_interprocedural.c
+++ b/tests/regression/24-octagon/02-octagon_interprocedural.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/24-octagon/02-octagon_interprocedural.c
+++ b/tests/regression/24-octagon/02-octagon_interprocedural.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/24-octagon/03-previously_problematic_a.c
+++ b/tests/regression/24-octagon/03-previously_problematic_a.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/03-previously_problematic_a.c
+++ b/tests/regression/24-octagon/03-previously_problematic_a.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/03-previously_problematic_a.c
+++ b/tests/regression/24-octagon/03-previously_problematic_a.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/03-previously_problematic_a.c
+++ b/tests/regression/24-octagon/03-previously_problematic_a.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/04-previously_problematic_b.c
+++ b/tests/regression/24-octagon/04-previously_problematic_b.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 typedef int wchar_t;

--- a/tests/regression/24-octagon/04-previously_problematic_b.c
+++ b/tests/regression/24-octagon/04-previously_problematic_b.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 typedef int wchar_t;

--- a/tests/regression/24-octagon/04-previously_problematic_b.c
+++ b/tests/regression/24-octagon/04-previously_problematic_b.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 typedef int wchar_t;

--- a/tests/regression/24-octagon/04-previously_problematic_b.c
+++ b/tests/regression/24-octagon/04-previously_problematic_b.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 typedef int wchar_t;

--- a/tests/regression/24-octagon/05-previously_problematic_c.c
+++ b/tests/regression/24-octagon/05-previously_problematic_c.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/05-previously_problematic_c.c
+++ b/tests/regression/24-octagon/05-previously_problematic_c.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/05-previously_problematic_c.c
+++ b/tests/regression/24-octagon/05-previously_problematic_c.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/06-previously_problematic_d.c
+++ b/tests/regression/24-octagon/06-previously_problematic_d.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/06-previously_problematic_d.c
+++ b/tests/regression/24-octagon/06-previously_problematic_d.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/06-previously_problematic_d.c
+++ b/tests/regression/24-octagon/06-previously_problematic_d.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/06-previously_problematic_d.c
+++ b/tests/regression/24-octagon/06-previously_problematic_d.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/07-previously_problematic_e.c
+++ b/tests/regression/24-octagon/07-previously_problematic_e.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/07-previously_problematic_e.c
+++ b/tests/regression/24-octagon/07-previously_problematic_e.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/07-previously_problematic_e.c
+++ b/tests/regression/24-octagon/07-previously_problematic_e.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/07-previously_problematic_e.c
+++ b/tests/regression/24-octagon/07-previously_problematic_e.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/08-previously_problematic_f.c
+++ b/tests/regression/24-octagon/08-previously_problematic_f.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/08-previously_problematic_f.c
+++ b/tests/regression/24-octagon/08-previously_problematic_f.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/08-previously_problematic_f.c
+++ b/tests/regression/24-octagon/08-previously_problematic_f.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/09-previously_problematic_g.c
+++ b/tests/regression/24-octagon/09-previously_problematic_g.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/09-previously_problematic_g.c
+++ b/tests/regression/24-octagon/09-previously_problematic_g.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/09-previously_problematic_g.c
+++ b/tests/regression/24-octagon/09-previously_problematic_g.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/10-previously_problematic_h.c
+++ b/tests/regression/24-octagon/10-previously_problematic_h.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/10-previously_problematic_h.c
+++ b/tests/regression/24-octagon/10-previously_problematic_h.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/10-previously_problematic_h.c
+++ b/tests/regression/24-octagon/10-previously_problematic_h.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 int main(int argc, char const *argv[])

--- a/tests/regression/24-octagon/11-previously_problematic_i.c
+++ b/tests/regression/24-octagon/11-previously_problematic_i.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 char buf2[67];

--- a/tests/regression/24-octagon/11-previously_problematic_i.c
+++ b/tests/regression/24-octagon/11-previously_problematic_i.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 char buf2[67];

--- a/tests/regression/24-octagon/11-previously_problematic_i.c
+++ b/tests/regression/24-octagon/11-previously_problematic_i.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // These examples were cases were we saw issues of not reaching a fixpoint during development of the octagon domain. Since those issues might
 // resurface, these tests without asserts are included
 char buf2[67];

--- a/tests/regression/24-octagon/12-previously_problematic_j.c
+++ b/tests/regression/24-octagon/12-previously_problematic_j.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron
 void main(void) {
   int i = 0;
   int j = i;

--- a/tests/regression/24-octagon/12-previously_problematic_j.c
+++ b/tests/regression/24-octagon/12-previously_problematic_j.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none
 void main(void) {
   int i = 0;
   int j = i;

--- a/tests/regression/24-octagon/12-previously_problematic_j.c
+++ b/tests/regression/24-octagon/12-previously_problematic_j.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron
+// SKIP PARAM: --set ana.activated[+] apron
 void main(void) {
   int i = 0;
   int j = i;

--- a/tests/regression/24-octagon/13-array_octagon.c
+++ b/tests/regression/24-octagon/13-array_octagon.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) {

--- a/tests/regression/24-octagon/13-array_octagon.c
+++ b/tests/regression/24-octagon/13-array_octagon.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) {

--- a/tests/regression/24-octagon/13-array_octagon.c
+++ b/tests/regression/24-octagon/13-array_octagon.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) {

--- a/tests/regression/24-octagon/14-array_octagon_keep_last.c
+++ b/tests/regression/24-octagon/14-array_octagon_keep_last.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) {

--- a/tests/regression/24-octagon/14-array_octagon_keep_last.c
+++ b/tests/regression/24-octagon/14-array_octagon_keep_last.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) {

--- a/tests/regression/24-octagon/14-array_octagon_keep_last.c
+++ b/tests/regression/24-octagon/14-array_octagon_keep_last.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) {

--- a/tests/regression/24-octagon/14-array_octagon_keep_last.c
+++ b/tests/regression/24-octagon/14-array_octagon_keep_last.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --set ana.activated[+] apron --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) {

--- a/tests/regression/24-octagon/15-array_octagon_prec.c
+++ b/tests/regression/24-octagon/15-array_octagon_prec.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/24-octagon/15-array_octagon_prec.c
+++ b/tests/regression/24-octagon/15-array_octagon_prec.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/24-octagon/15-array_octagon_prec.c
+++ b/tests/regression/24-octagon/15-array_octagon_prec.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/24-octagon/16-array_octagon_keep_last_prec.c
+++ b/tests/regression/24-octagon/16-array_octagon_keep_last_prec.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated[+] apron --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated[+] apron --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/24-octagon/16-array_octagon_keep_last_prec.c
+++ b/tests/regression/24-octagon/16-array_octagon_keep_last_prec.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated[+] apron --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/24-octagon/16-array_octagon_keep_last_prec.c
+++ b/tests/regression/24-octagon/16-array_octagon_keep_last_prec.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated[+] apron --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated[+] apron --enable annotation.int.enabled --set ana.int.refinement fixpoint --set sem.int.signed_overflow assume_none
 #include <assert.h>
 
 void main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/24-octagon/17-address.c
+++ b/tests/regression/24-octagon/17-address.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','expRelation','apron','mallocWrapper','assert']" --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 #include <assert.h>
 

--- a/tests/regression/24-octagon/17-address.c
+++ b/tests/regression/24-octagon/17-address.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 #include <assert.h>
 

--- a/tests/regression/24-octagon/17-address.c
+++ b/tests/regression/24-octagon/17-address.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron --set ana.base.privatization none
+// SKIP PARAM: --set solver td3 --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 #include <assert.h>
 

--- a/tests/regression/24-octagon/17-address.c
+++ b/tests/regression/24-octagon/17-address.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --enable ana.int.interval  --set ana.base.arrays.domain partitioned --set ana.activated[+] apron
+// SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
 // Example from https://www-apr.lip6.fr/~mine/publi/article-mine-HOSC06.pdf
 #include <assert.h>
 

--- a/tests/regression/25-vla/01-simple.c
+++ b/tests/regression/25-vla/01-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 int main(void)

--- a/tests/regression/25-vla/01-simple.c
+++ b/tests/regression/25-vla/01-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void)

--- a/tests/regression/25-vla/01-simple.c
+++ b/tests/regression/25-vla/01-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void)

--- a/tests/regression/25-vla/02-loop.c
+++ b/tests/regression/25-vla/02-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 int main(void)

--- a/tests/regression/25-vla/02-loop.c
+++ b/tests/regression/25-vla/02-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void)

--- a/tests/regression/25-vla/02-loop.c
+++ b/tests/regression/25-vla/02-loop.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 int main(void)

--- a/tests/regression/25-vla/03-calls.c
+++ b/tests/regression/25-vla/03-calls.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 // Variable-sized arrays
 void foo(int n, int a[n]);
 void foo2(int n, int a[30][n]);

--- a/tests/regression/25-vla/03-calls.c
+++ b/tests/regression/25-vla/03-calls.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 // Variable-sized arrays
 void foo(int n, int a[n]);
 void foo2(int n, int a[30][n]);

--- a/tests/regression/25-vla/03-calls.c
+++ b/tests/regression/25-vla/03-calls.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 // Variable-sized arrays
 void foo(int n, int a[n]);
 void foo2(int n, int a[30][n]);

--- a/tests/regression/25-vla/04-passing_ptr_to_array.c
+++ b/tests/regression/25-vla/04-passing_ptr_to_array.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 void foo(int (*a)[40]){

--- a/tests/regression/25-vla/04-passing_ptr_to_array.c
+++ b/tests/regression/25-vla/04-passing_ptr_to_array.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
+//PARAM: --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 void foo(int (*a)[40]){

--- a/tests/regression/25-vla/04-passing_ptr_to_array.c
+++ b/tests/regression/25-vla/04-passing_ptr_to_array.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 void foo(int (*a)[40]){

--- a/tests/regression/25-vla/05-more_passing.c
+++ b/tests/regression/25-vla/05-more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
+//PARAM: --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 #include<stdio.h>
 #include <assert.h>
 

--- a/tests/regression/25-vla/05-more_passing.c
+++ b/tests/regression/25-vla/05-more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include<stdio.h>
 #include <assert.h>
 

--- a/tests/regression/25-vla/05-more_passing.c
+++ b/tests/regression/25-vla/05-more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 #include<stdio.h>
 #include <assert.h>
 

--- a/tests/regression/25-vla/06-even_more_passing.c
+++ b/tests/regression/25-vla/06-even_more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 void foo2(int n , int (*a)[n] )

--- a/tests/regression/25-vla/06-even_more_passing.c
+++ b/tests/regression/25-vla/06-even_more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 #include <assert.h>
 
 void foo2(int n , int (*a)[n] )

--- a/tests/regression/25-vla/06-even_more_passing.c
+++ b/tests/regression/25-vla/06-even_more_passing.c
@@ -1,4 +1,4 @@
-//PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
+//PARAM: --enable ana.int.interval --disable ana.int.def_exc --set ana.base.arrays.domain partitioned
 #include <assert.h>
 
 void foo2(int n , int (*a)[n] )

--- a/tests/regression/26-undefined_behavior/01-only-intervals.c
+++ b/tests/regression/26-undefined_behavior/01-only-intervals.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc
 #include <assert.h>
 
 int main() {

--- a/tests/regression/26-undefined_behavior/01-only-intervals.c
+++ b/tests/regression/26-undefined_behavior/01-only-intervals.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc --set ana.base.privatization none
 #include <assert.h>
 
 int main() {

--- a/tests/regression/26-undefined_behavior/01-only-intervals.c
+++ b/tests/regression/26-undefined_behavior/01-only-intervals.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.int.def_exc
+// PARAM: --enable ana.int.interval --disable ana.int.def_exc
 #include <assert.h>
 
 int main() {

--- a/tests/regression/26-undefined_behavior/02-array-out-of-bounds.c
+++ b/tests/regression/26-undefined_behavior/02-array-out-of-bounds.c
@@ -1,4 +1,4 @@
-// PARAM:  --set dbg.debug true --enable ana.arrayoob --enable ana.int.interval --enable ana.int.enums
+// PARAM: --enable ana.arrayoob --enable ana.int.interval --enable ana.int.enums
 #include <stdio.h>
 //This is the most basic case
 int main()

--- a/tests/regression/26-undefined_behavior/03-array-out-of-bounds-pointer.c
+++ b/tests/regression/26-undefined_behavior/03-array-out-of-bounds-pointer.c
@@ -1,4 +1,4 @@
-// PARAM:  --set dbg.debug true --enable ana.arrayoob --enable ana.int.interval
+// PARAM: --enable ana.arrayoob --enable ana.int.interval
 //Pointer to arrays: out of bounds access
 #include <stdio.h>
 int main( )

--- a/tests/regression/26-undefined_behavior/04-multidimensional-array-oob-access.c
+++ b/tests/regression/26-undefined_behavior/04-multidimensional-array-oob-access.c
@@ -1,4 +1,4 @@
-// PARAM:  --set dbg.debug true --enable ana.arrayoob --enable ana.int.interval --enable ana.int.enums
+// PARAM: --enable ana.arrayoob --enable ana.int.interval --enable ana.int.enums
 //Multidimensional array: Out of bounds access
 #include <stdio.h>
 int main( )

--- a/tests/regression/26-undefined_behavior/05-dynamically-sized-array-oob-access.c
+++ b/tests/regression/26-undefined_behavior/05-dynamically-sized-array-oob-access.c
@@ -1,4 +1,4 @@
-// PARAM:  --set dbg.debug true --enable ana.arrayoob --enable ana.int.interval --enable ana.int.interval --enable ana.int.enums
+// PARAM: --enable ana.arrayoob --enable ana.int.interval --enable ana.int.interval --enable ana.int.enums
 
 // Variable sized array: oob access
 

--- a/tests/regression/26-undefined_behavior/06-pointer-to-arrays-of-different-sizes.c
+++ b/tests/regression/26-undefined_behavior/06-pointer-to-arrays-of-different-sizes.c
@@ -1,4 +1,4 @@
-// PARAM:  --set dbg.debug true --enable ana.arrayoob --enable ana.int.interval --enable ana.int.enums
+// PARAM: --enable ana.arrayoob --enable ana.int.interval --enable ana.int.enums
 //Pointer pointing to arrays of different sizes
 #include <stdio.h>
 int main( )

--- a/tests/regression/26-undefined_behavior/07-arrays-within-structures.c
+++ b/tests/regression/26-undefined_behavior/07-arrays-within-structures.c
@@ -1,4 +1,4 @@
-// PARAM:  --set dbg.debug true --enable ana.arrayoob --enable ana.int.interval --enable ana.int.interval --enable ana.int.enums 
+// PARAM: --enable ana.arrayoob --enable ana.int.interval --enable ana.int.interval --enable ana.int.enums
 // Arrays within structures. Source of sample struct:
 // https://codeforwin.org/2018/07/how-to-declare-initialize-and-access-array-of-structure.html
 #include <stdio.h>
@@ -13,7 +13,7 @@ int main() {
       {"vandah", 12, 89.5f},
       {"edin", 15, 98.0f},
       {"david", 17, 90.0f},
-  };  
+  };
   stu[0].roll = 2; //NOWARN
   stu[-1].roll = 10;    // WARN
   stu[1].marks = 90.5f; //NOWARN

--- a/tests/regression/29-svcomp/21-issue-casting.c
+++ b/tests/regression/29-svcomp/21-issue-casting.c
@@ -1,3 +1,5 @@
+// PARAM: --set ana.activated ["'base'","'mallocWrapper'"]
+// minimal analyses to reveal bug
 static long main(void)
 {
   unsigned int cmd;

--- a/tests/regression/29-svcomp/21-issue-casting.c
+++ b/tests/regression/29-svcomp/21-issue-casting.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated ["'base'","'mallocWrapper'","'assert'"] --set ana.base.privatization none
+// PARAM: --set ana.base.privatization none
 static long main(void)
 {
   unsigned int cmd;

--- a/tests/regression/29-svcomp/21-issue-casting.c
+++ b/tests/regression/29-svcomp/21-issue-casting.c
@@ -1,4 +1,3 @@
-// PARAM: --set ana.base.privatization none
 static long main(void)
 {
   unsigned int cmd;

--- a/tests/regression/29-svcomp/21-issue-casting.c
+++ b/tests/regression/29-svcomp/21-issue-casting.c
@@ -1,5 +1,6 @@
-// PARAM: --set ana.activated ["'base'","'mallocWrapper'"]
+// PARAM: --set ana.activated ["'base'","'mallocWrapper'"] --set ana.base.privatization none
 // minimal analyses to reveal bug
+// none privatization because mutex deactivated
 static long main(void)
 {
   unsigned int cmd;

--- a/tests/regression/30-fast_global_inits/01-on.c
+++ b/tests/regression/30-fast_global_inits/01-on.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 #include <assert.h>
 

--- a/tests/regression/30-fast_global_inits/01-on.c
+++ b/tests/regression/30-fast_global_inits/01-on.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 #include <assert.h>
 

--- a/tests/regression/30-fast_global_inits/01-on.c
+++ b/tests/regression/30-fast_global_inits/01-on.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 #include <assert.h>
 

--- a/tests/regression/30-fast_global_inits/02-off.c
+++ b/tests/regression/30-fast_global_inits/02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --disable exp.fast_global_inits
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --disable exp.fast_global_inits
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 #include <assert.h>
 

--- a/tests/regression/30-fast_global_inits/02-off.c
+++ b/tests/regression/30-fast_global_inits/02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --disable exp.fast_global_inits
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none --disable exp.fast_global_inits
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 #include <assert.h>
 

--- a/tests/regression/30-fast_global_inits/02-off.c
+++ b/tests/regression/30-fast_global_inits/02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none --disable exp.fast_global_inits
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --disable exp.fast_global_inits
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 #include <assert.h>
 

--- a/tests/regression/30-fast_global_inits/03-performance.c
+++ b/tests/regression/30-fast_global_inits/03-performance.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --enable exp.fast_global_inits --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --enable exp.fast_global_inits
 // Without fast_global_inits this takes >150s, when it is enabled < 0.1s
 #include <assert.h>
 

--- a/tests/regression/30-fast_global_inits/03-performance.c
+++ b/tests/regression/30-fast_global_inits/03-performance.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --enable exp.fast_global_inits
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --enable exp.fast_global_inits
 // Without fast_global_inits this takes >150s, when it is enabled < 0.1s
 #include <assert.h>
 

--- a/tests/regression/30-fast_global_inits/03-performance.c
+++ b/tests/regression/30-fast_global_inits/03-performance.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --enable exp.fast_global_inits  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --enable exp.fast_global_inits --set ana.base.privatization none
 // Without fast_global_inits this takes >150s, when it is enabled < 0.1s
 #include <assert.h>
 

--- a/tests/regression/30-fast_global_inits/04-non-zero.c
+++ b/tests/regression/30-fast_global_inits/04-non-zero.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable exp.fast_global_inits
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable exp.fast_global_inits
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 #include <assert.h>
 

--- a/tests/regression/30-fast_global_inits/05-non-zero-performance.c
+++ b/tests/regression/30-fast_global_inits/05-non-zero-performance.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable exp.fast_global_inits
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable exp.fast_global_inits
 #include <assert.h>
 
 int global_array[10000] = {9, 0, 3, 42, 11 }; // All non-specified ones will be zero

--- a/tests/regression/31-ikind-aware-ints/04-ptrdiff.c
+++ b/tests/regression/31-ikind-aware-ints/04-ptrdiff.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] var_eq --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] var_eq
 int *tmp;
 
 int main ()

--- a/tests/regression/31-ikind-aware-ints/04-ptrdiff.c
+++ b/tests/regression/31-ikind-aware-ints/04-ptrdiff.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated "['base', 'mallocWrapper','assert', 'escape', 'expRelation', 'var_eq']" --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated[+] var_eq --set ana.base.privatization none
 int *tmp;
 
 int main ()

--- a/tests/regression/31-ikind-aware-ints/05-shift.c
+++ b/tests/regression/31-ikind-aware-ints/05-shift.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval
 int main(void) {
     // Shifting by a negative number is UB, but we should still not crash on it, but go to top instead
     int v = -1;

--- a/tests/regression/31-ikind-aware-ints/05-shift.c
+++ b/tests/regression/31-ikind-aware-ints/05-shift.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated "['base', 'mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 int main(void) {
     // Shifting by a negative number is UB, but we should still not crash on it, but go to top instead
     int v = -1;

--- a/tests/regression/31-ikind-aware-ints/05-shift.c
+++ b/tests/regression/31-ikind-aware-ints/05-shift.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 int main(void) {
     // Shifting by a negative number is UB, but we should still not crash on it, but go to top instead
     int v = -1;

--- a/tests/regression/31-ikind-aware-ints/06-structs.c
+++ b/tests/regression/31-ikind-aware-ints/06-structs.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
+// PARAM: --enable ana.int.interval
 struct rtl8169_private {
    unsigned int features ;
 };

--- a/tests/regression/31-ikind-aware-ints/06-structs.c
+++ b/tests/regression/31-ikind-aware-ints/06-structs.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.activated "['base', 'threadflag', 'mallocWrapper','assert']" --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
 struct rtl8169_private {
    unsigned int features ;
 };

--- a/tests/regression/31-ikind-aware-ints/06-structs.c
+++ b/tests/regression/31-ikind-aware-ints/06-structs.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned
 struct rtl8169_private {
    unsigned int features ;
 };

--- a/tests/regression/31-ikind-aware-ints/17-def-enum-refine.c
+++ b/tests/regression/31-ikind-aware-ints/17-def-enum-refine.c
@@ -1,4 +1,4 @@
-//PARAM: --sets ana.int.refinement once  --enable ana.int.enums
+//PARAM: --set ana.int.refinement once  --enable ana.int.enums
 int main() {
   int x;
   _Bool c;

--- a/tests/regression/32-widen-context/01-on.c
+++ b/tests/regression/32-widen-context/01-on.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --enable ana.context.widen
+// PARAM: --enable ana.int.interval --enable ana.context.widen
 #include <assert.h>
 
 int f(int x) {

--- a/tests/regression/32-widen-context/02-on-attribute.c
+++ b/tests/regression/32-widen-context/02-on-attribute.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --disable ana.context.widen
+// PARAM: --enable ana.int.interval --disable ana.context.widen
 #include <assert.h>
 
 int f(int x) __attribute__((goblint_context("widen"))); // attributes are not permitted in a function definition

--- a/tests/regression/33-constants/01-const.c
+++ b/tests/regression/33-constants/01-const.c
@@ -1,4 +1,5 @@
 //PARAM: --set ana.activated '["constants"]'
+// intentional explicit ana.activated to do tutorial in isolation
 int f(int a, int b){
     int d = 3;
     int z = a + d;

--- a/tests/regression/33-constants/02-simple.c
+++ b/tests/regression/33-constants/02-simple.c
@@ -1,4 +1,5 @@
 //PARAM: --set ana.activated '["constants"]'
+// intentional explicit ana.activated to do tutorial in isolation
 
 int main(){
     int x = 3;

--- a/tests/regression/33-constants/03-empty-not-dead-branch.c
+++ b/tests/regression/33-constants/03-empty-not-dead-branch.c
@@ -1,4 +1,5 @@
 //PARAM: --set ana.activated '["constants"]'
+// intentional explicit ana.activated to do tutorial in isolation
 
 int g;
 

--- a/tests/regression/33-constants/04-empty-not-dead.c
+++ b/tests/regression/33-constants/04-empty-not-dead.c
@@ -1,4 +1,5 @@
 //PARAM: --set ana.activated '["constants"]'
+// intentional explicit ana.activated to do tutorial in isolation
 
 int g;
 

--- a/tests/regression/36-apron/49-assert-refine.c
+++ b/tests/regression/36-apron/49-assert-refine.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --sets ana.activated[+] apron
+// SKIP PARAM: --set ana.activated[+] apron
 #include <assert.h>
 
 void main() {

--- a/tests/regression/36-apron/71-tid-toy1.c
+++ b/tests/regression/36-apron/71-tid-toy1.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/73-tid-toy3.c
+++ b/tests/regression/36-apron/73-tid-toy3.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/75-tid-toy5.c
+++ b/tests/regression/36-apron/75-tid-toy5.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/76-tid-toy6.c
+++ b/tests/regression/36-apron/76-tid-toy6.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/77-tid-toy7.c
+++ b/tests/regression/36-apron/77-tid-toy7.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/78-tid-toy8.c
+++ b/tests/regression/36-apron/78-tid-toy8.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/79-tid-toy9.c
+++ b/tests/regression/36-apron/79-tid-toy9.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/80-tid-toy10.c
+++ b/tests/regression/36-apron/80-tid-toy10.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/81-tid-toy11.c
+++ b/tests/regression/36-apron/81-tid-toy11.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/87-sync.c
+++ b/tests/regression/36-apron/87-sync.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] threadJoins --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <stdio.h>
 #include <assert.h>

--- a/tests/regression/36-apron/92-traces-mutex-meet-cluster2.c
+++ b/tests/regression/36-apron/92-traces-mutex-meet-cluster2.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization mutex-meet-tid-cluster12 --enable ana.sv-comp.functions
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid-cluster12 --enable ana.sv-comp.functions
 extern int __VERIFIER_nondet_int();
 
 #include <pthread.h>

--- a/tests/regression/36-apron/93-traces-mutex-meet-cluster12.c
+++ b/tests/regression/36-apron/93-traces-mutex-meet-cluster12.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization mutex-meet-tid-cluster12 --enable ana.sv-comp.functions
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid-cluster12 --enable ana.sv-comp.functions
 extern int __VERIFIER_nondet_int();
 
 #include <pthread.h>

--- a/tests/regression/36-apron/97-no-loc.c
+++ b/tests/regression/36-apron/97-no-loc.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid --disable ana.thread.include-node
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set ana.apron.privatization mutex-meet-tid --disable ana.thread.include-node
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/36-apron/98-loc.c
+++ b/tests/regression/36-apron/98-loc.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid --enable ana.thread.include-node
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set ana.apron.privatization mutex-meet-tid --enable ana.thread.include-node
 #include <pthread.h>
 #include <assert.h>
 

--- a/tests/regression/40-threadid/01-threadid_history_unique.c
+++ b/tests/regression/40-threadid/01-threadid_history_unique.c
@@ -1,4 +1,4 @@
-// PARAM: --sets ana.activated[-] thread
+// PARAM: --set ana.activated[-] thread
 // requires thread ID with history
 #include <pthread.h>
 #include <stdio.h>

--- a/tests/regression/40-threadid/02-threadid_history_nonunique.c
+++ b/tests/regression/40-threadid/02-threadid_history_nonunique.c
@@ -1,4 +1,4 @@
-// PARAM: --sets ana.activated[-] thread
+// PARAM: --set ana.activated[-] thread
 // requires thread ID with history
 #include <pthread.h>
 #include <stdio.h>

--- a/tests/regression/40-threadid/03-threadid_history_two_unique.c
+++ b/tests/regression/40-threadid/03-threadid_history_two_unique.c
@@ -1,4 +1,4 @@
-// PARAM: --sets ana.activated[-] thread
+// PARAM: --set ana.activated[-] thread
 // requires thread ID with history
 #include <pthread.h>
 #include <stdio.h>

--- a/tests/regression/42-annotated-precision/08-22_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/08-22_01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int global;

--- a/tests/regression/42-annotated-precision/08-22_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/08-22_01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int global;

--- a/tests/regression/42-annotated-precision/08-22_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/08-22_01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int global;

--- a/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/09-22_02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1(void) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1(void) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/10-22_03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1(void) __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/11-22_04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/12-22_06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/13-22_07-global_array.c
+++ b/tests/regression/42-annotated-precision/13-22_07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int global_array[50];

--- a/tests/regression/42-annotated-precision/13-22_07-global_array.c
+++ b/tests/regression/42-annotated-precision/13-22_07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int global_array[50];

--- a/tests/regression/42-annotated-precision/13-22_07-global_array.c
+++ b/tests/regression/42-annotated-precision/13-22_07-global_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int global_array[50];

--- a/tests/regression/42-annotated-precision/15-23_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/15-23_01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int global;

--- a/tests/regression/42-annotated-precision/15-23_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/15-23_01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int global;

--- a/tests/regression/42-annotated-precision/15-23_01-simple_array.c
+++ b/tests/regression/42-annotated-precision/15-23_01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int global;

--- a/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
+++ b/tests/regression/42-annotated-precision/16-23_02-pointers_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int main(void) __attribute__((goblint_precision("no-interval")));

--- a/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
+++ b/tests/regression/42-annotated-precision/17-23_03-multidimensional_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 int main(void) {

--- a/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
+++ b/tests/regression/42-annotated-precision/18-23_04-nesting_arrays.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 struct kala {

--- a/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
+++ b/tests/regression/42-annotated-precision/19-23_06-interprocedural.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned  --set ana.base.partition-arrays.keep-expr "last" --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
+++ b/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
+++ b/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
+++ b/tests/regression/42-annotated-precision/21-23_14-replace_with_const.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.partition-arrays.keep-expr "last" --enable ana.base.partition-arrays.partition-by-const-on-return --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 #include <assert.h>
 
 void example1() __attribute__((goblint_precision("no-def_exc","interval")));

--- a/tests/regression/42-annotated-precision/22-26_05-dynamically-sized-array-oob-access.c
+++ b/tests/regression/42-annotated-precision/22-26_05-dynamically-sized-array-oob-access.c
@@ -1,4 +1,4 @@
-// PARAM:  --set dbg.debug true --enable ana.arrayoob --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --enable ana.arrayoob --enable annotation.int.enabled --set ana.int.refinement fixpoint
 
 // Variable sized array: oob access
 

--- a/tests/regression/42-annotated-precision/23-26_07-arrays-within-structures.c
+++ b/tests/regression/42-annotated-precision/23-26_07-arrays-within-structures.c
@@ -1,4 +1,4 @@
-// PARAM:  --set dbg.debug true --enable ana.arrayoob --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --enable ana.arrayoob --enable annotation.int.enabled --set ana.int.refinement fixpoint
 // Arrays within structures. Source of sample struct:
 // https://codeforwin.org/2018/07/how-to-declare-initialize-and-access-array-of-structure.html
 #include <stdio.h>

--- a/tests/regression/42-annotated-precision/24-30_02-off.c
+++ b/tests/regression/42-annotated-precision/24-30_02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.activated "['base','threadid','threadflag','escape','expRelation','mallocWrapper','assert']" --set ana.base.privatization none --disable exp.fast_global_inits --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.privatization none --disable exp.fast_global_inits --enable annotation.int.enabled --set ana.int.refinement fixpoint
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 #include <assert.h>
 

--- a/tests/regression/42-annotated-precision/24-30_02-off.c
+++ b/tests/regression/42-annotated-precision/24-30_02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --disable exp.fast_global_inits --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.base.arrays.domain partitioned --disable exp.fast_global_inits --enable annotation.int.enabled --set ana.int.refinement fixpoint
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 #include <assert.h>
 

--- a/tests/regression/42-annotated-precision/24-30_02-off.c
+++ b/tests/regression/42-annotated-precision/24-30_02-off.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --set ana.base.privatization none --disable exp.fast_global_inits --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set solver td3 --set ana.base.arrays.domain partitioned --disable exp.fast_global_inits --enable annotation.int.enabled --set ana.int.refinement fixpoint
 // This checks that partitioned arrays and fast_global_inits are no longer incompatible
 #include <assert.h>
 

--- a/tests/regression/42-annotated-precision/29-07_14-struct_in_struct.c
+++ b/tests/regression/42-annotated-precision/29-07_14-struct_in_struct.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.activated[+] uninit  --enable annotation.int.enabled --set ana.int.refinement fixpoint
 typedef struct {
 	int i;
 } S;

--- a/tests/regression/42-annotated-precision/29-07_14-struct_in_struct.c
+++ b/tests/regression/42-annotated-precision/29-07_14-struct_in_struct.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper']"  --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.activated[+] uninit  --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 typedef struct {
 	int i;
 } S;

--- a/tests/regression/42-annotated-precision/34-07_14-struct_in_struct_i.c
+++ b/tests/regression/42-annotated-precision/34-07_14-struct_in_struct_i.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated[+] uninit --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.activated[+] uninit --enable annotation.int.enabled --set ana.int.refinement fixpoint
 typedef struct {
 	int i;
 } S;

--- a/tests/regression/42-annotated-precision/34-07_14-struct_in_struct_i.c
+++ b/tests/regression/42-annotated-precision/34-07_14-struct_in_struct_i.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.activated "['base','threadid','threadflag','escape','uninit','mallocWrapper']"  --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
+// PARAM: --set ana.activated[+] uninit --set ana.base.privatization none --enable annotation.int.enabled --set ana.int.refinement fixpoint
 typedef struct {
 	int i;
 } S;

--- a/tests/regression/46-apron2/05-pointer-multilevel.c
+++ b/tests/regression/46-apron2/05-pointer-multilevel.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.apron.privatization top
+// SKIP PARAM: --set ana.activated[+] apron --set ana.apron.privatization top
 #include <assert.h>
 
 extern int __VERIFIER_nondet_int();

--- a/tests/regression/46-apron2/05-pointer-multilevel.c
+++ b/tests/regression/46-apron2/05-pointer-multilevel.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.base.privatization none --set ana.apron.privatization top
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
 #include <assert.h>
 
 extern int __VERIFIER_nondet_int();

--- a/tests/regression/46-apron2/05-pointer-multilevel.c
+++ b/tests/regression/46-apron2/05-pointer-multilevel.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.apron.privatization top
 #include <assert.h>
 
 extern int __VERIFIER_nondet_int();

--- a/tests/regression/46-apron2/06-pointer-multilevel-two.c
+++ b/tests/regression/46-apron2/06-pointer-multilevel-two.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.apron.privatization top
+// SKIP PARAM: --set ana.activated[+] apron --set ana.apron.privatization top
 #include <assert.h>
 
 extern int __VERIFIER_nondet_int();

--- a/tests/regression/46-apron2/06-pointer-multilevel-two.c
+++ b/tests/regression/46-apron2/06-pointer-multilevel-two.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.base.privatization none --set ana.apron.privatization top
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
 #include <assert.h>
 
 extern int __VERIFIER_nondet_int();

--- a/tests/regression/46-apron2/06-pointer-multilevel-two.c
+++ b/tests/regression/46-apron2/06-pointer-multilevel-two.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.apron.privatization top
 #include <assert.h>
 
 extern int __VERIFIER_nondet_int();

--- a/tests/regression/46-apron2/07-escaping-recursion.c
+++ b/tests/regression/46-apron2/07-escaping-recursion.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.apron.privatization top
 // Copy of 01/52 for Apron
 #include <assert.h>
 

--- a/tests/regression/46-apron2/07-escaping-recursion.c
+++ b/tests/regression/46-apron2/07-escaping-recursion.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.base.privatization none --set ana.apron.privatization top
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
 // Copy of 01/52 for Apron
 #include <assert.h>
 

--- a/tests/regression/46-apron2/07-escaping-recursion.c
+++ b/tests/regression/46-apron2/07-escaping-recursion.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.apron.privatization top
+// SKIP PARAM: --set ana.activated[+] apron --set ana.apron.privatization top
 // Copy of 01/52 for Apron
 #include <assert.h>
 

--- a/tests/regression/46-apron2/08-escape-local-in-pthread-dummy.c
+++ b/tests/regression/46-apron2/08-escape-local-in-pthread-dummy.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.base.privatization none --set ana.apron.privatization top
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
 // Copy of 45 01 for apron
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/46-apron2/08-escape-local-in-pthread-dummy.c
+++ b/tests/regression/46-apron2/08-escape-local-in-pthread-dummy.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
+// SKIP PARAM: --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
 // Copy of 45 01 for apron
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/46-apron2/09-escape-local-in-pthread-mm.c
+++ b/tests/regression/46-apron2/09-escape-local-in-pthread-mm.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization mutex-meet
+// SKIP PARAM: --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization mutex-meet
 // Copy of 45 01 for apron
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/46-apron2/09-escape-local-in-pthread-mm.c
+++ b/tests/regression/46-apron2/09-escape-local-in-pthread-mm.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.base.privatization none --set ana.apron.privatization mutex-meet
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization mutex-meet
 // Copy of 45 01 for apron
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/46-apron2/10-escape-local-in-pthread-mm-tid.c
+++ b/tests/regression/46-apron2/10-escape-local-in-pthread-mm-tid.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
 // Copy of 45 01 for apron
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/46-apron2/10-escape-local-in-pthread-mm-tid.c
+++ b/tests/regression/46-apron2/10-escape-local-in-pthread-mm-tid.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
 // Copy of 45 01 for apron
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/46-apron2/11-names.c
+++ b/tests/regression/46-apron2/11-names.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.base.privatization none --set ana.apron.privatization top
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
 #include <assert.h>
 
 extern int __VERIFIER_nondet_int();

--- a/tests/regression/46-apron2/11-names.c
+++ b/tests/regression/46-apron2/11-names.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
+// SKIP PARAM: --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization top
 #include <assert.h>
 
 extern int __VERIFIER_nondet_int();

--- a/tests/regression/46-apron2/12-escape-local-in-pthread-simple.c
+++ b/tests/regression/46-apron2/12-escape-local-in-pthread-simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization mutex-meet
+// SKIP PARAM: --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization mutex-meet
 // Copy of 45 01 for apron
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/46-apron2/12-escape-local-in-pthread-simple.c
+++ b/tests/regression/46-apron2/12-escape-local-in-pthread-simple.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.base.privatization none --set ana.apron.privatization mutex-meet
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.base.privatization none --set ana.apron.privatization mutex-meet
 // Copy of 45 01 for apron
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/46-apron2/13-initializer.c
+++ b/tests/regression/46-apron2/13-initializer.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/13-initializer.c
+++ b/tests/regression/46-apron2/13-initializer.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/14-invalidate.c
+++ b/tests/regression/46-apron2/14-invalidate.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/14-invalidate.c
+++ b/tests/regression/46-apron2/14-invalidate.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/15-invalidate-threadreturn.c
+++ b/tests/regression/46-apron2/15-invalidate-threadreturn.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/15-invalidate-threadreturn.c
+++ b/tests/regression/46-apron2/15-invalidate-threadreturn.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/16-rel-offset.c
+++ b/tests/regression/46-apron2/16-rel-offset.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid --set ana.base.arrays.domain partitioned
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid --set ana.base.arrays.domain partitioned
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/16-rel-offset.c
+++ b/tests/regression/46-apron2/16-rel-offset.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid --set ana.base.arrays.domain partitioned
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid --set ana.base.arrays.domain partitioned
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/17-passing.c
+++ b/tests/regression/46-apron2/17-passing.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated "['base','threadid','threadflag','mallocWrapper','assert','apron','escape']" --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid --set ana.base.arrays.domain partitioned
+// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid --set ana.base.arrays.domain partitioned
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/17-passing.c
+++ b/tests/regression/46-apron2/17-passing.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set solver td3 --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid --set ana.base.arrays.domain partitioned
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid --set ana.base.arrays.domain partitioned
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/17-passing.c
+++ b/tests/regression/46-apron2/17-passing.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid --set ana.base.arrays.domain partitioned
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.base.privatization none --set ana.apron.privatization mutex-meet-tid
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tests/regression/46-apron2/19-tid-toy-10-exit.c
+++ b/tests/regression/46-apron2/19-tid-toy-10-exit.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set ana.apron.privatization mutex-meet-tid
 // Copy of 80-tid-toy10 making use of pthread_exit
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/46-apron2/20-inprecise-returns.c
+++ b/tests/regression/46-apron2/20-inprecise-returns.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set ana.apron.privatization mutex-meet-tid
 // Based on 80-tid-toy10
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/46-apron2/21-tid-toy-10-exit-othert.c
+++ b/tests/regression/46-apron2/21-tid-toy-10-exit-othert.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set ana.apron.privatization mutex-meet-tid
 // Modification of 19 that would fail if pthread_exit was only handled for the top-level thread
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/52-apron-mukherjee/02-mukherjee_sigma.c
+++ b/tests/regression/52-apron-mukherjee/02-mukherjee_sigma.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set ana.apron.privatization mutex-meet-tid
 
 #include <stdlib.h>
 #include <pthread.h>

--- a/tests/regression/52-apron-mukherjee/18-mukherjee_qw2004.c
+++ b/tests/regression/52-apron-mukherjee/18-mukherjee_qw2004.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --enable ana.apron.threshold_widening --sets ana.apron.privatization mutex-meet-tid
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --enable ana.apron.threshold_widening --set ana.apron.privatization mutex-meet-tid
 
 #include <pthread.h>
 #include <assert.h>

--- a/tests/regression/54-unroll_arrays/01-simple_array.c
+++ b/tests/regression/54-unroll_arrays/01-simple_array.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
 #include <assert.h>
 int global;
 

--- a/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
+++ b/tests/regression/54-unroll_arrays/02-simple_array_in_loops.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 2
+// PARAM: --enable ana.int.interval --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 2
 #include <assert.h>
 int global;
 

--- a/tests/regression/55-loop-unrolling/01-simple-cases.c
+++ b/tests/regression/55-loop-unrolling/01-simple-cases.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5
 #include <assert.h>
 
 int global;

--- a/tests/regression/55-loop-unrolling/04-simple.c
+++ b/tests/regression/55-loop-unrolling/04-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
 // Simple example
 #include <assert.h>
 

--- a/tests/regression/55-loop-unrolling/05-continue.c
+++ b/tests/regression/55-loop-unrolling/05-continue.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
 // Simple example
 #include <assert.h>
 

--- a/tests/regression/55-loop-unrolling/06-simple-cases-unrolled.c
+++ b/tests/regression/55-loop-unrolling/06-simple-cases-unrolled.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
 #include <assert.h>
 
 int global;

--- a/tests/regression/55-loop-unrolling/07-nested-unroll.c
+++ b/tests/regression/55-loop-unrolling/07-nested-unroll.c
@@ -1,4 +1,4 @@
-// PARAM: --set solver td3 --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
 #include<assert.h>
 int main(void) {
     int arr[10][10];


### PR DESCRIPTION
Closes #798 among other things:
1. Removes all explicit `ana.activated` lists (except a few intentional ones) and replaces them by relative list changes or removes altogether if the test has nothing to do with deactivated analyses.
2. Remove irrelevant `--set ana.base.privatization none` from tests. In most cases these have nothing to do with the test (which often is a single-threaded program altogether). Overall orthogonal features should work with all privatizations.
3. Remove irrelevant `--set solver` from tests. In most cases these just set `td3`, but all orthogonal features should work soundly with all _generic_ solvers. Only a handful of tests are for a specific solver.
4. Remove `dbg.debug` from tests. This is always enabled by default.
5. Remove irrelevant `--set ana.base.arrays.domain partitioned` from tests. In most cases these have nothing to do with the test (which has no arrays at all).

A large proportion of affected tests are partitioned array ones and all sorts of copies of them that have copied the complete `PARAM` without testing anything related any more.