### PR TITLE
Derive `CilType` with ppx

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -285,7 +285,7 @@ module IntDomLifter (I : S) =
 struct
   open Cil
   type int_t = I.int_t
-  type t = { v : I.t; ikind : (ikind [@equal (=)] [@compare Stdlib.compare] [@hash fun x -> Hashtbl.hash x]) } [@@deriving eq, ord, hash]
+  type t = { v : I.t; ikind : CilType.Ikind.t } [@@deriving eq, ord, hash]
 
   (* Helper functions *)
   let check_ikinds x y = if x.ikind <> y.ikind then raise (IncompatibleIKinds ("ikinds " ^ Prelude.Ana.sprint Cil.d_ikind x.ikind ^ " and " ^ Prelude.Ana.sprint Cil.d_ikind y.ikind ^ " are incompatible. Values: " ^ Prelude.Ana.sprint I.pretty x.v ^ " and " ^ Prelude.Ana.sprint I.pretty y.v)) else ()

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -123,8 +123,10 @@ struct
   let name () = "ikind"
 
   (* Identity *)
+  (* Enum type, so polymorphic identity is fine. *)
+  (* Monomorphize polymorphic operations for optimization. *)
   let equal (x: t) (y: t) = x = y
-  let compare (x: t) (y: t) = compare x y
+  let compare (x: t) (y: t) = Stdlib.compare x y
   let hash (x: t) = Hashtbl.hash x
 
   (* Output *)
@@ -146,8 +148,10 @@ struct
   let name () = "fkind"
 
   (* Identity *)
+  (* Enum type, so polymorphic identity is fine. *)
+  (* Monomorphize polymorphic operations for optimization. *)
   let equal (x: t) (y: t) = x = y
-  let compare (x: t) (y: t) = compare x y
+  let compare (x: t) (y: t) = Stdlib.compare x y
   let hash (x: t) = Hashtbl.hash x
 
   (* Output *)
@@ -169,8 +173,10 @@ struct
   let name () = "unop"
 
   (* Identity *)
+  (* Enum type, so polymorphic identity is fine. *)
+  (* Monomorphize polymorphic operations for optimization. *)
   let equal (x: t) (y: t) = x = y
-  let compare (x: t) (y: t) = compare x y
+  let compare (x: t) (y: t) = Stdlib.compare x y
   let hash (x: t) = Hashtbl.hash x
 
   (* Output *)
@@ -192,8 +198,10 @@ struct
   let name () = "binop"
 
   (* Identity *)
+  (* Enum type, so polymorphic identity is fine. *)
+  (* Monomorphize polymorphic operations for optimization. *)
   let equal (x: t) (y: t) = x = y
-  let compare (x: t) (y: t) = compare x y
+  let compare (x: t) (y: t) = Stdlib.compare x y
   let hash (x: t) = Hashtbl.hash x
 
   (* Output *)
@@ -215,8 +223,10 @@ struct
   let name () = "wstring_type"
 
   (* Identity *)
+  (* Enum type, so polymorphic identity is fine. *)
+  (* Monomorphize polymorphic operations for optimization. *)
   let equal (x: t) (y: t) = x = y
-  let compare (x: t) (y: t) = compare x y
+  let compare (x: t) (y: t) = Stdlib.compare x y
   let hash (x: t) = Hashtbl.hash x
 
   (* Output *)
@@ -241,8 +251,10 @@ struct
   let name () = "encoding"
 
   (* Identity *)
+  (* Enum type, so polymorphic identity is fine. *)
+  (* Monomorphize polymorphic operations for optimization. *)
   let equal (x: t) (y: t) = x = y
-  let compare (x: t) (y: t) = compare x y
+  let compare (x: t) (y: t) = Stdlib.compare x y
   let hash (x: t) = Hashtbl.hash x
 
   (* Output *)
@@ -271,7 +283,7 @@ struct
 
   (* Identity *)
   let equal x y = x.vid = y.vid
-  let compare x y = compare x.vid y.vid
+  let compare x y = Stdlib.compare x.vid y.vid
   let hash x = x.vid - 4773
   (* let hash x = Hashtbl.hash x.vid *)
 
@@ -320,7 +332,7 @@ struct
 
   (* Identity *)
   let equal x y = x.ckey = y.ckey
-  let compare x y = compare x.ckey y.ckey
+  let compare x y = Stdlib.compare x.ckey y.ckey
   (* let hash x = Hashtbl.hash x.ckey *)
   let hash x = x.ckey
 
@@ -386,7 +398,7 @@ struct
   (* Identity *)
   (* TODO: Is this enough or do we have to recursively compare eitems, etc? *)
   let equal x y = x.ename = y.ename
-  let compare x y = compare x.ename y.ename
+  let compare x y = String.compare x.ename y.ename
   let hash x = Hashtbl.hash x.ename
 
   (* Output *)
@@ -410,7 +422,7 @@ struct
   (* Identity *)
   (* TODO: Is this enough or do we have to recursively compare ttype? *)
   let equal x y = x.tname = y.tname
