### PR TITLE
Fix handling of labels in unrolling & add possibility to run CIL checks on CFGs

### DIFF
--- a/goblint.opam
+++ b/goblint.opam
@@ -74,7 +74,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 # also remember to generate/adjust goblint.opam.locked!
 available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
-  [ "goblint-cil.2.0.0" "git+https://github.com/goblint/cil.git#bfb977b48d6d92e0ecbdab2e04f2576095506107" ]
+  [ "goblint-cil.2.0.0" "git+https://github.com/goblint/cil.git#6eec36947c793e2efe59b4f26dd6cd57498c830a" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # TODO: add back after release, only pinned for CI stability

--- a/goblint.opam
+++ b/goblint.opam
@@ -74,7 +74,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 # also remember to generate/adjust goblint.opam.locked!
 available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
-  [ "goblint-cil.2.0.0" "git+https://github.com/goblint/cil.git#6eec36947c793e2efe59b4f26dd6cd57498c830a" ]
+  [ "goblint-cil.2.0.0" "git+https://github.com/goblint/cil.git#638a407306d3ce1646ef2536af173d9ba38cfd33" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # TODO: add back after release, only pinned for CI stability

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -124,7 +124,7 @@ available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
   [
     "goblint-cil.2.0.0"
-    "git+https://github.com/goblint/cil.git#bfb977b48d6d92e0ecbdab2e04f2576095506107"
+    "git+https://github.com/goblint/cil.git#6eec36947c793e2efe59b4f26dd6cd57498c830a"
   ]
   [
     "apron.v0.9.13"

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -124,7 +124,7 @@ available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
   [
     "goblint-cil.2.0.0"
-    "git+https://github.com/goblint/cil.git#6eec36947c793e2efe59b4f26dd6cd57498c830a"
+    "git+https://github.com/goblint/cil.git#638a407306d3ce1646ef2536af173d9ba38cfd33"
   ]
   [
     "apron.v0.9.13"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -2,7 +2,7 @@
 # also remember to generate/adjust goblint.opam.locked!
 available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
-  [ "goblint-cil.2.0.0" "git+https://github.com/goblint/cil.git#6eec36947c793e2efe59b4f26dd6cd57498c830a" ]
+  [ "goblint-cil.2.0.0" "git+https://github.com/goblint/cil.git#638a407306d3ce1646ef2536af173d9ba38cfd33" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # TODO: add back after release, only pinned for CI stability

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -2,7 +2,7 @@
 # also remember to generate/adjust goblint.opam.locked!
 available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
-  [ "goblint-cil.2.0.0" "git+https://github.com/goblint/cil.git#bfb977b48d6d92e0ecbdab2e04f2576095506107" ]
+  [ "goblint-cil.2.0.0" "git+https://github.com/goblint/cil.git#6eec36947c793e2efe59b4f26dd6cd57498c830a" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # TODO: add back after release, only pinned for CI stability

--- a/src/util/cilCfg.ml
+++ b/src/util/cilCfg.ml
@@ -45,4 +45,6 @@ let createCFG (fileAST: file) =
         computeCFGInfo fd true
       | _ -> ()
     );
+  if get_bool "dbg.run_cil_check" then assert (Check.checkFile [] fileAST);
+
   Cilfacade.do_preprocess fileAST

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1803,6 +1803,13 @@
             "Should the analysis print information on which globals are protected by which mutex?",
           "type": "boolean",
           "default": false
+        },
+        "run_cil_check" : {
+          "title": "dbg.run_cil_check",
+          "description":
+            "Should the analysis call Check.checkFile after creating the CFG (helpful to verify that transformations respect CIL's invariants.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/tests/regression/55-loop-unrolling/01-simple-cases.c
+++ b/tests/regression/55-loop-unrolling/01-simple-cases.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --enable dbg.run_cil_check
 #include <goblint.h>
 
 int global;

--- a/tests/regression/55-loop-unrolling/02-break.c
+++ b/tests/regression/55-loop-unrolling/02-break.c
@@ -1,4 +1,4 @@
-// PARAM: --set exp.unrolling-factor 5
+// PARAM: --set exp.unrolling-factor 5  --enable dbg.run_cil_check
 #include <goblint.h>
 
 int main(void) {

--- a/tests/regression/55-loop-unrolling/03-break-right-place.c
+++ b/tests/regression/55-loop-unrolling/03-break-right-place.c
@@ -1,4 +1,4 @@
-// PARAM: --set exp.unrolling-factor 5
+// PARAM: --set exp.unrolling-factor 5  --enable dbg.run_cil_check
 #include <goblint.h>
 
 int main(void) {

--- a/tests/regression/55-loop-unrolling/04-simple.c
+++ b/tests/regression/55-loop-unrolling/04-simple.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5  --enable dbg.run_cil_check
 // Simple example
 #include <goblint.h>
 

--- a/tests/regression/55-loop-unrolling/05-continue.c
+++ b/tests/regression/55-loop-unrolling/05-continue.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5  --enable dbg.run_cil_check
 // Simple example
 #include <goblint.h>
 

--- a/tests/regression/55-loop-unrolling/06-simple-cases-unrolled.c
+++ b/tests/regression/55-loop-unrolling/06-simple-cases-unrolled.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5  --enable dbg.run_cil_check
 #include <goblint.h>
 
 int global;

--- a/tests/regression/55-loop-unrolling/07-nested-unroll.c
+++ b/tests/regression/55-loop-unrolling/07-nested-unroll.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5
+// PARAM: --enable ana.int.interval --set exp.unrolling-factor 5 --set ana.base.arrays.domain unroll --set ana.base.arrays.unrolling-factor 5  --enable dbg.run_cil_check
 #include <goblint.h>
 int main(void) {
     int arr[10][10];

--- a/tests/regression/55-loop-unrolling/08-bad.c
+++ b/tests/regression/55-loop-unrolling/08-bad.c
@@ -1,0 +1,17 @@
+// PARAM: --set exp.unrolling-factor 1 --enable dbg.run_cil_check
+int main() {
+  int m;
+
+  switch (m)
+  {
+      default:
+      do { } while (0);
+  }
+
+
+  goto lab;
+
+  lab: do { } while (0);
+
+  return 0;
+}

--- a/tests/regression/55-loop-unrolling/09-weird.c
+++ b/tests/regression/55-loop-unrolling/09-weird.c
@@ -1,0 +1,13 @@
+// PARAM: --set exp.unrolling-factor 2 --enable dbg.run_cil_check
+
+void main(void)
+{
+    int j = 0;
+
+    for(int i=0;i < 50;i++) {
+        goto somelab;
+        somelab: j = 8;
+    }
+
+    __goblint_check(j==8);
+}

--- a/tests/regression/55-loop-unrolling/09-weird.c
+++ b/tests/regression/55-loop-unrolling/09-weird.c
@@ -1,4 +1,5 @@
 // PARAM: --set exp.unrolling-factor 2 --enable dbg.run_cil_check
+#include <goblint.h>
 
 void main(void)
 {


### PR DESCRIPTION
Our handling of labels when unrolling loops was still slightly off:

- We did not populate the `labelAlphaTable`, so there were collisions possible with labels defined outside the loop that is being unrolled, as we started from a fresh alpha table.
- We were excessively copying statements (not leaving the original statement in the CFG as well (at the very end), causing `goto`s from outside the CFG to point to  statements that were not included in the current CFG anymore.

To catch such issues early from now on, I added the option `dbg.run_cil_check` that causes CIL integrity checks to run and enabled them for our loop unrolling tests.

**TODO:**

- [x] Wait for merge of https://github.com/goblint/cil/pull/121 and update pins


Closes #895 