### PR TITLE
Introduce new possible widening strategy `sides-local` for globals

### DIFF
--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -271,39 +271,28 @@ module WP =
         assert (S.system y = None);
         init y;
         (match x with None -> () | Some x -> if side_widen = "unstable_self" then add_infl x y);
-        let op =
-          if side_widen <> "sides-local" && HM.mem wpoint y then fun a b ->
-            if M.tracing then M.traceli "sol2" "side widen %a %a\n" S.Dom.pretty a S.Dom.pretty b;
-            let r = S.Dom.widen a (S.Dom.join a b) in
-            if M.tracing then M.traceu "sol2" "-> %a\n" S.Dom.pretty r;
-            r
-          else if side_widen = "sides-local" then fun a b ->
-            (if not (S.Dom.leq b a) then
-               let old_sides = HM.find_default sides y VS.empty in
-               match x with
-               | None ->
-                 (if M.tracing then M.traceli "sol2" "side widen %a %a\n" S.Dom.pretty a S.Dom.pretty b;
-                  let r = S.Dom.widen a (S.Dom.join a b) in
-                  if M.tracing then M.traceu "sol2" "-> %a\n" S.Dom.pretty r;
-                  r)
-               | Some x when VS.mem x old_sides ->
-                 (if M.tracing then M.traceli "sol2" "side widen %a %a\n" S.Dom.pretty a S.Dom.pretty b;
-                  let r = S.Dom.widen a (S.Dom.join a b) in
-                  if M.tracing then M.traceu "sol2" "-> %a\n" S.Dom.pretty r;
-                  r)
-               | _ -> S.Dom.join a b
-             else
-               a)
-          else
-            S.Dom.join
+        let widen a b =
+          if M.tracing then M.traceli "sol2" "side widen %a %a\n" S.Dom.pretty a S.Dom.pretty b;
+          let r = S.Dom.widen a (S.Dom.join a b) in
+          if M.tracing then M.traceu "sol2" "-> %a\n" S.Dom.pretty r;
+          r
+        in
+        let old_sides = HM.find_default sides y VS.empty in
+        let op a b = match side_widen with
+          | "sides-local" when not (S.Dom.leq b a) -> (
+              match x with
+              | None -> widen a b
+              | Some x when VS.mem x old_sides -> widen a b
+              | _ -> S.Dom.join a b
+            )
+          | _ when HM.mem wpoint y  -> widen a b
+          | _ -> S.Dom.join a b
         in
         let old = HM.find rho y in
         let tmp = op old d in
         if tracing then trace "sol2" "stable add %a\n" S.Var.pretty_trace y;
         HM.replace stable y ();
         if not (S.Dom.leq tmp old) then (
-          (* if there already was a `side x y d` that changed rho[y] and now again, we make y a wpoint *)
-          let old_sides = HM.find_default sides y VS.empty in
           let sided = match x with
             | Some x ->
               let sided = VS.mem x old_sides in
@@ -320,11 +309,13 @@ module WP =
           | "always" -> (* Any side-effect after the first one will be widened which will unnecessarily lose precision. *)
             wpoint_if true
           | "never" -> (* On side-effect cycles, this should terminate via the outer `solver` loop. TODO check. *)
-            wpoint_if false
-          | "sides" -> (* x caused more than one update to y. >=3 partial context calls will be precise since sides come from different x. TODO this has 8 instead of 5 phases of `solver` for side_cycle.c *)
+            ()
+          | "sides-local" -> (* Never make globals widening points in this strategy, the widening check happens by checking sides *)
+            ()
+          | "sides" ->
+            (* if there already was a `side x y d` that changed rho[y] and now again, we make y a wpoint *)
+            (* x caused more than one update to y. >=3 partial context calls will be precise since sides come from different x. TODO this has 8 instead of 5 phases of `solver` for side_cycle.c *)
             wpoint_if sided
-          | "sides-local" ->
-            wpoint_if false
           | "sides-pp" ->
             (match x with
             | Some x ->

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1953,7 +1953,7 @@
             "side_widen": {
               "title": "solvers.td3.side_widen",
               "description":
-                "When to widen in side. never: never widen, always: always widen, sides: widen if there are multiple side-effects from the same var resulting in a new value, cycle: widen if a called or a start var get destabilized, unstable_called: widen if any called var gets destabilized, unstable_self: widen if side-effected var gets destabilized, sides-pp: widen if there are multiple side-effects from the same program point resulting in a new value.",
+                "When to widen in side. never: never widen, always: always widen, sides: widen if there are multiple side-effects from the same var resulting in a new value, cycle: widen if a called or a start var get destabilized, unstable_called: widen if any called var gets destabilized, unstable_self: widen if side-effected var gets destabilized, sides-pp: widen if there are multiple side-effects from the same program point resulting in a new value, sides-local: Widen with contributions from variables from which multiple side-effects leading to a new value originate.",
               "type": "string",
               "enum": ["never", "always", "sides", "cycle", "unstable_called", "unstable_self", "sides-pp","sides-local"],
               "default": "sides"

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1955,7 +1955,7 @@
               "description":
                 "When to widen in side. never: never widen, always: always widen, sides: widen if there are multiple side-effects from the same var resulting in a new value, cycle: widen if a called or a start var get destabilized, unstable_called: widen if any called var gets destabilized, unstable_self: widen if side-effected var gets destabilized, sides-pp: widen if there are multiple side-effects from the same program point resulting in a new value.",
               "type": "string",
-              "enum": ["never", "always", "sides", "cycle", "unstable_called", "unstable_self", "sides-pp"],
+              "enum": ["never", "always", "sides", "cycle", "unstable_called", "unstable_self", "sides-pp","sides-local"],
               "default": "sides"
             },
             "space": {

--- a/tests/regression/01-cpa/71-widen-sides.c
+++ b/tests/regression/01-cpa/71-widen-sides.c
@@ -1,4 +1,6 @@
 // PARAM: --set ana.ctx_insens "['base', 'mallocWrapper']"  --enable ana.int.interval --sets solvers.td3.side_widen sides-local
+#include <goblint.h>
+
 int further(int n) {
     // Even sides-local can not save us here :(
     __goblint_check(n <= 1); //TODO

--- a/tests/regression/01-cpa/71-widen-sides.c
+++ b/tests/regression/01-cpa/71-widen-sides.c
@@ -1,0 +1,28 @@
+// PARAM: --set ana.ctx_insens "['base', 'mallocWrapper']"  --enable ana.int.interval --sets solvers.td3.side_widen sides-local
+int further(int n) {
+    // Even sides-local can not save us here :(
+    __goblint_check(n <= 1); //TODO
+}
+
+
+int fun(int n, const char* arg) {
+    // Fails with solvers.td3.side_widen sides, needs sides-local
+    __goblint_check(n <= 1);
+    further(n);
+}
+
+void doIt(char* const arg) {
+    // These calls cause side-effects to the start state of [fun]
+    // As the calls happen after each other, we have two increasing contributions to [fun] from this unknown
+    // In the setting with solvers.td3.side_widen sides, [fun] thus becomes a wpoint
+    fun(0, arg);
+}
+
+
+int main() {
+    doIt("one");
+    doIt("two");
+
+    // In the setting with solvers.td3.side_widen sides, widening happens and the bound is lost
+    fun(1, "org");
+}


### PR DESCRIPTION
During #855 we discovered some asserts cannot be re-established. This is likely due to a different evaluation order.

Helmut and I traced down some surprising cases, where information about a a parameter is lost, despite it's values being from `[0,1]` and given explicitly in the program. This can be remedied in some cases by not designating a global a widening point, and instead selectively applying widening only for contributions from unknowns that have made increasing contributions before.

This seem like an interesting thing one would like to play around with, but it has immediately obvious limitations as well.

This PR adds the new option and an example program highlighting both where it helps and where it does not.