-  let compare x y = compare x.tname y.tname
+  let compare x y = String.compare x.tname y.tname
   let hash x = Hashtbl.hash x.tname
 
   (* Output *)
@@ -433,7 +445,7 @@ struct
 
   (* Identity *)
   let equal x y = x.sid = y.sid
-  let compare x y = compare x.sid y.sid
+  let compare x y = Stdlib.compare x.sid y.sid
   (* let hash x = Hashtbl.hash x.sid * 97 *)
   let hash x = x.sid
 
@@ -559,8 +571,8 @@ struct
 
   type t = offset =
     | NoOffset
-    | Field      of Fieldinfo.t * t
-    | Index    of Exp.t * t
+    | Field of Fieldinfo.t * t
+    | Index of Exp.t * t
   [@@deriving eq, ord, hash]
 
   let name () = "offset"
@@ -613,8 +625,8 @@ struct
   include Std
 
   type lhost = Cil.lhost =
-    | Var        of Varinfo.t
-    | Mem        of Exp.t
+    | Var of Varinfo.t
+    | Mem of Exp.t
   [@@deriving eq, ord, hash]
 
   type t = lhost * Offset.t [@@deriving eq, ord, hash]
@@ -658,22 +670,22 @@ struct
   include Std
 
   type t = exp =
-    | Const      of Constant.t
-    | Lval       of Lval.t
-    | SizeOf     of Typ.t
-    | Real       of t
-    | Imag       of t
-    | SizeOfE    of t
-    | SizeOfStr  of string
-    | AlignOf    of Typ.t
-    | AlignOfE   of t
-    | UnOp       of Unop.t * t * Typ.t
-    | BinOp      of Binop.t * t * t * Typ.t
-    | Question   of t * t * t * Typ.t
-    | CastE      of Typ.t * t
-    | AddrOf     of Lval.t
+    | Const of Constant.t
+    | Lval of Lval.t
+    | SizeOf of Typ.t
+    | Real of t
+    | Imag of t
+    | SizeOfE of t
+    | SizeOfStr of string
+    | AlignOf of Typ.t
+    | AlignOfE of t
+    | UnOp of Unop.t * t * Typ.t
+    | BinOp of Binop.t * t * t * Typ.t
+    | Question of t * t * t * Typ.t
+    | CastE of Typ.t * t
+    | AddrOf of Lval.t
     | AddrOfLabel of (Stmt.t ref [@hash fun x -> Stmt.hash !x]) (* TODO: ref in ppx_deriving_hash *)
-    | StartOf    of Lval.t
+    | StartOf of Lval.t
   [@@deriving eq, ord, hash]
 
   let name () = "exp"

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -12,6 +12,9 @@ struct
   include Printable.Std
 end
 
+let hash_float = Hashtbl.hash (* TODO: float hash in ppx_deriving_hash *)
+let hash_ref hash r = hash !r (* TODO: ref in ppx_deriving_hash *)
+
 module Cilint: S with type t = Cilint.cilint =
 struct
   include Std
@@ -284,8 +287,7 @@ struct
   (* Identity *)
   let equal x y = x.vid = y.vid
   let compare x y = Stdlib.compare x.vid y.vid
-  let hash x = x.vid - 4773
-  (* let hash x = Hashtbl.hash x.vid *)
+  let hash x = x.vid
 
   (* Output *)
   let show x = x.vname
@@ -309,15 +311,14 @@ struct
   (* Identity *)
   let equal x y = Varinfo.equal x.svar y.svar
   let compare x y = Varinfo.compare x.svar y.svar
-  (* let hash x = x.svar.vid * 3 *)
   let hash x = Varinfo.hash x.svar
 
   (* Output *)
