### PR TITLE
Metadata for v2.0.0

### DIFF
--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -5,9 +5,11 @@ on:
   push:
     paths:
       - 'CITATION.cff'
+      - '.zenodo.json'
   pull_request:
     paths:
       - 'CITATION.cff'
+      - '.zenodo.json'
 
 jobs:
   cff-validate:
@@ -21,3 +23,29 @@ jobs:
         uses: docker://citationcff/cffconvert:latest
         with:
           args: --validate
+
+  zenodo-validate:
+    strategy:
+      matrix:
+        node-version:
+          - 14
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install ajv
+        run: npm install -g ajv-cli ajv-draft-04
+
+      - name: Download Zenodo schema
+        run: wget https://zenodo.org/schemas/deposits/records/legacyrecord.json
+
+      - name: Validate .zenodo.json
+        run: ajv validate -s legacyrecord.json -d .zenodo.json

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -47,5 +47,8 @@ jobs:
       - name: Download Zenodo schema
         run: wget https://zenodo.org/schemas/deposits/records/legacyrecord.json
 
+      - name: Migrate Zenodo schema # https://github.com/ajv-validator/ajv-cli/issues/199
+        run: ajv migrate -s legacyrecord.json
+
       - name: Validate .zenodo.json
         run: ajv validate -s legacyrecord.json -d .zenodo.json

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'CITATION.cff'
       - '.zenodo.json'
+      - '.github/workflows/metadata.yml' # meta
   pull_request:
     paths:
       - 'CITATION.cff'
       - '.zenodo.json'
+      - '.github/workflows/metadata.yml' # meta
 
 jobs:
   cff-validate:

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -44,7 +44,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install ajv
-        run: npm install -g ajv-cli ajv-draft-04
+        run: npm install -g ajv-cli
 
       - name: Download Zenodo schema
         run: wget https://zenodo.org/schemas/deposits/records/legacyrecord.json

--- a/.github/workflows/options.yml
+++ b/.github/workflows/options.yml
@@ -25,9 +25,8 @@ jobs:
       - name: Install ajv-cli
         run: npm install -g ajv-cli
 
-      - name: Work around meta-schema missing error # https://github.com/ajv-validator/ajv-cli/issues/199
-        run: |
-          sed -i 's|"$schema": "http://json-schema.org/draft-04/schema#",||' src/util/options.schema.json
+      - name: Migrate schema # https://github.com/ajv-validator/ajv-cli/issues/199
+        run: ajv migrate -s src/util/options.schema.json
 
       - name: Validate conf
         run: ajv validate -s src/util/options.schema.json -d "conf/**/*.json"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -35,8 +35,6 @@
     }
   ],
   "description": "Static analysis framework for C",
-  "license": {
-    "id": "MIT"
-  },
+  "license": "MIT",
   "title": "Goblint"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,42 @@
+{
+  "creators": [
+    {
+      "affiliation": "University of Tartu",
+      "name": "Vojdani, Vesal"
+    },
+    {
+      "affiliation": "University of Tartu",
+      "name": "Apinis, Kalmer"
+    },
+    {
+      "affiliation": "Technische Universität München",
+      "name": "Schwarz, Martin D."
+    },
+    {
+      "affiliation": "Technische Universität München",
+      "name": "Herz, Alexander"
+    },
+    {
+      "affiliation": "Technische Universität München",
+      "name": "Vogler, Ralf"
+    },
+    {
+      "affiliation": "Technische Universität München",
+      "name": "Schwarz, Michael"
+    },
+    {
+      "affiliation": "Technische Universität München",
+      "name": "Erhard, Julian"
+    },
+    {
+      "affiliation": "University of Tartu",
+      "name": "Saan, Simmo",
+      "orcid": "0000-0003-4553-1350"
+    }
+  ],
+  "description": "Static analysis framework for C",
+  "license": {
+    "id": "MIT"
+  },
+  "title": "Goblint"
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,40 +1,41 @@
 {
+  "upload_type": "software",
+  "title": "Goblint",
+  "description": "Static analysis framework for C",
   "creators": [
     {
-      "affiliation": "University of Tartu",
-      "name": "Vojdani, Vesal"
+      "name": "Vojdani, Vesal",
+      "affiliation": "University of Tartu"
     },
     {
-      "affiliation": "University of Tartu",
-      "name": "Apinis, Kalmer"
+      "name": "Apinis, Kalmer",
+      "affiliation": "University of Tartu"
     },
     {
-      "affiliation": "Technische Universität München",
-      "name": "Schwarz, Martin D."
+      "name": "Schwarz, Martin D.",
+      "affiliation": "Technische Universität München"
     },
     {
-      "affiliation": "Technische Universität München",
-      "name": "Herz, Alexander"
+      "name": "Herz, Alexander",
+      "affiliation": "Technische Universität München"
     },
     {
-      "affiliation": "Technische Universität München",
-      "name": "Vogler, Ralf"
+      "name": "Vogler, Ralf",
+      "affiliation": "Technische Universität München"
     },
     {
-      "affiliation": "Technische Universität München",
-      "name": "Schwarz, Michael"
+      "name": "Schwarz, Michael",
+      "affiliation": "Technische Universität München"
     },
     {
-      "affiliation": "Technische Universität München",
-      "name": "Erhard, Julian"
+      "name": "Erhard, Julian",
+      "affiliation": "Technische Universität München"
     },
     {
-      "affiliation": "University of Tartu",
       "name": "Saan, Simmo",
+      "affiliation": "University of Tartu",
       "orcid": "0000-0003-4553-1350"
     }
   ],
-  "description": "Static analysis framework for C",
-  "license": "MIT",
-  "title": "Goblint"
+  "license": "MIT"
 }


### PR DESCRIPTION
Closes #461.

### TODO
- [ ] Decide who are authors in `CITATION.cff`, `.zenodo.json` and opam package.
- [ ] Decide author order.
- [ ] Add everyone else as _contributors_ in `.zenodo.json`.
 
    Contributors have an extra role field, which is one of the following: ContactPerson, DataCollector, DataCurator, DataManager, Distributor, Editor, Funder, HostingInstitution, Producer, ProjectLeader, ProjectManager, ProjectMember, RegistrationAgency, RegistrationAuthority, RelatedPerson, Researcher, ResearchGroup, RightsHolder, Supervisor, Sponsor, WorkPackageLeader, Other.
    I suppose they should have the ProjectMember role (this is what CPAchecker also uses on Zenodo), except Helmut (and maybe Vesal, depending on whether he goes to authors or not) could have Supervisor role.