### PR TITLE
Remove `ID.is_bool` and `ID.is_int`

### DIFF
--- a/src/analyses/assert.ml
+++ b/src/analyses/assert.ml
@@ -34,14 +34,11 @@ struct
 
     let check_assert e st =
       match ctx.ask (Queries.EvalInt e) with
-      | v when Queries.ID.is_bool v ->
-        begin match Queries.ID.to_bool v with
-          | Some false ->  `Lifted false
-          | Some true  ->  `Lifted true
-          | _ -> `Top
-        end
       | v when Queries.ID.is_bot v -> `Bot
-      | _ -> `Top
+      | v ->
+        match Queries.ID.to_bool v with
+        | Some b -> `Lifted b
+        | None -> `Top
     in
     let expr = sprint d_exp e in
     let warn warn_fn ?annot msg = if check then

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -163,6 +163,11 @@ struct
     | Le -> ID.le
     | Ge -> ID.ge
     | Eq -> ID.eq
+    (* TODO: This causes inconsistent results:
+       def_exc and interval definitely in conflict:
+         evalint: base eval_rv m -> (Not {0, 1}([-31,31]),[1,1])
+         evalint: base eval_rv 1 -> (1,[1,1])
+         evalint: base query_evalint m == 1 -> (0,[1,1]) *)
     | Ne -> ID.ne
     | BAnd -> ID.bitand
     | BOr -> ID.bitor
@@ -1801,6 +1806,10 @@ struct
            (* Both values can not be in the meet together, but it's not sound to exclude the meet from both.
             * e.g. a=[0,1], b=[1,2], meet a b = [1,1], but (a != b) does not imply a=[0,0], b=[2,2] since others are possible: a=[1,1], b=[2,2]
             * Only if a is a definite value, we can exclude it from b: *)
+           (* TODO: This causes inconsistent results:
+              interval not sufficiently refined:
+                inv_bin_int: unequal: (Unknown int([-31,31]),[0,1]) and (0,[0,0]); ikind: int; a': (Not {0}([-31,31]),[-2147483648,2147483647]), b': (0,[0,0])
+                binop: m == 0, a': (Not {0}([-31,31]),[0,1]), b': (0,[0,0]) *)
            let excl a b = match ID.to_int a with Some x -> ID.of_excl_list ikind [x] | None -> b in
            let a' = excl b a in
            let b' = excl a b in
@@ -1814,6 +1823,10 @@ struct
         (match ID.minimal a, ID.maximal a, ID.minimal b, ID.maximal b with
          | Some l1, Some u1, Some l2, Some u2 ->
            (* if M.tracing then M.tracel "inv" "Op: %s, l1: %Ld, u1: %Ld, l2: %Ld, u2: %Ld\n" (show_binop op) l1 u1 l2 u2; *)
+           (* TODO: This causes inconsistent results:
+              def_exc and interval in conflict:
+                binop m < 0 with (Not {-1}([-31,31]),[-1,0]) < (0,[0,0]) == (1,[1,1])
+                binop: m < 0, a': (Not {-1, 0}([-31,31]),[-1,-1]), b': (0,[0,0]) *)
            (match op, ID.to_bool c with
             | Le, Some true
             | Gt, Some false -> meet_bin (ID.ending ikind u2) (ID.starting ikind l1)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -892,9 +892,11 @@ struct
             (* get definite ints from vs *)
             let rec to_int_set = function
               | [] -> BISet.empty ()
-              | `Int i :: vs when ID.is_int i ->
-                let i' = Option.get (ID.to_int i) in
-                BISet.add i' (to_int_set vs)
+              | `Int i :: vs ->
+                begin match ID.to_int i with
+                  | Some i' -> BISet.add i' (to_int_set vs)
+                  | None -> to_int_set vs
+                end
               | _ :: vs ->
                 to_int_set vs
             in
@@ -1780,11 +1782,12 @@ struct
         in
         let a''' =
           (* if both b and c are definite, we can get a precise value in the congruence domain *)
-          if ID.is_int b && ID.is_int c then
+          match ID.to_int b, ID.to_int c with
+          | Some b, Some c ->
             (* a%b == c  -> a: c+bℤ *)
-            let t = ID.of_congruence ikind ((BatOption.get @@ ID.to_int c), (BatOption.get @@ ID.to_int b)) in
+            let t = ID.of_congruence ikind (c, b) in
             ID.meet a'' t
-          else a''
+          | _, _ -> a''
         in
         meet_bin a''' b'
       | Eq | Ne as op ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1113,7 +1113,7 @@ struct
                   | `NoOffset -> NoOffset
                   | `Field (f, offs) -> Field (f, offs_to_offset offs)
                   | `Index (i, offs) ->
