### PR TITLE
Try to fix lval lattice

### DIFF
--- a/unittest/cdomains/lvalTest.ml
+++ b/unittest/cdomains/lvalTest.ml
@@ -16,6 +16,17 @@ let a_lv_top = LV.from_var_offset (a_var, `Index (i_top, `NoOffset))
 let i_not_0 = ID.join i_1 (ID.of_int ikind (Z.of_int 2))
 let a_lv_not_0 = LV.from_var_offset (a_var, `Index (i_not_0, `NoOffset))
 
+let s = Cil.mkCompInfo true "s" (fun self ->
+    [
+      ("fst", Cil.intType, None, [], Cil.locUnknown);
+      ("snd", Cil.intType, None, [], Cil.locUnknown);
+    ]
+  ) []
+let f_fst = List.nth s.cfields 0
+let f_snd = List.nth s.cfields 1
+let a_lv_fst = LV.from_var_offset (a_var, `Field (f_fst, `NoOffset))
+let a_lv_snd = LV.from_var_offset (a_var, `Field (f_snd, `NoOffset))
+
 
 let assert_leq x y =
   assert_bool (Format.sprintf "expected: %s leq: %s" (LV.show x) (LV.show y)) (LV.leq x y)
@@ -27,28 +38,77 @@ let assert_equal x y =
 
 
 let test_equal_0 _ =
-  assert_equal a_lv a_lv_0
+  assert_equal a_lv a_lv_0;
+  assert_equal a_lv_0 a_lv;
+  assert_equal a_lv a_lv_fst;
+  assert_equal a_lv_fst a_lv;
+  assert_equal a_lv_0 a_lv_fst;
+  assert_equal a_lv_fst a_lv_0
 
 let test_compare_0 _ =
-  assert_bool "test_compare_0" @@ (LV.compare a_lv a_lv_0 = 0)
+  assert_bool "test_compare_0" @@ (LV.compare a_lv a_lv_0 = 0);
+  assert_bool "test_compare_0" @@ (LV.compare a_lv_0 a_lv = 0);
+  assert_bool "test_compare_0" @@ (LV.compare a_lv a_lv_fst = 0);
+  assert_bool "test_compare_0" @@ (LV.compare a_lv_fst a_lv = 0);
+  assert_bool "test_compare_0" @@ (LV.compare a_lv_0 a_lv_fst = 0);
+  assert_bool "test_compare_0" @@ (LV.compare a_lv_fst a_lv_0 = 0)
 
 let test_hash_0 _ =
-  assert_bool "test_hash_0" @@ (LV.hash a_lv = LV.hash a_lv_0)
+  assert_bool "test_hash_0" @@ (LV.hash a_lv = LV.hash a_lv_0);
+  assert_bool "test_hash_0" @@ (LV.hash a_lv = LV.hash a_lv_fst)
 
 let test_leq_0 _ =
   assert_leq a_lv a_lv_0;
-  assert_not_leq a_lv_0 a_lv
+  assert_leq a_lv a_lv_top;
+  assert_leq a_lv_0 a_lv;
+  assert_leq a_lv_0 a_lv_top;
+  assert_not_leq a_lv a_lv_1;
+  assert_not_leq a_lv_1 a_lv;
+  assert_not_leq a_lv_0 a_lv_1;
+  assert_not_leq a_lv_1 a_lv_0;
+
+  assert_leq a_lv a_lv_fst;
+  assert_leq a_lv_0 a_lv_fst;
+  assert_leq a_lv_fst a_lv;
+  assert_leq a_lv_fst a_lv_0;
+  assert_leq a_lv_fst a_lv_top;
+  assert_not_leq a_lv_fst a_lv_1;
+  assert_not_leq a_lv_1 a_lv_fst
 
 let test_join_0 _ =
+  assert_equal a_lv_0 (LV.join a_lv a_lv_0);
+  assert_equal a_lv_0 (LV.join a_lv_0 a_lv);
   assert_equal a_lv_top (LV.join a_lv_0 a_lv_1);
