### PR TITLE
Add some information on how to build Goblint for benchmarking

### DIFF
--- a/docs/user-guide/benchmarking.md
+++ b/docs/user-guide/benchmarking.md
@@ -1,0 +1,12 @@
+# Benchmarking
+
+To achieve reproducible builds and the best performance for benchmarking, it is recommended to compile Goblint using the `release` option:
+
+```sh
+make release
+```
+
+Run `goblint --version` to see an overview of the version of Goblint and Cil in the compiled binary.
+This information is useful to be able to identify which versions were used to obtain your benchmark results.
+If the above command prints a "`-dirty`" suffix in the "`Goblint version`", this indicates that the analyzer repository was not clean when the binary was built.
+The "`Profile:`" information that is shown should be "`release`", after building Goblint as described.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - user-guide/configuring.md
     - user-guide/inspecting.md
     - user-guide/annotating.md
+    - user-guide/benchmarking.md
   - 'Developer guide':
     - developer-guide/developing.md
     - developer-guide/firstanalysis.md


### PR DESCRIPTION
This PR adds the information that one should build Goblint with `make release` for benchmarking, and to check whether Goblint was built within a clean Git repo.  