### PR TITLE
Filter analyzed functions in `tf_proc` according to number of arguments

### DIFF
--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -635,19 +635,33 @@ struct
         Queries.LS.fold (fun ((x,_)) xs -> x::xs) ls []
     in
     let one_function f =
-      match Cilfacade.find_varinfo_fundec f with
-      | fd when LibraryFunctions.use_special f.vname ->
-        M.info ~category:Analyzer "Using special for defined function %s" f.vname;
-        tf_special_call ctx lv f args
-      | fd ->
-        tf_normal_call ctx lv e fd args getl sidel getg sideg
-      | exception Not_found ->
-        tf_special_call ctx lv f args
+      match f.vtype with
+      | TFun (_, params, var_arg, _)  ->
+        let arg_length = List.length args in
+        let p_length = Option.map_default List.length 0 params in
+        if p_length = arg_length || (var_arg && arg_length >= p_length) then
+          begin Some (match Cilfacade.find_varinfo_fundec f with
+              | fd when LibraryFunctions.use_special f.vname ->
+                M.info ~category:Analyzer "Using special for defined function %s" f.vname;
+                tf_special_call ctx lv f args
+              | fd ->
+                tf_normal_call ctx lv e fd args getl sidel getg sideg
+              | exception Not_found ->
+                tf_special_call ctx lv f args)
+          end
+        else begin
+          M.warn ~tags:[CWE 685] "Potential call to function %a with wrong number of arguments. This call will be ignored." CilType.Varinfo.pretty f;
+          None
+        end
+      | _ ->
+        M.warn  ~category:Call "Something that is not a function (%a) is called." CilType.Varinfo.pretty f;
+        None
     in
-    if [] = functions then
+    let funs = List.filter_map one_function functions in
+    if [] = funs then begin
+      M.warn ~category:Unsound "No fitting function to be called at call site. Continuing with state before call.";
       d (* because LevelSliceLifter *)
-    else
-      let funs = List.map one_function functions in
+    end else
       common_joins ctx funs !r !spawns
 
   let tf_asm var edge prev_node getl sidel getg sideg d =

--- a/src/util/messageCategory.ml
+++ b/src/util/messageCategory.ml
@@ -27,6 +27,7 @@ type cast = TypeMismatch [@@deriving eq, ord, hash]
 type category =
   | Assert
   | Behavior of behavior
+  | Call
   | Integer of integer
   | Float
   | Race
@@ -167,6 +168,7 @@ let should_warn e =
     match e with
     | Assert -> "assert"
     | Behavior _ -> "behavior"
+    | Call -> "call"
     | Integer _ -> "integer"
     | Float -> "float"
     | Race -> "race"
@@ -186,6 +188,7 @@ let path_show e =
   match e with
   | Assert -> ["Assert"]
   | Behavior x -> "Behavior" :: Behavior.path_show x
+  | Call -> ["Call"]
   | Integer x -> "Integer" :: Integer.path_show x
   | Float -> ["Float"]
   | Race -> ["Race"]
@@ -214,7 +217,7 @@ let behaviorName = function
       | Unknown -> "Unknown Aob"
 let categoryName = function
   | Assert -> "Assert"
-
+  | Call -> "Call"
   | Race -> "Race"
   | Deadlock -> "Deadlock"
   | Cast x -> "Cast"
@@ -239,6 +242,7 @@ let from_string_list (s: string list) =
   | h :: t -> match h with
     | "assert" -> Assert
     | "behavior" -> Behavior.from_string_list t
+    | "call" -> Call
     | "integer" -> Integer.from_string_list t
     | "float" -> Float
     | "race" -> Race

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1824,6 +1824,12 @@
           "type": "boolean",
           "default": true
         },
