### PR TITLE
Flow-insensitive YAML witness invariants

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1142,7 +1142,9 @@ struct
       Invariant.none
 
   let query_invariant_global ctx g =
-    if GobConfig.get_bool "ana.base.invariant.enabled" then (
+    if GobConfig.get_bool "ana.base.invariant.enabled" && get_bool "exp.earlyglobs" then (
+      (* Currently these global invariants are only sound for single-threaded mode with earlyglobs. *)
+      (* TODO: account for single-threaded values without earlyglobs. *)
       match g with
       | `Left g' -> (* priv *)
         Priv.invariant_global (priv_getg ctx.global) g'

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1330,10 +1330,7 @@ struct
       let g: V.t = Obj.obj g in
       begin match g with
         | `Left g' -> (* priv *)
-          (* ignore (Pretty.printf "WarnGlobal %a\n" CilType.Varinfo.pretty g); *)
-          (* let accs = G.access (ctx.global g) in
-          Stats.time "access" (Access.warn_global safe vulnerable unsafe g') accs *)
-          Invariant.none (* TODO: delegate to Priv *)
+          Priv.invariant_global (priv_getg ctx.global) g'
         | `Right _ -> (* thread return *)
           Invariant.none
       end

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1101,109 +1101,30 @@ struct
 
   let query_invariant ctx context =
     let cpa = ctx.local.BaseDomain.cpa in
-    let scope = Node.find_fundec ctx.node in
 
-    (* VS is used to detect and break cycles in deref_invariant calls *)
-    let module VS = Set.Make (Basetype.Variables) in
-
-    let rec ad_invariant ~vs ~offset c x =
-      let c_exp = Cil.(Lval (BatOption.get c.Invariant.lval)) in
-      let i_opt = AD.fold (fun addr acc_opt ->
-          BatOption.bind acc_opt (fun acc ->
-              match addr with
-              | Addr.UnknownPtr ->
-                None
-              | Addr.Addr (vi, offs) when Addr.Offs.is_definite offs ->
-                let rec offs_to_offset = function
-                  | `NoOffset -> NoOffset
-                  | `Field (f, offs) -> Field (f, offs_to_offset offs)
-                  | `Index (i, offs) ->
-                    (* Addr.Offs.is_definite implies Idx.to_int returns Some *)
-                    let i_definite = BatOption.get (ValueDomain.IndexDomain.to_int i) in
-                    let i_exp = Cil.(kinteger64 ILongLong (IntOps.BigIntOps.to_int64 i_definite)) in
-                    Index (i_exp, offs_to_offset offs)
-                in
-                let offset = offs_to_offset offs in
-
-                let i =
-                  if InvariantCil.(not (exp_contains_tmp c_exp) && exp_is_in_scope scope c_exp && not (var_is_tmp vi) && var_is_in_scope scope vi && not (var_is_heap vi)) then
-                    let addr_exp = AddrOf (Var vi, offset) in (* AddrOf or Lval? *)
-                    Invariant.of_exp Cil.(BinOp (Eq, c_exp, addr_exp, intType))
-                  else
-                    Invariant.none
-                in
-                let i_deref = deref_invariant ~vs c vi offset (Mem c_exp, NoOffset) in
-
-                Some (Invariant.(acc || (i && i_deref)))
-              | Addr.NullPtr ->
-                let i =
-                  let addr_exp = integer 0 in
-                  if InvariantCil.(not (exp_contains_tmp c_exp) && exp_is_in_scope scope c_exp) then
-                    Invariant.of_exp Cil.(BinOp (Eq, c_exp, addr_exp, intType))
-                  else
-                    Invariant.none
-                in
-                Some (Invariant.(acc || i))
-              (* TODO: handle Addr.StrPtr? *)
-              | _ ->
-                None
-            )
-        ) x (Some (Invariant.bot ()))
-      in
-      match i_opt with
-      | Some i -> i
-      | None -> Invariant.none
-
-    and blob_invariant ~vs ~offset c (v, _, _) =
-      vd_invariant ~vs ~offset c v
-
-    and vd_invariant ~vs ~offset c = function
-      | `Int n ->
-        let e = Lval (BatOption.get c.Invariant.lval) in
-        if InvariantCil.(not (exp_contains_tmp e) && exp_is_in_scope scope e) then
-          ID.invariant e n
-        else
-          Invariant.none
-      | `Float n ->
-        let e = Lval (BatOption.get c.Invariant.lval) in
-        if InvariantCil.(not (exp_contains_tmp e) && exp_is_in_scope scope e) then
-          FD.invariant e n
-        else
-          Invariant.none
-      | `Address n -> ad_invariant ~vs ~offset c n
-      | `Blob n -> blob_invariant ~vs ~offset c n
-      | `Struct n -> ValueDomain.Structs.invariant ~value_invariant:(vd_invariant ~vs) ~offset c n
-      | `Union n -> ValueDomain.Unions.invariant ~value_invariant:(vd_invariant ~vs) ~offset c n
-      | _ -> Invariant.none (* TODO *)
-
-    and deref_invariant ~vs c vi offset lval =
-      let v = CPA.find vi cpa in
-      key_invariant_lval ~vs c vi offset lval v
-
-    and key_invariant_lval ~vs c k offset lval v =
-      if not (VS.mem k vs) then
-        let vs' = VS.add k vs in
-        let key_context: Invariant.context = {c with lval=Some lval} in
-        vd_invariant ~vs:vs' ~offset key_context v
-      else
-        Invariant.none
+    let module Arg =
+    struct
+      let context = context
+      let scope = Node.find_fundec ctx.node
+      let find v = CPA.find v cpa
+    end
     in
+    let module I = ValueDomain.ValueInvariant (Arg) in
 
     let cpa_invariant =
-      let key_invariant k v = key_invariant_lval ~vs:VS.empty context k NoOffset (var k) v in
       match context.lval with
       | None ->
         CPA.fold (fun k v a ->
             let i =
               if not (InvariantCil.var_is_heap k) then
-                key_invariant k v
+                I.key_invariant k v
               else
                 Invariant.none
             in
             Invariant.(a && i)
           ) cpa Invariant.none
       | Some (Var k, _) when not (InvariantCil.var_is_heap k) ->
-        (try key_invariant k (CPA.find k cpa) with Not_found -> Invariant.none)
+        (try I.key_invariant k (CPA.find k cpa) with Not_found -> Invariant.none)
       | _ -> Invariant.none
     in
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1143,7 +1143,8 @@ struct
 
   let query_invariant_global ctx g =
     if GobConfig.get_bool "ana.base.invariant.enabled" && get_bool "exp.earlyglobs" then (
-      (* Currently these global invariants are only sound for single-threaded mode with earlyglobs. *)
+      (* Currently these global invariants are only sound with earlyglobs enabled for both single- and multi-threaded programs.
+         Otherwise, the values of globals in single-threaded mode are not accounted for. *)
       (* TODO: account for single-threaded values without earlyglobs. *)
       match g with
       | `Left g' -> (* priv *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1326,6 +1326,17 @@ struct
       let vf' x = vf (Obj.repr (V.priv x)) in
       Priv.iter_sys_vars (priv_getg ctx.global) vq vf'
     | Q.Invariant context -> query_invariant ctx context
+    | Q.InvariantGlobal g ->
+      let g: V.t = Obj.obj g in
+      begin match g with
+        | `Left g' -> (* priv *)
+          (* ignore (Pretty.printf "WarnGlobal %a\n" CilType.Varinfo.pretty g); *)
+          (* let accs = G.access (ctx.global g) in
+          Stats.time "access" (Access.warn_global safe vulnerable unsafe g') accs *)
+          Invariant.none (* TODO: delegate to Priv *)
+        | `Right _ -> (* thread return *)
+          Invariant.none
+      end
     | _ -> Q.Result.top q
 
   let update_variable variable typ value cpa =

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1136,6 +1136,17 @@ struct
     else
       Invariant.none
 
+  let query_invariant_global ctx g =
+    if GobConfig.get_bool "ana.base.invariant.enabled" then (
+      match g with
+      | `Left g' -> (* priv *)
+        Priv.invariant_global (priv_getg ctx.global) g'
+      | `Right _ -> (* thread return *)
+        Invariant.none
+    )
+    else
+      Invariant.none
+
   let query ctx (type a) (q: a Q.t): a Q.result =
     match q with
     | Q.EvalFunvar e ->
@@ -1249,12 +1260,7 @@ struct
     | Q.Invariant context -> query_invariant ctx context
     | Q.InvariantGlobal g ->
       let g: V.t = Obj.obj g in
-      begin match g with
-        | `Left g' -> (* priv *)
-          Priv.invariant_global (priv_getg ctx.global) g'
-        | `Right _ -> (* thread return *)
-          Invariant.none
-      end
+      query_invariant_global ctx g
     | _ -> Q.Result.top q
 
   let update_variable variable typ value cpa =

--- a/src/analyses/basePriv.mli
+++ b/src/analyses/basePriv.mli
@@ -22,7 +22,11 @@ sig
   val enter_multithreaded: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t
   val threadenter: Queries.ask -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t
   val iter_sys_vars: (V.t -> G.t) -> VarQuery.t -> V.t VarQuery.f -> unit (** [Queries.IterSysVars] for base. *)
-  val invariant_global: (V.t -> G.t) -> V.t -> Invariant.t (** [Queries.InvariantGlobal] for base. *)
+
+  val invariant_global: (V.t -> G.t) -> V.t -> Invariant.t
+  (** Provides [Queries.InvariantGlobal] result for base.
+
+      Should account for all unprotected/weak values of global variables. *)
 
   val init: unit -> unit
   val finalize: unit -> unit

--- a/src/analyses/basePriv.mli
+++ b/src/analyses/basePriv.mli
@@ -22,6 +22,7 @@ sig
   val enter_multithreaded: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t
   val threadenter: Queries.ask -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t
   val iter_sys_vars: (V.t -> G.t) -> VarQuery.t -> V.t VarQuery.f -> unit (** [Queries.IterSysVars] for base. *)
+  val invariant_global: (V.t -> G.t) -> V.t -> Invariant.t (** [Queries.InvariantGlobal] for base. *)
 
   val init: unit -> unit
   val finalize: unit -> unit

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -261,6 +261,10 @@ struct
           (* WarnGlobal is special: it only goes to corresponding analysis and the argument variant is unlifted for it *)
           let (n, g): V.t = Obj.obj g in
           f ~q:(WarnGlobal (Obj.repr g)) (Result.top ()) (n, spec n, assoc n ctx.local)
+        | Queries.InvariantGlobal g ->
+          (* InvariantGlobal is special: it only goes to corresponding analysis and the argument variant is unlifted for it *)
+          let (n, g): V.t = Obj.obj g in
+          f ~q:(InvariantGlobal (Obj.repr g)) (Result.top ()) (n, spec n, assoc n ctx.local)
         | Queries.PartAccess a ->
           Obj.repr (access ctx a)
         | Queries.IterSysVars (vq, fi) ->

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -1289,3 +1289,14 @@ struct
 
   let key_invariant k v = key_invariant_lval ~vs:VS.empty context k NoOffset (var k) v
 end
+
+let invariant_global find g =
+  let module Arg =
+  struct
+    let context = Invariant.default_context
+    let scope = dummyFunDec
+    let find = find
+  end
+  in
+  let module I = ValueInvariant (Arg) in
+  I.key_invariant g (find g)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -108,6 +108,7 @@ type _ t =
   | CreatedThreads: ConcDomain.ThreadSet.t t
   | MustJoinedThreads: ConcDomain.MustThreadSet.t t
   | Invariant: invariant_context -> Invariant.t t
+  | InvariantGlobal: Obj.t -> Invariant.t t (** Argument must be of corresponding [Spec.V.t]. *)
   | WarnGlobal: Obj.t -> Unit.t t (** Argument must be of corresponding [Spec.V.t]. *)
   | IterSysVars: VarQuery.t * Obj.t VarQuery.f -> Unit.t t (** [iter_vars] for [Constraints.FromSpec]. [Obj.t] represents [Spec.V.t]. *)
 
@@ -157,6 +158,7 @@ struct
     | CreatedThreads ->  (module ConcDomain.ThreadSet)
     | MustJoinedThreads -> (module ConcDomain.MustThreadSet)
     | Invariant _ -> (module Invariant)
+    | InvariantGlobal _ -> (module Invariant)
     | WarnGlobal _ -> (module Unit)
     | IterSysVars _ -> (module Unit)
 
@@ -205,6 +207,7 @@ struct
     | CreatedThreads -> ConcDomain.ThreadSet.top ()
     | MustJoinedThreads -> ConcDomain.MustThreadSet.top ()
     | Invariant _ -> Invariant.top ()
+    | InvariantGlobal _ -> Invariant.top ()
     | WarnGlobal _ -> Unit.top ()
     | IterSysVars _ -> Unit.top ()
 end
@@ -252,6 +255,7 @@ struct
     | Any (WarnGlobal _) -> 35
     | Any (Invariant _) -> 36
     | Any (IterSysVars _) -> 37
+    | Any (InvariantGlobal _) -> 38
 
   let compare a b =
     let r = Stdlib.compare (order a) (order b) in
@@ -282,6 +286,7 @@ struct
       | Any (EvalThread e1), Any (EvalThread e2) -> CilType.Exp.compare e1 e2
       | Any (WarnGlobal vi1), Any (WarnGlobal vi2) -> compare (Hashtbl.hash vi1) (Hashtbl.hash vi2)
       | Any (Invariant i1), Any (Invariant i2) -> compare_invariant_context i1 i2
+      | Any (InvariantGlobal vi1), Any (InvariantGlobal vi2) -> compare (Hashtbl.hash vi1) (Hashtbl.hash vi2)
       | Any (IterSysVars (vq1, vf1)), Any (IterSysVars (vq2, vf2)) -> VarQuery.compare vq1 vq2 (* not comparing fs *)
       (* only argumentless queries should remain *)
       | _, _ -> Stdlib.compare (order a) (order b)
@@ -312,6 +317,7 @@ struct
     | Any (EvalThread e) -> CilType.Exp.hash e
     | Any (WarnGlobal vi) -> Hashtbl.hash vi
     | Any (Invariant i) -> hash_invariant_context i
+    | Any (InvariantGlobal vi) -> Hashtbl.hash vi
     (* only argumentless queries should remain *)
     | _ -> 0
 

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1125,6 +1125,14 @@ struct
                 ()
             ) em;
       end
+    | InvariantGlobal g ->
+      let g: V.t = Obj.obj g in
+      begin match g with
+        | `Left g ->
+          S.query (conv ctx) (InvariantGlobal (Obj.repr g))
+        | `Right g ->
+          Queries.Result.top q
+      end
     | IterSysVars (vq, vf) ->
       (* vars for S *)
       let vf' x = vf (Obj.repr (V.s (Obj.obj x))) in

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -252,7 +252,7 @@ struct
                   let entry = Entry.loop_invariant ~task ~location ~invariant in
                   entry :: acc
                 ) acc invs
-            | `Bot | `Top -> (* TODO: 0 for bot? *)
+            | `Bot | `Top -> (* TODO: 0 for bot (dead code)? *)
               acc
           end
         end else begin
@@ -273,7 +273,7 @@ struct
                   let entry = Entry.flow_insensitive_invariant ~task ~invariant in
                   entry :: acc
                 ) acc invs
-            | `Bot | `Top -> (* TODO: 0 for bot? *)
+            | `Bot | `Top -> (* global bot might only be possible for alloc variables, if at all, so emit nothing *)
               acc
           end
         | `Right _ -> (* contexts global *)

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -64,6 +64,14 @@ struct
   }
 
   (* non-standard extension *)
+  let flow_insensitive_invariant ~task ~(invariant): Entry.t = {
+    entry_type = FlowInsensitiveInvariant {
+      flow_insensitive_invariant = invariant;
+      };
+    metadata = metadata ~task ();
+  }
+
+  (* non-standard extension *)
   let precondition_loop_invariant ~task ~location ~precondition ~(invariant): Entry.t = {
     entry_type = PreconditionLoopInvariant {
         location;
@@ -155,6 +163,26 @@ struct
       }
     in
     Spec.query ctx
+
+  let ask_global (gh: EQSys.G.t GHT.t) =
+    (* copied from Control for WarnGlobal *)
+    (* build a ctx for using the query system *)
+    let rec ctx =
+      { ask    = (fun (type a) (q: a Queries.t) -> Spec.query ctx q)
+      ; emit   = (fun _ -> failwith "Cannot \"emit\" in query context.")
+      ; node   = MyCFG.dummy_node (* TODO maybe ask should take a node (which could be used here) instead of a location *)
+      ; prev_node = MyCFG.dummy_node
+      ; control_context = (fun () -> ctx_failwith "No context in query context.")
+      ; context = (fun () -> ctx_failwith "No context in query context.")
+      ; edge    = MyCFG.Skip
+      ; local  = Spec.startstate dummyFunDec.svar (* bot and top both silently raise and catch Deadcode in DeadcodeLifter *) (* TODO: is this startstate bad? *)
+      ; global = (fun v -> EQSys.G.spec (try GHT.find gh (EQSys.GVar.spec v) with Not_found -> EQSys.G.bot ())) (* TODO: how can be missing? *)
+      ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
+      ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
+      ; sideg  = (fun v g    -> failwith "Cannot \"split\" in query context.")
+      }
+    in
+    Spec.query ctx
 end
 
 module Make
@@ -233,6 +261,25 @@ struct
       ) nh []
     in
 
+    (* Generate flow-insensitive invariants *)
+    let entries = GHT.fold (fun g v acc ->
+        match g with
+        | `Left g -> (* Spec global *)
+          begin match Query.ask_global gh (InvariantGlobal (Obj.repr g)) with
+            | `Lifted inv ->
+              let invs = WitnessUtil.InvariantExp.process_exp inv in
+              List.fold_left (fun acc inv ->
+                  let invariant = Entry.invariant (CilType.Exp.show inv) in
+                  let entry = Entry.flow_insensitive_invariant ~task ~invariant in
+                  entry :: acc
+                ) acc invs
+            | `Bot | `Top -> (* TODO: 0 for bot? *)
+              acc
+          end
+        | `Right _ -> (* contexts global *)
+          acc
+      ) gh entries
+    in
 
     (* Generate precondition invariants.
        We do this in three steps:

--- a/src/witness/yamlWitnessType.ml
+++ b/src/witness/yamlWitnessType.ml
@@ -170,6 +170,25 @@ struct
     {location; loop_invariant}
 end
 
+module FlowInsensitiveInvariant =
+struct
+  type t = {
+    flow_insensitive_invariant: Invariant.t;
+  }
+
+  let entry_type = "flow_insensitive_invariant"
+
+  let to_yaml' {flow_insensitive_invariant} =
+    [
+      ("flow_insensitive_invariant", Invariant.to_yaml flow_insensitive_invariant);
+    ]
+
+  let of_yaml y =
+    let open GobYaml in
+    let+ flow_insensitive_invariant = y |> find "flow_insensitive_invariant" >>= Invariant.of_yaml in
+    {flow_insensitive_invariant}
+end
+
 module PreconditionLoopInvariant =
 struct
   type t = {
@@ -274,18 +293,21 @@ module EntryType =
 struct
   type t =
     | LoopInvariant of LoopInvariant.t
+    | FlowInsensitiveInvariant of FlowInsensitiveInvariant.t
     | PreconditionLoopInvariant of PreconditionLoopInvariant.t
     | LoopInvariantCertificate of LoopInvariantCertificate.t
     | PreconditionLoopInvariantCertificate of PreconditionLoopInvariantCertificate.t
 
   let entry_type = function
     | LoopInvariant _ -> LoopInvariant.entry_type
+    | FlowInsensitiveInvariant _ -> FlowInsensitiveInvariant.entry_type
     | PreconditionLoopInvariant _ -> PreconditionLoopInvariant.entry_type
     | LoopInvariantCertificate _ -> LoopInvariantCertificate.entry_type
     | PreconditionLoopInvariantCertificate _ -> PreconditionLoopInvariantCertificate.entry_type
 
   let to_yaml' = function
     | LoopInvariant x -> LoopInvariant.to_yaml' x
+    | FlowInsensitiveInvariant x -> FlowInsensitiveInvariant.to_yaml' x
     | PreconditionLoopInvariant x -> PreconditionLoopInvariant.to_yaml' x
     | LoopInvariantCertificate x -> LoopInvariantCertificate.to_yaml' x
     | PreconditionLoopInvariantCertificate x -> PreconditionLoopInvariantCertificate.to_yaml' x
@@ -296,6 +318,9 @@ struct
     if entry_type = LoopInvariant.entry_type then
       let+ x = y |> LoopInvariant.of_yaml in
       LoopInvariant x
+    else if entry_type = FlowInsensitiveInvariant.entry_type then
+      let+ x = y |> FlowInsensitiveInvariant.of_yaml in
+      FlowInsensitiveInvariant x
     else if entry_type = PreconditionLoopInvariant.entry_type then
       let+ x = y |> PreconditionLoopInvariant.of_yaml in
       PreconditionLoopInvariant x


### PR DESCRIPTION
This adds the generation of non-standard `flow_insensitive_invariant` entries to YAML witnesses. Base privatizations are extended to emit such invariants based on their internal unprotected/weak values.

### TODO
- [ ] ~~`flow_insensitive_invariant` checking validation?~~ Too inefficient, would have to evaluate such invariant at every node in every context.
- [x] Invariants from `earlyglobs`? Works automatically, because `earlyglobs` delegates to base privatization.
- [ ] Flow-insensitive invariants for singlethreaded non-`earlyglobs`?