### PR TITLE
Add definitions for library functions used in `cp` program

### DIFF
--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -102,6 +102,8 @@ let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__readlink_chk", unknown [drop "path" [r]; drop "buf" [w]; drop "len" []; drop "buflen" []]);
     ("__readlink_alias", unknown [drop "path" [r]; drop "buf" [w]; drop "len" []]);
     ("__overflow", unknown [drop "f" [r]; drop "ch" []]);
+    ("__ctype_get_mb_cur_max", unknown []);
+    ("__xmknod", unknown [drop "ver" []; drop "path" [r]; drop "mode" []; drop "dev" [r; w]]);
   ]
 
 let big_kernel_lock = AddrOf (Cil.var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType)))
@@ -119,8 +121,6 @@ let linux_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("acquire_console_sem", special [] @@ Lock { lock = console_sem; try_ = false; write = true; return_on_success = true });
     ("release_console_sem", special [] @@ Unlock console_sem);
     ("misc_deregister", unknown [drop "misc" [r_deep]]);
-    ("__ctype_get_mb_cur_max", unknown []);
-    ("__xmknod", unknown [drop "ver" []; drop "path" [r]; drop "mode" []; drop "dev" [r; w]]);
   ]
 
 (** Goblint functions. *)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -20,6 +20,13 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("realloc", special [__ "ptr" [r; f]; __ "size" []] @@ fun ptr size -> Realloc { ptr; size });
     ("abort", special [] Abort);
     ("exit", special [drop "exit_code" []] Abort);
+    ("ungetc", unknown [drop "c" []; drop "stream" [w]]);
+    (* ("fscanf", unknown [drop "stream" [w]; drop "format" [r]]); (* TODO: How to specify varargs? *) *)
+    ("__freading", unknown [drop "stream" [r]]);
+    ("mbsinit", unknown [drop "ps" [r]]);
+    ("mbrtowc", unknown [drop "pwc" [w]; drop "s" [r]; drop "n" []; drop "ps" [w]]);
+    ("iswspace", unknown [drop "wc" []]);
+    ("iswalnum", unknown [drop "wc" []]);
   ]
 
 (** C POSIX library functions.
@@ -29,6 +36,18 @@ let posix_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_bzero", special [__ "dest" [w]; __ "count" []] @@ fun dest count -> Bzero { dest; count; });
     ("explicit_bzero", special [__ "dest" [w]; __ "count" []] @@ fun dest count -> Bzero { dest; count; });
     ("__explicit_bzero_chk", special [__ "dest" [w]; __ "count" []; drop "os" []] @@ fun dest count -> Bzero { dest; count; });
+    ("nl_langinfo", unknown [drop "item" []]);
+    ("nl_langinfo_l", unknown [drop "item" []; drop "locale" [r]]);
+    ("getc_unlocked", unknown [drop "stream" [w]]);
+    ("getchar_unlocked", unknown []);
+    ("putc_unlocked", unknown [drop "c" []; drop "stream" [w]]);
+    ("putchar_unlocked", unknown [drop "c" []]);
+    ("lseek", unknown [drop "fd" [w]; drop "offset" []; drop "whence" []]);
+    ("fseeko", unknown [drop "stream" [w]; drop "offset" []; drop "whence" []]);
+    ("iconv_open", unknown [drop "tocode" [r]; drop "fromcode" [r]]);
+    ("iconv", unknown [drop "cd" [r]; drop "inbuf" [r]; drop "inbytesleft" []; drop "outbuf" [w]; drop "outbytesleft" []]);
+    ("iconv_close", unknown [drop "cd" [w]]);
+    ("strnlen", unknown [drop "s" [r]; drop "maxlen" []]);
   ]
 
 (** Pthread functions. *)
@@ -41,7 +60,7 @@ let pthread_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("pthread_cond_timedwait", special [__ "cond" []; __ "mutex" []; __ "abstime" [r]] @@ fun cond mutex abstime -> TimedWait {cond; mutex; abstime});
   ]
 
-(** GCC builtin functions.
+(** GCC builtin functions and GCC specific extensions.
     These are not builtin versions of functions from other lists. *)
 let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_object_size", unknown [drop "ptr" [r]; drop' []]);
@@ -50,6 +69,10 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_unreachable", special' [] @@ fun () -> if get_bool "sem.builtin_unreachable.dead_code" then Abort else Unknown); (* https://github.com/sosy-lab/sv-benchmarks/issues/1296 *)
     ("__assert_rtn", special [drop "func" [r]; drop "file" [r]; drop "line" []; drop "exp" [r]] @@ Abort); (* gcc's built-in assert *)
     ("__builtin_return_address", unknown [drop "level" []]);
+    (* ("error", unknown [drop "status" []; drop "errnum" []; drop "format" [w]]); (* TODO: varargs *) *)
+    ("fputs_unlocked", unknown [drop "s" [r]; drop "stream" [w]]);
+    ("gettext", unknown [drop "msgid" [r]]);
+
   ]
 
 let big_kernel_lock = AddrOf (Cil.var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType)))
