### PR TITLE
var_eq unsoundness with dereferenced floats

### DIFF
--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -46,10 +46,7 @@ struct
         end
       | x -> x
 
-  let isFloat e =
-    match Cil.unrollTypeDeep (Cilfacade.typeOf e) with
-    | TFloat _ -> true
-    | _ -> false
+  let isFloat e = Cilfacade.isFloatType (Cilfacade.typeOf e)
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     let lvalsEq l1 l2 = CilType.Lval.equal l1 l2 in (* == would be wrong here *)

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -47,7 +47,7 @@ struct
   let threadspawn ctx lval f args fctx = ctx.local
   let exitstate  v = D.top ()
 
-  let typ_equal = CilType.Typ.equal
+  let typ_equal = CilType.Typ.equal (* TODO: Used to have equality checking, which ignores attributes. Is that needed? *)
 
   let contains_float_subexp e =
     let visitor = object

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -47,67 +47,7 @@ struct
   let threadspawn ctx lval f args fctx = ctx.local
   let exitstate  v = D.top ()
 
-  let const_equal c1 c2 =
-    match c1, c2 with
-    |	CStr (s1,_)  , CStr (s2,_)	 -> s1 = s2
-    |	CWStr (is1,_), CWStr (is2,_) -> is1 = is2
-    |	CChr c1  , CChr c2   -> c1 = c2
-    |	CInt (v1,k1,_), CInt (v2,k2,_) -> Cilint.compare_cilint v1 v2 = 0 && k1 = k2
-    |	CReal (f1,k1,_) , CReal (f2,k2,_)  -> f1 = f2 && k1 = k2
-    |	CEnum (_,n1,e1), CEnum (_,n2,e2) -> n1 = n2 && e1.ename = e2.ename
-    | _ -> false
-
-  let option_eq f x y =
-    match x, y with
-    | Some x, Some y -> f x y
-    | None, None -> true
-    | _ -> false
-
-  let rec typ_equal t1 t2 =
-    let args_eq (s1,t1,_) (s2,t2,_) = s1 = s2 && typ_equal t1 t2 in
-    let eitem_eq (s1,e1,l1) (s2,e2,l2) = s1 = s2 && l1 = l2 && exp_equal e1 e2 in
-    match t1, t2 with
-    | TVoid _, TVoid _ -> true
-    | TInt (k1,_), TInt (k2,_) -> k1 = k2
-    | TFloat (k1,_), TFloat (k2,_) -> k1 = k2
-    | TPtr (t1,_), TPtr (t2,_) -> typ_equal t1 t2
-    | TArray (t1,d1,_), TArray (t2,d2,_) -> option_eq exp_equal d1 d2 && typ_equal t1 t2
-    | TFun (rt1, arg1, _,  b1), TFun (rt2, arg2, _, b2) -> b1 = b2 && typ_equal rt1 rt2 && option_eq (GobList.equal args_eq) arg1 arg2
-    | TNamed (ti1, _), TNamed (ti2, _) -> ti1.tname = ti2.tname && typ_equal ti1.ttype ti2.ttype
-    | TComp (c1,_), TComp (c2,_) -> CilType.Compinfo.equal c1 c2
-    | TEnum (e1,_), TEnum (e2,_) -> e1.ename = e2.ename && GobList.equal eitem_eq e1.eitems e2.eitems
-    | TBuiltin_va_list _, TBuiltin_va_list _ -> true
-    | _ -> false
-
-  and lval_equal (l1,o1) (l2,o2) =
-    let rec offs_equal o1 o2 =
-      match o1, o2 with
-      | NoOffset, NoOffset -> true
-      | Field (f1, o1), Field (f2,o2) -> CilType.Fieldinfo.equal f1 f2 && offs_equal o1 o2
-      | Index (i1,o1), Index (i2,o2) -> exp_equal i1 i2 && offs_equal o1 o2
-      | _ -> false
-    in
-    offs_equal o1 o2
-    && match l1, l2 with
-    | Var v1, Var v2 -> CilType.Varinfo.equal v1 v2
-    | Mem m1, Mem m2 -> exp_equal m1 m2
-    | _ -> false
-
-  and exp_equal e1 e2 =
-    match e1, e2 with
-    |	Const c1,	Const c2 -> const_equal c1 c2
-    |	AddrOf l1,	AddrOf l2
-    |	StartOf l1,	StartOf l2
-    |	Lval l1 ,	Lval  l2 -> lval_equal l1 l2
-    |	SizeOf t1,	SizeOf t2 -> typ_equal t1 t2
-    |	SizeOfE e1,	SizeOfE e2 -> exp_equal e1 e2
-    |	SizeOfStr s1,	SizeOfStr s2 -> s1 = s2
-    |	AlignOf t1,	AlignOf t2 -> typ_equal t1 t2
-    |	AlignOfE e1,	AlignOfE e2 -> exp_equal e1 e2
-    |	UnOp (o1,e1,t1),	UnOp (o2,e2,t2) -> o1 = o2 && typ_equal t1 t2 && exp_equal e1 e2
-    |	BinOp (o1,e11,e21,t1),	BinOp(o2,e12,e22,t2) -> o1 = o2 && typ_equal t1 t2 && exp_equal e11 e12 && exp_equal e21 e22
-    |	CastE (t1,e1),	CastE (t2,e2) -> typ_equal t1 t2 && exp_equal e1 e2
-    | _ -> false
+  let typ_equal = CilType.Typ.equal
 
   let contains_float_subexp e =
     let visitor = object