-  let show x = x.svar.vname
-  include Printable.SimpleShow (
+  let pretty () x = Varinfo.pretty () x.svar
+  include Printable.SimplePretty (
     struct
       type nonrec t = t
-      let show = show
+      let pretty = pretty
     end
     )
 end
@@ -333,7 +334,6 @@ struct
   (* Identity *)
   let equal x y = x.ckey = y.ckey
   let compare x y = Stdlib.compare x.ckey y.ckey
-  (* let hash x = Hashtbl.hash x.ckey *)
   let hash x = x.ckey
 
   (* Output *)
@@ -356,25 +356,12 @@ struct
 
   (* Identity *)
   let equal x y = x.fname = y.fname && Compinfo.equal x.fcomp y.fcomp
-  (* let equal x y = x.fname = y.fname && compFullName x.fcomp = compFullName y.fcomp *)
-  (* let equal f1 f2 = f1.fname = f2.fname *)
-  (* let equal x y = compFullName x.fcomp ^ x.fname = compFullName y.fcomp ^ y.fname *)
-  (* let equal fld1 fld2 = fld1.fcomp.ckey = fld2.fcomp.ckey && fld1.fname = fld2.fname *)
-  (* let equal xf yf = xf.floc = yf.floc && xf.fname = yf.fname && Cil.typeSig xf.ftype = Cil.typeSig yf.ftype && xf.fbitfield = yf.fbitfield && xf.fattr = yf.fattr *)
   let compare x y =
     let r = String.compare x.fname y.fname in
     if r <> 0 then
       r
     else
       Compinfo.compare x.fcomp y.fcomp
-  (* let compare x y = compare (x.fname, compFullName x.fcomp) (y.fname, compFullName y.fcomp) *)
-  (* let compare a b =
-    let r = Typ.compare a.ftype b.ftype in
-    if r <> 0 then
-      r
-    else
-      compare (a.fname, a.fbitfield, a.fattr, a.floc) (b.fname, b.fbitfield, b.fattr, b.floc) *)
-  (* let hash x = Hashtbl.hash (x.fname, Compinfo.hash x.fcomp) *)
   let hash x = 31 * (Hashtbl.hash x.fname) + Compinfo.hash x.fcomp
 
   (* Output *)
@@ -446,7 +433,6 @@ struct
   (* Identity *)
   let equal x y = x.sid = y.sid
   let compare x y = Stdlib.compare x.sid y.sid
-  (* let hash x = Hashtbl.hash x.sid * 97 *)
   let hash x = x.sid
 
   (* Output *)
@@ -482,15 +468,8 @@ struct
 
   let name () = "typ"
 
-  (* Identity *)
-  (* call to typeSig here is necessary, otherwise compare might not terminate *)
-  (* let equal x y = Util.equals (Cil.typeSig x) (Cil.typeSig y) *)
-  (* let compare x y = compare (Cil.typeSig x) (Cil.typeSig y) *)
-  (* let equal x y = compare x y = 0 *)
-  (* let hash (x:typ) = Hashtbl.hash x *)
-
   (* Output *)
-  let pretty () x = d_type () x
+  let pretty () x = dn_type () x
   include Printable.SimplePretty (
     struct
       type nonrec t = t
@@ -535,25 +514,11 @@ struct
     | CStr of string * Encoding.t
     | CWStr of int64 list * Wstring_type.t
     | CChr of char
-    | CReal of (float [@hash Hashtbl.hash]) * Fkind.t * string option (* TODO: float hash in ppx_deriving_hash *)
+    | CReal of float * Fkind.t * string option
     | CEnum of Exp.t * string * Enuminfo.t
   [@@deriving eq, ord, hash]
 
   let name () = "constant"
-
-  (* Identity *)
-  (* let compare a b =
-    match a,b with
-    | CEnum (ea, sa, ia), CEnum (eb, sb, ib) ->
-      let r = Exp.compare ea eb in
-      if r <> 0 then
-        r
-      else
-        compare (sa, ia) (sb, ib)
-    | _ ->
-      compare a b
-  let equal a b = compare a b = 0
-  let hash x = Hashtbl.hash x (* TODO: is this right? *) *)
 
   (* Output *)
   let pretty () x = d_const () x
@@ -577,39 +542,6 @@ struct
 
   let name () = "offset"
 
-  (* Identity *)
-  (* let rec compare a b =
-    let order x =
-      match x with
-      | NoOffset -> 0
-      | Field _ -> 1
-      | Index _ -> 2
-    in
-    let r = Stdlib.compare (order a) (order b) in
-    if r <> 0 then
-      r
-    else
-      match a, b with
-      | NoOffset, NoOffset -> 0
-      | Field (f1, o1), Field(f2, o2) ->
-        let r = Fieldinfo.compare f1 f2 in
-        if r <> 0 then
-          r
-        else
-          compare o1 o2
-      | Index (e1, o1), Index(e2, o2) ->
-        let r = Exp.compare e1 e2 in
-        if r <> 0 then
-          r
-        else
-          compare o1 o2
-      | _ -> failwith "CilType.Offset.compare: mismatching offsets"
-  let equal x y = compare x y = 0
-  let rec hash = function
-    | NoOffset -> 31 * 0
-    | Field (f, o) -> 31 * (31 * 1 + Fieldinfo.hash f) + hash o
-    | Index (e, o) -> 31 * (31 * 2 + Exp.hash e) + hash o *)
-
   (* Output *)
   let pretty () x = d_offset nil () x
   include Printable.SimplePretty (
@@ -632,28 +564,6 @@ struct
   type t = lhost * Offset.t [@@deriving eq, ord, hash]
 
   let name () = "lval"
-
-  (* Identity *)
-  (* let compare a b =
-    match a, b with
-    | (Var v1, o1), (Var v2, o2) ->
-      let r = Varinfo.compare v1 v2 in
-      if r <> 0 then
-        r
-      else
-        Offset.compare o1 o2
-    | (Mem e1, o1), (Mem e2, o2) ->
-      let r = Exp.compare e1 e2 in
-      if r <> 0 then
-        r
-      else
-        Offset.compare o1 o2
-    | (Var _, _), (Mem _, _) -> -1
-    | (Mem _, _), (Var _, _) -> 1
-  let equal x y = compare x y = 0
-  let hash = function
-    | (Var v, o) -> 31 * (31 * 0 + Varinfo.hash v) + Offset.hash o
-    | (Mem e, o) -> 31 * (31 * 1 + Exp.hash e) + Offset.hash o *)
 
   (* Output *)
   let pretty () x = dn_lval () x
@@ -684,118 +594,11 @@ struct
     | Question of t * t * t * Typ.t
     | CastE of Typ.t * t
     | AddrOf of Lval.t
-    | AddrOfLabel of (Stmt.t ref [@hash fun x -> Stmt.hash !x]) (* TODO: ref in ppx_deriving_hash *)
+    | AddrOfLabel of Stmt.t ref
     | StartOf of Lval.t
   [@@deriving eq, ord, hash]
 
   let name () = "exp"
-
-  (* Identity *)
-  (* ArrayDomain seems to rely on this constructor order for "simpler" expressions *)
-  (* TODO: fix ArrayDomain *)
-  (* let order = function
-    | Const _ -> 0
-    | Lval _ -> 1
-    | SizeOf _ -> 2
-    | SizeOfE _ -> 3
-    | SizeOfStr _ -> 4
-    | AlignOf _ -> 5
-    | AlignOfE _ -> 6
-    | UnOp _ -> 7
-    | BinOp _ -> 9
-    | CastE _ -> 10
-    | AddrOf _ -> 11
-    | StartOf _ -> 12
-    | Question _ -> 13
-    | AddrOfLabel _ -> 14
-    | Real _ -> 15
-    | Imag _ -> 16
-
-  (* Need custom compare because normal compare on CIL Exp might not terminate *)
-  let rec compare a b =
-    if a == b then
-      0
-    else
-      let r = Stdlib.compare (order a) (order b) in
-      if r <> 0 then
-        r
-      else
-        match a,b with
-        | Const c1, Const c2 -> Constant.compare c1 c2
-        | AddrOf l1, AddrOf l2
-        | StartOf l1, StartOf l2
-        | Lval l1, Lval l2 -> Lval.compare l1 l2
-        | AlignOf t1, AlignOf t2
-        | SizeOf t1, SizeOf t2 -> Typ.compare t1 t2
-        | AlignOfE e1, AlignOfE e2
-        | SizeOfE e1, SizeOfE e2 -> compare e1 e2
-        | SizeOfStr s1, SizeOfStr s2 -> String.compare s1 s2
-        | UnOp (op1, e1, t1), UnOp (op2, e2, t2) ->
-          let r = Stdlib.compare op1 op2 in
-          if r <> 0 then
-            r
-          else
-            let r = Typ.compare t1 t2 in
-            if r <> 0 then
-              r
-            else
-              compare e1 e2
-        | BinOp (op1, e1a, e1b, t1), BinOp (op2, e2a, e2b, t2) ->
-          let r = Stdlib.compare op1 op2 in
-          if r <> 0 then
-            r
-          else
-            let r = Typ.compare t1 t2 in
-            if r <> 0 then
-              r
-            else
-              let r = compare e1a e2a in
-              if r <> 0 then
-                r
-              else
-                compare e1b e2b
-        | CastE (t1, e1), CastE (t2, e2) ->
-          let r = Typ.compare t1 t2 in
-          if r <> 0 then
-            r
-          else
-            compare e1 e2
-        | AddrOfLabel s1, AddrOfLabel s2 -> Stdlib.compare s1 s2 (* TODO: is this right? *)
-        | Question (e1a, e1b, e1c, t1), Question (e2a, e2b, e2c, t2) ->
-          let r = Typ.compare t1 t2 in
-          if r <> 0 then
-            r
-          else
-            let r = compare e1a e2a in
-            if r <> 0 then
-              r
-            else
-              let r = compare e1b e2b in
-              if r <> 0 then
-                r
-              else
-                compare e1c e2c
-        (* TODO: Real, Imag missing *)
-        | _ -> failwith "CilType.Exp.compare: mismatching exps"
-  let equal a b = compare a b = 0
-  let rec hash_arg = function
-    | Const c -> Constant.hash c
-    | AddrOf l
-    | StartOf l
-    | Lval l -> Lval.hash l
-    | AlignOf t
-    | SizeOf t -> Typ.hash t
-    | AlignOfE e
-    | SizeOfE e
-    | Real e
-    | Imag e -> hash e
-    | SizeOfStr s -> Hashtbl.hash s
-    | UnOp (op, e, t) -> 31 * (31 * Hashtbl.hash op + hash e) + Typ.hash t
-    | BinOp (op, e1, e2, t) -> 31 * (31 * (31 * Hashtbl.hash op + hash e1) + hash e2) + Typ.hash t
-    | CastE (t, e) -> 31 * Typ.hash t + hash e
-    | AddrOfLabel s -> Hashtbl.hash s (* TODO: is this right? *)
-    | Question (e1, e2, e3, t) -> 31 * (31 * (31 * hash e1 + hash e2) + hash e3) + Typ.hash t
-  and hash x = 31 * order x + hash_arg x *)
 
   (* Output *)
   let pretty () x = dn_exp () x
@@ -833,7 +636,7 @@ struct
   let name () = "attrparam"
 
   (* Output *)
-  let pretty () x = d_attrparam () x
+  let pretty () x = dn_attrparam () x
   include Printable.SimplePretty (
     struct
       type nonrec t = t
@@ -851,7 +654,7 @@ struct
   let name () = "attribute"
 
   (* Output *)
-  let pretty () x = d_attr () x
+  let pretty () x = dn_attr () x
   include Printable.SimplePretty (
     struct
       type nonrec t = t
@@ -869,7 +672,7 @@ struct
   let name () = "attributes"
 
   (* Output *)
-  let pretty () x = d_attrlist () x
+  let pretty () x = dn_attrlist () x
   include Printable.SimplePretty (
     struct
       type nonrec t = t

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -15,28 +15,6 @@ end
 let hash_float = Hashtbl.hash (* TODO: float hash in ppx_deriving_hash *)
 let hash_ref hash r = hash !r (* TODO: ref in ppx_deriving_hash *)
 
-module Cilint: S with type t = Cilint.cilint =
-struct
-  include Std
-
-  type t = Cilint.cilint
-
-  let name () = "cilint"
-
-  (* Identity *)
-  let equal = Z.equal
-  let compare = Z.compare
-  let hash = Z.hash
-
-  (* Output *)
-  let show = Z.to_string
-  include Printable.SimpleShow (
-    struct
-      type nonrec t = t
-      let show = show
-    end
-    )
-end
 
 module Location:
 sig
@@ -485,7 +463,7 @@ struct
   include Std
 
   type t = typsig =
-    | TSArray of t * Cilint.t option * Attributes.t
+    | TSArray of t * Z.t option * Attributes.t
     | TSPtr of t * Attributes.t
     | TSComp of bool * string * Attributes.t
     | TSFun of t * t list option * bool * Attributes.t
@@ -510,7 +488,7 @@ struct
   include Std
 
   type t = constant =
-    | CInt of Cilint.t * Ikind.t * string option
+    | CInt of Z.t * Ikind.t * string option
     | CStr of string * Encoding.t
     | CWStr of int64 list * Wstring_type.t
     | CChr of char

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -12,6 +12,29 @@ struct
   include Printable.Std
 end
 
+module Cilint: S with type t = Cilint.cilint =
+struct
+  include Std
+
+  type t = Cilint.cilint
+
+  let name () = "cilint"
+
+  (* Identity *)
+  let equal = Z.equal
+  let compare = Z.compare
+  let hash = Z.hash
+
+  (* Output *)
+  let show = Z.to_string
+  include Printable.SimpleShow (
+    struct
+      type nonrec t = t
+      let show = show
+    end
+    )
+end
+
 module Location:
 sig
   include S with type t = location
@@ -120,6 +143,149 @@ struct
   let pp fmt x = Format.fprintf fmt "%s" x.vname (* for deriving show *)
 end
 
+module Ikind: S with type t = ikind =
+struct
+  include Std
+
+  type t = ikind
+
+  let name () = "ikind"
+
+  (* Identity *)
+  let equal (x: t) (y: t) = x = y
+  let compare (x: t) (y: t) = compare x y
+  let hash (x: t) = Hashtbl.hash x
+
+  (* Output *)
+  let pretty () x = d_ikind () x
+  include Printable.SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
+end
+
+module Fkind: S with type t = fkind =
+struct
+  include Std
+
+  type t = fkind
+
+  let name () = "fkind"
+
+  (* Identity *)
+  let equal (x: t) (y: t) = x = y
+  let compare (x: t) (y: t) = compare x y
+  let hash (x: t) = Hashtbl.hash x
+
+  (* Output *)
+  let pretty () x = d_fkind () x
+  include Printable.SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
+end
+
+module Unop: S with type t = unop =
+struct
+  include Std
+
+  type t = unop
+
+  let name () = "unop"
+
+  (* Identity *)
+  let equal (x: t) (y: t) = x = y
+  let compare (x: t) (y: t) = compare x y
+  let hash (x: t) = Hashtbl.hash x
+
+  (* Output *)
+  let pretty () x = d_unop () x
+  include Printable.SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
+end
+
+module Binop: S with type t = binop =
+struct
+  include Std
+
+  type t = binop
+
+  let name () = "binop"
+
+  (* Identity *)
+  let equal (x: t) (y: t) = x = y
+  let compare (x: t) (y: t) = compare x y
+  let hash (x: t) = Hashtbl.hash x
+
+  (* Output *)
+  let pretty () x = d_binop () x
+  include Printable.SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
+end
+
+module Wstring_type: S with type t = wstring_type =
+struct
+  include Std
+
+  type t = wstring_type
+
+  let name () = "wstring_type"
+
+  (* Identity *)
+  let equal (x: t) (y: t) = x = y
+  let compare (x: t) (y: t) = compare x y
+  let hash (x: t) = Hashtbl.hash x
+
+  (* Output *)
+  let show = function
+    | Wchar_t -> "wchar_t"
+    | Char16_t -> "char16_t"
+    | Char32_t -> "char32_t"
+  include Printable.SimpleShow (
+    struct
+      type nonrec t = t
+      let show = show
+    end
+    )
+end
+
+module Encoding: S with type t = encoding =
+struct
+  include Std
+
+  type t = encoding
+
+  let name () = "encoding"
+
+  (* Identity *)
+  let equal (x: t) (y: t) = x = y
+  let compare (x: t) (y: t) = compare x y
+  let hash (x: t) = Hashtbl.hash x
+
+  (* Output *)
+  let show = function
+    | No_encoding -> "no encoding"
+    | Utf8 -> "utf-8"
+  include Printable.SimpleShow (
+    struct
+      type nonrec t = t
+      let show = show
+    end
+    )
+end
+
 module Stmt: S with type t = stmt =
 struct
   include Std
@@ -131,7 +297,8 @@ struct
   (* Identity *)
   let equal x y = x.sid = y.sid
   let compare x y = compare x.sid y.sid
-  let hash x = Hashtbl.hash x.sid * 97
+  (* let hash x = Hashtbl.hash x.sid * 97 *)
+  let hash x = x.sid
 
   (* Output *)
   let pretty () x = dn_stmt () x
@@ -154,7 +321,8 @@ struct
   (* Identity *)
   let equal x y = Varinfo.equal x.svar y.svar
   let compare x y = Varinfo.compare x.svar y.svar
-  let hash x = x.svar.vid * 3
+  (* let hash x = x.svar.vid * 3 *)
+  let hash x = Varinfo.hash x.svar
 
   (* Output *)
   let show x = x.svar.vname
@@ -166,7 +334,55 @@ struct
     )
 end
 
-module Typ:
+module Typeinfo: S with type t = typeinfo =
+struct
+  include Std
+
+  type t = typeinfo
+
+  let name () = "typeinfo"
+
+  (* Identity *)
+  (* TODO: Is this enough or do we have to recursively compare ttype? *)
+  let equal x y = x.tname = y.tname
+  let compare x y = compare x.tname y.tname
+  let hash x = Hashtbl.hash x.tname
+
+  (* Output *)
+  let show x = x.tname
+  include Printable.SimpleShow (
+    struct
+      type nonrec t = t
+      let show = show
+    end
+    )
+end
+
+module Enuminfo: S with type t = enuminfo =
+struct
+  include Std
+
+  type t = enuminfo
+
+  let name () = "enuminfo"
+
+  (* Identity *)
+  (* TODO: Is this enough or do we have to recursively compare eitems, etc? *)
+  let equal x y = x.ename = y.ename
+  let compare x y = compare x.ename y.ename
+  let hash x = Hashtbl.hash x.ename
+
+  (* Output *)
+  let show x = x.ename
+  include Printable.SimpleShow (
+    struct
+      type nonrec t = t
+      let show = show
+    end
+    )
+end
+
+module rec Typ:
 sig
   include S with type t = typ
   val pp: Format.formatter -> t -> unit (* for deriving show *)
@@ -174,15 +390,27 @@ end =
 struct
   include Std
 
-  type t = typ
+  type t = typ =
+    | TVoid of Attributes.t
+    | TInt of Ikind.t * Attributes.t
+    | TFloat of Fkind.t * Attributes.t
+    | TPtr of t * Attributes.t
+    | TArray of t * Exp.t option * Attributes.t
+    | TFun of t * (string * t * Attributes.t) list option * bool * Attributes.t
+    | TNamed of Typeinfo.t * Attributes.t
+    | TComp of Compinfo.t * Attributes.t
+    | TEnum of Enuminfo.t * Attributes.t
+    | TBuiltin_va_list of Attributes.t
+  [@@deriving eq, ord, hash]
 
   let name () = "typ"
 
   (* Identity *)
   (* call to typeSig here is necessary, otherwise compare might not terminate *)
-  let equal x y = Util.equals (Cil.typeSig x) (Cil.typeSig y)
-  let compare x y = compare (Cil.typeSig x) (Cil.typeSig y)
-  let hash (x:typ) = Hashtbl.hash x
+  (* let equal x y = Util.equals (Cil.typeSig x) (Cil.typeSig y) *)
+  (* let compare x y = compare (Cil.typeSig x) (Cil.typeSig y) *)
+  (* let equal x y = compare x y = 0 *)
+  (* let hash (x:typ) = Hashtbl.hash x *)
 
   (* Output *)
   let pretty () x = d_type () x
@@ -196,7 +424,103 @@ struct
   let pp fmt x = Format.fprintf fmt "%s" (show x) (* for deriving show *)
 end
 
-module Compinfo: S with type t = compinfo =
+and Typsig: S with type t = typsig =
+struct
+  include Std
+
+  type t = typsig =
+    | TSArray of t * Cilint.t option * Attributes.t
+    | TSPtr of t * Attributes.t
+    | TSComp of bool * string * Attributes.t
+    | TSFun of t * t list option * bool * Attributes.t
+    | TSEnum of string * Attributes.t
+    | TSBase of Typ.t
+  [@@deriving eq, ord, hash]
+
+  let name () = "typsig"
+
+  (* Output *)
+  let pretty () x = d_typsig () x
+  include Printable.SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
+end
+
+and Attrparam: S with type t = attrparam =
+struct
+  include Std
+
+  type t = attrparam =
+    | AInt of int
+    | AStr of string
+    | ACons of string * t list
+    | ASizeOf of Typ.t
+    | ASizeOfE of t
+    | ASizeOfS of Typsig.t
+    | AAlignOf of Typ.t
+    | AAlignOfE of t
+    | AAlignOfS of Typsig.t
+    | AUnOp of Unop.t * t
+    | ABinOp of Binop.t * t * t
+    | ADot of t * string
+    | AStar of t
+    | AAddrOf of t
+    | AIndex of t * t
+    | AQuestion of t * t * t
+  [@@deriving eq, ord, hash]
+
+  let name () = "attrparam"
+
+  (* Output *)
+  let pretty () x = d_attrparam () x
+  include Printable.SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
+end
+
+and Attribute: S with type t = attribute =
+struct
+  include Std
+
+  type t = attribute = Attr of string * Attrparam.t list [@@deriving eq, ord, hash]
+
+  let name () = "attribute"
+
+  (* Output *)
+  let pretty () x = d_attr () x
+  include Printable.SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
+end
+
+and Attributes: S with type t = attributes =
+struct
+  include Std
+
+  type t = Attribute.t list [@@deriving eq, ord, hash]
+
+  let name () = "attributes"
+
+  (* Output *)
+  let pretty () x = d_attrlist () x
+  include Printable.SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
+end
+
+and Compinfo: S with type t = compinfo =
 struct
   include Std
 
@@ -207,7 +531,8 @@ struct
   (* Identity *)
   let equal x y = x.ckey = y.ckey
   let compare x y = compare x.ckey y.ckey
-  let hash x = Hashtbl.hash x.ckey
+  (* let hash x = Hashtbl.hash x.ckey *)
+  let hash x = x.ckey
 
   (* Output *)
   let show x = compFullName x
@@ -219,7 +544,7 @@ struct
     )
 end
 
-module Fieldinfo: S with type t = fieldinfo =
+and Fieldinfo: S with type t = fieldinfo =
 struct
   include Std
 
@@ -247,7 +572,8 @@ struct
       r
     else
       compare (a.fname, a.fbitfield, a.fattr, a.floc) (b.fname, b.fbitfield, b.fattr, b.floc) *)
-  let hash x = Hashtbl.hash (x.fname, Compinfo.hash x.fcomp)
+  (* let hash x = Hashtbl.hash (x.fname, Compinfo.hash x.fcomp) *)
+  let hash x = 31 * (Hashtbl.hash x.fname) + Compinfo.hash x.fcomp
 
   (* Output *)
   let show x = x.fname
@@ -259,17 +585,35 @@ struct
     )
 end
 
-module rec Exp: S with type t = exp =
+and Exp: S with type t = exp =
 struct
   include Std
 
-  type t = exp
+  type t = exp =
+    | Const      of Constant.t
+    | Lval       of Lval.t
+    | SizeOf     of Typ.t
+    | Real       of t
+    | Imag       of t
+    | SizeOfE    of t
+    | SizeOfStr  of string
+    | AlignOf    of Typ.t
+    | AlignOfE   of t
+    | UnOp       of Unop.t * t * Typ.t
+    | BinOp      of Binop.t * t * t * Typ.t
+    | Question   of t * t * t * Typ.t
+    | CastE      of Typ.t * t
+    | AddrOf     of Lval.t
+    | AddrOfLabel of (Stmt.t ref [@hash fun x -> Stmt.hash !x]) (* TODO: ref in ppx_deriving_hash *)
+    | StartOf    of Lval.t
+  [@@deriving eq, ord, hash]
 
   let name () = "exp"
 
   (* Identity *)
   (* ArrayDomain seems to rely on this constructor order for "simpler" expressions *)
-  let order = function
+  (* TODO: fix ArrayDomain *)
+  (* let order = function
     | Const _ -> 0
     | Lval _ -> 1
     | SizeOf _ -> 2
@@ -371,7 +715,7 @@ struct
     | CastE (t, e) -> 31 * Typ.hash t + hash e
     | AddrOfLabel s -> Hashtbl.hash s (* TODO: is this right? *)
     | Question (e1, e2, e3, t) -> 31 * (31 * (31 * hash e1 + hash e2) + hash e3) + Typ.hash t
-  and hash x = 31 * order x + hash_arg x
+  and hash x = 31 * order x + hash_arg x *)
 
   (* Output *)
   let pretty () x = dn_exp () x
@@ -387,12 +731,16 @@ and Offset: S with type t = offset =
 struct
   include Std
 
-  type t = offset
+  type t = offset =
+    | NoOffset
+    | Field      of Fieldinfo.t * t
+    | Index    of Exp.t * t
+  [@@deriving eq, ord, hash]
 
   let name () = "offset"
 
   (* Identity *)
-  let rec compare a b =
+  (* let rec compare a b =
     let order x =
       match x with
       | NoOffset -> 0
@@ -422,7 +770,7 @@ struct
   let rec hash = function
     | NoOffset -> 31 * 0
     | Field (f, o) -> 31 * (31 * 1 + Fieldinfo.hash f) + hash o
-    | Index (e, o) -> 31 * (31 * 2 + Exp.hash e) + hash o
+    | Index (e, o) -> 31 * (31 * 2 + Exp.hash e) + hash o *)
 
   (* Output *)
   let pretty () x = d_offset nil () x
@@ -438,12 +786,17 @@ and Lval: S with type t = lval =
 struct
   include Std
 
-  type t = lval
+  type lhost = Cil.lhost =
+    | Var        of Varinfo.t
+    | Mem        of Exp.t
+  [@@deriving eq, ord, hash]
+
+  type t = lhost * Offset.t [@@deriving eq, ord, hash]
 
   let name () = "lval"
 
   (* Identity *)
-  let compare a b =
+  (* let compare a b =
     match a, b with
     | (Var v1, o1), (Var v2, o2) ->
       let r = Varinfo.compare v1 v2 in
@@ -462,7 +815,7 @@ struct
   let equal x y = compare x y = 0
   let hash = function
     | (Var v, o) -> 31 * (31 * 0 + Varinfo.hash v) + Offset.hash o
-    | (Mem e, o) -> 31 * (31 * 1 + Exp.hash e) + Offset.hash o
+    | (Mem e, o) -> 31 * (31 * 1 + Exp.hash e) + Offset.hash o *)
 
   (* Output *)
   let pretty () x = dn_lval () x
@@ -478,12 +831,19 @@ and Constant: S with type t = constant =
 struct
   include Std
 
-  type t = constant
+  type t = constant =
+    | CInt of Cilint.t * Ikind.t * string option
+    | CStr of string * Encoding.t
+    | CWStr of int64 list * Wstring_type.t
+    | CChr of char
+    | CReal of (float [@hash Hashtbl.hash]) * Fkind.t * string option (* TODO: float hash in ppx_deriving_hash *)
+    | CEnum of Exp.t * string * Enuminfo.t
+  [@@deriving eq, ord, hash]
 
   let name () = "constant"
 
   (* Identity *)
-  let compare a b =
+  (* let compare a b =
     match a,b with
     | CEnum (ea, sa, ia), CEnum (eb, sb, ib) ->
       let r = Exp.compare ea eb in
@@ -494,7 +854,7 @@ struct
     | _ ->
       compare a b
   let equal a b = compare a b = 0
-  let hash x = Hashtbl.hash x (* TODO: is this right? *)
+  let hash x = Hashtbl.hash x (* TODO: is this right? *) *)
 
   (* Output *)
   let pretty () x = d_const () x

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -446,6 +446,15 @@ struct
 
   let name () = "typ"
 
+  (* Identity *)
+  (* Optimize derived with physical equality. *)
+  let equal x y = x == y || equal x y
+  let compare x y =
+    if x == y then
+      0
+    else
+      compare x y
+
   (* Output *)
   let pretty () x = dn_type () x
   include Printable.SimplePretty (
@@ -543,6 +552,15 @@ struct
 
   let name () = "lval"
 
+  (* Identity *)
+  (* Optimize derived with physical equality. *)
+  let equal x y = x == y || equal x y
+  let compare x y =
+    if x == y then
+      0
+    else
+      compare x y
+
   (* Output *)
   let pretty () x = dn_lval () x
   include Printable.SimplePretty (
@@ -577,6 +595,15 @@ struct
   [@@deriving eq, ord, hash]
 
   let name () = "exp"
+
+  (* Identity *)
+  (* Optimize derived with physical equality. *)
+  let equal x y = x == y || equal x y
+  let compare x y =
+    if x == y then
+      0
+    else
+      compare x y
 
   (* Output *)
   let pretty () x = dn_exp () x


### PR DESCRIPTION
This work stems from profiling #796, where I observed the following:
1. `CilType.Exp` has too many hash collisions from its polymorphic hashing. Notably, all offsets of accessing a struct variable produce an `lval`/`exp` with the same hash. This is probably because the polymorphic hashing gets stuck in the struct type circular references and never hashes the offset itself.
2. `CilType.Typ` comparisons spend most of their time converting the `typ`s to temporary `typsig`s, which involve many allocations and GC. Furthermore, the implementation of `Cil.typeSig`, which does the conversion, isn't the best either: it creates fresh visitor objects at every level of recursion to handle attributes.

Therefore, to get proper identity function (comparison and hashing) for all these recursively related CIL types, this PR uses ppx to derive these functions for the entire type family. This avoids the usual pitfalls of polymorphic comparisons because the usual suspects (`compinfo`, `fieldinfo`, possibly others) still have manual implementations which don't recurse into _all_ the fields.

### TODO
- [x] Performance change on sv-benchmarks.
- [x] Check if physical equality checks help any further.