### PR TITLE
Add library functions for `__atomic_{store,load}_n`

### DIFF
--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -132,6 +132,8 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_popcount", unknown [drop "x" []]);
     ("__builtin_popcountl", unknown [drop "x" []]);
     ("__builtin_popcountll", unknown [drop "x" []]);
+    ("__atomic_store_n", unknown [drop "ptr" [w]; drop "val" []; drop "memorder" []]);
+    ("__atomic_load_n", unknown [drop "ptr" [w]; drop "memorder" []]);
   ]
 
 let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[

--- a/tests/regression/41-stdlib/06-atomic.c
+++ b/tests/regression/41-stdlib/06-atomic.c
@@ -1,0 +1,11 @@
+int g = 8;
+
+int main() {
+    int i;
+    __atomic_store_n (&i, 12, __ATOMIC_RELAXED);
+    int i = __atomic_load_n (&i, __ATOMIC_RELAXED);
+    __goblint_check(i == 12); //TODO
+
+    // Should not be invalidated
+    __goblint_check(g == 8);
+}


### PR DESCRIPTION
Calls occur in sv-comp. This is a stop-gap measure before we get proper support for C11 in Goblint. References #868 

(These are indeed builtins despite their name not starting with `__builtin`: https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html)