-  skip_if true "TODO";
-  assert_equal a_lv_top (LV.join a_lv a_lv_1) (* TODO *)
+  assert_equal a_lv_top (LV.join a_lv a_lv_1);
+
+  assert_equal a_lv_fst (LV.join a_lv a_lv_fst);
+  assert_equal a_lv_fst (LV.join a_lv_fst a_lv);
+  assert_equal a_lv_fst (LV.join a_lv_0 a_lv_fst);
+  assert_equal a_lv_fst (LV.join a_lv_fst a_lv_0);
+  assert_equal a_lv_top (LV.join a_lv_fst a_lv_1);
+
+  assert_equal a_lv_top (LV.join a_lv a_lv_not_0)
+
+let test_meet_0 _ =
+  assert_equal a_lv (LV.meet a_lv a_lv_0);
+  assert_equal a_lv (LV.meet a_lv_0 a_lv);
+  assert_equal a_lv_0 (LV.meet a_lv_0 a_lv_top);
+  assert_equal a_lv_0 (LV.meet a_lv_top a_lv_0);
+  assert_equal a_lv (LV.meet a_lv a_lv_top);
+  assert_equal a_lv (LV.meet a_lv_top a_lv);
+
+  assert_equal a_lv_fst (LV.meet a_lv a_lv_fst);
+  assert_equal a_lv_fst (LV.meet a_lv_fst a_lv);
+  assert_equal a_lv_fst (LV.meet a_lv_0 a_lv_fst);
+  assert_equal a_lv_fst (LV.meet a_lv_fst a_lv_0);
+  assert_equal a_lv_fst (LV.meet a_lv_fst a_lv_top);
+  assert_equal a_lv_fst (LV.meet a_lv_top a_lv_fst)
 
 let test_leq_not_0 _ =
   assert_leq a_lv_1 a_lv_not_0;
   OUnit.assert_equal ~printer:[%show: [`Eq | `Neq | `Top]] `Neq (ID.equal_to (Z.of_int 0) i_not_0);
   OUnit.assert_equal ~printer:[%show: [`MustZero | `MustNonzero | `MayZero]] `MustNonzero (LV.Offs.cmp_zero_offset (`Index (i_not_0, `NoOffset)));
-  assert_leq a_lv a_lv_not_0;
+  assert_not_leq a_lv a_lv_not_0;
   assert_not_leq a_lv_0 a_lv_not_0
 
 let test () =
@@ -57,6 +117,7 @@ let test () =
     "test_compare_0" >:: test_compare_0;
     "test_hash_0" >:: test_hash_0;
     "test_join_0" >:: test_join_0;
+    "test_meet_0" >:: test_meet_0;
     "test_leq_0" >:: test_leq_0;
     "test_leq_not_0" >:: test_leq_not_0;
   ]


### PR DESCRIPTION
This is an attempt to address https://github.com/goblint/analyzer/issues/101#issuecomment-1200996946 and https://github.com/goblint/analyzer/pull/809#discussion_r935693299 by adding more lval lattice tests for _some_ possibly reasonable structure and getting them to pass.

I've opened this separate from #809 because with the growing complexity and nuance of the domain, I'm no longer sure what the intended behavior should be. Right now I have added a bunch of extra cases to treat `a`, `a[0]` and `a.fst` (first field) equivalently.

One can imagine increasingly complex lvals that this doesn't treat correctly. For example, `a.snd` (second field) and `a[0].snd` are the same memory location, but we don't currently treat them as equivalent, because the above equivalence is only ever applied at the end of the offset, not at every intermediate offset. I suspect the only way to deal with that would be to compute some edit distance between the offsets (i.e. where `[0]` and `.fst` can be inserted or removed to get from one to the other), but that would be insane. I guess this is why some people use automata to describe access paths...