### PR TITLE
Wrap library

### DIFF
--- a/src/apronPrecCompare.ml
+++ b/src/apronPrecCompare.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 (* Utility program to compare precision of results of the apron analysis with different privatizations and/or differents apron domains *)
 (* The result files that can be compared here may be created by passing an output file name in "exp.apron.prec-dump" to Goblint *)
 module B = PrecCompare.MakeDump (ApronPrecCompareUtil)

--- a/src/dune
+++ b/src/dune
@@ -6,7 +6,6 @@
 (library
   (name goblint_lib)
   (public_name goblint.lib)
-  (wrapped false)
   (modules :standard \ goblint mainspec privPrecCompare apronPrecCompare messagesCompare)
   (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc cpu arg-complete fpath yaml yaml.unix uuidm
     ; Conditionally compile based on whether apron optional dependency is installed or not.

--- a/src/goblint.ml
+++ b/src/goblint.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 open GobConfig
 open Goblintutil
 open Maingoblint

--- a/src/mainspec.ml
+++ b/src/mainspec.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 open Prelude (* otherwise open_in would return wrong type for SpecUtil *)
 open SpecUtil
 

--- a/src/messagesCompare.ml
+++ b/src/messagesCompare.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 module MS = Set.Make (Messages.Message)
 
 let colors = ref true

--- a/src/privPrecCompare.ml
+++ b/src/privPrecCompare.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 (* Utility program to compare precision of results of the base analysis with different privatizations *)
 (* The result files that can be compared here may be created by passing an output file name in "exp.priv-prec-dump" to Goblint *)
 module A = PrecCompare.MakeDump (PrivPrecCompareUtil)

--- a/unittest/analyses/libraryDslTest.ml
+++ b/unittest/analyses/libraryDslTest.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 open OUnit2
 
 let memset_desc: LibraryDesc.t = LibraryDsl.(

--- a/unittest/cdomains/floatDomainTest.ml
+++ b/unittest/cdomains/floatDomainTest.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 open OUnit2
 open FloatOps
 
@@ -34,7 +35,7 @@ struct
     ((IT.equal v1 itb_unknown) && (IT.equal v2 itb_unknown)) || ((IT.equal v1 itb_true) && (IT.equal v2 itb_false)) || ((IT.equal v1 itb_false) && (IT.equal v2 itb_true))
 
   (**interval tests *)
-  let test_FI_nan _ = 
+  let test_FI_nan _ =
     assert_equal (FI.top ()) (FI.of_const Float.nan)
 
 
@@ -75,7 +76,7 @@ struct
       (FI.of_const (-. 0.)) - fi_zero = fi_zero
     end
 
-  let test_FI_mul_specific _ = 
+  let test_FI_mul_specific _ =
     let ( * ) = FI.mul in
     let (=) a b = assert_equal b a in
     begin
@@ -123,7 +124,7 @@ struct
     end
 
   let test_FI_casti2f_specific _ =
-    let cast_bool a b = 
+    let cast_bool a b =
       assert_equal b (FI.of_int (IT.of_int IBool (Big_int_Z.big_int_of_int a))) in
     begin
       cast_bool 0 fi_zero;
@@ -155,7 +156,7 @@ struct
     end
 
   let test_FI_castf2i_specific _ =
-    let cast ikind a b = 
+    let cast ikind a b =
       OUnit2.assert_equal ~cmp:IT.equal ~printer:IT.show b (FI.to_int ikind a) in
     begin
       GobConfig.set_bool "ana.int.interval" true;
@@ -183,8 +184,8 @@ struct
       GobConfig.set_bool "ana.int.interval" false;
     end
 
-  let test_FI_meet_specific _ = 
-    let check_meet a b c = 
+  let test_FI_meet_specific _ =
+    let check_meet a b c =
       assert_equal c (FI.meet a b) in
     begin
       check_meet (FI.top ()) (FI.top ()) (FI.top ());
@@ -194,7 +195,7 @@ struct
     end
 
   let test_FI_join_specific _ =
-    let check_join a b c = 
+    let check_join a b c =
       assert_equal c (FI.join a b) in
     begin
       check_join (FI.top ()) (FI.top ()) (FI.top ());
@@ -203,7 +204,7 @@ struct
     end
 
   let test_FI_leq_specific _ =
-    let check_leq flag a b = 
+    let check_leq flag a b =
       OUnit2.assert_equal flag (FI.leq a b) in
     begin
       check_leq true (FI.top ()) (FI.top ());
@@ -216,7 +217,7 @@ struct
     end
 
   let test_FI_widen_specific _ =
-    let check_widen a b c = 
+    let check_widen a b c =
       assert_equal c (FI.widen a b) in
     begin
       check_widen (FI.top ()) (FI.top ()) (FI.top ());
@@ -228,7 +229,7 @@ struct
     end
 
   let test_FI_narrow_specific _ =
-    let check_narrow a b c = 
+    let check_narrow a b c =
       assert_equal c (FI.narrow a b) in
     begin
       check_narrow (FI.top ()) (FI.top ()) (FI.top ());
@@ -248,11 +249,11 @@ struct
 
   (**interval tests using QCheck arbitraries *)
   let test_FI_not_bot =
-    QCheck.Test.make ~name:"test_FI_not_bot" (FI.arbitrary ()) (fun arg -> 
+    QCheck.Test.make ~name:"test_FI_not_bot" (FI.arbitrary ()) (fun arg ->
         not (FI.is_bot arg))
 
   let test_FI_of_const_not_bot =
-    QCheck.Test.make ~name:"test_FI_of_const_not_bot" QCheck.float (fun arg -> 
+    QCheck.Test.make ~name:"test_FI_of_const_not_bot" QCheck.float (fun arg ->
         not (FI.is_bot (FI.of_const arg)))
 
   let test_FI_div_zero_result_top =
@@ -278,26 +279,26 @@ struct
   let test_FI_add =
     QCheck.Test.make ~name:"test_FI_add" (QCheck.pair QCheck.float QCheck.float) (fun (arg1, arg2) ->
         let result = FI.add (FI.of_const arg1) (FI.of_const arg2) in
-        (FI.leq (FI.of_const (Option.get (to_float (add Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) && 
+        (FI.leq (FI.of_const (Option.get (to_float (add Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) &&
         (FI.leq (FI.of_const (Option.get (to_float (add Down (of_float Nearest arg1) (of_float Nearest arg2))))) result))
 
   let test_FI_sub =
     QCheck.Test.make ~name:"test_FI_sub" (QCheck.pair QCheck.float QCheck.float) (fun (arg1, arg2) ->
         let result = FI.sub (FI.of_const arg1) (FI.of_const arg2) in
-        (FI.leq (FI.of_const (Option.get (to_float (sub Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) && 
+        (FI.leq (FI.of_const (Option.get (to_float (sub Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) &&
         (FI.leq (FI.of_const (Option.get (to_float (sub Down (of_float Nearest arg1) (of_float Nearest arg2))))) result))
 
   let test_FI_mul =
     QCheck.Test.make ~name:"test_FI_mul" (QCheck.pair QCheck.float QCheck.float) (fun (arg1, arg2) ->
         let result = FI.mul (FI.of_const arg1) (FI.of_const arg2) in
-        (FI.leq (FI.of_const (Option.get (to_float (mul Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) && 
+        (FI.leq (FI.of_const (Option.get (to_float (mul Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) &&
         (FI.leq (FI.of_const (Option.get (to_float (mul Down (of_float Nearest arg1) (of_float Nearest arg2))))) result))
 
 
   let test_FI_div =
     QCheck.Test.make ~name:"test_FI_div" (QCheck.pair QCheck.float QCheck.float) (fun (arg1, arg2) ->
         let result = FI.div (FI.of_const arg1) (FI.of_const arg2) in
-        (FI.leq (FI.of_const (Option.get (to_float (div Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) && 
+        (FI.leq (FI.of_const (Option.get (to_float (div Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) &&
         (FI.leq (FI.of_const (Option.get (to_float (div Down (of_float Nearest arg1) (of_float Nearest arg2))))) result))
 
 
@@ -336,9 +337,9 @@ end
 module FloatIntervalTest32 = FloatInterval(CFloat)(FloatDomain.F32Interval)
 module FloatIntervalTest64 = FloatInterval(CDouble)(FloatDomain.F64Interval)
 
-let test () = 
+let test () =
   "floatDomainTest" >:::
-  [ 
+  [
     "float_interval32" >::: FloatIntervalTest32.test ();
     "float_interval_qcheck32" >::: FloatIntervalTest32.test_qcheck ();
     "float_interval64" >::: FloatIntervalTest64.test ();

--- a/unittest/cdomains/intDomainTest.ml
+++ b/unittest/cdomains/intDomainTest.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 open OUnit2
 open Z
 

--- a/unittest/cdomains/lvalTest.ml
+++ b/unittest/cdomains/lvalTest.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 open OUnit2
 
 module ID = IntDomain.IntDomWithDefaultIkind (IntDomain.IntDomLifter (IntDomain.DefExc)) (IntDomain.PtrDiffIkind)

--- a/unittest/domains/mapDomainTest.ml
+++ b/unittest/domains/mapDomainTest.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 open OUnit2
 
 module GroupableDriver : MapDomain.Groupable with type t = string  =

--- a/unittest/maindomaintest.ml
+++ b/unittest/maindomaintest.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 (* open! Defaults (* Enums / ... need initialized conf *) *)
 
 module PrintableChar =

--- a/unittest/solver/solverTest.ml
+++ b/unittest/solver/solverTest.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 open OUnit2
 open Pretty
 

--- a/unittest/util/compilationDatabaseTest.ml
+++ b/unittest/util/compilationDatabaseTest.ml
@@ -1,3 +1,4 @@
+open Goblint_lib
 open OUnit2
 
 let command_object_from_string s =


### PR DESCRIPTION
In the spirit of https://github.com/goblint/cil/pull/107, this also wraps Goblint's own library. This has a lot fewer changes because the Goblint library is only used by a handful of executables and Gobview.

### TODO
- [x] Update submodule after https://github.com/goblint/gobview/pull/17 is merged.