### PR TITLE
Do not produce overflow warnings from Apron & Unroll typedefs for `invariant`

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2069,7 +2069,7 @@ struct
          | _ -> failwith "unreachable")
       | Const _ , _ -> st (* nothing to do *)
       | CastE ((TFloat (_, _)), e), `Float c ->
-        (match Cilfacade.typeOf e, FD.get_fkind c with
+        (match unrollType (Cilfacade.typeOf e), FD.get_fkind c with
          | TFloat (FLongDouble as fk, _), FFloat
          | TFloat (FDouble as fk, _), FFloat
          | TFloat (FLongDouble as fk, _), FDouble
@@ -2082,7 +2082,7 @@ struct
         (match eval e st with
          | `Int i ->
            if ID.leq i (ID.cast_to ik i) then
-             match Cilfacade.typeOf e with
+             match unrollType (Cilfacade.typeOf e) with
              | TInt(ik_e, _)
              | TEnum ({ekind = ik_e; _ }, _) ->
                let c' = ID.cast_to ik_e c in

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -936,8 +936,8 @@ struct
       else
         match eval_interval_expr d e with
         | (Some min, Some max) -> ID.of_interval ~suppress_ovwarn:true ik (min, max)
-        | (Some min, None) -> ID.starting ik min
-        | (None, Some max) -> ID.ending ik max
+        | (Some min, None) -> ID.starting ~suppress_ovwarn:true ik min
+        | (None, Some max) -> ID.ending ~suppress_ovwarn:true ik max
         | (None, None) -> ID.top_of ik
 
   let invariant ~scope x =

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -935,7 +935,7 @@ struct
         | `Top -> ID.top_of ik
       else
         match eval_interval_expr d e with
-        | (Some min, Some max) -> ID.of_interval ik (min, max)
+        | (Some min, Some max) -> ID.of_interval ~suppress_ovwarn:true ik (min, max)
         | (Some min, None) -> ID.starting ik min
         | (None, Some max) -> ID.ending ik max
         | (None, None) -> ID.top_of ik

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -214,8 +214,8 @@ module type IkindUnawareS =
 sig
   include B
   include Arith with type t:= t
-  val starting   : Cil.ikind -> int_t -> t
-  val ending     : Cil.ikind -> int_t -> t
+  val starting   : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
+  val ending     : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
   val of_int: int_t -> t
   (** Transform an integer literal to your internal domain representation. *)
 
@@ -249,8 +249,8 @@ sig
   val meet: Cil.ikind -> t -> t -> t
   val narrow: Cil.ikind -> t -> t -> t
   val widen: Cil.ikind -> t -> t -> t
-  val starting : Cil.ikind -> int_t -> t
-  val ending : Cil.ikind -> int_t -> t
+  val starting : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
+  val ending : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
   val of_int: Cil.ikind -> int_t -> t
   (** Transform an integer literal to your internal domain representation. *)
 
@@ -292,8 +292,8 @@ sig
 
   val of_congruence: Cil.ikind -> int_t * int_t -> t
 
-  val starting   : Cil.ikind -> int_t -> t
-  val ending     : Cil.ikind -> int_t -> t
+  val starting   : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
+  val ending     : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
 
   val is_top_of: Cil.ikind -> t -> bool
 

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -223,7 +223,7 @@ sig
   (** Transform a known boolean value to the default internal representation. It
     * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
 
-  val of_interval: Cil.ikind -> int_t * int_t -> t
+  val of_interval: ?suppress_ovwarn:bool -> Cil.ikind -> int_t * int_t -> t
 
   val of_congruence: Cil.ikind -> int_t * int_t -> t
   val arbitrary: unit -> t QCheck.arbitrary
@@ -258,7 +258,7 @@ sig
   (** Transform a known boolean value to the default internal representation. It
     * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
 
-  val of_interval: Cil.ikind -> int_t * int_t -> t
+  val of_interval: ?suppress_ovwarn:bool -> Cil.ikind -> int_t * int_t -> t
   val of_congruence: Cil.ikind -> int_t * int_t -> t
   val is_top_of: Cil.ikind -> t -> bool
   val invariant_ikind : Cil.exp -> Cil.ikind -> t -> Invariant.t
@@ -288,7 +288,7 @@ sig
   (** Transform a known boolean value to the default internal representation of the specified ikind. It
     * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
 
-  val of_interval: Cil.ikind -> int_t * int_t -> t
+  val of_interval: ?suppress_ovwarn:bool -> Cil.ikind -> int_t * int_t -> t
 
   val of_congruence: Cil.ikind -> int_t * int_t -> t
 

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -24,7 +24,7 @@ struct
 
   let of_int ik = lift (I.of_int ik)
   let of_bool ik = lift (I.of_bool ik)
-  let of_interval ik = lift (I.of_interval ik)
+  let of_interval ?(suppress_ovwarn=false) ik = lift (I.of_interval ~suppress_ovwarn ik)
   let of_excl_list ik = lift (I.of_excl_list ik)
   let of_congruence ik = lift (I.of_congruence ik)
   let starting ik = lift (I.starting ik)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -27,8 +27,8 @@ struct
   let of_interval ?(suppress_ovwarn=false) ik = lift (I.of_interval ~suppress_ovwarn ik)
   let of_excl_list ik = lift (I.of_excl_list ik)
   let of_congruence ik = lift (I.of_congruence ik)
-  let starting ?(suppress_ovwarn=false) ik = lift (I.starting ik)
-  let ending ?(suppress_ovwarn=false) ik = lift (I.ending ik)
+  let starting ?(suppress_ovwarn=false) ik = lift (I.starting  ~suppress_ovwarn ik)
+  let ending ?(suppress_ovwarn=false) ik = lift (I.ending  ~suppress_ovwarn ik)
 
   let to_int x = unlift_opt I.to_int x
   let to_bool x = unlift_opt I.to_bool x

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -27,8 +27,8 @@ struct
   let of_interval ?(suppress_ovwarn=false) ik = lift (I.of_interval ~suppress_ovwarn ik)
   let of_excl_list ik = lift (I.of_excl_list ik)
   let of_congruence ik = lift (I.of_congruence ik)
-  let starting ?(suppress_ovwarn=false) ik = lift (I.starting  ~suppress_ovwarn ik)
-  let ending ?(suppress_ovwarn=false) ik = lift (I.ending  ~suppress_ovwarn ik)
+  let starting ?(suppress_ovwarn=false) ik = lift (I.starting ~suppress_ovwarn ik)
+  let ending ?(suppress_ovwarn=false) ik = lift (I.ending ~suppress_ovwarn ik)
 
   let to_int x = unlift_opt I.to_int x
   let to_bool x = unlift_opt I.to_bool x

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -27,8 +27,8 @@ struct
   let of_interval ?(suppress_ovwarn=false) ik = lift (I.of_interval ~suppress_ovwarn ik)
   let of_excl_list ik = lift (I.of_excl_list ik)
   let of_congruence ik = lift (I.of_congruence ik)
-  let starting ik = lift (I.starting ik)
-  let ending ik = lift (I.ending ik)
+  let starting ?(suppress_ovwarn=false) ik = lift (I.starting ik)
+  let ending ?(suppress_ovwarn=false) ik = lift (I.ending ik)
 
   let to_int x = unlift_opt I.to_int x
   let to_bool x = unlift_opt I.to_bool x

--- a/tests/regression/02-base/99-refine-typedef.c
+++ b/tests/regression/02-base/99-refine-typedef.c
@@ -1,0 +1,24 @@
+// PARAM: --enable ana.int.interval
+typedef signed long int __int64_t;
+typedef __int64_t int64_t;
+
+int main(int argc, char * argv[])
+{
+    // Those two should behave identically, as the typedef should be unrolled
+
+    int64_t data;
+    if (data < 100LL)
+    {
+        __goblint_check(data < 100);
+        int64_t result = data + 1; //NOWARN
+    }
+
+    signed long int data2;
+    if(data2 < 100LL)
+    {
+        __goblint_check(data2 < 100);
+        signed long int result2 = data2 + 1; //NOWARN
+    }
+
+    return 0;
+}

--- a/tests/regression/02-base/99-refine-typedef.c
+++ b/tests/regression/02-base/99-refine-typedef.c
@@ -1,4 +1,6 @@
 // PARAM: --enable ana.int.interval
+#include <goblint.h>
+
 typedef signed long int __int64_t;
 typedef __int64_t int64_t;
 

--- a/tests/regression/46-apron2/26-overflow.c
+++ b/tests/regression/46-apron2/26-overflow.c
@@ -1,0 +1,14 @@
+// SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
+#include<stdio.h>
+typedef long long int64_t;
+
+int main(int argc, char * argv[])
+{
+    long long data;
+    if (data < 0x7fffffffffffffffLL)
+    {
+        long long result = data + 1; //NOWARN
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Apron sometimes will produce answers that are imprecise in response to EvalInt queries, which then get normalized to top if they do not fit within the specified `ikind`. Currently, we emit an overflow warning in such cases. However, this is not necessary: If there is an actual overflow, the interval domain will emit the required warnings.

The old behavior meant that enabling Apron could lead to spurious overflow warnings. (Closes #889)

Additionally, we were not unrolling `TNamed` in `invariant` which lead to precision loss when an alias for an integer type is used in an invariant.

@sim642: Could you maybe run this with the subset of the Juliet suite you mentioned in #879 to see if there are improvements, if you have capacity in Tartu? The Munich server is at capacity these days.