### PR TITLE
Check type of source and destination in handling of memcpy in Base

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2519,7 +2519,7 @@ struct
 
           (* When src and destination type coincide, take value from the source, otherwise use top *)
           let value = if typeSig dest_typ = typeSig src_typ then
-              let src_cast_lval = mkMem ~addr:(Cil.mkCast ~e:src ~newt:(TPtr (dest_typ, []))) ~off:NoOffset in
+              let src_cast_lval = mkMem ~addr:(Cilfacade.mkCast ~e:src ~newt:(TPtr (dest_typ, []))) ~off:NoOffset in
               eval_rv (Analyses.ask_of_ctx ctx) gs st (Lval src_cast_lval)
             else
               VD.top_value (unrollType dest_typ)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2507,22 +2507,25 @@ struct
         | _, [dst; src]
         | _, [dst; src; _]
         | "__builtin___memcpy_chk", [dst; src; _; _] ->
-          let dest_typ = typeOf (Cil.stripCasts dst) in
-          let src_typ = typeOf (Cil.stripCasts src) in
+          let get_type lval =
+            let address = eval_lv (Analyses.ask_of_ctx ctx) gs st lval in
+            AD.get_type address
+          in
           let dst_lval = mkMem ~addr:(Cil.stripCasts dst) ~off:NoOffset in
+          let src_lval = mkMem ~addr:(Cil.stripCasts src) ~off:NoOffset in
 
-          (* When src and destination type coincide, we can assign, otherwise we assign top *)
-          if typeSig dest_typ = typeSig src_typ then begin
-            let src_a = mkMem ~addr:(Cil.stripCasts src) ~off:NoOffset in
-            assign ctx dst_lval (Lval src_a)
-          end else begin
-            let value = match unrollType dest_typ with
-              | TPtr (t, _) -> VD.top_value t
-              | _ -> failwith "memcpy to non-ptr type."
-            in
-            let dest_a = eval_lv (Analyses.ask_of_ctx ctx) gs st dst_lval in
-            set ~ctx (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ value
-          end
+          let dest_typ = get_type dst_lval in
+          let src_typ = get_type src_lval in
+
+          (* When src and destination type coincide, take value from the source, otherwise use top *)
+          let value = if typeSig dest_typ = typeSig src_typ then
+              let src_cast_lval = mkMem ~addr:(Cil.mkCast ~e:src ~newt:(TPtr (dest_typ, []))) ~off:NoOffset in
+              eval_rv (Analyses.ask_of_ctx ctx) gs st (Lval src_cast_lval)
+            else
+              VD.top_value (unrollType dest_typ)
+          in
+          let dest_a = eval_lv (Analyses.ask_of_ctx ctx) gs st dst_lval in
+          set ~ctx (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ value
         | _ -> failwith "strcpy arguments are strange/complicated."
       end
     | Unknown, "__builtin" ->

--- a/tests/regression/02-base/90-memcpy.c
+++ b/tests/regression/02-base/90-memcpy.c
@@ -1,6 +1,7 @@
 
 // Test case taken from sqlite3.c
 #include <string.h>
+#include <stdlib.h>
 
 typedef unsigned long u64;
 
@@ -45,9 +46,80 @@ int bar(){
     return 0;
 }
 
+int foo_heap(){
+    int *m = malloc(sizeof(int));
+    void *n = malloc(sizeof(int));
+
+    *(int*) n = 23;
+    memcpy(m,n,sizeof(int));
+
+    __goblint_check(m == 23); //UNKNOWN
+
+    return 0;
+}
+
+int foo_heap2(){
+    void *m = malloc(sizeof(int));
+    int *n = malloc(sizeof(int));
+
+    *n = 23;
+    memcpy(m,n,sizeof(int));
+
+    __goblint_check(*(int*) m == 23); //UNKNOWN
+
+    return 0;
+}
+
+int foo_heap3(){
+    int *m = malloc(sizeof(int));
+    int *n = malloc(sizeof(int));
+
+    *n = 23;
+    memcpy(m,n,sizeof(int));
+
+    __goblint_check(*m == 23);
+
+    return 0;
+}
+
+int foo_heap4(){
+    int *m = malloc(sizeof(int));
+    int *n = malloc(sizeof(int));
+
+    *m = 0;
+    *n = 23;
+    void *pd = m;
+    void *ps = n;
+
+    memcpy(pd, ps, sizeof(int));
+
+    __goblint_check(*m == 23); //UNKNOWN
+
+    return 0;
+}
+
+int locals_via_void_ptr(){
+    int d = 4;
+    int s = 23;
+
+    void *pd = &d;
+    void *ps = &s;
+
+    memcpy(pd, ps, sizeof(int));
+
+    __goblint_check( d == 23);
+
+    return 0;
+}
+
 int main(){
     sqlite3IsNaN(23.0);
     foo();
     bar();
+    foo_heap();
+    foo_heap2();
+    foo_heap3();
+    foo_heap4();
+    locals_via_void_ptr();
     return 0;
 }

--- a/tests/regression/02-base/90-memcpy.c
+++ b/tests/regression/02-base/90-memcpy.c
@@ -17,7 +17,18 @@ static int sqlite3IsNaN(double x){
   return rc;
 }
 
+int foo(){
+    int x = 23;
+    int y;
+
+    memcpy(&y, &x, sizeof(int));
+
+    __goblint_check(y == 23);
+    return 0;
+}
+
 int main(){
     sqlite3IsNaN(23.0);
+    foo();
     return 0;
 }

--- a/tests/regression/02-base/90-memcpy.c
+++ b/tests/regression/02-base/90-memcpy.c
@@ -1,0 +1,23 @@
+
+// Test case taken from sqlite3.c
+#include <string.h>
+
+typedef unsigned long u64;
+
+# define EXP754 (((u64)0x7ff)<<52)
+# define MAN754 ((((u64)1)<<52)-1)
+# define IsNaN(X) (((X)&EXP754)==EXP754 && ((X)&MAN754)!=0)
+
+
+static int sqlite3IsNaN(double x){
+  int rc;   /* The value return */
+  u64 y;
+  memcpy(&y,&x,sizeof(y));  // Goblint used to crash here
+  rc = IsNaN(y);
+  return rc;
+}
+
+int main(){
+    sqlite3IsNaN(23.0);
+    return 0;
+}

--- a/tests/regression/02-base/90-memcpy.c
+++ b/tests/regression/02-base/90-memcpy.c
@@ -27,8 +27,27 @@ int foo(){
     return 0;
 }
 
+int bar(){
+    int arr[10];
+    double y;
+
+    for(int i = 0; i < 10; i++){
+        arr[i] = 0;
+    }
+    __goblint_check(arr[0] == 0);
+    __goblint_check(arr[3] == 0);
+
+    memcpy(&arr, &y, sizeof(double));
+
+    __goblint_check(arr[0] == 0); //UNKNOWN!
+    __goblint_check(arr[3] == 0); //UNKNOWN
+
+    return 0;
+}
+
 int main(){
     sqlite3IsNaN(23.0);
     foo();
+    bar();
     return 0;
 }


### PR DESCRIPTION
In the handling of `memcpy` in `Base`, check whether the source and destination type coincide. If the types are the same, the `assign` from source to destination is done as before. If the types do not coincide, `top` is assigned to the destination.

This fixes  #813, where the previous handling of `memcpy` lead a `unsigned long` to contain an abstract `double` value. In turn, this lead to a crash where a `double` value appeared for a variable where an integer value was expected in the handling of a conditional.