### PR TITLE
Limit address sets to include at most one string pointer 

### DIFF
--- a/conf/examples/very-precise.json
+++ b/conf/examples/very-precise.json
@@ -55,7 +55,8 @@
       },
       "structs" : {
         "domain" : "combined-sk"
-      }
+      },
+      "limit-string-addresses": false
     }
   },
   "exp": {

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -328,7 +328,11 @@ struct
     | None, _
     | _, None -> None
     | Some a, Some b when a = b -> Some a
-    | Some a, Some b (* when a <> b *) -> None
+    | Some a, Some b (* when a <> b *) ->
+      if GobConfig.get_bool "ana.base.limit-string-addresses" then
+        None
+      else
+        raise Lattice.Uncomparable
 
   let meet_string_ptr x y = match x, y with
     | None, a

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -187,7 +187,11 @@ struct
   [@@deriving eq, ord, hash] (* TODO: StrPtr equal problematic if the same literal appears more than once *)
 
   let hash x = match x with
-    | StrPtr _ -> 13859
+    | StrPtr _ ->
+      if GobConfig.get_bool "ana.base.limit-string-addresses" then
+        13859
+      else
+        hash x
     | _ -> hash x
 
   include Printable.Std

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -320,7 +320,8 @@ struct
     | _ -> false
 
   let leq x y = match x, y with
-    | StrPtr a  , StrPtr b   -> a = b
+    | StrPtr _, StrPtr None -> true
+    | StrPtr a, StrPtr b   -> a = b
     | Addr (x,o), Addr (y,u) -> CilType.Varinfo.equal x y && Offs.leq o u
     | _                      -> x = y
 

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -183,7 +183,7 @@ struct
     | Addr of CilType.Varinfo.t * Offs.t (** Pointer to offset of a variable. *)
     | NullPtr (** NULL pointer. *)
     | UnknownPtr (** Unknown pointer. Could point to globals, heap and escaped variables. *)
-    | StrPtr of string option (** String literal pointer. *)
+    | StrPtr of string option (** String literal pointer. [StrPtr None] abstracts any string pointer *)
   [@@deriving eq, ord, hash] (* TODO: StrPtr equal problematic if the same literal appears more than once *)
 
   let hash x = match x with
@@ -331,7 +331,7 @@ struct
     | Some a, Some b (* when a <> b *) -> None
 
   let meet_string_ptr x y = match x, y with
-    | None, a -> a
+    | None, a
     | a, None -> a
     | Some a, Some b when a = b -> Some a
     | Some a, Some b (* when a <> b *) -> raise Lattice.Uncomparable

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -606,6 +606,11 @@
               },
               "additionalProperties": false
             },
+            "limit-string-addresses": {
+              "title": "ana.base.limit-string-addresses",
+              "type": "boolean",
+              "default": true
+            },
             "partition-arrays": {
               "title": "ana.base.partition-arrays",
               "type": "object",

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -608,6 +608,7 @@
             },
             "limit-string-addresses": {
               "title": "ana.base.limit-string-addresses",
+              "description": "Limit abstract address sets to keep at most one distinct string pointer.",
               "type": "boolean",
               "default": true
             },

--- a/tests/regression/02-base/88-string-ptrs-limited.c
+++ b/tests/regression/02-base/88-string-ptrs-limited.c
@@ -1,0 +1,37 @@
+//PARAM: --enable ana.base.limit-string-addresses
+#include <stdlib.h>
+
+char *unknown_function();
+
+int main(){
+    char* str = "Hello";
+    char* str2 = "Hello";
+    char* str3 = "hi";
+    char* str4 = "other string";
+
+    // Unknown since the there may be multiple copies of the same string
+    __goblint_check(str != str2); // UNKNOWN!
+
+    __goblint_check(str == str);
+    __goblint_check(str != str3);
+
+    char *ptr = NULL;
+    int top = rand();
+
+    if(top){
+        ptr = str2;
+    } else {
+        ptr = str3;
+    }
+    __goblint_check(ptr == str); //UNKNOWN!
+
+    // This is unknwon due to only keeping one string pointer in abstract address sets
+    __goblint_check(ptr != str4); //UNKNOWN
+
+    char *ptr2 = unknown_function();
+
+    __goblint_check(ptr2 == str); //UNKNOWN!
+    __goblint_check(ptr2 == ptr); //UNKNOWN!
+
+    return 0;
+}

