### PR TITLE
Add warning when both branches are dead

### DIFF
--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1111,6 +1111,8 @@ struct
                 let loc = Node.location g in (* TODO: looking up location now doesn't work nicely with incremental *)
                 let cilinserted = if loc.synthetic then "(possibly inserted by CIL) " else "" in
                 M.warn ~loc:(Node g) ~tags:[CWE (if tv then 571 else 570)] ~category:Deadcode "condition '%a' %sis always %B" d_exp exp cilinserted tv
+              | `Bot when exp <> one ->
+                M.error ~loc:(Node g) ~category:Analyzer "both branches over condition '%a' are dead"  d_exp exp
               | `Bot (* all branches dead? can happen at our inserted Neg(1)-s because no Pos(1) *)
               | `Top -> (* may be both true and false *)
                 ()


### PR DESCRIPTION
This adds a warning when both branches of a condition are unreachable, usually hitning at an issue in the analyzer. Does not produce such warnings for edges with guard `1`, as Gpblint adds `Neg(1)` edges to ensure connectedness of CFGs.

Closes #826.