### PR TITLE
Attempt to optimize base eval mustbeequal layer

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -199,7 +199,7 @@ struct
     | _ -> false
 
   (* Evaluate binop for two abstract values: *)
-  let evalbinop (a: Q.ask) (st: store) (op: binop) (t1:typ) (a1:value) (t2:typ) (a2:value) (t:typ) :value =
+  let evalbinop_base (a: Q.ask) (st: store) (op: binop) (t1:typ) (a1:value) (t2:typ) (a2:value) (t:typ) :value =
     if M.tracing then M.tracel "eval" "evalbinop %a %a %a\n" d_binop op VD.pretty a1 VD.pretty a2;
     (* We define a conversion function for the easy cases when we can just use
      * the integer domain operations. *)
@@ -680,46 +680,7 @@ struct
       This is used by base responding to EvalInt to immediately directly avoid EvalInt query cycle, which would return top.
       Recursive [eval_rv] calls on subexpressions still go through [eval_rv_ask_evalint]. *)
   and eval_rv_no_ask_evalint a gs st exp =
-    eval_rv_ask_mustbeequal a gs st exp (* just as alias, so query doesn't weirdly have to call eval_rv_ask_mustbeequal *)
-
-  (** Evaluate expression using MustBeEqual query.
-      Otherwise just delegate to next eval_rv function. *)
-  and eval_rv_ask_mustbeequal a gs st exp =
-    let eval_next () = eval_rv_base a gs st exp in
-    if M.tracing then M.traceli "evalint" "base eval_rv_ask_mustbeequal %a\n" d_exp exp;
-    let binop op e1 e2 =
-      let must_be_equal () =
-        let r = Q.must_be_equal a e1 e2 in
-        if M.tracing then M.tracel "query" "MustBeEqual (%a, %a) = %b\n" d_exp e1 d_exp e2 r;
-        r
-      in
-      match op with
-      | MinusA when must_be_equal () ->
-        let ik = Cilfacade.get_ikind_exp exp in
-        `Int (ID.of_int ik BI.zero)
-      | MinusPI (* TODO: untested *)
-      | MinusPP when must_be_equal () ->
-        let ik = Cilfacade.ptrdiff_ikind () in
-        `Int (ID.of_int ik BI.zero)
-      (* Eq case is unnecessary: Q.must_be_equal reconstructs BinOp (Eq, _, _, _) and repeats EvalInt query for that, yielding a top from query cycle and never being must equal *)
-      | Le
-      | Ge when must_be_equal () ->
-        let ik = Cilfacade.get_ikind_exp exp in
-        `Int (ID.of_bool ik true)
-      | Ne
-      | Lt
-      | Gt when must_be_equal () ->
-        let ik = Cilfacade.get_ikind_exp exp in
-        `Int (ID.of_bool ik false)
-      | _ -> eval_next ()
-    in
-    let r =
-      match exp with
-      | BinOp (op,arg1,arg2,_) when Cil.isIntegralType (Cilfacade.typeOf exp) -> binop op arg1 arg2
-      | _ -> eval_next ()
-    in
-    if M.tracing then M.traceu "evalint" "base eval_rv_ask_mustbeequal %a -> %a\n" d_exp exp VD.pretty r;
-    r
+    eval_rv_base a gs st exp (* just as alias, so query doesn't weirdly have to call eval_rv_base *)
 
   and eval_rv_back_up a gs st exp =
     if get_bool "ana.base.eval.deep-query" then
@@ -760,13 +721,6 @@ struct
       )
       else
         (c1, c2)
-    in
-    let binop_case ~arg1 ~arg2 ~op ~typ =
-      let a1 = eval_rv a gs st arg1 in
-      let a2 = eval_rv a gs st arg2 in
-      let t1 = Cilfacade.typeOf arg1 in
-      let t2 = Cilfacade.typeOf arg2 in
-      evalbinop a st op t1 a1 t2 a2 typ
     in
     let r =
       (* query functions were no help ... now try with values*)
@@ -844,10 +798,9 @@ struct
         let a1 = eval_rv a gs st e1 in
         let a2 = eval_rv a gs st e2 in
         let (e1, e2) = binop_remove_same_casts ~extra_is_safe:(VD.equal a1 a2) ~e1 ~e2 ~t1 ~t2 ~c1 ~c2 in
-        let a1 = eval_rv a gs st e1 in (* re-evaluate because might be with cast *)
-        let a2 = eval_rv a gs st e2 in
-        evalbinop a st op t1 a1 t2 a2 typ
-      | BinOp (LOr, arg1, arg2, typ) as exp ->
+        (* re-evaluate e1 and e2 in evalbinop because might be with cast *)
+        evalbinop a gs st op ~e1 ~t1 ~e2 ~t2 typ
+      | BinOp (LOr, e1, e2, typ) as exp ->
         let (let*) = Option.bind in
         (* split nested LOr Eqs to equality pairs, if possible *)
         let rec split = function
@@ -922,10 +875,10 @@ struct
         in
         begin match eqs_value with
           | Some x -> x
-          | None -> binop_case ~arg1 ~arg2 ~op:LOr ~typ (* fallback to general case *)
+          | None -> evalbinop a gs st LOr ~e1 ~e2 typ (* fallback to general case *)
         end
-      | BinOp (op,arg1,arg2,typ) ->
-        binop_case ~arg1 ~arg2 ~op ~typ
+      | BinOp (op,e1,e2,typ) ->
+        evalbinop a gs st op ~e1 ~e2 typ
       (* Unary operators *)
       | UnOp (op,arg1,typ) ->
         let a1 = eval_rv a gs st arg1 in
@@ -959,6 +912,49 @@ struct
     in
     if M.tracing then M.traceu "evalint" "base eval_rv_base %a -> %a\n" d_exp exp VD.pretty r;
     r
+
+  and evalbinop (a: Q.ask) (gs:glob_fun) (st: store) (op: binop) ~(e1:exp) ?(t1:typ option) ~(e2:exp) ?(t2:typ option) (t:typ): value =
+    evalbinop_mustbeequal a gs st op ~e1 ?t1 ~e2 ?t2 t
+
+  (** Evaluate BinOp using MustBeEqual query.
+      Otherwise just delegate to next evalbinop function. *)
+  and evalbinop_mustbeequal (a: Q.ask) (gs:glob_fun) (st: store) (op: binop) ~(e1:exp) ?(t1:typ option) ~(e2:exp) ?(t2:typ option) (t:typ): value =
+    let evalbinop_next () =
+      let a1 = eval_rv a gs st e1 in
+      let a2 = eval_rv a gs st e2 in
+      let t1 = Option.default_delayed (fun () -> Cilfacade.typeOf e1) t1 in
+      let t2 = Option.default_delayed (fun () -> Cilfacade.typeOf e2) t2 in
+      evalbinop_base a st op t1 a1 t2 a2 t
+    in
+    if Cil.isIntegralType t then (
+      let must_be_equal () =
+        let r = Q.must_be_equal a e1 e2 in
+        if M.tracing then M.tracel "query" "MustBeEqual (%a, %a) = %b\n" d_exp e1 d_exp e2 r;
+        r
+      in
+      match op with
+      | MinusA when must_be_equal () ->
+        let ik = Cilfacade.get_ikind t in
+        `Int (ID.of_int ik BI.zero)
+      | MinusPI (* TODO: untested *)
+      | MinusPP when must_be_equal () ->
+        let ik = Cilfacade.ptrdiff_ikind () in
+        `Int (ID.of_int ik BI.zero)
+      (* Eq case is unnecessary: Q.must_be_equal reconstructs BinOp (Eq, _, _, _) and repeats EvalInt query for that, yielding a top from query cycle and never being must equal *)
+      | Le
+      | Ge when must_be_equal () ->
+        let ik = Cilfacade.get_ikind t in
+        `Int (ID.of_bool ik true)
+      | Ne
+      | Lt
+      | Gt when must_be_equal () ->
+        let ik = Cilfacade.get_ikind t in
+        `Int (ID.of_bool ik false)
+      | _ -> evalbinop_next ()
+    )
+    else
+      evalbinop_next ()
+
   (* A hackish evaluation of expressions that should immediately yield an
    * address, e.g. when calling functions. *)
   and eval_fv a (gs:glob_fun) st (exp:exp): AD.t =


### PR DESCRIPTION
While trying to squeeze maximum performance out of #796, I at some point completely removed this layer for some speedup I guess, but not to remove features, this is an attempt to slightly optimize it instead.

The point being that when base evals some binary operators (comparisons and minus), then the mustbeequal layer first queries whether they must be exactly equal (this was refactored in #770, but the idea is still the same). If so, then some nice definite value can be returned immediately, which base's structural eval layer wouldn't do, unless the values are definite.

However, I was under the impression that this has a performance penalty in the much more likely case that they are not equal. Namely, base is also answering that mustbeequal check itself, so first evaluating some `x == y`, which then is unknown and then falling back to evaluating `x <= y` or whatever, duplicating some work.
So the optimization here is to switch the two around: evaluate normally first and if that's not definite, try mustbeequal as a fallback for the rare cases it helps.

After benchmarking on sv-benchmark, it turns out this "optimization" doesn't really make any difference:
![image](https://user-images.githubusercontent.com/378740/194252660-b2c6b225-ccfd-4b42-b0d3-eff9d6830119.png)
So I'm not sure if we should just close this PR or keep it for a little bit of refactoring it does, moving the mustbeequal check down to where all the other binop evaluation is happening. I guess the optimizations from #590 and #770 are already enough to practically avoid this supposed double work.

There's one case this might still make _some_ difference: if Apron is enabled, then it avoids a more expensive Apron query if base itself already can find a definite answer. Or in another way, if some `x <= y` is evaluated, Apron is also queried for that directly, so even if then querying Apron for `x == y` would give a definite answer, it would give that answer to the initial `x <= y` query as well.

As far as I remember, these mustbeequal layer things have very little benefit. Only a single test specifically added in #770 requires them to pass, all the partitioned array ones work without as well (probably because they just need exprelation for the equalites it handles, not other comparisons and subtractions). But that's a separate discussion whether to remove them altogether.