### PR TITLE
Fix base Invariant query lval and offset handling

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1187,7 +1187,7 @@ struct
           let i =
             match k with
             | (Var v, offset) when not (InvariantCil.var_is_heap v) ->
-              (try I.key_invariant_lval ~vs:I.VS.empty ~lval:(Some k) v offset k (Arg.find v) with Not_found -> Invariant.none)
+              (try I.key_invariant_lval v ~offset ~lval:k (Arg.find v) with Not_found -> Invariant.none)
             | _ -> Invariant.none
           in
           Invariant.(a && i)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1186,8 +1186,8 @@ struct
       CilLval.Set.fold (fun k a ->
           let i =
             match k with
-            | (Var k, offset) ->
-              (try var_invariant ~offset k with Not_found -> Invariant.none)
+            | (Var v, offset) when not (InvariantCil.var_is_heap v) ->
+              (try I.key_invariant_lval ~vs:I.VS.empty ~lval:(Some k) v offset k (Arg.find v) with Not_found -> Invariant.none)
             | _ -> Invariant.none
           in
           Invariant.(a && i)

--- a/src/cdomains/structDomain.ml
+++ b/src/cdomains/structDomain.ml
@@ -90,9 +90,7 @@ struct
     (* invariant for one field *)
     | Field (f, offset) ->
       let v = get x f in
-      let c_lval = Option.get lval in
-      let f_lval = Cil.addOffsetLval (Field (f, NoOffset)) c_lval in
-      value_invariant ~offset ~lval:(Some f_lval) v
+      value_invariant ~offset ~lval v
     (* invariant for one index *)
     | Index (i, offset) ->
       Invariant.none

--- a/src/cdomains/structDomain.ml
+++ b/src/cdomains/structDomain.ml
@@ -28,7 +28,7 @@ sig
   val widen_with_fct: (value -> value -> value) -> t -> t -> t
   val join_with_fct: (value -> value -> value) -> t -> t -> t
   val leq_with_fct: (value -> value -> bool) -> t -> t -> bool
-  val invariant: value_invariant:(offset:Cil.offset -> lval:Cil.lval option -> value -> Invariant.t) -> offset:Cil.offset -> lval:Cil.lval option -> t -> Invariant.t
+  val invariant: value_invariant:(offset:Cil.offset -> lval:Cil.lval -> value -> Invariant.t) -> offset:Cil.offset -> lval:Cil.lval -> t -> Invariant.t
 end
 
 module Simple (Val: Arg) =
@@ -81,10 +81,9 @@ struct
     match offset with
     (* invariants for all fields *)
     | NoOffset ->
-      let c_lval = Option.get lval in
       fold (fun f v acc ->
-          let f_lval = Cil.addOffsetLval (Field (f, NoOffset)) c_lval in
-          let i = value_invariant ~offset ~lval:(Some f_lval) v in
+          let f_lval = Cil.addOffsetLval (Field (f, NoOffset)) lval in
+          let i = value_invariant ~offset ~lval:f_lval v in
           Invariant.(acc && i)
         ) x (Invariant.top ())
     (* invariant for one field *)

--- a/src/cdomains/structDomain.mli
+++ b/src/cdomains/structDomain.mli
@@ -27,7 +27,7 @@ sig
   val widen_with_fct: (value -> value -> value) -> t -> t -> t
   val join_with_fct: (value -> value -> value) -> t -> t -> t
   val leq_with_fct: (value -> value -> bool) -> t -> t -> bool
-  val invariant: value_invariant:(offset:Cil.offset -> lval:Cil.lval option -> value -> Invariant.t) -> offset:Cil.offset -> lval:Cil.lval option -> t -> Invariant.t
+  val invariant: value_invariant:(offset:Cil.offset -> lval:Cil.lval -> value -> Invariant.t) -> offset:Cil.offset -> lval:Cil.lval -> t -> Invariant.t
 end
 
 module Simple (Val: Arg): S with type value = Val.t and type field = fieldinfo

--- a/src/cdomains/unionDomain.ml
+++ b/src/cdomains/unionDomain.ml
@@ -10,7 +10,7 @@ module type S =
 sig
   include Lattice.S
   type value
-  val invariant: value_invariant:(offset:Cil.offset -> lval:Cil.lval option -> value -> Invariant.t) -> offset:Cil.offset -> lval:Cil.lval option -> t -> Invariant.t
+  val invariant: value_invariant:(offset:Cil.offset -> lval:Cil.lval -> value -> Invariant.t) -> offset:Cil.offset -> lval:Cil.lval -> t -> Invariant.t
 end
 
 module Field =  Lattice.Flat (CilType.Fieldinfo) (struct
@@ -27,14 +27,13 @@ struct
     match offset with
     (* invariants for all fields *)
     | Cil.NoOffset ->
-      let c_lval = Option.get lval in
       begin match lift_f with
-      | `Lifted f ->
-        let f_lval = Cil.addOffsetLval (Field (f, NoOffset)) c_lval in
-        value_invariant ~offset ~lval:(Some f_lval) v
-      | `Top
-      | `Bot ->
-        Invariant.none
+        | `Lifted f ->
+          let f_lval = Cil.addOffsetLval (Field (f, NoOffset)) lval in
+          value_invariant ~offset ~lval:f_lval v
+        | `Top
+        | `Bot ->
+          Invariant.none
       end
     (* invariant for one field *)
     | Field (f, offset) ->

--- a/src/cdomains/unionDomain.ml
+++ b/src/cdomains/unionDomain.ml
@@ -38,12 +38,10 @@ struct
       end
     (* invariant for one field *)
     | Field (f, offset) ->
-      let c_lval = Option.get lval in
       begin match lift_f with
         | `Lifted f' ->
           let v = Values.cast ~torg:f'.ftype f.ftype v in
-          let f_lval = Cil.addOffsetLval (Field (f, NoOffset)) c_lval in
-          value_invariant ~offset ~lval:(Some f_lval) v
+          value_invariant ~offset ~lval v
         | `Top
         | `Bot ->
           Invariant.none

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -1221,7 +1221,7 @@ struct
   module VS = Set.Make (Basetype.Variables)
 
   let rec ad_invariant ~vs ~offset ~lval x =
-    let c_exp = Cil.(Lval (Option.get lval)) in
+    let c_exp = Lval lval in
     let i_opt = AD.fold (fun addr acc_opt ->
         BatOption.bind acc_opt (fun acc ->
             match addr with
@@ -1246,7 +1246,7 @@ struct
                 else
                   Invariant.none
               in
-              let i_deref = deref_invariant ~vs ~lval vi offset (Mem c_exp, NoOffset) in
+              let i_deref = deref_invariant ~vs vi ~offset ~lval:(Mem c_exp, NoOffset) in
 
               Some (Invariant.(acc || (i && i_deref)))
             | Addr.NullPtr ->
@@ -1273,13 +1273,13 @@ struct
 
   and vd_invariant ~vs ~offset ~lval = function
     | `Int n ->
-      let e = Lval (Option.get lval) in
+      let e = Lval lval in
       if InvariantCil.(not (exp_contains_tmp e) && exp_is_in_scope scope e) then
         ID.invariant e n
       else
         Invariant.none
     | `Float n ->
-      let e = Lval (Option.get lval) in
+      let e = Lval lval in
       if InvariantCil.(not (exp_contains_tmp e) && exp_is_in_scope scope e) then
         FD.invariant e n
       else
@@ -1290,20 +1290,18 @@ struct
     | `Union n -> Unions.invariant ~value_invariant:(vd_invariant ~vs) ~offset ~lval n
     | _ -> Invariant.none (* TODO *)
 
-  (* TODO: remove duplicate lval arguments? *)
-  and deref_invariant ~vs ~lval vi offset lval' =
+  and deref_invariant ~vs vi ~offset ~lval =
     let v = find vi in
-    key_invariant_lval ~vs ~lval vi offset lval' v
+    key_invariant_lval ~vs vi ~offset ~lval v
 
-  and key_invariant_lval ~vs ~lval k offset lval' v =
+  and key_invariant_lval ?(vs=VS.empty) k ~offset ~lval v =
     if not (VS.mem k vs) then
       let vs' = VS.add k vs in
-      vd_invariant ~vs:vs' ~offset ~lval:(Some lval') v
+      vd_invariant ~vs:vs' ~offset ~lval v
     else
       Invariant.none
 
-
-  let key_invariant k ?(offset=NoOffset) v = key_invariant_lval ~vs:VS.empty ~lval:None k offset (var k) v
+  let key_invariant k ?(offset=NoOffset) v = key_invariant_lval k ~offset ~lval:(var k) v
 end
 
 let invariant_global find g =


### PR DESCRIPTION
In https://github.com/goblint/analyzer/pull/855#discussion_r997807164 an issue was revealed with base invariant dereferenced pointer offsets. The behavior of appending offsets to lvals as they're traversed was added in #819, but due to messy lval and offset handling in this code, I believe I did it incorrectly at the time.

### Behavior before #819
* An invariant query for the lval `s.f` (field on a struct) started from variable `s` traversing to `.f` and starting from lval `s`. The field _was not_ appended to lval, so field invariant was _incorrectly_ about `s`.
* An invariant query for all variables, but containing a pointer `p = &s.f` started dereferencing from variable `s` traversing to `.f` and starting from lval `*p`. The field _was not_ appended to lval, so dereferenced invariant was _correctly_ about `s.f`.

### Current behavior after #819
* An invariant query for the lval `s.f` (field on a struct) started from variable `s` traversing to `.f` and starting from lval `s`. The field _was_ appended to lval, so field invariant was _correctly_ about `s.f`.
* An invariant query for all variables, but containing a pointer `p = &s.f` started dereferencing from variable `s` traversing to `.f` and starting from lval `*p`. The field _was_ appended to lval, so dereferenced invariant was _incorrectly_ about `s.f.f`, which is non-existent.

### Behavior after this PR
* An invariant query for the lval `s.f` (field on a struct) starts from variable `s` traversing to `.f` and starting from lval `s.f` (_note change_). The field _is not_ appended to lval, so field invariant is _correctly_ about `s.f`.
* An invariant query for all variables, but containing a pointer `p = &s.f` starts dereferencing from variable `s` traversing to `.f` and starting from lval `*p`. The field _is not_ appended to lval, so dereferenced invariant is _correctly_ about `s.f`.

In conclusion, the fix is to revert back to not appending offsets to lvals when traversing them for the invariant, so dereferenced invariants are correct. But to fix queries for specific lvals, the key is to start with the precise lval (and not append offsets) instead of starting with just the variable (and appending offsets).
The situation should be analogous with unions.