### PR TITLE
First approximation of `pthread_setspecific` by escaping things reachable from the argument and invalidating all globals

### DIFF
--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -75,6 +75,9 @@ let pthread_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("pthread_cond_broadcast", special [__ "cond" []] @@ fun cond -> Broadcast cond);
     ("pthread_cond_wait", special [__ "cond" []; __ "mutex" []] @@ fun cond mutex -> Wait {cond; mutex});
     ("pthread_cond_timedwait", special [__ "cond" []; __ "mutex" []; __ "abstime" [r]] @@ fun cond mutex abstime -> TimedWait {cond; mutex; abstime});
+    ("pthread_setspecific", unknown ~attrs:[InvalidateGlobals] [drop "key" []; drop "value" [w_deep]]);
+    ("pthread_getspecific", unknown ~attrs:[InvalidateGlobals] [drop "key" []]);
+    ("pthread_key_delete", unknown [drop "key" [f]]);
   ]
 
 (** GCC builtin functions.

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -346,6 +346,10 @@ let classify fn exps: categories =
   | "pthread_mutex_unlock" | "__pthread_mutex_unlock" | "up_read" | "up_write"
   | "up" | "pthread_spin_unlock"
     -> `Unlock
+  | "pthread_setspecific" as x ->
+    (if not (GobConfig.get_bool "sem.unknown_function.invalidate.globals") then
+       failwith "pthread_setspecific is only analyzed soundly when sem.unknown_function.invalidate.globals is set.");
+    `Unknown x
   | x -> `Unknown x
 
 

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -349,10 +349,6 @@ let classify fn exps: categories =
   | "pthread_mutex_unlock" | "__pthread_mutex_unlock" | "up_read" | "up_write"
   | "up" | "pthread_spin_unlock"
     -> `Unlock
-  | "pthread_setspecific" as x ->
-    (if not (GobConfig.get_bool "sem.unknown_function.invalidate.globals") then
-       failwith "pthread_setspecific is only analyzed soundly when sem.unknown_function.invalidate.globals is set.");
-    `Unknown x
   | x -> `Unknown x
 
 

--- a/tests/regression/41-stdlib/04-pthread-specific.c
+++ b/tests/regression/41-stdlib/04-pthread-specific.c
@@ -1,0 +1,27 @@
+#include<pthread.h>
+#include<goblint.h>
+
+pthread_key_t key;
+
+void *t_fun(void *arg) {
+  int var = 8;
+  pthread_setspecific(key,&var);
+  int* ptr = (int*)pthread_getspecific(key);
+  *ptr = 12;
+  __goblint_check(var == 8); //UNKNOWN!
+}
+
+int main (void)
+{
+    pthread_t tid1, tid2;
+
+    pthread_key_create (&key, NULL);
+    pthread_create (&tid1, NULL, (void *)t_fun, NULL);
+    pthread_create (&tid2, NULL, (void *)t_fun, NULL);
+    pthread_join (tid1, NULL);
+    pthread_join (tid2, NULL);
+
+    pthread_key_delete(key);
+
+    return 0;
+}

--- a/tests/regression/41-stdlib/04-pthread-specific.c
+++ b/tests/regression/41-stdlib/04-pthread-specific.c
@@ -8,6 +8,8 @@ void *t_fun(void *arg) {
   pthread_setspecific(key,&var);
   int* ptr = (int*)pthread_getspecific(key);
   *ptr = 12;
+  var = 8;
+  *ptr = 12;
   __goblint_check(var == 8); //UNKNOWN!
 }
 


### PR DESCRIPTION
Our analysis currently is sound here, as the second argument to the function is considered escaped, and treated flow-insensitively from there on. Also, it is invalidated when `sem.unknown_function.invalidate.globals` is set.

Any later writes thus do not lead to the value being changed back from `T` and thus all writes through the pointer obtained back from `pthread_getspecific` are also accounted for.

This adds an assert that fails if the code makes use of `pthread_setspecific` and ``sem.unknown_function.invalidate.globals` is disabled, leading to unsound results.

This a temporary measure before #876 is attacked.