### PR TITLE
Int Domains: Do not refine on joining or widening

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -2753,12 +2753,15 @@ module IntDomTupleImpl = struct
         , map (r.f1 (module I3)) c
         , map (r.f1 (module I4)) d )
 
-  let map2 ik r (xa, xb, xc, xd) (ya, yb, yc, yd) =
-    refine ik
+  let map2 ?(norefine=false) ik r (xa, xb, xc, xd) (ya, yb, yc, yd) =
+    let r =
       ( opt_map2 (r.f2 (module I1)) xa ya
       , opt_map2 (r.f2 (module I2)) xb yb
       , opt_map2 (r.f2 (module I3)) xc yc
       , opt_map2 (r.f2 (module I4)) xd yd )
+    in
+    if norefine then r else refine ik r
+
 
   (* f1: unary ops *)
   let neg ?no_ov ik =
@@ -2827,13 +2830,13 @@ module IntDomTupleImpl = struct
 
   (* f2: binary ops *)
   let join ik =
-    map2 ik {f2= (fun (type a) (module I : S with type t = a) ?no_ov -> I.join ik)}
+    map2 ~norefine:true ik {f2= (fun (type a) (module I : S with type t = a) ?no_ov -> I.join ik)}
 
   let meet ik =
     map2 ik {f2= (fun (type a) (module I : S with type t = a) ?no_ov -> I.meet ik)}
 
   let widen ik =
-    map2 ik {f2= (fun (type a) (module I : S with type t = a) ?no_ov -> I.widen ik)}
+    map2 ~norefine:true ik {f2= (fun (type a) (module I : S with type t = a) ?no_ov -> I.widen ik)}
 
   let narrow ik =
     map2 ik {f2= (fun (type a) (module I : S with type t = a) ?no_ov -> I.narrow ik)}

--- a/tests/regression/38-int-refinements/05-invalid-widen.c
+++ b/tests/regression/38-int-refinements/05-invalid-widen.c
@@ -1,0 +1,8 @@
+//PARAM: --set ana.int.refinement once --enable ana.int.enums
+#include <goblint.h>
+
+int main() {
+  int a = 3;
+  while (1)
+    a += 2;
+}


### PR DESCRIPTION
Currently, we run into issues where due to refinement being applied after joining values we end up with a left argument to `widen` that is not `leq` the right `argument` (according to lattice order, property would still hold for concretizations).

With this PR, we only apply refinements upon transfer functions, meets, and narrows. The intuition here is that the corresponding refinement will be performed later on anyway, and very little actual gain can be hoped for when refining a value resulting from a join of two values that were already refined.

Closes #864 