### PR TITLE
Handle overflows in congruence domain more precisely

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2308,7 +2308,7 @@ struct
     res
 
   (* Handle unsigned overflows.
-     From n === k mod (2^a * b), we conclude n === k mod 2^a, for a <= 2^{bitwidth}.
+     From n === k mod (2^a * b), we conclude n === k mod 2^a, for a <= bitwidth.
      The congruence modulo b may not persist on an overflow. *)
   let handle_overflow ik (c, m) =
     if m =: Ints_t.zero then

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2307,16 +2307,40 @@ struct
     if M.tracing then  M.trace "congruence" "shift_left : %a %a becomes %a \n" pretty x pretty y pretty res;
     res
 
+  let find_power_of_two n =
+    let two = Ints_t.of_int 2 in
+    let rec find n acc =
+      if n %: two =: Ints_t.zero then
+        find (n /: two) (two *: acc)
+      else
+        acc
+    in
+    find n Ints_t.one
+
+  (* From n === k mod (2^a * b), we conclude n === k mod 2^a,
+     for a <= 2^{bitwidth}.
+     The congruence modulo b may not persist on an overflow. *)
+  let handle_overflow ik (c, m) =
+    let max = (snd (Size.range ik)) +: Ints_t.one in
+    let m' = Ints_t.max max (find_power_of_two m) in
+    let res = normalize ik (Some (c, m')) in
+    res
+
   let mul ?(no_ov=false) ik x y =
+    let no_ov_case (c1, m1) (c2, m2) =
+      (c1 *: c2, Ints_t.gcd (c1 *: m2) (Ints_t.gcd (m1 *: c2) (m1 *: m2)))
+    in
     match x, y with
     | None, None -> bot ()
     | None, _ | _, None ->
       raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (show x) (show y)))
     | Some (c1, m1), Some (c2, m2) when no_ov ->
-      Some (c1 *: c2, Ints_t.gcd (c1 *: m2) (Ints_t.gcd (m1 *: c2) (m1 *: m2)))
+      Some (no_ov_case (c1, m1) (c2, m2))
     | Some (c1, m1), Some (c2, m2) when m1 =: Ints_t.zero && m2 =: Ints_t.zero && not (Cil.isSigned ik) ->
       let (_, max_ik) = range ik in
       Some((c1 *: c2) %: (max_ik +: Ints_t.one), Ints_t.zero)
+    | Some a, Some b when not (Cil.isSigned ik) ->
+      handle_overflow ik (no_ov_case a b )
     | _ -> top ()
 
   let mul ?no_ov ik x y =
@@ -2329,16 +2353,21 @@ struct
     | None -> bot()
     | Some _ ->  mul ~no_ov ik (of_int ik (Ints_t.of_int (-1))) x
 
-
   let add ?(no_ov=false) ik x y =
+    let no_ov_case (c1, m1) (c2, m2) =
+      c1 +: c2, Ints_t.gcd m1 m2
+    in
     match (x, y) with
     | None, None -> bot ()
     | None, _ | _, None ->
-       raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (show x) (show y)))
-    | Some (c1, m1), Some (c2, m2) when no_ov -> normalize ik (Some (c1 +: c2, Ints_t.gcd m1 m2))
+      raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (show x) (show y)))
+    | Some a, Some b when no_ov ->
+      normalize ik (Some (no_ov_case a b))
     | Some (c1, m1), Some (c2, m2) when m1 =: Ints_t.zero && m2 =: Ints_t.zero && not (Cil.isSigned ik) ->
       let (_, max_ik) = range ik in
       Some((c1 +: c2) %: (max_ik +: Ints_t.one), Ints_t.zero)
+    | Some a, Some b when not (Cil.isSigned ik) ->
+      handle_overflow ik (no_ov_case a b)
     | _ -> top ()
 
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2322,7 +2322,7 @@ struct
      The congruence modulo b may not persist on an overflow. *)
   let handle_overflow ik (c, m) =
     let max = (snd (Size.range ik)) +: Ints_t.one in
