### PR TITLE
Add Apron octagon narrow

### DIFF
--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -1201,8 +1201,22 @@ struct
     if M.tracing then M.traceu "apron" "-> %a\n" pretty w;
     w
 
-  (* TODO: better narrow *)
-  let narrow x y = x
+  let narrow x y =
+    let x_env = A.env x in
+    let y_env = A.env y in
+    if Environment.equal x_env y_env then (
+        if Oct.manager_is_oct Man.mgr then (
+          let octmgr = Oct.manager_to_oct Man.mgr in
+          let x_oct = Oct.Abstract1.to_oct x in
+          let y_oct = Oct.Abstract1.to_oct y in
+          let r = Oct.narrowing octmgr (Abstract1.abstract0 x_oct) (Abstract1.abstract0 y_oct) in
+          Oct.Abstract1.of_oct {env = x_env; abstract0 = r}
+        )
+        else
+          x
+    )
+    else
+      y (* env decreased, can't decrease infinitely *)
 
   (* TODO: check environments in pretty_diff? *)
 end

--- a/tests/regression/46-apron2/22-oct-narrow.c
+++ b/tests/regression/46-apron2/22-oct-narrow.c
@@ -1,0 +1,11 @@
+// SKIP PARAM: --set ana.activated[+] apron --disable ana.int.interval --set ana.apron.domain octagon
+#include <assert.h>
+
+int main() {
+  int i = 0;
+  while (i < 100) {
+    i++;
+  }
+  assert(i == 100);
+  return 0;
+}


### PR DESCRIPTION
Narrowing has been missing from our apron analysis because there's no general `narrowing` in Apron, but there is one for `Oct`, so we might as well use it if it's there.