### PR TITLE
Add option `sem.null-pointer.dereference`

### DIFF
--- a/conf/svcomp.json
+++ b/conf/svcomp.json
@@ -69,6 +69,9 @@
     },
     "int": {
       "signed_overflow": "assume_none"
+    },
+    "null-pointer": {
+      "dereference": "assume_none"
     }
   }
 }

--- a/conf/svcomp21.json
+++ b/conf/svcomp21.json
@@ -56,6 +56,9 @@
   "sem": {
     "unknown_function": {
       "spawn": false
+    },
+    "null-pointer": {
+      "dereference": "assume_none"
     }
   },
   "witness": {

--- a/conf/svcomp22.json
+++ b/conf/svcomp22.json
@@ -59,6 +59,9 @@
     },
     "int": {
       "signed_overflow": "assume_none"
+    },
+    "null-pointer": {
+      "dereference": "assume_none"
     }
   },
   "witness": {

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -416,7 +416,12 @@ struct
       in
       let f = function
         | Addr.Addr (x, o) -> f_addr (x, o)
-        | Addr.NullPtr -> VD.bot () (* TODO: why bot? *)
+        | Addr.NullPtr ->
+          begin match get_string "sem.null-pointer.dereference" with
+            | "assume_none" -> VD.bot ()
+            | "assume_top" -> top
+            | _ -> assert false
+          end
         | Addr.UnknownPtr -> top (* top may be more precise than VD.top, e.g. for address sets, such that known addresses are kept for soundness *)
         | Addr.StrPtr _ -> `Int (ID.top_of IChar)
       in

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1163,6 +1163,20 @@
           },
           "additionalProperties": false
         },
+        "null-pointer": {
+          "title": "sem.null-pointer",
+          "type": "object",
+          "properties": {
+            "dereference": {
+              "title": "sem.null-pointer.dereference",
+              "description": "NULL pointer dereference handling. assume_top: assume it results in a top value, assume_none: assume it doesn't happen",
+              "type": "string",
+              "enum": ["assume_top", "assume_none"],
+              "default": "assume_none"
+            }
+          },
+          "additionalProperties": false
+        },
         "malloc": {
           "title": "sem.malloc",
           "type": "object",

--- a/tests/regression/02-base/96-null-deref-top.c
+++ b/tests/regression/02-base/96-null-deref-top.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <stddef.h>
+
+int main() {
+  int r; // rand
+  int i = 0;
+  int *p;
+
+  if (r)
+    p = &i;
+  else
+    p = NULL;
+
+  if (*p == 2) // WARN
+    assert(1); // reachable (via UB)
+  return 0;
+}

--- a/tests/regression/02-base/97-null-deref-none.c
+++ b/tests/regression/02-base/97-null-deref-none.c
@@ -1,4 +1,4 @@
-// PARAM: --set sem.null-pointer.dereference assume_top
+// PARAM: --set sem.null-pointer.dereference assume_none
 #include <assert.h>
 #include <stddef.h>
 
@@ -13,6 +13,6 @@ int main() {
     p = NULL;
 
   if (*p == 2) // WARN
-    assert(1); // reachable (via UB)
+    assert(0); // NOWARN (unreachable)
   return 0;
 }


### PR DESCRIPTION
Adds an option, which determines how we handle `NULL` pointer dereferences: as top value or as bottom value (i.e. ignore the possibility). To my surprise, the latter is our current behavior, probably so we don't massively lose precision on real-world programs. It's also how SV-COMP programs should be, free of undefined behavior.

But we should have the option nevertheless. Interestingly, changing the default has no consequences on the regression suite.

In particular, this came up in https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/merge_requests/1364. I (and Goblint also) didn't consider the possibility of the error being reachable due to dereferencing `NULL` pointer and possibly reading anything. The sv-benchmarks task is still wrong, but in a different way then I initially thought.