-    let m' = Ints_t.max max (find_power_of_two m) in
+    let m' = Ints_t.min max (find_power_of_two m) in
     let res = normalize ik (Some (c, m')) in
     res
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2307,22 +2307,14 @@ struct
     if M.tracing then  M.trace "congruence" "shift_left : %a %a becomes %a \n" pretty x pretty y pretty res;
     res
 
-  let find_power_of_two n =
-    let two = Ints_t.of_int 2 in
-    let rec find n acc =
-      if n %: two =: Ints_t.zero then
-        find (n /: two) (two *: acc)
-      else
-        acc
-    in
-    find n Ints_t.one
-
   (* Handle unsigned overflows. 
      From n === k mod (2^a * b), we conclude n === k mod 2^a, for a <= 2^{bitwidth}.
      The congruence modulo b may not persist on an overflow. *)
   let handle_overflow ik (c, m) =
     let max = (snd (Size.range ik)) +: Ints_t.one in
-    let m' = find_power_of_two m in
+    (* Find largest m'=2^k (for some k) such that m is divisible by m' *)
+    let tz = Ints_t.trailing_zeros m in
+    let m' = Ints_t.shift_left (Ints_t.of_int 1) tz in
     if m' >=: max then
       (* if m' >= 2 ^ {bitlength}, there is only one value in range *)
       let c' = c %: max in

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2317,14 +2317,14 @@ struct
     in
     find n Ints_t.one
 
-  (* From n === k mod (2^a * b), we conclude n === k mod 2^a,
-     for a <= 2^{bitwidth}.
+  (* Handle unsigned overflows. 
+     From n === k mod (2^a * b), we conclude n === k mod 2^a, for a <= 2^{bitwidth}.
      The congruence modulo b may not persist on an overflow. *)
   let handle_overflow ik (c, m) =
     let max = (snd (Size.range ik)) +: Ints_t.one in
     let m' = find_power_of_two m in
-    if m' >: max then
-      (* if m' > 2 ^ {bitlength}, there is only one value in range *)
+    if m' >=: max then
+      (* if m' >= 2 ^ {bitlength}, there is only one value in range *)
       let c' = c %: max in
       Some (c', Ints_t.zero)
     else

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2307,20 +2307,24 @@ struct
     if M.tracing then  M.trace "congruence" "shift_left : %a %a becomes %a \n" pretty x pretty y pretty res;
     res
 
-  (* Handle unsigned overflows. 
+  (* Handle unsigned overflows.
      From n === k mod (2^a * b), we conclude n === k mod 2^a, for a <= 2^{bitwidth}.
      The congruence modulo b may not persist on an overflow. *)
   let handle_overflow ik (c, m) =
-    let max = (snd (Size.range ik)) +: Ints_t.one in
-    (* Find largest m'=2^k (for some k) such that m is divisible by m' *)
-    let tz = Ints_t.trailing_zeros m in
-    let m' = Ints_t.shift_left (Ints_t.of_int 1) tz in
-    if m' >=: max then
-      (* if m' >= 2 ^ {bitlength}, there is only one value in range *)
-      let c' = c %: max in
-      Some (c', Ints_t.zero)
+    if m =: Ints_t.zero then
+      normalize ik (Some (c, m))
     else
-      normalize ik (Some (c, m'))
+      (* Find largest m'=2^k (for some k) such that m is divisible by m' *)
+      let tz = Ints_t.trailing_zeros m in
+      let m' = Ints_t.shift_left (Ints_t.of_int 1) tz in
+
+      let max = (snd (Size.range ik)) +: Ints_t.one in
+      if m' >=: max then
+        (* if m' >= 2 ^ {bitlength}, there is only one value in range *)
+        let c' = c %: max in
+        Some (c', Ints_t.zero)
+      else
+        normalize ik (Some (c, m'))
 
   let mul ?(no_ov=false) ik x y =
     let no_ov_case (c1, m1) (c2, m2) =

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2322,9 +2322,13 @@ struct
      The congruence modulo b may not persist on an overflow. *)
   let handle_overflow ik (c, m) =
     let max = (snd (Size.range ik)) +: Ints_t.one in
-    let m' = Ints_t.min max (find_power_of_two m) in
-    let res = normalize ik (Some (c, m')) in
-    res
+    let m' = find_power_of_two m in
+    if m' >: max then
+      (* if m' > 2 ^ {bitlength}, there is only one value in range *)
+      let c' = c %: max in
+      Some (c', Ints_t.zero)
+    else
+      normalize ik (Some (c, m'))
 
   let mul ?(no_ov=false) ik x y =
     let no_ov_case (c1, m1) (c2, m2) =

--- a/src/util/intOps.ml
+++ b/src/util/intOps.ml
@@ -279,7 +279,10 @@ struct
   let ge x y = of_bool (compare x y >= 0)
 end
 
-module BigIntOps = IntOpsDecorator(BigIntOpsBase)
+module BigIntOps = struct
+  include IntOpsDecorator(BigIntOpsBase)
+  let trailing_zeros x = Z.trailing_zeros x
+end
 module NIntOps = IntOpsDecorator(NIntOpsBase)
 module Int32Ops = IntOpsDecorator(Int32OpsBase)
 module Int64Ops = IntOpsDecorator(Int64OpsBase)

--- a/tests/regression/37-congruence/08-mod-16-unsigned-overflow.c
+++ b/tests/regression/37-congruence/08-mod-16-unsigned-overflow.c
@@ -1,0 +1,14 @@
+// PARAM: --enable ana.int.congruence
+#include <goblint.h>
+int main()
+{
+	unsigned int a = 0;
+	unsigned int b = 16;
+	while (1)
+	{
+		a = a + b;
+		b = b + b;
+		__goblint_check(a % 16 == 0);
+	}
+	return 0;
+}

--- a/tests/regression/37-congruence/09-mod-pow-two-unsigned-overflow.c
+++ b/tests/regression/37-congruence/09-mod-pow-two-unsigned-overflow.c
@@ -1,0 +1,17 @@
+// PARAM: --enable ana.int.congruence
+#include <goblint.h>
+
+int main()
+{
+	unsigned int a = 0;
+	unsigned int b = 16;
+
+	while (1)
+	{
+		a = a + b * 3;
+		b = b + b * 5;
+		__goblint_checks(a % 16 == 0);
+	}
+
+	return 0;
+}

--- a/tests/regression/37-congruence/09-mod-pow-two-unsigned-overflow.c
+++ b/tests/regression/37-congruence/09-mod-pow-two-unsigned-overflow.c
@@ -10,7 +10,7 @@ int main()
 	{
 		a = a + b * 3;
 		b = b + b * 5;
-		__goblint_checks(a % 16 == 0);
+		__goblint_check(a % 16 == 0);
 	}
 
 	return 0;

--- a/tests/regression/37-congruence/10-overflow-special-cases.c
+++ b/tests/regression/37-congruence/10-overflow-special-cases.c
@@ -15,9 +15,14 @@ int basic(){
 			__goblint_check(a % two_pow_16 == 3);
 			__goblint_check(b % two_pow_16 == 5);
 
-			int e = a * b;
+			unsigned int e = a * b;
 			__goblint_check(e % two_pow_16 == 15);
 			__goblint_check(e == 15); // UNKNOWN!
+
+			// Congruence lost by cast to signed int
+			int e_sign = e;
+			__goblint_check(e_sign % two_pow_16 == 15); //UNKNOWN!
+			__goblint_check(e_sign == 15); // UNKNOWN!
 		}
 	}
 }
@@ -36,7 +41,7 @@ int special(){
 			__goblint_check(a % two_pow_18 == two_pow_17);
 			__goblint_check(b % two_pow_18 == two_pow_17);
 
-			int e = a * b;
+			unsigned int e = a * b;
 			__goblint_check(e == 0);
 		}
 	}
@@ -65,7 +70,7 @@ int special2(){
 			__goblint_check(a % two_pow_18 == x);
 			__goblint_check(b % two_pow_18 == x);
 
-			int e = a * b;
+			unsigned int e = a * b;
 			__goblint_check(e == two_pow_30);
 		}
 	}
@@ -73,9 +78,6 @@ int special2(){
 	// Hint why the above holds:
 	__goblint_check( x * x  == two_pow_30);
 }
-
-
-
 
 int main()
 {

--- a/tests/regression/37-congruence/10-overflow-special-cases.c
+++ b/tests/regression/37-congruence/10-overflow-special-cases.c
@@ -1,0 +1,85 @@
+// PARAM: --enable ana.int.congruence
+#include <goblint.h>
+// #include <assert.h>
+// #define __goblint_check(e) assert(e)
+
+int basic(){
+	unsigned int two_pow_16 = 65536;
+	unsigned int a;
+	unsigned int b;
+
+	if (a % two_pow_16 == 3)
+	{
+		if (b % two_pow_16 == 5)
+		{
+			__goblint_check(a % two_pow_16 == 3);
+			__goblint_check(b % two_pow_16 == 5);
+
+			int e = a * b;
+			__goblint_check(e % two_pow_16 == 15);
+			__goblint_check(e == 15); // UNKNOWN!
+		}
+	}
+}
+
+int special(){
+	unsigned int two_pow_18 = 262144;
+	unsigned int two_pow_17 = 131072;
+
+	unsigned int a;
+	unsigned int b;
+
+	if (a % two_pow_18 == two_pow_17)
+	{
+		if (b % two_pow_18 == two_pow_17)
+		{
+			__goblint_check(a % two_pow_18 == two_pow_17);
+			__goblint_check(b % two_pow_18 == two_pow_17);
+
+			int e = a * b;
+			__goblint_check(e == 0);
+		}
+	}
+
+	// Hint why the above works:
+	__goblint_check( two_pow_17 * two_pow_17 == 0);
+}
+
+
+int special2(){
+	unsigned int two_pow_30 = 1073741824;
+	unsigned int two_pow_18 = 262144;
+	unsigned int two_pow_17 = 131072;
+	unsigned int two_pow_16 = 65536;
+	unsigned int two_pow_15 = 32768;
+
+	unsigned int x = two_pow_17 + two_pow_15;
+
+	unsigned int a;
+	unsigned int b;
+
+	if (a % two_pow_18 == x)
+	{
+		if (b % two_pow_18 == x)
+		{
+			__goblint_check(a % two_pow_18 == x);
+			__goblint_check(b % two_pow_18 == x);
+
+			int e = a * b;
+			__goblint_check(e == two_pow_30);
+		}
+	}
+
+	// Hint why the above holds:
+	__goblint_check( x * x  == two_pow_30);
+}
+
+
+
+
+int main()
+{
+	basic();
+	special();
+	special2();
+}

--- a/tests/regression/37-congruence/10-overflow-unsigned-special-cases.c
+++ b/tests/regression/37-congruence/10-overflow-unsigned-special-cases.c
@@ -27,23 +27,19 @@ int basic(){
 	}
 }
 
-int special(){
+int constant_result(){
 	unsigned int two_pow_18 = 262144;
 	unsigned int two_pow_17 = 131072;
 
 	unsigned int a;
-	unsigned int b;
 
 	if (a % two_pow_18 == two_pow_17)
 	{
-		if (b % two_pow_18 == two_pow_17)
-		{
-			__goblint_check(a % two_pow_18 == two_pow_17);
-			__goblint_check(b % two_pow_18 == two_pow_17);
+		__goblint_check(a % two_pow_18 == two_pow_17);
 
-			unsigned int e = a * b;
-			__goblint_check(e == 0);
-		}
+		// There can only be one result in Z/2^32
+		unsigned int e = a * a;
+		__goblint_check(e == 0);
 	}
 
 	// Hint why the above works:
@@ -51,28 +47,23 @@ int special(){
 }
 
 
-int special2(){
+int constant_result2(){
 	unsigned int two_pow_30 = 1073741824;
 	unsigned int two_pow_18 = 262144;
 	unsigned int two_pow_17 = 131072;
-	unsigned int two_pow_16 = 65536;
 	unsigned int two_pow_15 = 32768;
 
 	unsigned int x = two_pow_17 + two_pow_15;
 
 	unsigned int a;
-	unsigned int b;
 
 	if (a % two_pow_18 == x)
 	{
-		if (b % two_pow_18 == x)
-		{
-			__goblint_check(a % two_pow_18 == x);
-			__goblint_check(b % two_pow_18 == x);
+		__goblint_check(a % two_pow_18 == x);
 
-			unsigned int e = a * b;
-			__goblint_check(e == two_pow_30);
-		}
+		// There can only be one result in Z/2^32
+		unsigned int e = a * a;
+		__goblint_check(e == two_pow_30);
 	}
 
 	// Hint why the above holds:
@@ -82,6 +73,6 @@ int special2(){
 int main()
 {
 	basic();
-	special();
-	special2();
+	constant_result();
+	constant_result2();
 }

--- a/tests/regression/37-congruence/11-overflow-signed.c
+++ b/tests/regression/37-congruence/11-overflow-signed.c
@@ -36,7 +36,7 @@ int special(){
 	if (a % two_pow_18 == two_pow_17)
 	{
 		__goblint_check(a % two_pow_18 == two_pow_17);
-	
+
 		unsigned int e = a * a;
 		__goblint_check(e == 0); //UNKNOWN!
 	}

--- a/tests/regression/37-congruence/11-overflow-signed.c
+++ b/tests/regression/37-congruence/11-overflow-signed.c
@@ -1,0 +1,71 @@
+// PARAM: --enable ana.int.congruence
+#include <goblint.h>
+// #include <assert.h>
+// #define __goblint_check(e) assert(e)
+
+int basic(){
+	int two_pow_16 = 65536;
+	int a;
+	int b;
+
+	if (a % two_pow_16 == 3)
+	{
+		if (b % two_pow_16 == 5)
+		{
+			__goblint_check(a % two_pow_16 == 3);
+			__goblint_check(b % two_pow_16 == 5);
+
+			unsigned int e = a * b;
+			__goblint_check(e % two_pow_16 == 15); // UNKNOWN!
+			__goblint_check(e == 15); // UNKNOWN!
+
+			// Congruence lost by cast to signed int
+			int e_sign = e;
+			__goblint_check(e_sign % two_pow_16 == 15); //UNKNOWN!
+			__goblint_check(e_sign == 15); // UNKNOWN!
+		}
+	}
+}
+
+int special(){
+	int two_pow_18 = 262144;
+	int two_pow_17 = 131072;
+
+	int a;
+
+	if (a % two_pow_18 == two_pow_17)
+	{
+		__goblint_check(a % two_pow_18 == two_pow_17);
+	
+		unsigned int e = a * a;
+		__goblint_check(e == 0); //UNKNOWN!
+	}
+}
+
+
+int special2(){
+	int two_pow_30 = 1073741824;
+	int two_pow_18 = 262144;
+	int two_pow_17 = 131072;
+	int two_pow_15 = 32768;
+
+	int x = two_pow_17 + two_pow_15;
+
+	int a;
+	int b;
+
+	if (a % two_pow_18 == x)
+	{
+		__goblint_check(a % two_pow_18 == x); //TODO
+
+		unsigned int e = a * a;
+		__goblint_check(e == two_pow_30); //UNKNOWN!
+	}
+}
+
+int main()
+{
+	basic();
+	special();
+	special2();
+}


### PR DESCRIPTION
This PR introduces more precise handling of unsigned overflows for congruences. 
When the integer (in the sense of whole number) result `n` of an operation would be known to be `n === k mod 2^a * b`, we can keep the information `n === k mod 2^a` (and possibly reduce k to normalize it), for an `a <= bitlength`.
As discussed with @michael-schwarz , this information still holds when cutting off the result in the whole numbers into the residue class ring `Z/2^{bitlength}`.  
Fixes #893.