-                    (* Addr.Offs.is_definite implies Idx.is_int *)
+                    (* Addr.Offs.is_definite implies Idx.to_int returns Some *)
                     let i_definite = BatOption.get (ValueDomain.IndexDomain.to_int i) in
                     let i_exp = Cil.(kinteger64 ILongLong (IntOps.BigIntOps.to_int64 i_definite)) in
                     Index (i_exp, offs_to_offset offs)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2213,15 +2213,19 @@ struct
     (* First we want to see, if we can determine a dead branch: *)
     match valu with
     (* For a boolean value: *)
-    | `Int value when (ID.is_bool value) ->
+    | `Int value ->
       if M.tracing then M.traceu "branch" "Expression %a evaluated to %a\n" d_exp exp ID.pretty value;
-      (* to suppress pattern matching warnings: *)
-      let fromJust x = match x with Some x -> x | None -> assert false in
-      let v = fromJust (ID.to_bool value) in
-      (* Eliminate the dead branch and just propagate to the true branch *)
-      if v = tv then refine () else begin
-        if M.tracing then M.tracel "branch" "A The branch %B is dead!\n" tv;
-        raise Deadcode
+      begin match ID.to_bool value with
+        | Some v ->
+          (* Eliminate the dead branch and just propagate to the true branch *)
+          if v = tv then
+            refine ()
+          else (
+            if M.tracing then M.tracel "branch" "A The branch %B is dead!\n" tv;
+            raise Deadcode
+          )
+        | None ->
+          refine () (* like fallback below *)
       end
     (* for some reason refine () can refine these, but not raise Deadcode in struct *)
     | `Address ad when tv && AD.is_null ad ->

--- a/src/analyses/extractPthread.ml
+++ b/src/analyses/extractPthread.ml
@@ -1081,7 +1081,7 @@ module Spec : Analyses.MCPSpec = struct
       else
         let env = Env.get ctx in
         (* write out edges with call to f coming from all predecessor nodes of the caller *)
-        ( if Ctx.is_int d_callee.ctx
+        ( if Ctx.to_int d_callee.ctx <> None
           then
             let last_pred = d_caller.pred in
             let action = Action.Call (fun_ctx d_callee.ctx f.svar) in

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -104,7 +104,6 @@ sig
   val equal_to: int_t -> t -> [`Eq | `Neq | `Top]
 
   val to_bool: t -> bool option
-  val is_bool: t -> bool
   val to_excl_list: t -> (int_t list * (int64 * int64)) option
   val of_excl_list: Cil.ikind -> int_t list -> t
   val is_excl_list: t -> bool
@@ -330,7 +329,6 @@ struct
   let equal_to i x = I.equal_to i x.v
   let to_bool x = I.to_bool x.v
   let of_bool ikind b = { v = I.of_bool ikind b; ikind}
-  let is_bool x = I.is_bool x.v
   let to_excl_list x = I.to_excl_list x.v
   let of_excl_list ikind is = {v = I.of_excl_list ikind is; ikind}
   let is_excl_list x = I.is_excl_list x.v
@@ -599,7 +597,6 @@ struct
   let top_bool = Some (Ints_t.zero, Ints_t.one)
 
   let of_bool _ik = function true -> one | false -> zero
-  let is_bool x = x <> None && not (leq zero x) || equal x zero
   let to_bool (a: t) = match a with
     | None -> None
     | Some (l, u) when Ints_t.compare l Ints_t.zero = 0 && Ints_t.compare u Ints_t.zero = 0 -> Some false
