### PR TITLE
Do not set overflow flag during refinement

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -905,7 +905,7 @@ struct
       let l' = if Ints_t.equal l min_ik then l else shrink Ints_t.add l in
       let u' = if Ints_t.equal u max_ik then u else shrink Ints_t.sub u in
       let intv' = norm ik @@ Some (l', u') in
-      let range = norm ik (Some (Ints_t.of_bigint (Size.min_from_bit_range rl), Ints_t.of_bigint (Size.max_from_bit_range rh))) in
+      let range = norm ~suppress_ovwarn:true ik (Some (Ints_t.of_bigint (Size.min_from_bit_range rl), Ints_t.of_bigint (Size.max_from_bit_range rh))) in
       meet ik intv' range
 
   let refine_with_incl_list ik (intv: t) (incl : (int_t list) option) : t =

--- a/tests/regression/38-int-refinements/04-ov.c
+++ b/tests/regression/38-int-refinements/04-ov.c
@@ -1,0 +1,8 @@
+// PARAM: --enable ana.int.interval --set ana.int.refinement once
+int main() {
+  int i, j;
+  if (i < j) //NOWARN
+    return 1;
+  else
+    return 2;
+}


### PR DESCRIPTION
This is another fix in the same vein as #890, where a call to `norm` caused the overflow flag being set unncessarily.
@karoliineh could you verify this fix behaves as expected.

Closes #866.