### PR TITLE
Generate invariants about local variables again in EvalAssert transformation

### DIFF
--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -565,7 +565,7 @@ struct
             Hashtbl.replace h k v') e;
           h
         in
-        let ask loc = (fun (type a) (q: a Queries.t) ->
+        let ask ~node loc = (fun (type a) (q: a Queries.t) ->
             let local = Hashtbl.find_option joined loc in
             match local with
             | None -> Queries.Result.bot q
@@ -573,7 +573,7 @@ struct
               let rec ctx =
                 { ask    = (fun (type a) (q: a Queries.t) -> Spec.query ctx q)
                 ; emit   = (fun _ -> failwith "Cannot \"emit\" in query context.")
-                ; node   = MyCFG.dummy_node (* TODO maybe ask should take a node (which could be used here) instead of a location *)
+                ; node   = node
                 ; prev_node = MyCFG.dummy_node
                 ; control_context = (fun () -> ctx_failwith "No context in query context.")
                 ; context = (fun () -> ctx_failwith "No context in query context.")
@@ -588,7 +588,7 @@ struct
               Spec.query ctx q
           )
         in
-        let ask loc = { Queries.f = fun (type a) (q: a Queries.t) -> ask loc q } in
+        let ask ?(node=MyCFG.dummy_node) loc = { Queries.f = fun (type a) (q: a Queries.t) -> ask ~node loc q } in
         List.iter (fun name -> Transform.run name ask file) active_transformations
       );
 

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -131,7 +131,8 @@ let check_arguments () =
   if get_bool "ana.base.context.interval" && not (get_bool "ana.base.context.int") then (set_bool "ana.base.context.interval" false; warn "ana.base.context.interval implicitly disabled by ana.base.context.int");
   if get_bool "incremental.only-rename" then (set_bool "incremental.load" true; warn "incremental.only-rename implicitly activates incremental.load. Previous AST is loaded for diff and rename, but analyis results are not reused.");
   if get_bool "incremental.restart.sided.enabled" && get_string_list "incremental.restart.list" <> [] then warn "Passing a non-empty list to incremental.restart.list (manual restarting) while incremental.restart.sided.enabled (automatic restarting) is activated.";
-  if get_bool "ana.autotune.enabled" && get_bool "incremental.load" then (set_bool "ana.autotune.enabled" false; warn "ana.autotune.enabled implicitly disabled by incremental.load")
+  if get_bool "ana.autotune.enabled" && get_bool "incremental.load" then (set_bool "ana.autotune.enabled" false; warn "ana.autotune.enabled implicitly disabled by incremental.load");
+  if get_bool "exp.basic-blocks" && not (get_bool "justcil") && List.mem "assert" @@ get_string_list "trans.activated" then (set_bool "exp.basic-blocks" false; warn "The option exp.basic-blocks implicitely disabled by activating the \"assert\" tranformation.")
 
 (** Initialize some globals in other modules. *)
 let handle_flags () =

--- a/src/transform/evalAssert.ml
+++ b/src/transform/evalAssert.ml
@@ -50,7 +50,6 @@ module EvalAssert = struct
       in
 
       let make_assert ~node loc lval =
-        Node.current_node := Some node;
         let lvals = match lval with
           | None -> CilLval.Set.top ()
           | Some lval -> CilLval.(Set.singleton lval)

--- a/src/transform/evalAssert.ml
+++ b/src/transform/evalAssert.ml
@@ -82,7 +82,7 @@ module EvalAssert = struct
           | Call (lval, _, _, _, _) when emit_other -> instrument' lval
           | _ -> []
         in
-        let rec instrument_instructions = function
+        let instrument_instructions = function
         | [i] when unique_succ || s.succs <> [] ->
             (* Successor of it has only one predecessor, we can query for the value there; or *)
             (* Successor has multiple predecessors, results may be imprecise but remain correct *)

--- a/src/transform/expressionEvaluation.ml
+++ b/src/transform/expressionEvaluation.ml
@@ -52,7 +52,7 @@ struct
     (* Concatenate lines into one *)
     |> List.fold_left (^) ""
 
-  class evaluator (file : Cil.file) (ask : Cil.location -> Queries.ask) =
+  class evaluator (file : Cil.file) (ask : ?node:Node.t -> Cil.location -> Queries.ask) =
     object (self)
 
       val global_variables =
@@ -162,7 +162,7 @@ struct
   let file_compare (_, l, _, _) (_, l', _, _) = let open Cil in compare l.file l'.file
   let byte_compare (_, l, _, _) (_, l', _, _) = let open Cil in compare l.byte l'.byte
 
-  let transform (ask : Cil.location -> Queries.ask) (file : Cil.file) =
+  let transform (ask : ?node:Node.t -> Cil.location -> Queries.ask) (file : Cil.file) =
     let query = match !gv_query with
       | Some q -> Ok q
       | _ -> query_from_file (GobConfig.get_string transformation_query_file_name_identifier)

--- a/src/transform/transform.ml
+++ b/src/transform/transform.ml
@@ -2,7 +2,7 @@ open Prelude
 open GoblintCil
 
 module type S = sig
-  val transform : (Cil.location -> Queries.ask) -> file -> unit (* modifications are done in-place by CIL :( *)
+  val transform : (?node:Node.t -> Cil.location -> Queries.ask) -> file -> unit (* modifications are done in-place by CIL :( *)
 end
 
 let h = Hashtbl.create 13
@@ -14,7 +14,7 @@ let run name =
 
 module PartialEval = struct
   let loc = ref locUnknown (* when we visit an expression, we need the current location -> store at stmts *)
-  class visitor ask = object
+  class visitor (ask: ?node:Node.t -> Cil.location -> Queries.ask) = object
     inherit nopCilVisitor
     method! vstmt s =
       loc := Cilfacade.get_stmtLoc s;


### PR DESCRIPTION
Currently, the `EvalAssert` transformation does not produce assertions about local variables. The reason why this was broken was because the `ask` used for the transformations had the `dummy_node` as the current node, and it was checked using that `dummy_node` whether variables are in scope.

This PR: 
- adds an optional `node` parameter to the `ask` passed to the transformations; if the parameter is given, it will be used as the current node. The `EvalAssert` transformation passes the current statement as the node.
- simplifies the handling in `EvalAssert` of instructions. Previously, it was checked whether the successor of an instruction has multiple predecessors, but in both cases the handling was the same. This is now unified. Instead it is checked whether an instruction has multiple successors -- which is unexpected, since there should be no branching caused by an instruction. 