### PR TITLE
tracing: add option to set pretty printer output width

### DIFF
--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -40,6 +40,12 @@ let print_help ch =
   fprintf ch "Some common configurations to start from can be found in conf/examples/*\n";
   exit 0
 
+let _ =
+  (* avoid a circular dependency between Tracing and GobConfig by using a reference *)
+  Tracing.get_trace_width :=
+    fun () ->
+      match get_int "dbg.trace_width" with 0 -> Stdlib.Int.max_int | w -> w
+
 (** [Arg] option specification *)
 let rec option_spec_list: Arg_complete.speclist Lazy.t = lazy (
   let add_string l = let f str = l := str :: !l in Arg_complete.String (f, Arg_complete.empty) in

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1797,6 +1797,13 @@
             "Should the analysis print information on which globals are protected by which mutex?",
           "type": "boolean",
           "default": false
+        },
+        "trace_width": {
+          "title": "dbg.trace_width",
+          "description":
+            "Width to pass to the pretty-printer for trace output. Passing 0 sets no maximum width.",
+          "type": "integer",
+          "default": 80
         }
       },
       "additionalProperties": false

--- a/src/util/tracing.ml
+++ b/src/util/tracing.ml
@@ -17,7 +17,7 @@ let activated = ref Strs.empty
 let active_dep = Hashtbl.create 9
 let tracevars = ref ([]: string list)
 let tracelocs = ref ([]: int list)
-
+let get_trace_width = ref (fun () -> 80)
 
 let addsystem sys = trace_sys := Strs.add sys !trace_sys
 let activate (sys:string) (subsys: string list): unit =
@@ -85,8 +85,8 @@ let traceTag (sys : string) : Pretty.doc =
   let rec ind (i : int) : string = if (i <= 0) then "" else " " ^ (ind (i-1)) in
   (text ((ind !indent_level) ^ "%%% " ^ sys ^ ": "))
 
-let printtrace sys d: unit =
-  fprint stderr ~width:max_int ((traceTag sys) ++ d);
+let printtrace sys d : unit =
+  fprint stderr ~width:(!get_trace_width ()) (traceTag sys ++ d);
   flush stderr
 
 let gtrace always f sys var ?loc do_subsys fmt =


### PR DESCRIPTION
The tracing module uses `Pretty.doc` values, but sets `max_int` as the width of the output. Therefore, any `doc` that uses optional line breaks won't use the opportunity to insert line breaks into the output, since as far as the pretty printer is concerned, there is infinite width.

Adds an option `dbg.trace_width`. The default width is 80, suitable for basically all screens. If set to 0, the old behaviour is restored.