@@ -67,6 +90,7 @@ let linux_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("acquire_console_sem", special [] @@ Lock { lock = console_sem; try_ = false; write = true; return_on_success = true });
     ("release_console_sem", special [] @@ Unlock console_sem);
     ("misc_deregister", unknown [drop "misc" [r_deep]]);
+    ("__ctype_get_mb_cur_max", unknown []);
   ]
 
 (** Goblint functions. *)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -93,6 +93,8 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("euidaccess", unknown [drop "pathname" [r]; drop "mode" []]);
     ("rpmatch", unknown [drop "response" [r]]);
     ("getpagesize", unknown []);
+    ("__read_chk", unknown [drop "__fd" []; drop "__buf" [w]; drop "__nbytes" []; drop "__buflen" []]);
+    ("__read_alias", unknown [drop "__fd" []; drop "__buf" [w]; drop "__nbytes" []]);
   ]
 
 let big_kernel_lock = AddrOf (Cil.var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType)))
@@ -422,6 +424,8 @@ let invalidate_actions = [
     "send", readsAll;(*safe*)
     "snprintf", writes [1];(*keep [1]*)
     "__builtin___snprintf_chk", writes [1];(*keep [1]*)
+    "__builtin___sprintf_chk", writes [1];(*keep [1]*)
+    "__overflow", reads [1];
     "sprintf", writes [1];(*keep [1]*)
     "sscanf", writesAllButFirst 2 readsAll;(*drop 2*)
     "strcmp", readsAll;(*safe*)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -91,7 +91,7 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
 
 let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("fputs_unlocked", unknown [drop "s" [r]; drop "stream" [w]]);
-    ("futimesat", unknown [drop "dirfd" [w]; drop "pathname" [r]; drop "times" []]);
+    ("futimesat", unknown [drop "dirfd" [w]; drop "pathname" [r]; drop "times" [r]]);
     ("error", unknown ((drop "status" []):: (drop "errnum" []) :: (drop "format" [r]) :: (VarArgs (drop' [r]))));
     ("gettext", unknown [drop "msgid" [r]]);
     ("euidaccess", unknown [drop "pathname" [r]; drop "mode" []]);

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -21,7 +21,7 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("abort", special [] Abort);
     ("exit", special [drop "exit_code" []] Abort);
     ("ungetc", unknown [drop "c" []; drop "stream" [w]]);
-    (* ("fscanf", unknown [drop "stream" [w]; drop "format" [r]]); (* TODO: How to specify varargs? *) *)
+    ("fscanf", unknown ((drop "stream" [w]) :: (drop "format" [r]) :: (VarArgs (drop' [w])))); (* TODO: How to specify varargs? *)
     ("__freading", unknown [drop "stream" [r]]);
     ("mbsinit", unknown [drop "ps" [r]]);
     ("mbrtowc", unknown [drop "pwc" [w]; drop "s" [r]; drop "n" []; drop "ps" [w]]);
@@ -86,7 +86,7 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_unreachable", special' [] @@ fun () -> if get_bool "sem.builtin_unreachable.dead_code" then Abort else Unknown); (* https://github.com/sosy-lab/sv-benchmarks/issues/1296 *)
     ("__assert_rtn", special [drop "func" [r]; drop "file" [r]; drop "line" []; drop "exp" [r]] @@ Abort); (* gcc's built-in assert *)
     ("__builtin_return_address", unknown [drop "level" []]);
-    (* ("error", unknown [drop "status" []; drop "errnum" []; drop "format" [w]]); (* TODO: varargs *) *)
+    ("error", unknown ((drop "status" []):: (drop "errnum" []) :: (drop "format" [w]) :: (VarArgs (drop' [r]))));
     ("fputs_unlocked", unknown [drop "s" [r]; drop "stream" [w]]);
     ("gettext", unknown [drop "msgid" [r]]);
     ("futimesat", unknown [drop "dirfd" [w]; drop "pathname" [r]; drop "times" []]);

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -27,6 +27,7 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("mbrtowc", unknown [drop "pwc" [w]; drop "s" [r]; drop "n" []; drop "ps" [w]]);
     ("iswspace", unknown [drop "wc" []]);
     ("iswalnum", unknown [drop "wc" []]);
+    ("iswprint", unknown [drop "wc" []]);
   ]
 
 (** C POSIX library functions.
@@ -48,6 +49,22 @@ let posix_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("iconv", unknown [drop "cd" [r]; drop "inbuf" [r]; drop "inbytesleft" []; drop "outbuf" [w]; drop "outbytesleft" []]);
     ("iconv_close", unknown [drop "cd" [w]]);
     ("strnlen", unknown [drop "s" [r]; drop "maxlen" []]);
+    ("chmod", unknown [drop "pathname" [r]; drop "mode" []]);
+    ("fchmod", unknown [drop "fd" [r]; drop "mode" []]);
+    ("fchown", unknown [drop "fd" [r]; drop "owner" []; drop "group" []]);
+    ("lchown", unknown [drop "pathname" [r]; drop "owner" []; drop "group" []]);
+    ("clock_gettime", unknown [drop "clockid" []; drop "tp" [w]]);
+    ("gettimeofday", unknown [drop "tv" [w]; drop "tz" [w]]);
+    ("futimens", unknown [drop "fd" [w]; drop "times" []]);
+    ("utimes", unknown [drop "filename" [r]; drop "times" []]);
+    ("linkat", unknown [drop "olddirfd" []; drop "oldpath" [r]; drop "newdirfd" []; drop "newpath" [r]; drop "flags" []]);
+    ("dirfd", unknown [drop "dirp" [r]]);
+    ("fdopendir", unknown [drop "fd" []]);
+    ("pathconf", unknown [drop "path" [r]; drop "name" []]);
+    ("rename" , unknown [drop "oldpath" [r]; drop "newpath" [r];]);
+    ("symlink" , unknown [drop "oldpath" [r]; drop "newpath" [r];]);
+    ("ftruncate", unknown [drop "fd" [r]; drop "length" []]);
+    ("mkfifo", unknown [drop "pathname" [r]; drop "mode" []]);
   ]
 
 (** Pthread functions. *)
@@ -72,7 +89,10 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     (* ("error", unknown [drop "status" []; drop "errnum" []; drop "format" [w]]); (* TODO: varargs *) *)
     ("fputs_unlocked", unknown [drop "s" [r]; drop "stream" [w]]);
     ("gettext", unknown [drop "msgid" [r]]);
-
+    ("futimesat", unknown [drop "dirfd" [w]; drop "pathname" [r]; drop "times" []]);
+    ("euidaccess", unknown [drop "pathname" [r]; drop "mode" []]);
+    ("rpmatch", unknown [drop "response" [r]]);
+    ("getpagesize", unknown []);
   ]
 
 let big_kernel_lock = AddrOf (Cil.var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType)))

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -86,6 +86,7 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_unreachable", special' [] @@ fun () -> if get_bool "sem.builtin_unreachable.dead_code" then Abort else Unknown); (* https://github.com/sosy-lab/sv-benchmarks/issues/1296 *)
     ("__assert_rtn", special [drop "func" [r]; drop "file" [r]; drop "line" []; drop "exp" [r]] @@ Abort); (* gcc's built-in assert *)
     ("__builtin_return_address", unknown [drop "level" []]);
+    ("__builtin___sprintf_chk", unknown (drop "s" [w] :: drop "flag" [] :: drop "os" [] :: drop "fmt" [r] :: VarArgs (drop' [])));
   ]
 
 let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
@@ -100,6 +101,7 @@ let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__read_alias", unknown [drop "__fd" []; drop "__buf" [w]; drop "__nbytes" []]);
     ("__readlink_chk", unknown [drop "path" [r]; drop "buf" [w]; drop "len" []; drop "buflen" []]);
     ("__readlink_alias", unknown [drop "path" [r]; drop "buf" [w]; drop "len" []]);
+    ("__overflow", unknown [drop "f" [r]; drop "ch" []]);
   ]
 
 let big_kernel_lock = AddrOf (Cil.var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType)))
@@ -431,8 +433,6 @@ let invalidate_actions = [
     "send", readsAll;(*safe*)
     "snprintf", writes [1];(*keep [1]*)
     "__builtin___snprintf_chk", writes [1];(*keep [1]*)
-    "__builtin___sprintf_chk", writes [1];(*keep [1]*)
-    "__overflow", reads [1];
     "sprintf", writes [1];(*keep [1]*)
     "sscanf", writesAllButFirst 2 readsAll;(*drop 2*)
     "strcmp", readsAll;(*safe*)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -95,6 +95,8 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("getpagesize", unknown []);
     ("__read_chk", unknown [drop "__fd" []; drop "__buf" [w]; drop "__nbytes" []; drop "__buflen" []]);
     ("__read_alias", unknown [drop "__fd" []; drop "__buf" [w]; drop "__nbytes" []]);
+    ("__readlink_chk", unknown [drop "path" [r]; drop "buf" [w]; drop "len" []; drop "buflen" []]);
+    ("__readlink_alias", unknown [drop "path" [r]; drop "buf" [w]; drop "len" []]);
   ]
 
 let big_kernel_lock = AddrOf (Cil.var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType)))
@@ -113,6 +115,7 @@ let linux_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("release_console_sem", special [] @@ Unlock console_sem);
     ("misc_deregister", unknown [drop "misc" [r_deep]]);
     ("__ctype_get_mb_cur_max", unknown []);
+    ("__xmknod", unknown [drop "ver" []; drop "path" [r]; drop "mode" []; drop "dev" [r]]);
   ]
 
 (** Goblint functions. *)


### PR DESCRIPTION
Adds definitions for the library functions encountered during #855. The following definitions are still missing:

- [x] `atexit` part of (#799)
- [x] `error`
- [x] `fscanf`

@sim642 Is there currently support for varargs in your library DSL? We would need it here.