--- a/tests/regression/02-base/88-string-ptrs-limited.c
+++ b/tests/regression/02-base/88-string-ptrs-limited.c
@@ -25,7 +25,7 @@ int main(){
     }
     __goblint_check(ptr == str); //UNKNOWN!
 
-    // This is unknwon due to only keeping one string pointer in abstract address sets
+    // This is unknown due to only keeping one string pointer in abstract address sets
     __goblint_check(ptr != str4); //UNKNOWN
 
     char *ptr2 = unknown_function();

--- a/tests/regression/02-base/88-strings.c
+++ b/tests/regression/02-base/88-strings.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main(){
+    char* str = "Hello";
+    char* str2 = "Hello";
+    char* str3 = "hi";
+    char* str4 = "other string";
+
+    // Unknown since the there may be multiple copies of the same string
+    __goblint_check(str != str2); // UNKNOWN!
+
+    __goblint_check(str == str);
+    __goblint_check(str != str3);
+
+    char *ptr = NULL;
+    int top = rand();
+
+    if(top){
+        ptr = str2;
+    } else {
+        ptr = str3;
+    }
+    __goblint_check(*ptr == *str); //UNKNOWN
+
+    // This is unknwon due to only keeping one string pointer in abstract address sets
+    __goblint_check(*ptr == *str4); //UNKNOWN
+
+
+    return 0;
+}

--- a/tests/regression/02-base/88-strings.c
+++ b/tests/regression/02-base/88-strings.c
@@ -26,6 +26,10 @@ int main(){
     // This is unknwon due to only keeping one string pointer in abstract address sets
     __goblint_check(*ptr == *str4); //UNKNOWN
 
+    char *ptr2 = unknown_function(); 
+
+    __goblint_check(ptr == ptr2); //UNKNOWN
+    __goblint_check(ptr2 == str); //UNKNOWN
 
     return 0;
 }

--- a/tests/regression/02-base/89-string-ptrs-not-limited.c
+++ b/tests/regression/02-base/89-string-ptrs-not-limited.c
@@ -1,5 +1,7 @@
-#include <assert.h>
+//PARAM: --disable ana.base.limit-string-addresses
 #include <stdlib.h>
+
+char *unknown_function();
 
 int main(){
     char* str = "Hello";
@@ -21,15 +23,14 @@ int main(){
     } else {
         ptr = str3;
     }
-    __goblint_check(*ptr == *str); //UNKNOWN
+    __goblint_check(ptr == str); //UNKNOWN!
 
-    // This is unknwon due to only keeping one string pointer in abstract address sets
-    __goblint_check(*ptr == *str4); //UNKNOWN
+    __goblint_check(ptr != str4);
 
-    char *ptr2 = unknown_function(); 
+    char *ptr2 = unknown_function();
 
-    __goblint_check(ptr == ptr2); //UNKNOWN
-    __goblint_check(ptr2 == str); //UNKNOWN
+    __goblint_check(ptr2 == str); //UNKNOWN!
+    __goblint_check(ptr2 == ptr); //UNKNOWN!
 
     return 0;
 }


### PR DESCRIPTION
This PR changes the abstraction of a string pointer from `StrPtr of string` to `StrPtr of string option`. Now, a `StrPtr None` abstracts any possible string pointer.

As there is the possibility that there may the same string in the binary multiple times, the function `is_definite` was changed so that `is_definite (StrPtr _)` now returns false. 

Closes #807 