### PR TITLE
Generalize protection logging from apron

### DIFF
--- a/src/analyses/apron/apronPriv.apron.ml
+++ b/src/analyses/apron/apronPriv.apron.ml
@@ -426,8 +426,6 @@ struct
       | _ -> false
     in
     AD.keep_filter oct protected
-
-  let finalize () = ProtectionLogging.dump ()
 end
 
 (** Per-mutex meet. *)
@@ -582,7 +580,7 @@ struct
     {apr = AD.bot (); priv = startstate ()}
 
   let init () = ()
-  let finalize () = finalize ()
+  let finalize () = ()
 end
 
 (** May written variables. *)
@@ -1147,7 +1145,7 @@ struct
     | VarQuery.Global g -> vf (V.global g)
     | _ -> ()
 
-  let finalize () = finalize ()
+  let finalize () = ()
 end
 
 module TracingPriv = functor (Priv: S) -> functor (AD: ApronDomain.S3) ->

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -6,37 +6,6 @@ module Q = Queries
 module IdxDom = ValueDomain.IndexDomain
 module VD     = BaseDomain.VD
 
-module ProtectionLogging =
-struct
-  module GM = Hashtbl.Make(ValueDomain.Addr)
-  module VarSet = SetDomain.Make(Basetype.Variables)
-  let gm = GM.create 10
-
-  let record m x =
-    if !GU.postsolving && GobConfig.get_bool "dbg.print_protection" then
-      let old = GM.find_default gm m (VarSet.empty ()) in
-      let n = VarSet.add x old in
-      GM.replace gm m n
-
-  let dump () =
-    if GobConfig.get_bool "dbg.print_protection" then (
-      let max_cluster = ref 0 in
-      let num_mutexes = ref 0 in
-      let sum_protected = ref 0 in
-      Printf.printf "\n\nProtecting mutexes:\n";
-      GM.iter (fun m vs ->
-          let s = VarSet.cardinal vs in
-          max_cluster := max !max_cluster s;
-          sum_protected := !sum_protected + s;
-          incr num_mutexes;
-          Printf.printf "%s -> %s\n" (ValueDomain.Addr.show m) (VarSet.show vs) ) gm;
-      Printf.printf "\nMax number of protected: %i\n" !max_cluster;
-      Printf.printf "Num mutexes: %i\n" !num_mutexes;
-      Printf.printf "Sum protected: %i\n" !sum_protected
-    );
-
-
-end
 
 module Protection =
 struct
@@ -56,11 +25,6 @@ struct
     is_global ask x &&
     not (VD.is_immediate_type x.vtype) &&
     ask.f (Q.MustBeProtectedBy {mutex=m; global=x; write=true})
-
-  let is_protected_by ask m x =
-    let r = is_protected_by ask m x in
-    if r then ProtectionLogging.record m x;
-    r
 end
 
 module MutexGlobals =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -93,12 +93,12 @@ struct
 
   module GM = Hashtbl.Make (ValueDomain.Addr)
 
-  let max_cluster = ref 0
+  let max_protected = ref 0
   let num_mutexes = ref 0
   let sum_protected = ref 0
 
   let init _ =
-    max_cluster := 0;
+    max_protected := 0;
     num_mutexes := 0;
     sum_protected := 0
 
@@ -175,7 +175,7 @@ struct
           if GobConfig.get_bool "dbg.print_protection" then (
             let (protected, _) = G.protected (ctx.global g) in (* readwrite protected *)
             let s = VarSet.cardinal protected in
-            max_cluster := max !max_cluster s;
+            max_protected := max !max_protected s;
             sum_protected := !sum_protected + s;
             incr num_mutexes;
             M.info_noloc ~category:Race "Mutex %a read-write protects %d variable(s): %a" ValueDomain.Addr.pretty m s VarSet.pretty protected
@@ -243,7 +243,7 @@ struct
     if GobConfig.get_bool "dbg.print_protection" then (
       M.msg_group Info ~category:Race "Mutex read-write protection summary" [
         (Pretty.dprintf "Number of mutexes: %d" !num_mutexes, None);
-        (Pretty.dprintf "Max number variables of protected by a mutex: %d" !max_cluster, None);
+        (Pretty.dprintf "Max number variables of protected by a mutex: %d" !max_protected, None);
         (Pretty.dprintf "Total number of protected variables (including duplicates): %d" !sum_protected, None);
       ]
     )

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -219,7 +219,7 @@ struct
             let el = (locks, if write then locks else Mutexes.top ()) in
             ctx.sideg (V.protecting v) (G.create_protecting el);
 
-            if !GU.postsolving && GobConfig.get_bool "dbg.print_protection" then (
+            if !GU.postsolving then (
               let held_locks = (if write then snd else fst) (G.protecting (ctx.global (V.protecting v))) in
               let vs_empty = VarSet.empty () in
               Mutexes.iter (fun addr ->


### PR DESCRIPTION
The protection logging from apron analysis can be generalized into mutex analysis to compute, in traces paper notation, $G_m$-s from $\mathcal{M}[g]$-s. So far this information was just used for some benchmarking stats, but it's also useful for other things, e.g. witness invariants only about globals which are protected.

While moving this code, there are opportunities to also make other changes, to be discussed below.