### PR TITLE
Move let syntax for applicative functor/monad to general library

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -835,7 +835,7 @@ struct
         (* re-evaluate e1 and e2 in evalbinop because might be with cast *)
         evalbinop a gs st op ~e1 ~t1 ~e2 ~t2 typ
       | BinOp (LOr, e1, e2, typ) as exp ->
-        let (let*) = Option.bind in
+        let open GobOption.Syntax in
         (* split nested LOr Eqs to equality pairs, if possible *)
         let rec split = function
           (* copied from above to support pointer equalities with implicit casts inserted *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -844,9 +844,9 @@ struct
           | BinOp (Eq, arg1, arg2, _) ->
             Some [(arg1, arg2)]
           | BinOp (LOr, arg1, arg2, _) ->
-            let* s1 = split arg1 in
-            let* s2 = split arg2 in
-            Some (s1 @ s2)
+            let+ s1 = split arg1
+            and+ s2 = split arg2 in
+            s1 @ s2
           | _ ->
             None
         in

--- a/src/analyses/threadId.ml
+++ b/src/analyses/threadId.ml
@@ -5,8 +5,7 @@ module LF = LibraryFunctions
 
 open Prelude.Ana
 open Analyses
-
-let (let+) xs f = List.map f xs (* TODO: move to general library *)
+open GobList.Syntax
 
 module Thread = ThreadIdDomain.Thread
 module ThreadLifted = ThreadIdDomain.ThreadLifted

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -179,20 +179,21 @@ let int_of_scalar ?round (scalar: Scalar.t) =
   if Scalar.is_infty scalar <> 0 then (* infinity means unbounded *)
     None
   else
+    let open GobOption.Syntax in
     match scalar with
     | Float f -> (* octD, boxD *)
       (* bound_texpr on bottom also gives Float even with MPQ *)
-      let f_opt = match round with
+      let+ f = match round with
         | Some `Floor -> Some (Float.floor f)
         | Some `Ceil -> Some (Float.ceil f)
         | None when Stdlib.Float.is_integer f-> Some f
         | None -> None
       in
-      Option.map (fun f -> BI.of_bigint (Z.of_float f)) f_opt
+      BI.of_bigint (Z.of_float f)
     | Mpqf scalar -> (* octMPQ, boxMPQ, polkaMPQ *)
       let n = Mpqf.get_num scalar in
       let d = Mpqf.get_den scalar in
-      let z_opt =
+      let+ z =
         if Mpzf.cmp_int d 1 = 0 then (* exact integer (denominator 1) *)
           Some n
         else
@@ -202,7 +203,7 @@ let int_of_scalar ?round (scalar: Scalar.t) =
             | None -> None
           end
       in
-      Option.map Z_mlgmpidl.z_of_mpzf z_opt
+      Z_mlgmpidl.z_of_mpzf z
     | _ ->
       failwith ("int_of_scalar: unsupported: " ^ Scalar.to_string scalar)
 

--- a/src/util/gobList.ml
+++ b/src/util/gobList.ml
@@ -6,7 +6,9 @@ let rec combine_short l1 l2 = match l1, l2 with
   | _, _ -> []
 
 let assoc_eq_opt (eq: 'a -> 'a -> bool) (x: 'a) (ys: ('a * 'b) list) : ('b option) =
-  Option.map Tuple2.second (List.find_opt (fun (x',_) -> eq x x') ys)
+  let open GobOption.Syntax in
+  let+ (_, y) = List.find_opt (fun (x', _) -> eq x x') ys in
+  y
 
 let rec fold_left3 f acc l1 l2 l3 = match l1, l2, l3 with
   | [], [], [] -> acc

--- a/src/util/gobList.ml
+++ b/src/util/gobList.ml
@@ -36,3 +36,14 @@ let until_last_with (pred: 'a -> bool) (xs: 'a list) =
     | h::t -> if pred h then until_last_helper (h::seen@last) [] t else until_last_helper last (h::seen) t
   in
   until_last_helper [] [] xs
+
+
+module Syntax =
+struct
+  let (let+) x f = List.map f x
+  let (and+) = List.cartesian_product
+  let (let*) x f = List.concat_map f x
+  let (and*) = (and+)
+
+  let (>>=) x f= List.concat_map f x
+end

--- a/src/util/gobList.ml
+++ b/src/util/gobList.ml
@@ -40,12 +40,16 @@ let until_last_with (pred: 'a -> bool) (xs: 'a list) =
   until_last_helper [] [] xs
 
 
+(** Open this to use applicative functor/monad syntax for {!list}. *)
 module Syntax =
 struct
+  (* Applicative functor. *)
   let (let+) x f = List.map f x
   let (and+) = List.cartesian_product
+
+  (* Monad *)
   let (let*) x f = List.concat_map f x
   let (and*) = (and+)
 
-  let (>>=) x f= List.concat_map f x
+  let (>>=) x f = List.concat_map f x
 end

--- a/src/util/gobOption.ml
+++ b/src/util/gobOption.ml
@@ -5,3 +5,16 @@ let exists p = function
 let for_all p = function
   | Some x -> p x
   | None -> true
+
+
+module Syntax =
+struct
+  let (let+) x f = Option.map f x
+  let (and+) x y = match x, y with
+    | Some x, Some y -> Some (x, y)
+    | _, _ -> None
+  let (let*) = Option.bind
+  let (and*) = (and+)
+
+  let (>>=) = Option.bind
+end

--- a/src/util/gobOption.ml
+++ b/src/util/gobOption.ml
@@ -7,12 +7,16 @@ let for_all p = function
   | None -> true
 
 
+(** Open this to use applicative functor/monad syntax for {!option}. *)
 module Syntax =
 struct
+  (* Applicative functor. *)
   let (let+) x f = Option.map f x
   let (and+) x y = match x, y with
     | Some x, Some y -> Some (x, y)
     | _, _ -> None
+
+  (* Monad *)
   let (let*) = Option.bind
   let (and*) = (and+)
 

--- a/src/util/gobResult.ml
+++ b/src/util/gobResult.ml
@@ -1,0 +1,12 @@
+module Syntax =
+struct
+  let (let+) x f = Result.map f x
+  let (and+) x y = match x, y with
+    | Ok x, Ok y -> Ok (x, y)
+    | Error e, _
+    | _, Error e -> Error e
+  let (let*) = Result.bind
+  let (and*) = (and+)
+
+  let (>>=) = Result.bind
+end

--- a/src/util/gobResult.ml
+++ b/src/util/gobResult.ml
@@ -1,10 +1,14 @@
+(** Open this to use applicative functor/monad syntax for {!result}. *)
 module Syntax =
 struct
+  (* Applicative functor. *)
   let (let+) x f = Result.map f x
   let (and+) x y = match x, y with
     | Ok x, Ok y -> Ok (x, y)
     | Error e, _
     | _, Error e -> Error e
+
+  (* Monad *)
   let (let*) = Result.bind
   let (and*) = (and+)
 

--- a/src/util/gobYaml.ml
+++ b/src/util/gobYaml.ml
@@ -11,8 +11,8 @@ let rec list_map (f: 'a -> ('b, 'e) result) (l: 'a list): ('b list, 'e) result =
   match l with
   | [] -> Ok []
   | x :: xs ->
-    let* y = f x in
-    let+ ys = list_map f xs in
+    let+ y = f x
+    and+ ys = list_map f xs in
     y :: ys
 
 let find s y =

--- a/src/util/gobYaml.ml
+++ b/src/util/gobYaml.ml
@@ -1,8 +1,6 @@
 include Yaml.Util
 
-let (let*) = Result.bind
-let (let+) r f = Result.map f r
-let (>>=) = Result.bind
+include GobResult.Syntax
 
 let option_map (f: 'a -> ('b, 'e) result) (o: 'a option): ('b option, 'e) result =
   match o with

--- a/src/util/messageUtil.ml
+++ b/src/util/messageUtil.ml
@@ -1,15 +1,13 @@
 open GobConfig
 
 let ansi_color_table =
+  let open GobList.Syntax in
   let colors = [("gray", "30"); ("red", "31"); ("green", "32"); ("yellow", "33"); ("blue", "34");
                 ("violet", "35"); ("turquoise", "36"); ("white", "37"); ("reset", "0;00")] in
   let modes = [(Fun.id, "0" (* normal *)); (String.uppercase_ascii, "1" (* bold *))] in
-  colors
-  |> List.concat_map (fun (color, color_code) ->
-      List.map (fun (mode_fn, mode_code) ->
-          (mode_fn color, Format.sprintf "\027[%s;%sm" mode_code color_code)
-        ) modes
-    )
+  let+ (color, color_code) = colors
+  and+ (mode_fn, mode_code) = modes in
+  (mode_fn color, Format.sprintf "\027[%s;%sm" mode_code color_code)
 
 let colors_on fd = (* use colors? *)
   let c = get_string "colors" in

--- a/src/util/messages.ml
+++ b/src/util/messages.ml
@@ -5,6 +5,8 @@ module GU = Goblintutil
 
 module Category = MessageCategory
 
+open GobResult.Syntax
+
 
 module Severity =
 struct
@@ -52,8 +54,8 @@ struct
 
   let to_yojson x = CilType.Location.to_yojson (to_cil x)
   let of_yojson x =
-    CilType.Location.of_yojson x
-    |> BatResult.map (fun loc -> CilLocation loc)
+    let+ loc = CilType.Location.of_yojson x in
+    CilLocation loc
 end
 
 module Piece =
@@ -84,11 +86,11 @@ struct
 
   let of_yojson = function
     | (`Assoc l) as json when List.mem_assoc "group_text" l ->
-      group_of_yojson json
-      |> BatResult.map (fun group -> Group group)
+      let+ group = group_of_yojson json in
+      Group group
     | json ->
-      Piece.of_yojson json
-      |> BatResult.map (fun piece -> Single piece)
+      let+ piece = Piece.of_yojson json in
+      Single piece
 end
 
 module Tag =
@@ -112,10 +114,8 @@ struct
 
   let of_yojson = function
     | `Assoc [("Category", category)] ->
-      Category.of_yojson category
-      |> BatResult.map (fun category ->
-          Category category
-        )
+      let+ category = Category.of_yojson category in
+      Category category
     | `Assoc [("CWE", `Int n)] -> Result.Ok (CWE n)
     | _ -> Result.Error "Messages.Tag.of_yojson"
 end

--- a/src/witness/witnessUtil.ml
+++ b/src/witness/witnessUtil.ml
@@ -183,7 +183,7 @@ struct
     ) file_loc_es
 
   let find_opt (file_loc_es: t) (loc: Cil.location): ES.t option =
-    let (let*) = Option.bind in (* TODO: move to general library *)
+    let open GobOption.Syntax in
     let* loc_es = FileH.find_option file_loc_es loc.file in
     let* (_, es) = LocM.find_first_opt (fun loc' ->
         CilType.Location.compare loc loc' <= 0 (* allow inexact match *)

--- a/src/witness/yamlWitnessType.ml
+++ b/src/witness/yamlWitnessType.ml
@@ -17,9 +17,9 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let* name = y |> find "name" >>= to_string in
-    let* version = y |> find "version" >>= to_string in
-    let+ command_line = y |> find "command_line" >>= to_string in
+    let+ name = y |> find "name" >>= to_string
+    and+ version = y |> find "version" >>= to_string
+    and+ command_line = y |> find "command_line" >>= to_string in
     {name; version; command_line}
 end
 
@@ -51,15 +51,14 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let* input_files = y |> find "input_files" >>= list >>= list_map to_string in
-    let* input_file_hashes = y |> find "input_file_hashes" >>= entries >>= list_map (fun (file, y_hash) ->
+    let+ input_files = y |> find "input_files" >>= list >>= list_map to_string
+    and+ input_file_hashes = y |> find "input_file_hashes" >>= entries >>= list_map (fun (file, y_hash) ->
         let+ hash = to_string y_hash in
         (file, hash)
       )
-    in
-    let* data_model = y |> find "data_model" >>= to_string in
-    let* language = y |> find "language" >>= to_string in
-    let+ specification = y |> Yaml.Util.find "specification" >>= option_map to_string in
+    and+ data_model = y |> find "data_model" >>= to_string
+    and+ language = y |> find "language" >>= to_string
+    and+ specification = y |> Yaml.Util.find "specification" >>= option_map to_string in
     {input_files; input_file_hashes; data_model; language; specification}
 end
 
@@ -88,11 +87,11 @@ struct
       )
   let of_yaml y =
     let open GobYaml in
-    let* format_version = y |> find "format_version" >>= to_string in
-    let* uuid = y |> find "uuid" >>= to_string in
-    let* creation_time = y |> find "creation_time" >>= to_string in
-    let* producer = y |> find "producer" >>= Producer.of_yaml in
-    let+ task = y |> Yaml.Util.find "task" >>= option_map Task.of_yaml in
+    let+ format_version = y |> find "format_version" >>= to_string
+    and+ uuid = y |> find "uuid" >>= to_string
+    and+ creation_time = y |> find "creation_time" >>= to_string
+    and+ producer = y |> find "producer" >>= Producer.of_yaml
+    and+ task = y |> Yaml.Util.find "task" >>= option_map Task.of_yaml in
     {format_version; uuid; creation_time; producer; task}
 end
 
@@ -117,11 +116,11 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let* file_name = y |> find "file_name" >>= to_string in
-    let* file_hash = y |> find "file_hash" >>= to_string in
-    let* line = y |> find "line" >>= to_int in
-    let* column = y |> find "column" >>= to_int in
-    let+ function_ = y |> find "function" >>= to_string in
+    let+ file_name = y |> find "file_name" >>= to_string
+    and+ file_hash = y |> find "file_hash" >>= to_string
+    and+ line = y |> find "line" >>= to_int
+    and+ column = y |> find "column" >>= to_int
+    and+ function_ = y |> find "function" >>= to_string in
     {file_name; file_hash; line; column; function_}
 end
 
@@ -142,9 +141,9 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let* string = y |> find "string" >>= to_string in
-    let* type_ = y |> find "type" >>= to_string in
-    let+ format = y |> find "format" >>= to_string in
+    let+ string = y |> find "string" >>= to_string
+    and+ type_ = y |> find "type" >>= to_string
+    and+ format = y |> find "format" >>= to_string in
     {string; type_; format}
 end
 
@@ -165,8 +164,8 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let* location = y |> find "location" >>= Location.of_yaml in
-    let+ loop_invariant = y |> find "loop_invariant" >>= Invariant.of_yaml in
+    let+ location = y |> find "location" >>= Location.of_yaml
+    and+ loop_invariant = y |> find "loop_invariant" >>= Invariant.of_yaml in
     {location; loop_invariant}
 end
 
@@ -208,9 +207,9 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let* location = y |> find "location" >>= Location.of_yaml in
-    let* loop_invariant = y |> find "loop_invariant" >>= Invariant.of_yaml in
-    let+ precondition = y |> find "precondition" >>= Invariant.of_yaml in
+    let+ location = y |> find "location" >>= Location.of_yaml
+    and+ loop_invariant = y |> find "loop_invariant" >>= Invariant.of_yaml
+    and+ precondition = y |> find "precondition" >>= Invariant.of_yaml in
     {location; loop_invariant; precondition}
 end
 
@@ -231,9 +230,9 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let* uuid = y |> find "uuid" >>= to_string in
-    let* type_ = y |> find "type" >>= to_string in
-    let+ file_hash = y |> find "file_hash" >>= to_string in
+    let+ uuid = y |> find "uuid" >>= to_string
+    and+ type_ = y |> find "type" >>= to_string
+    and+ file_hash = y |> find "file_hash" >>= to_string in
     {uuid; type_; file_hash}
 end
 
@@ -254,9 +253,9 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let* string = y |> find "string" >>= to_string in
-    let* type_ = y |> find "type" >>= to_string in
-    let+ format = y |> find "format" >>= to_string in
+    let+ string = y |> find "string" >>= to_string
+    and+ type_ = y |> find "type" >>= to_string
+    and+ format = y |> find "format" >>= to_string in
     {string; type_; format}
 end
 
@@ -277,8 +276,8 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let* target = y |> find "target" >>= Target.of_yaml in
-    let+ certification = y |> find "certification" >>= Certification.of_yaml in
+    let+ target = y |> find "target" >>= Target.of_yaml
+    and+ certification = y |> find "certification" >>= Certification.of_yaml in
     {target; certification}
 end
 
@@ -349,7 +348,7 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let* metadata = y |> find "metadata" >>= Metadata.of_yaml in
-    let+ entry_type = y |> EntryType.of_yaml in
+    let+ metadata = y |> find "metadata" >>= Metadata.of_yaml
+    and+ entry_type = y |> EntryType.of_yaml in
     {entry_type; metadata}
 end


### PR DESCRIPTION
Currently definitions of `(let+)` and `(let*)` for `option`, `result` and `list` have been scattered here and there. This moves complete sets of definitions to general library extension modules.

Also adapts existing usages to be more appropriate and adds a couple of new places where these reduce already quite deep indentation.