### PR TITLE
Clean up some special functions

### DIFF
--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -179,12 +179,12 @@ struct
 
   let special ctx lv f arglist : D.t =
     let desc = LF.find f in
-    match desc.special arglist, f.vname with
+    match desc.special arglist with
     (* TODO: remove Lock/Unlock cases when all those libraryfunctions use librarydescs and don't read mutex contents *)
-    | Lock _, _
-    | Unlock _, _ ->
+    | Lock _
+    | Unlock _ ->
       ctx.local
-    | _, _ ->
+    | _ ->
       LibraryDesc.Accesses.iter desc.accs (fun {kind; deep = reach} exp ->
           access_one_top ~deref:true ctx kind reach exp (* access dereferenced using special accesses *)
         ) arglist;

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -180,31 +180,9 @@ struct
   let special ctx lv f arglist : D.t =
     let desc = LF.find f in
     match desc.special arglist, f.vname with
-    (* TODO: remove cases *)
-    | _, "_lock_kernel" ->
-      ctx.local
-    | _, "_unlock_kernel" ->
-      ctx.local
-    | Lock { try_ = failing; write = rw; return_on_success = nonzero_return_when_aquired; _ }, _
-      -> ctx.local
-    | Unlock _, "__raw_read_unlock"
-    | Unlock _, "__raw_write_unlock"  ->
-      ctx.local
+    (* TODO: remove Lock/Unlock cases when all those libraryfunctions use librarydescs and don't read mutex contents *)
+    | Lock _, _
     | Unlock _, _ ->
-      ctx.local
-    | _, "spinlock_check" -> ctx.local
-    | _, "acquire_console_sem" when get_bool "kernel" ->
-      ctx.local
-    | _, "release_console_sem" when get_bool "kernel" ->
-      ctx.local
-    | _, "__builtin_prefetch" | _, "misc_deregister" ->
-      ctx.local
-    | _, "__VERIFIER_atomic_begin" when get_bool "ana.sv-comp.functions" ->
-      ctx.local
-    | _, "__VERIFIER_atomic_end" when get_bool "ana.sv-comp.functions" ->
-      ctx.local
-    | _, "pthread_cond_wait"
-    | _, "pthread_cond_timedwait" ->
       ctx.local
     | _, _ ->
       LibraryDesc.Accesses.iter desc.accs (fun {kind; deep = reach} exp ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2565,9 +2565,9 @@ struct
         | Some v -> assign ctx v (List.hd args)
         | None -> ctx.local (* just calling __builtin_expect(...) without assigning is a nop, since the arguments are CIl exp and therefore have no side-effects *)
       end
-    | Unknown, "spinlock_check" ->
+    | Identity e, _ ->
       begin match lv with
-        | Some x -> assign ctx x (List.hd args)
+        | Some x -> assign ctx x e
         | None -> ctx.local
       end
     (**Floating point classification and trigonometric functions defined in c99*)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2506,7 +2506,8 @@ struct
       let dest_a, dest_typ = addr_type_of_exp dest in
       let value = VD.zero_init_value dest_typ in
       set ~ctx (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ value
-    | Memcpy { dest = dst; src }, _ ->
+    | Memcpy { dest = dst; src }, _
+    | Strcpy { dest = dst; src }, _ ->
       (* invalidating from interactive *)
       (* let dest_a, dest_typ = addr_type_of_exp dst in
           let value = VD.top_value dest_typ in

--- a/src/analyses/libraryDesc.ml
+++ b/src/analyses/libraryDesc.ml
@@ -48,7 +48,7 @@ type special =
   | Memcpy of { dest: Cil.exp; src: Cil.exp }
   | Strcpy of { dest: Cil.exp; src: Cil.exp } (* TODO: add count for strncpy when actually used *)
   | Abort
-  | Identity of Cil.exp
+  | Identity of Cil.exp (** Identity function. Some compiler optimization annotation functions map to this. *)
   | Unknown (** Anything not belonging to other types. *) (* TODO: rename to Other? *)
 
 

--- a/src/analyses/libraryDesc.ml
+++ b/src/analyses/libraryDesc.ml
@@ -45,6 +45,7 @@ type special =
   | Math of { fun_args: math; }
   | Memset of { dest: Cil.exp; ch: Cil.exp; count: Cil.exp; }
   | Bzero of { dest: Cil.exp; count: Cil.exp; }
+  | Memcpy of { dest: Cil.exp; src: Cil.exp } (* TODO: separate for strcpy, etc *)
   | Abort
   | Identity of Cil.exp
   | Unknown (** Anything not belonging to other types. *) (* TODO: rename to Other? *)

--- a/src/analyses/libraryDesc.ml
+++ b/src/analyses/libraryDesc.ml
@@ -45,7 +45,8 @@ type special =
   | Math of { fun_args: math; }
   | Memset of { dest: Cil.exp; ch: Cil.exp; count: Cil.exp; }
   | Bzero of { dest: Cil.exp; count: Cil.exp; }
-  | Memcpy of { dest: Cil.exp; src: Cil.exp } (* TODO: separate for strcpy, etc *)
+  | Memcpy of { dest: Cil.exp; src: Cil.exp }
+  | Strcpy of { dest: Cil.exp; src: Cil.exp } (* TODO: add count for strncpy when actually used *)
   | Abort
   | Identity of Cil.exp
   | Unknown (** Anything not belonging to other types. *) (* TODO: rename to Other? *)

--- a/src/analyses/libraryDsl.ml
+++ b/src/analyses/libraryDsl.ml
@@ -69,6 +69,12 @@ let special ?(attrs:attr list=[]) args_desc special_cont = {
   attrs;
 }
 
+let special' ?(attrs:attr list=[]) args_desc special_cont = {
+  special = (fun args -> Fun.flip (match_args args_desc) (special_cont ()) args); (* eta-expanded such that special_cont is re-executed on each call instead of once during LibraryFunctions construction *)
+  accs = accs args_desc;
+  attrs;
+}
+
 let unknown ?attrs args_desc = special ?attrs args_desc Unknown
 
 let empty____desc = {

--- a/src/analyses/libraryDsl.mli
+++ b/src/analyses/libraryDsl.mli
@@ -20,6 +20,10 @@ type ('k, 'r) args_desc =
 (** Create library function descriptor from arguments descriptor and continuation function, which takes as many arguments as are captured using {!__} and returns the corresponding {!LibraryDesc.special}. *)
 val special: ?attrs:LibraryDesc.attr list -> ('k, LibraryDesc.special) args_desc -> 'k -> LibraryDesc.t
 
+(** Create library function descriptor from arguments descriptor, which must {!drop} all arguments, and continuation function, which takes as an {!unit} argument and returns the corresponding {!LibraryDesc.special}.
+    Unlike {!special}, this allows the {!LibraryDesc.special} of an argumentless function to depend on options, such that they aren't evaluated at initialization time in {!LibraryFunctions}.  *)
+val special': ?attrs:LibraryDesc.attr list -> (LibraryDesc.special, LibraryDesc.special) args_desc -> (unit -> LibraryDesc.special) -> LibraryDesc.t
+
 (** Create unknown library function descriptor from arguments descriptor, which must {!drop} all arguments. *)
 val unknown: ?attrs:LibraryDesc.attr list -> (LibraryDesc.special, LibraryDesc.special) args_desc -> LibraryDesc.t
 

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -66,7 +66,7 @@ let linux_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("_unlock_kernel", special [drop "func" [r]; drop "file" [r]; drop "line" []] @@ Unlock big_kernel_lock);
     ("acquire_console_sem", special [] @@ Lock { lock = console_sem; try_ = false; write = true; return_on_success = true });
     ("release_console_sem", special [] @@ Unlock console_sem);
-    ("misc_deregister", unknown [drop "misc" [r_deep; s_deep]]); (* TODO: why does this need to spawn to pass 04-mutex/40-rw_lock_rc? *)
+    ("misc_deregister", unknown [drop "misc" [r_deep]]);
   ]
 
 (** Goblint functions. *)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -55,7 +55,7 @@ let linux_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("_unlock_kernel", special [drop "func" [r]; drop "file" [r]; drop "line" []] @@ Unlock big_kernel_lock);
     ("acquire_console_sem", special [] @@ Lock { lock = console_sem; try_ = false; write = true; return_on_success = true });
     ("release_console_sem", special [] @@ Unlock console_sem);
-    ("misc_deregister", unknown [drop "misc" [r_deep]]);
+    ("misc_deregister", unknown [drop "misc" [r_deep; s_deep]]); (* TODO: why does this need to spawn to pass 04-mutex/40-rw_lock_rc? *)
   ]
 
 (** Goblint functions. *)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -14,8 +14,8 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("memcpy", special [__ "dest" [w]; __ "src" [r]; drop "n" []] @@ fun dest src -> Memcpy { dest; src });
     ("__builtin_memcpy", special [__ "dest" [w]; __ "src" [r]; drop "n" []] @@ fun dest src -> Memcpy { dest; src });
     ("__builtin___memcpy_chk", special [__ "dest" [w]; __ "src" [r]; drop "n" []; drop "os" []] @@ fun dest src -> Memcpy { dest; src });
-    ("strncpy", special [__ "dest" [w]; __ "src" [r]; drop "n" []] @@ fun dest src -> Memcpy { dest; src }); (* using Memcpy! *)
-    ("strcpy", special [__ "dest" [w]; __ "src" [r]] @@ fun dest src -> Memcpy { dest; src }); (* using Memcpy! *)
+    ("strncpy", special [__ "dest" [w]; __ "src" [r]; drop "n" []] @@ fun dest src -> Strcpy { dest; src });
+    ("strcpy", special [__ "dest" [w]; __ "src" [r]] @@ fun dest src -> Strcpy { dest; src });
     ("malloc", special [__ "size" []] @@ fun size -> Malloc size);
     ("realloc", special [__ "ptr" [r; f]; __ "size" []] @@ fun ptr size -> Realloc { ptr; size });
     ("abort", special [] Abort);

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -44,7 +44,7 @@ let pthread_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
 let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_object_size", unknown [drop "ptr" [r]; drop' []]);
     ("__builtin_prefetch", unknown (drop "addr" [] :: VarArgs (drop' [])));
-    ("__builtin_expect", special [__ "exp" []; drop' []] @@ fun exp -> Identity exp);
+    ("__builtin_expect", special [__ "exp" []; drop' []] @@ fun exp -> Identity exp); (* Identity, because just compiler optimization annotation. *)
     ("__builtin_unreachable", special' [] @@ fun () -> if get_bool "sem.builtin_unreachable.dead_code" then Abort else Unknown); (* https://github.com/sosy-lab/sv-benchmarks/issues/1296 *)
     ("__assert_rtn", special [drop "func" [r]; drop "file" [r]; drop "line" []; drop "exp" [r]] @@ Abort); (* gcc's built-in assert *)
     ("__builtin_return_address", unknown [drop "level" []]);
@@ -59,7 +59,7 @@ let linux_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("spin_lock_irqsave", special [__ "lock" []; drop "flags" []] @@ fun lock -> Lock { lock; try_ = get_bool "sem.lock.fail"; write = true; return_on_success = true });
     ("spin_unlock_irqrestore", special [__ "lock" []; drop "flags" []] @@ fun lock -> Unlock lock);
     ("_raw_spin_unlock_irqrestore", special [__ "lock" []; drop "flags" []] @@ fun lock -> Unlock lock);
-    ("spinlock_check", special [__ "lock" []] @@ fun lock -> Identity lock);
+    ("spinlock_check", special [__ "lock" []] @@ fun lock -> Identity lock);  (* Identity, because we don't want lock internals. *)
     ("_lock_kernel", special [drop "func" [r]; drop "file" [r]; drop "line" []] @@ Lock { lock = big_kernel_lock; try_ = false; write = true; return_on_success = true });
     ("_unlock_kernel", special [drop "func" [r]; drop "file" [r]; drop "line" []] @@ Unlock big_kernel_lock);
     ("acquire_console_sem", special [] @@ Lock { lock = console_sem; try_ = false; write = true; return_on_success = true });

--- a/src/analyses/libraryFunctions.mli
+++ b/src/analyses/libraryFunctions.mli
@@ -11,3 +11,6 @@ val is_safe_uncalled : string -> bool
 
 (** Find library function descriptor for function. *)
 val find: Cil.varinfo -> LibraryDesc.t
+
+
+val verifier_atomic_var: Cil.varinfo

--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -217,8 +217,9 @@ struct
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     may (fun x -> warn_deref_exp (Analyses.ask_of_ctx ctx) ctx.local (Lval x)) lval;
     List.iter (warn_deref_exp (Analyses.ask_of_ctx ctx) ctx.local) arglist;
-    match f.vname, lval with
-    | "malloc", Some lv ->
+    let desc = LibraryFunctions.find f in
+    match desc.special arglist, lval with
+    | Malloc _, Some lv ->
       begin
         match get_concrete_lval (Analyses.ask_of_ctx ctx) lv with
         | Some (Var v, offs) ->

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -99,7 +99,7 @@ struct
       ls
     | Queries.MustBeAtomic ->
       let held_locks = Lockset.export_locks (Lockset.filter snd ctx.local) in
-      Mutexes.mem MutexEventsAnalysis.verifier_atomic held_locks
+      Mutexes.mem (LockDomain.Addr.from_var LF.verifier_atomic_var) held_locks
     | Queries.IterSysVars (Global g, f) ->
       f (Obj.repr g)
     | _ -> Queries.Result.top q

--- a/src/analyses/mutexEventsAnalysis.ml
+++ b/src/analyses/mutexEventsAnalysis.ml
@@ -9,9 +9,6 @@ open Prelude.Ana
 open Analyses
 open GobConfig
 
-let big_kernel_lock = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType))
-let console_sem = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[console semaphore]" intType))
-let verifier_atomic = LockDomain.Addr.from_var (Goblintutil.create_var (makeGlobalVar "[__VERIFIER_atomic]" intType))
 
 module Spec: MCPSpec =
 struct
@@ -65,41 +62,27 @@ struct
   let return ctx exp fundec : D.t =
     (* deprecated but still valid SV-COMP convention for atomic block *)
     if get_bool "ana.sv-comp.functions" && String.starts_with fundec.svar.vname "__VERIFIER_atomic_" then
-      ctx.emit (Events.Unlock verifier_atomic)
+      ctx.emit (Events.Unlock (LockDomain.Addr.from_var LF.verifier_atomic_var))
 
   let body ctx f : D.t =
     (* deprecated but still valid SV-COMP convention for atomic block *)
     if get_bool "ana.sv-comp.functions" && String.starts_with f.svar.vname "__VERIFIER_atomic_" then
-      ctx.emit (Events.Lock (verifier_atomic, true))
+      ctx.emit (Events.Lock (LockDomain.Addr.from_var LF.verifier_atomic_var, true))
 
   let special (ctx: (unit, _, _, _) ctx) lv f arglist : D.t =
     let remove_rw x = x in
-    let unlock remove_fn =
-      match f.vname, arglist with
-      | _, [arg]
-      | ("spin_unlock_irqrestore" | "_raw_spin_unlock_irqrestore"), [arg; _] ->
-        List.iter (fun e ->
-            ctx.split () [Events.Unlock (remove_fn e)]
-          ) (eval_exp_addr (Analyses.ask_of_ctx ctx) arg);
-        raise Analyses.Deadcode
-      | _ -> failwith "unlock has multiple arguments"
+    let unlock arg remove_fn =
+      List.iter (fun e ->
+          ctx.split () [Events.Unlock (remove_fn e)]
+        ) (eval_exp_addr (Analyses.ask_of_ctx ctx) arg);
+      raise Analyses.Deadcode
     in
     let desc = LF.find f in
     match desc.special arglist, f.vname with
-    | _, "_lock_kernel" ->
-      ctx.emit (Events.Lock (big_kernel_lock, true))
-    | _, "_unlock_kernel" ->
-      ctx.emit (Events.Unlock big_kernel_lock)
-    | Lock { try_ = failing; write = rw; return_on_success = nonzero_return_when_aquired; _ }, _ ->
-      begin match f.vname, arglist with
-        | _, [arg]
-        | "spin_lock_irqsave", [arg; _] ->
-          (*print_endline @@ "Mutex `Lock "^f.vname;*)
-          lock ctx rw failing nonzero_return_when_aquired (Analyses.ask_of_ctx ctx) lv arg
-        | _ -> failwith "lock has multiple arguments"
-      end
-    | Unlock _, "__raw_read_unlock"
-    | Unlock _, "__raw_write_unlock"  ->
+    | Lock { lock = arg; try_ = failing; write = rw; return_on_success = nonzero_return_when_aquired }, _ ->
+      lock ctx rw failing nonzero_return_when_aquired (Analyses.ask_of_ctx ctx) lv arg
+    | Unlock arg, ("__raw_read_unlock" | "__raw_write_unlock") ->
+      (* TODO: why is this needed? *)
       let drop_raw_lock x =
         let rec drop_offs o =
           match o with
@@ -112,26 +95,12 @@ struct
         | Some (v,o) -> Addr.from_var_offset (v, drop_offs o)
         | None -> x
       in
-      unlock (fun l -> remove_rw (drop_raw_lock l))
-    | Unlock _, _ ->
-      (*print_endline @@ "Mutex `Unlock "^f.vname;*)
-      unlock remove_rw
-    | _, "spinlock_check" -> ()
-    | _, "acquire_console_sem" when get_bool "kernel" ->
-      ctx.emit (Events.Lock (console_sem, true))
-    | _, "release_console_sem" when get_bool "kernel" ->
-      ctx.emit (Events.Unlock console_sem)
-    | _, "__builtin_prefetch" | _, "misc_deregister" ->
-      ()
-    | _, "__VERIFIER_atomic_begin" when get_bool "ana.sv-comp.functions" ->
-      ctx.emit (Events.Lock (verifier_atomic, true))
-    | _, "__VERIFIER_atomic_end" when get_bool "ana.sv-comp.functions" ->
-      ctx.emit (Events.Unlock verifier_atomic)
-    | _, "pthread_cond_wait"
-    | _, "pthread_cond_timedwait" ->
+      unlock arg (fun l -> remove_rw (drop_raw_lock l))
+    | Unlock arg, _ ->
+      unlock arg remove_rw
+    | CondWait { lock = m_arg; _}, _ ->
       (* mutex is unlocked while waiting but relocked when returns *)
       (* emit unlock-lock events for privatization *)
-      let m_arg = List.nth arglist 1 in
       let ms = eval_exp_addr (Analyses.ask_of_ctx ctx) m_arg in
       List.iter (fun m ->
           (* unlock-lock each possible mutex as a split to be dependent *)

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -84,13 +84,10 @@ struct
   let special ctx lval f arglist =
     let desc = LF.find f in
     match desc.special arglist, f.vname with
-    | Lock _, _ ->
-      D.add (Analyses.ask_of_ctx ctx) (List.hd arglist) ctx.local
-    | Unlock _, _ ->
-      D.remove (Analyses.ask_of_ctx ctx) (List.hd arglist) ctx.local
-    | Unknown, fn when VarEq.safe_fn fn ->
-      Messages.info ~category:Unsound "Analyzer assuming that %s does not change lockset." fn;
-      ctx.local
+    | Lock { lock; _ }, _ ->
+      D.add (Analyses.ask_of_ctx ctx) lock ctx.local
+    | Unlock lock, _ ->
+      D.remove (Analyses.ask_of_ctx ctx) lock ctx.local
     | _, _ ->
       let st =
         match lval with

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -512,18 +512,18 @@ struct
   (* remove all variables that are reachable from arguments *)
   let special ctx lval f args =
     let desc = LibraryFunctions.find f in
-    match desc.special args, f.vname with
-    | Identity e, _ ->
+    match desc.special args with
+    | Identity e ->
       begin match lval with
         | Some x -> assign ctx x e
         | None -> unknown_fn ctx lval f args
       end
-    | ThreadCreate { arg; _ }, _ ->
+    | ThreadCreate { arg; _ } ->
       begin match D.is_bot ctx.local with
       | true -> raise Analyses.Deadcode
       | false -> remove_reachable ~deep:true (Analyses.ask_of_ctx ctx) [arg] ctx.local
       end
-    | _, _ -> unknown_fn ctx lval f args
+    | _ -> unknown_fn ctx lval f args
   (* query stuff *)
 
   let eq_set (e:exp) s =

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -509,11 +509,6 @@ struct
       |> remove_reachable ~deep:false ask shallow_args
       |> remove_reachable ~deep:true ask deep_args
 
-  let safe_fn = function
-    | "memcpy" -> true
-    | "__builtin_return_address" -> true
-    | _ -> false
-
   (* remove all variables that are reachable from arguments *)
   let special ctx lval f args =
     let desc = LibraryFunctions.find f in
@@ -523,7 +518,6 @@ struct
         | Some x -> assign ctx x e
         | None -> unknown_fn ctx lval f args
       end
-    | Unknown, x when safe_fn x -> ctx.local
     | ThreadCreate { arg; _ }, _ ->
       begin match D.is_bot ctx.local with
       | true -> raise Analyses.Deadcode

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -518,9 +518,9 @@ struct
   let special ctx lval f args =
     let desc = LibraryFunctions.find f in
     match desc.special args, f.vname with
-    | Unknown, "spinlock_check" ->
+    | Identity e, _ ->
       begin match lval with
-        | Some x -> assign ctx x (List.hd args)
+        | Some x -> assign ctx x e
         | None -> unknown_fn ctx lval f args
       end
     | Unknown, x when safe_fn x -> ctx.local

--- a/tests/regression/04-mutex/40-rw_lock_rc.c
+++ b/tests/regression/04-mutex/40-rw_lock_rc.c
@@ -1,4 +1,5 @@
-// PARAM: --set kernel true --set mainfun[+] "'test_init'"
+// PARAM: --set kernel true --set mainfun[+] "'test_init'" --set ana.thread.domain plain
+// TODO: make unknown function spawns non-unique with history thread domain for data1 self-race
 #include <linux/module.h>
 #include <linux/fs.h>
 #include <linux/init.h>


### PR DESCRIPTION
This replaces many name-based `special` function handling with proper `LibraryFunctions`.