@@ -126,7 +66,7 @@ struct
     | _ -> false
     | exception Exit -> true
   let exp_equal e1 e2 =
-    exp_equal e1 e2 && not (contains_float_subexp e1)
+    CilType.Exp.equal e1 e2 && not (contains_float_subexp e1)
 
   (* TODO: what does interesting mean? *)
   let rec interesting x =

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -54,11 +54,8 @@ struct
       inherit Cil.nopCilVisitor
 
       method! vexpr e =
-        let t = Cil.unrollType (Cilfacade.typeOf e) in
-        begin match t with
-          | TFloat _ -> raise Exit
-          | _ -> ()
-        end;
+        if Cilfacade.isFloatType (Cilfacade.typeOf e) then
+          raise Exit;
         DoChildren
     end
     in
@@ -359,12 +356,12 @@ struct
       M.tracel "var_eq" "add_eq is_global_var %a = %B\n" d_plainlval lv (is_global_var ask (Lval lv) = Some false);
       M.tracel "var_eq" "add_eq interesting %a = %B\n" d_plainexp rv (interesting rv);
       M.tracel "var_eq" "add_eq is_global_var %a = %B\n" d_plainexp rv (is_global_var ask rv = Some false);
-      M.tracel "var_eq" "add_eq type %a = %B\n" d_plainlval lv ((isArithmeticType lvt && match lvt with | TFloat _ -> false | _ -> true ) || isPointerType lvt);
+      M.tracel "var_eq" "add_eq type %a = %B\n" d_plainlval lv (isIntegralType lvt || isPointerType lvt);
     );
     if is_global_var ask (Lval lv) = Some false
     && interesting rv
     && is_global_var ask rv = Some false
-    && ((isArithmeticType lvt && match lvt with | TFloat _ -> false | _ -> true ) || isPointerType lvt)
+    && (isIntegralType lvt || isPointerType lvt)
     then D.add_eq (rv,Lval lv) (remove ask lv st)
     else remove ask lv st
   (*    in

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -8,8 +8,13 @@ module GU = Goblintutil
 include Cilfacade0
 
 (** Is character type (N1570 6.2.5.15)? *)
-let isCharType = function
+let isCharType = function (* TODO: also unrollType here? *)
   | TInt ((IChar | ISChar | IUChar), _) -> true
+  | _ -> false
+
+let isFloatType t =
+  match Cil.unrollType t with
+  | TFloat _ -> true
   | _ -> false
 
 let init_options () =

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -8,7 +8,8 @@ module GU = Goblintutil
 include Cilfacade0
 
 (** Is character type (N1570 6.2.5.15)? *)
-let isCharType = function (* TODO: also unrollType here? *)
+let isCharType t =
+  match Cil.unrollType t with
   | TInt ((IChar | ISChar | IUChar), _) -> true
   | _ -> false
 

--- a/tests/regression/01-cpa/45-float.c
+++ b/tests/regression/01-cpa/45-float.c
@@ -23,4 +23,10 @@ int main(){
     } else {
         __goblint_check(1);
     }
- }
+
+    float *p = &top;
+    float *q = &fs;
+    __goblint_check(*p == *p); //UNKNOWN!
+    __goblint_check(q[1] == q[1]); //UNKNOWN!
+    return 0;
+}


### PR DESCRIPTION
In dc17de5f0da6df7299df890b67cca4823871dc97 and a889df0be8621f0c63601f2cc8b347c5d512075f some fixes were made to var_eq to make it sound w.r.t. floats.

I was thinking about deduplicating this hand-written code in favor of #840:
https://github.com/goblint/analyzer/blob/790b3a93d1577d8d3471c89d0798f9f7506cfcbc/src/analyses/varEq.ml#L66-L110
The previous fixes are _ad hoc_ in the middle of this otherwise manual version of `CilType.Exp.equal`, which makes reuse impossible.
While wondering, why those fixes were made where they were (for `varinfo` and for `fieldinfo` comparison), I realized that those are insufficient, e.g. with pointers to floats like `*p == *p`.

I think we should change that implementation to use `CilType.Exp.equal` directly, but have some completely separate check for float problems, which is complete. I'm not precisely sure what that would be, maybe check if any subexpression has `float` type? Other ideas?

**EDIT:** I implemented it now and it seems to work at least.