### PR TITLE
Make autotuner set `apron.no-context` for functions where it sets `base.no-interval`

### DIFF
--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -130,7 +130,7 @@ let disableIntervalContextsInRecursiveFunctions () =
       (*detect direct recursion and recursion with one indirection*)
       if FunctionSet.mem f set || (not @@ FunctionSet.disjoint (calledFunctions f) (callingFunctions f)) then (
         print_endline ("function " ^ (f.vname) ^" is recursive, disable interval context");
-        f.vattr <- addAttributes (f.vattr) [Attr ("goblint_context",[AStr "base.no-interval"])];
+        f.vattr <- addAttributes (f.vattr) [Attr ("goblint_context",[AStr "base.no-interval"; AStr "apron.no-context"])];
       )
     )
 

--- a/tests/regression/46-apron2/26-autotune.c
+++ b/tests/regression/46-apron2/26-autotune.c
@@ -1,0 +1,25 @@
+//SKIP PARAM: --enable ana.int.interval --sets sem.int.signed_overflow assume_none --set ana.activated[+] apron --enable ana.autotune.enabled
+// Check that autotuner disables context for apron as well for recursive calls
+#include <goblint.h>
+
+int f(int x, int y) {
+  __goblint_check(x == y);
+
+  int top;
+  if(top) {
+    x = x+1;
+    y = y+1;
+  }
+
+  __goblint_check(x == y);
+
+  if (x)
+    return f(x,y);
+  else
+    return x;
+}
+
+int main () {
+  int a = f(1,1);
+  return 0;
+}


### PR DESCRIPTION
The option is there to prevent a blow-up of contexts because of intervals. When apron is enabled, the same blowup could still happen because of it. Thus, this disables the apron contexts for those functions where the autotune turns of intervals in contexts.