### PR TITLE
Add support for `pthread_spin_lock`

### DIFF
--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -313,6 +313,9 @@ let invalidate_actions = [
     "pthread_mutex_lock", readsAll;(*safe*)
     "pthread_mutex_trylock", readsAll;
     "pthread_mutex_unlock", readsAll;(*safe*)
+    "pthread_spin_lock", readsAll;(*safe*)
+    "pthread_spin_trylock", readsAll;
+    "pthread_spin_unlock", readsAll;(*safe*)
     "__pthread_mutex_lock", readsAll;(*safe*)
     "__pthread_mutex_trylock", readsAll;
     "__pthread_mutex_unlock", readsAll;(*safe*)
@@ -329,6 +332,8 @@ let invalidate_actions = [
     "pthread_mutex_destroy", readsAll;(*safe*)
     "pthread_mutexattr_settype", readsAll;(*safe*)
     "pthread_mutexattr_init", readsAll;(*safe*)
+    "pthread_spin_init", readsAll;(*safe*)
+    "pthread_spin_destroy", readsAll;(*safe*)
     "pthread_self", readsAll;(*safe*)
     "read", writes [2];(*keep [2]*)
     "recv", writes [2];(*keep [2]*)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -161,13 +161,13 @@ let classify fn exps: categories =
   | "_spin_trylock" | "spin_trylock" | "mutex_trylock" | "_spin_trylock_irqsave"
   | "down_trylock"
     -> `Lock(true, true, true)
-  | "pthread_mutex_trylock" | "pthread_rwlock_trywrlock"
+  | "pthread_mutex_trylock" | "pthread_rwlock_trywrlock" | "pthread_spin_trylock"
     -> `Lock (true, true, false)
   | "_spin_lock" | "_spin_lock_irqsave" | "_spin_lock_bh" | "down_write"
   | "mutex_lock" | "mutex_lock_interruptible" | "_write_lock" | "_raw_write_lock"
   | "pthread_rwlock_wrlock" | "GetResource" | "_raw_spin_lock"
   | "_raw_spin_lock_flags" | "_raw_spin_lock_irqsave" | "_raw_spin_lock_irq" | "_raw_spin_lock_bh"
-  | "spin_lock_irqsave" | "spin_lock"
+  | "spin_lock_irqsave" | "spin_lock" | "pthread_spin_lock"
     -> `Lock (get_bool "sem.lock.fail", true, true)
   | "pthread_mutex_lock" | "__pthread_mutex_lock"
     -> `Lock (get_bool "sem.lock.fail", true, false)
@@ -178,7 +178,7 @@ let classify fn exps: categories =
   | "_spin_unlock" | "spin_unlock" | "_spin_unlock_irqrestore" | "_spin_unlock_bh" | "_raw_spin_unlock_bh"
   | "mutex_unlock" | "_write_unlock" | "_read_unlock" | "_raw_spin_unlock_irqrestore"
   | "pthread_mutex_unlock" | "__pthread_mutex_unlock" | "spin_unlock_irqrestore" | "up_read" | "up_write"
-  | "up"
+  | "up" | "pthread_spin_unlock"
     -> `Unlock
   | x -> `Unknown x
 

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -99,8 +99,8 @@ struct
 
   let is_mutex_type (t: typ): bool = match t with
     | TNamed (info, attr) -> info.tname = "pthread_mutex_t" || info.tname = "spinlock_t" || info.tname = "pthead_spinlock_t"
-  | TInt (IInt, attr) -> hasAttribute "mutex" attr
-  | _ -> false
+    | TInt (IInt, attr) -> hasAttribute "mutex" attr
+    | _ -> false
 
   let is_immediate_type t = is_mutex_type t || isFunctionType t
 

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -98,7 +98,7 @@ struct
   ] [@@deriving eq, ord, hash]
 
   let is_mutex_type (t: typ): bool = match t with
-  | TNamed (info, attr) -> info.tname = "pthread_mutex_t" || info.tname = "spinlock_t"
+    | TNamed (info, attr) -> info.tname = "pthread_mutex_t" || info.tname = "spinlock_t" || info.tname = "pthead_spinlock_t"
   | TInt (IInt, attr) -> hasAttribute "mutex" attr
   | _ -> false
 

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -10,7 +10,7 @@ module M = Messages
 
 let is_ignorable_type (t: typ): bool =
   match t with
-  | TNamed ({ tname = "atomic_t" | "pthread_mutex_t" | "pthread_rwlock_t" | "spinlock_t" | "pthread_cond_t"; _ }, _) -> true
+  | TNamed ({ tname = "atomic_t" | "pthread_mutex_t" | "pthread_rwlock_t" | "pthread_spinlock_t" | "spinlock_t" | "pthread_cond_t"; _ }, _) -> true
   | TComp ({ cname = "lock_class_key"; _ }, _) -> true
   | TInt (IInt, attr) when hasAttribute "mutex" attr -> true
   | t when hasAttribute "atomic" (typeAttrs t) -> true (* C11 _Atomic *)

--- a/tests/regression/04-mutex/73-simple_nr_spinlock.c
+++ b/tests/regression/04-mutex/73-simple_nr_spinlock.c
@@ -1,0 +1,23 @@
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+pthread_spinlock_t spinlock1;
+pthread_spinlock_t spinlock2;
+
+void *t_fun(void *arg) {
+  pthread_spin_lock(&spinlock1);
+  myglobal=myglobal+1; // NORACE
+  pthread_spin_unlock(&spinlock1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_spin_lock(&spinlock1);
+  myglobal=myglobal+1; // NORACE
+  pthread_spin_unlock(&spinlock1);
+  pthread_join (id, NULL);
+  return 0;
+}


### PR DESCRIPTION
For some reason, we considered `spin_lock`, `spin_unlock` etc. but not the `pthread_spin_lock` and `pthread_spin_unlock` functions from the `pthread` library.