@@ -962,7 +959,6 @@ struct
   let of_bool x = if x then Ints_t.one else Ints_t.zero
   let to_bool' x = x <> Ints_t.zero
   let to_bool x = Some (to_bool' x)
-  let is_bool _ = true
   let of_int  x = x
   let to_int  x = Some x
   let is_int  _ = true
@@ -1038,7 +1034,6 @@ struct
   let to_bool x = match x with
     | `Lifted x -> Base.to_bool x
     | _ -> None
-  let is_bool = is_int
 
   let to_excl_list x = None
   let of_excl_list ik x = top_of ik
@@ -1121,7 +1116,6 @@ struct
   let to_bool x = match x with
     | `Lifted x -> Base.to_bool x
     | _ -> None
-  let is_bool = is_int
 
   let lift1 f x = match x with
     | `Lifted x -> `Lifted (f x)
@@ -1471,11 +1465,6 @@ struct
     | `Definite x -> BigInt.to_bool x
     | `Excluded (s,r) when S.mem BI.zero s -> Some true
     | _ -> None
-  let is_bool x =
-    match x with
-    | `Definite x -> true
-    | `Excluded (s,r) -> S.mem BI.zero s
-    | _ -> false
 
   let of_interval ik (x,y) = if BigInt.compare x y = 0 then of_int ik x else top_of ik
 
@@ -1703,7 +1692,6 @@ struct
 
   let of_bool x = x
   let to_bool x = Some x
-  let is_bool x = not x
   let of_int x  = x = Int64.zero
   let to_int x  = if x then None else Some Int64.zero
   let is_int x  = not x
@@ -1960,7 +1948,6 @@ module Enums : S with type int_t = BigInt.t = struct
     | Inc xs when BISet.for_all ((<>) BI.zero) xs -> Some true
     | Exc (xs,_) when BISet.exists ((=) BI.zero) xs -> Some true
     | _ -> None
-  let is_bool = BatOption.is_some % to_bool
   let to_int = function Inc x when BISet.is_singleton x -> Some (BISet.choose x) | _ -> None
   let is_int = BatOption.is_some % to_int
 
@@ -2218,7 +2205,6 @@ struct
   let top_bool = top()
 
   let of_bool _ik = function true -> one | false -> zero
-  let is_bool x = x <> None && not (leq zero x) || equal x zero
 
   let to_bool (a: t) = match a with
     | None -> None
@@ -2669,7 +2655,6 @@ module IntDomTupleImpl = struct
   let is_top = for_all % mapp { fp = fun (type a) (module I:S with type t = a) -> I.is_top }
   let is_top_of ik = for_all % mapp { fp = fun (type a) (module I:S with type t = a) -> I.is_top_of ik }
   let is_int = exists % mapp { fp = fun (type a) (module I:S with type t = a) -> I.is_int }
-  let is_bool = exists % mapp { fp = fun (type a) (module I:S with type t = a) -> I.is_bool }
   let is_excl_list = exists % mapp { fp = fun (type a) (module I:S with type t = a) -> I.is_excl_list }
 
   let map2p r (xa, xb, xc, xd) (ya, yb, yc, yd) =

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -189,10 +189,6 @@ sig
   (** Give a boolean interpretation of an abstract value if possible, otherwise
     * don't return anything.*)
 
-  val is_bool: t -> bool
-  (** Checks if the element is a definite boolean value. If this function
-    * returns [true], the above [to_bool] should return a real value. *)
-
   val to_excl_list: t -> (int_t list * (int64 * int64)) option
   (** Gives a list representation of the excluded values from included range of bits if possible. *)
 

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -179,10 +179,6 @@ sig
   (** Return a single integer value if the value is a known constant, otherwise
     * don't return anything. *)
 
-  val is_int: t -> bool
-  (** Checks if the element is a definite integer value. If this function
-    * returns [true], the above [to_int] should return a real value. *)
-
   val equal_to: int_t -> t -> [`Eq | `Neq | `Top]
 
   val to_bool: t -> bool option

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -54,7 +54,7 @@ struct
     | `NoOffset , `NoOffset -> true
     | `Field (x1,y1) , `Field (x2,y2) -> CilType.Compinfo.equal x1.fcomp x2.fcomp && may_be_same_offset y1 y2 (* TODO: why not fieldinfo equal? *)
     | `Index (x1,y1) , `Index (x2,y2)
-      -> (not (IdxDom.is_int x1) || not (IdxDom.is_int x2))
+      -> ((IdxDom.to_int x1 = None) || (IdxDom.to_int x2 = None))
          || IdxDom.equal x1 x2 && may_be_same_offset y1 y2
     | _ -> false
 

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -15,7 +15,7 @@ module type IdxDomain =
 sig
   include Printable.S
   val equal_to: IntOps.BigIntOps.t -> t -> [`Eq | `Neq | `Top]
-  val is_int: t -> bool
+  val to_int: t -> IntOps.BigIntOps.t option
 end
 
 module OffsetPrintable (Idx: IdxDomain) =
@@ -73,7 +73,7 @@ struct
   let rec is_definite = function
     | `NoOffset -> true
     | `Field (f,o) -> is_definite o
-    | `Index (i,o) ->  Idx.is_int i && is_definite o
+    | `Index (i,o) ->  Idx.to_int i <> None && is_definite o
 
   (* append offset o2 to o1 *)
   (* TODO: unused *)

--- a/src/cdomains/symbLocksDomain.ml
+++ b/src/cdomains/symbLocksDomain.ml
@@ -305,7 +305,7 @@ struct
       )
 
     let equal_to _ _ = `Top
-    let is_int _ = false
+    let to_int _ = None
   end
 
   include Lval.Normal (Idx)

--- a/src/domains/intDomainProperties.ml
+++ b/src/domains/intDomainProperties.ml
@@ -7,7 +7,6 @@ sig
   include Lattice.S
   include IntDomain.Arith with type t := t
   val of_int: BI.t -> t
-  val is_int: t -> bool
   val to_int: t -> BI.t option
   val of_bool: bool -> t
   val to_bool: t -> bool option

--- a/src/domains/intDomainProperties.ml
+++ b/src/domains/intDomainProperties.ml
@@ -10,7 +10,6 @@ sig
   val is_int: t -> bool
   val to_int: t -> BI.t option
   val of_bool: bool -> t
-  val is_bool: t -> bool
   val to_bool: t -> bool option
   val of_excl_list: Cil.ikind -> BI.t list -> t
   val is_excl_list: t -> bool

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -31,7 +31,6 @@ struct
   let ending ik = lift (I.ending ik)
 
   let to_int x = unlift_opt I.to_int x
-  let is_int x = unlift_is I.is_int x
   let to_bool x = unlift_opt I.to_bool x
 
   let is_bot_ikind = function

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -33,7 +33,6 @@ struct
   let to_int x = unlift_opt I.to_int x
   let is_int x = unlift_is I.is_int x
   let to_bool x = unlift_opt I.to_bool x
-  let is_bool x = unlift_is I.is_bool x
 
   let is_bot_ikind = function
     | `Bot -> false

--- a/src/transform/expressionEvaluation.ml
+++ b/src/transform/expressionEvaluation.ml
@@ -127,17 +127,19 @@ struct
                 value_after
 
       method private try_ask location expression =
-        try
-          (match ~? (fun () -> (ask location).Queries.f (Queries.EvalInt expression)) with
-           (* Evaluable: Definite *)
-           | Some ((`Lifted x') as x) when Queries.ID.is_int x -> Some (Some (not(IntOps.BigIntOps.equal (Option.get @@ Queries.ID.to_int x) IntOps.BigIntOps.zero)))
-           (* Inapplicable: Unreachable *)
-           | Some x when Queries.ID.is_bot_ikind x -> None
-           (* Evaluable: Inconclusive *)
-           | Some x -> Some None
-           (* Inapplicable: Unlisted *)
-           | None -> None)
-        with Not_found -> None
+        match ~? (fun () -> (ask location).Queries.f (Queries.EvalInt expression)) with
+        (* Inapplicable: Unreachable *)
+        | Some x when Queries.ID.is_bot_ikind x -> None
+        | Some x ->
+          begin match Queries.ID.to_int x with
+            (* Evaluable: Definite *)
+            | Some i -> Some (Some (not(IntOps.BigIntOps.equal i IntOps.BigIntOps.zero)))
+            (* Evaluable: Inconclusive *)
+            | None -> Some None
+          end
+        (* Inapplicable: Unlisted *)
+        | None
+        | exception Not_found -> None
 
     end
 

--- a/src/transform/transform.ml
+++ b/src/transform/transform.ml
@@ -21,13 +21,12 @@ module PartialEval = struct
       (* ignore @@ Pretty.printf "Set loc at stmt %a to %a\n" d_stmt s CilType.Location.pretty !loc; *)
       DoChildren
     method! vexpr e =
-      let eval e = match (ask !loc).Queries.f (Queries.EvalInt e) with
-        | x when Queries.ID.is_int x ->
-          let i = Option.get @@ Queries.ID.to_int x in
+      let eval e = match Queries.ID.to_int ((ask !loc).Queries.f (Queries.EvalInt e)) with
+        | Some i ->
           let e' = integer @@ IntOps.BigIntOps.to_int i in
           ignore @@ Pretty.printf "Replacing non-constant expression %a with %a at %a\n" d_exp e d_exp e' CilType.Location.pretty !loc;
           e'
-        | _ ->
+        | None ->
           ignore @@ Pretty.printf "Can't replace expression %a at %a\n" d_exp e CilType.Location.pretty !loc; e
       in
       match e with

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -427,15 +427,12 @@ struct
                   let x = ask_local lvar d (Queries.EvalInt inv_exp) in
                   if Queries.ID.is_bot x || Queries.ID.is_bot_ikind x then (* dead code *)
                     Option.get (VR.result_of_enum (VR.bot ()))
-                  else if Queries.ID.is_bool x then (
-                    let verdict = Option.get (Queries.ID.to_bool x) in
-                    if verdict then
-                      Confirmed
-                    else
-                      Refuted
+                  else (
+                    match Queries.ID.to_bool x with
+                    | Some true -> Confirmed
+                    | Some false -> Refuted
+                    | None -> Unconfirmed
                   )
-                  else
-                    Unconfirmed
                 | Error e ->
                   ParseError
               in
@@ -510,10 +507,11 @@ struct
                   let x = ask_local lvar pre_d (Queries.EvalInt pre_exp) in
                   if Queries.ID.is_bot x || Queries.ID.is_bot_ikind x then (* dead code *)
                     true
-                  else if Queries.ID.is_bool x then
-                    Option.get (Queries.ID.to_bool x)
-                  else
-                    false
+                  else (
+                    match Queries.ID.to_bool x with
+                    | Some b -> b
+                    | None -> false
+                  )
                 | Error e ->
                   M.error ~category:Witness ~loc:msgLoc "CIL couldn't parse precondition: %s" inv;
                   M.info ~category:Witness ~loc:msgLoc "precondition has undefined variables or side effects: %s" inv;

--- a/tests/regression/01-cpa/57-def_exc-interval-inconsistent.c
+++ b/tests/regression/01-cpa/57-def_exc-interval-inconsistent.c
@@ -1,0 +1,23 @@
+// PARAM: --enable ana.int.def_exc --enable ana.int.interval --enable ana.sv-comp.functions --set sem.int.signed_overflow assume_none --set ana.int.refinement never
+// used to crash in branch when is_bool returned true, but to_bool returned None on (0,[1,1])
+// manually minimized from sv-benchmarks/c/recursive/MultCommutative-2.c
+extern int __VERIFIER_nondet_int(void);
+
+void f(int m) {
+    if (m < 0) {
+        f(-m);
+    }
+    if (m == 0) {
+        return;
+    }
+    f(m - 1);
+}
+
+int main() {
+    int m = __VERIFIER_nondet_int();
+    if (m < 0 || m > 1) {
+        return 0;
+    }
+    f(m); // m=[0,1]
+    return 0;
+}

--- a/unittest/cdomains/intDomainTest.ml
+++ b/unittest/cdomains/intDomainTest.ml
@@ -33,10 +33,8 @@ struct
   let test_bool _ =
     assert_equal (Some true ) (I.to_bool ione);
     assert_equal (Some false) (I.to_bool izero);
-    assert_bool "0 isn't bool" (I.is_bool izero);
-    assert_bool "1 isn't bool" (I.is_bool ione);
-    assert_bool "true isn't bool" (I.is_bool itrue);
-    assert_bool "false isn't bool" (I.is_bool ifalse);
+    assert_equal (Some true ) (I.to_bool itrue);
+    assert_equal (Some false) (I.to_bool ifalse);
     assert_equal ~printer:I.show itrue  (I.lt ione  itwo);
     assert_equal ~printer:I.show ifalse (I.gt ione  itwo);
     assert_equal ~printer:I.show itrue  (I.le ione  ione);

--- a/unittest/cdomains/intDomainTest.ml
+++ b/unittest/cdomains/intDomainTest.ml
@@ -23,8 +23,6 @@ struct
     assert_equal ~printer:I.show ione  (I.of_int one);
     assert_equal ~printer:I.show itrue (I.of_bool true);
     assert_equal ~printer:I.show ifalse(I.of_bool false);
-    assert_bool "IntDomain cannot hold 1" (I.is_int ione) ;
-    assert_bool "IntDomain cannot hold 0" (I.is_int izero) ;
     assert_equal (Some one ) (I.to_int ione);
     assert_equal (Some zero) (I.to_int izero);
     assert_equal (Some zero) (I.to_int ifalse)


### PR DESCRIPTION
This fixes an assert failing in `sv-benchmarks/c/recursive/MultCommutative-2` here:
https://github.com/goblint/analyzer/blob/a4e917f86c983d7c97138364b07e031a7715e3d5/src/analyses/base.ml#L2216-L2220
The problem was that `ID.is_bool value = true` but `ID.to_bool = None`, which of course shouldn't happen.

The offending `value` is `(0,[1,1])`, which is the result of a sequence of imprecise refinements (documented in TODOs). These don't happen with `--set ana.int.refinement once`, but these imprecisions are nontrivial to avoid (e.g. intervals cannot represent exclusion sets).

The easier way to avoid the inconsistency between `is_bool` and `to_bool` is not to have `is_bool` because `is_bool x` is equivalent to `to_bool x <> None`. Most places where we use `is_bool` also end up calling `to_bool`, like above, which doubles the work. Same goes for `is_int`.