+        "call": {
+          "title": "warn.call",
+          "description": "function call warnings",
+          "type": "boolean",
+          "default": true
+        },
         "integer": {
           "title": "warn.integer",
           "description": "integer (Overflow, Div_by_zero) warnings",

--- a/tests/regression/00-sanity/32-check.c
+++ b/tests/regression/00-sanity/32-check.c
@@ -1,4 +1,5 @@
 // just a few sanity checks on checks
+#include <goblint.h>
 
 int main() {
   int success = 1;

--- a/tests/regression/01-cpa/24-library_functions.c
+++ b/tests/regression/01-cpa/24-library_functions.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
 // DO NOT run this code!
 

--- a/tests/regression/01-cpa/72-library-function-pointer.c
+++ b/tests/regression/01-cpa/72-library-function-pointer.c
@@ -1,0 +1,33 @@
+#include <fcntl.h>
+#include <unistd.h>
+
+typedef void (*fnct_ptr)(void);
+typedef int (*open_t)(const char*,int,int);
+typedef int (*ftruncate_t)(int,off_t);
+
+// Goblint used to crash on this example because the number of supplied arguments for myopen is bigger than
+// than the expected number of arguments for the library function descriptior of ftruncate.
+//  -- "open" expects 3 arguments, while "ftruncate" expects only 2.
+int main(){
+    fnct_ptr ptr;
+    int top;
+
+    if (top){
+        ptr = &open;
+    } else {
+        ptr = &ftruncate;
+    }
+
+    if (top) {
+        // Some (nonsensical, but compiling) call to open
+        open_t myopen;
+        myopen = (open_t) ptr;
+        myopen("some/path", O_CREAT, 0);
+    } else {
+        // Some (nonsensical, but compiling) call to ftruncate
+        ftruncate_t myftruncate;
+        myftruncate = (ftruncate_t) ptr;
+        myftruncate(0, 100);
+    }
+    return 0;
+}

--- a/tests/regression/02-base/48-unknown_func_struct.c
+++ b/tests/regression/02-base/48-unknown_func_struct.c
@@ -8,10 +8,8 @@ typedef struct list {
     struct list *next;
 } list_t;
 
-// void mutate_list(list_t n){
-//     list_t *next = n.next;
-//     next->val = 42;
-// }
+void mutate_list(list_t n);
+void mutate_list2(list_t* n);
 
 int main(){
     list_t first;

--- a/tests/regression/02-base/49-unknown_func_union.c
+++ b/tests/regression/02-base/49-unknown_func_union.c
@@ -14,10 +14,7 @@ typedef union either {
     struct list node;
 } either_t;
 
-// void mutate_either(either_t e){
-//     list_t *next = e.node.next;
-//     next->val = 42;
-// }
+void mutate_either(either_t e);
 
 int main(){
     list_t first;

--- a/tests/regression/02-base/50-unknown_func_array.c
+++ b/tests/regression/02-base/50-unknown_func_array.c
@@ -8,12 +8,7 @@ typedef struct arr {
     int *ptrs[LENGTH];
 } arr_t;
 
-// int mutate_array(arr_t a){
-//     int t = rand();
-//     for(int i=0; i<LENGTH; i++) {
-//         *(a.ptrs[i]) = t;
-//     }
-// }
+int mutate_array(arr_t a);
 
 int main(){
     arr_t a;

--- a/tests/regression/02-base/79-unknown-spawn.c
+++ b/tests/regression/02-base/79-unknown-spawn.c
@@ -2,8 +2,10 @@
 #include <goblint.h>
 #include <stddef.h>
 
+int magic(void* (f (void *)));
+
 void *t_fun(void *arg) {
-  __goblint_check(1); // reachable
+  // __goblint_check(1); // reachable
   return NULL;
 }
 

--- a/tests/regression/02-base/88-string-ptrs-limited.c
+++ b/tests/regression/02-base/88-string-ptrs-limited.c
@@ -1,6 +1,8 @@
 //PARAM: --enable ana.base.limit-string-addresses
 #include <stdlib.h>
+#include <goblint.h>
 
+int rand();
 char *unknown_function();
 
 int main(){

--- a/tests/regression/02-base/89-string-ptrs-not-limited.c
+++ b/tests/regression/02-base/89-string-ptrs-not-limited.c
@@ -1,6 +1,8 @@
 //PARAM: --disable ana.base.limit-string-addresses
 #include <stdlib.h>
+#include <goblint.h>
 
+int rand();
 char *unknown_function();
 
 int main(){

--- a/tests/regression/02-base/90-memcpy.c
+++ b/tests/regression/02-base/90-memcpy.c
@@ -2,6 +2,7 @@
 // Test case taken from sqlite3.c
 #include <string.h>
 #include <stdlib.h>
+#include <goblint.h>
 
 typedef unsigned long u64;
 

--- a/tests/regression/03-practical/25-zstd-customMem.c
+++ b/tests/regression/03-practical/25-zstd-customMem.c
@@ -1,5 +1,6 @@
 // Extracted from zstd
 #include <stddef.h>
+#include <stdlib.h>
 #include <goblint.h>
 
 typedef void* (*ZSTD_allocFunction) (void* opaque, size_t size);

--- a/tests/regression/06-symbeq/31-zstd-thread-pool.c
+++ b/tests/regression/06-symbeq/31-zstd-thread-pool.c
@@ -10,6 +10,7 @@
 
 #include<stdlib.h>
 #include<pthread.h>
+#include<goblint.h>
 #define ZSTD_pthread_mutex_t            pthread_mutex_t
 #define ZSTD_pthread_mutex_init(a, b)   pthread_mutex_init((a), (b))
 #define ZSTD_pthread_mutex_destroy(a)   pthread_mutex_destroy((a))

--- a/tests/regression/06-symbeq/35-zstd-thread-pool-multi.c
+++ b/tests/regression/06-symbeq/35-zstd-thread-pool-multi.c
@@ -10,6 +10,7 @@
 
 #include<stdlib.h>
 #include<pthread.h>
+#include<goblint.h>
 #define ZSTD_pthread_mutex_t            pthread_mutex_t
 #define ZSTD_pthread_mutex_init(a, b)   pthread_mutex_init((a), (b))
 #define ZSTD_pthread_mutex_destroy(a)   pthread_mutex_destroy((a))

--- a/tests/regression/06-symbeq/38-chrony-name2ipaddress.c
+++ b/tests/regression/06-symbeq/38-chrony-name2ipaddress.c
@@ -6,6 +6,8 @@
 #include <netdb.h>
 #include <pthread.h>
 #include <string.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
 
 void *
 Malloc(size_t size)

--- a/tests/regression/09-regions/08-kernel_list_nr.c
+++ b/tests/regression/09-regions/08-kernel_list_nr.c
@@ -1,11 +1,12 @@
-// PARAM: --set ana.activated[+] "'region'"  --set kernel true --set nonstatic true 
+// PARAM: --set ana.activated[+] "'region'"  --set kernel true --set nonstatic true
 #include<linux/module.h>
 #include<linux/list.h>
 #include<linux/mutex.h>
+#include <linux/slab.h>
 
 struct s {
   struct list_head list;
-}; 
+};
 
 struct list_head A, B;
 
@@ -16,10 +17,10 @@ static DEFINE_MUTEX(B_mutex);
 void t1() {
   struct s *p = kmalloc(sizeof(struct s), GFP_KERNEL);
   INIT_LIST_HEAD(&p->list);
-  
+
   mutex_lock(&A_mutex);
-  list_add(&p->list, &A); 
-  if (p->list.next) 
+  list_add(&p->list, &A);
+  if (p->list.next)
     p->list.next->prev = NULL; //NORACE
   mutex_unlock(&A_mutex);
 }
@@ -27,7 +28,7 @@ void t1() {
 void t2 () {
   struct s *p = kmalloc(sizeof(struct s), GFP_KERNEL);
   INIT_LIST_HEAD(&p->list);
-  
+
   mutex_lock(&A_mutex);
   list_add(&p->list, &A);
   mutex_unlock(&A_mutex);

--- a/tests/regression/09-regions/15-kernel_foreach_nr.c
+++ b/tests/regression/09-regions/15-kernel_foreach_nr.c
@@ -2,11 +2,12 @@
 #include<linux/module.h>
 #include<linux/list.h>
 #include<linux/mutex.h>
+#include <linux/slab.h>
 
 struct s {
   int datum;
   struct list_head list;
-}; 
+};
 
 struct list_head slot[10];
 struct mutex slots_mutex[10];
@@ -19,20 +20,20 @@ struct s *new(int x) {
 }
 
 void t1(int i) {
-  struct s *p; 
-  
+  struct s *p;
+
   p = new(1);
   mutex_lock(&slots_mutex[i]);
-  list_add(&p->list, &slot[i]); 
+  list_add(&p->list, &slot[i]);
   p = new(2);
-  list_add(&p->list, &slot[i]); 
+  list_add(&p->list, &slot[i]);
   mutex_unlock(&slots_mutex[i]);
 }
 
 void t2 (int j) {
   struct s *pos;
   int j;
-  
+
   mutex_lock(&slots_mutex[j]);
   list_for_each_entry(pos, &slot[j], list) {
     pos->datum++; // NORACE!

--- a/tests/regression/56-witness/05-prec-problem.c
+++ b/tests/regression/56-witness/05-prec-problem.c
@@ -1,5 +1,6 @@
 //PARAM: --enable witness.yaml.enabled --enable ana.int.interval
 #include <stdlib.h>
+#include <goblint.h>
 
 int foo(int* ptr1, int* ptr2){
     int result;


### PR DESCRIPTION
This PR changes the `FromSpec.tf_proc` function such that it checks whether the number of arguments matches the number of parameters that are expected according to the function type. 

At calls to function pointers, calls to functions with a different number of parameters are excluded. This way, when such a pointer may point to a library function, this library function is not considered to be called when its declared type has a different number of parameters than are passed to invocation of the function pointer. Thus, the crash is avoided, when the declaration of the library function in the code is the same as we expect according to our library description.
Otherwise, Goblint may still crash.  

A special handling is implemented for functions that are declared, or that are declared, but without an explicit parameter list:
For such functions, the abstract call is performed, i.e. it is assumed that the number of parameters fits. This was necessary in order to not break 8 regression tests that rely on `__goblint_assume_join` (where parameters are not declared in `goblint.h`) and a number of 
builtin float functions (e.g. `__builtin_isgreater`, `__builtin_islessgreater`, `__builtin_isunordered`, `__builtin_fpclassify`, and others).
Fixes #881