### PR TITLE
Fix pseudo ret comparison

### DIFF
--- a/tests/incremental/02-cfg-comparison/00-infinite-loop.c
+++ b/tests/incremental/02-cfg-comparison/00-infinite-loop.c
@@ -1,5 +1,3 @@
-// SKIP
-// TODO: fix pseudo return handling in CFG comparison
 void main()
 { int x;
   int y = 0;

--- a/tests/incremental/02-cfg-comparison/00-infinite-loop.json
+++ b/tests/incremental/02-cfg-comparison/00-infinite-loop.json
@@ -1,5 +1,3 @@
 {
-  "incremental": {
-    "compare": "cfg"
-  }
+
 }

--- a/tests/incremental/02-cfg-comparison/01-added-return-stmt.c
+++ b/tests/incremental/02-cfg-comparison/01-added-return-stmt.c
@@ -1,0 +1,7 @@
+void main() {
+  int y = 0;
+  label:
+  __goblint_check(y==0);
+  goto label;
+  y++;
+}

--- a/tests/incremental/02-cfg-comparison/01-added-return-stmt.json
+++ b/tests/incremental/02-cfg-comparison/01-added-return-stmt.json
@@ -1,0 +1,5 @@
+{
+  "incremental": {
+    "compare": "cfg"
+  }
+}

--- a/tests/incremental/02-cfg-comparison/01-added-return-stmt.json
+++ b/tests/incremental/02-cfg-comparison/01-added-return-stmt.json
@@ -1,5 +1,3 @@
 {
-  "incremental": {
-    "compare": "cfg"
-  }
+
 }

--- a/tests/incremental/02-cfg-comparison/01-added-return-stmt.patch
+++ b/tests/incremental/02-cfg-comparison/01-added-return-stmt.patch
@@ -1,0 +1,8 @@
+--- tests/incremental/02-cfg-comparison/01-added-return-stmt.c
++++ tests/incremental/02-cfg-comparison/01-added-return-stmt.c
+@@ -4,4 +4,5 @@ void main() {
+   __goblint_check(y==0);
+   goto label;
+   y++;
++  return;
+ }

--- a/tests/incremental/02-cfg-comparison/02-added-return-after-exit.c
+++ b/tests/incremental/02-cfg-comparison/02-added-return-after-exit.c
@@ -1,0 +1,6 @@
+void main() {
+  int y = 0;
+  __goblint_check(y==0);
+  y++;
+  exit(0);
+}

--- a/tests/incremental/02-cfg-comparison/02-added-return-after-exit.json
+++ b/tests/incremental/02-cfg-comparison/02-added-return-after-exit.json
@@ -1,0 +1,5 @@
+{
+  "incremental": {
+    "compare": "cfg"
+  }
+}

--- a/tests/incremental/02-cfg-comparison/02-added-return-after-exit.json
+++ b/tests/incremental/02-cfg-comparison/02-added-return-after-exit.json
@@ -1,5 +1,3 @@
 {
-  "incremental": {
-    "compare": "cfg"
-  }
+
 }

--- a/tests/incremental/02-cfg-comparison/02-added-return-after-exit.patch
+++ b/tests/incremental/02-cfg-comparison/02-added-return-after-exit.patch
@@ -1,0 +1,8 @@
+--- tests/incremental/02-cfg-comparison/02-added-return-after-exit.c
++++ tests/incremental/02-cfg-comparison/02-added-return-after-exit.c
+@@ -3,4 +3,5 @@ void main() {
+   __goblint_check(y==0);
+   y++;
+   exit(0);
++  return;
+ }


### PR DESCRIPTION
As described in #574 it leads to an exception during the updating of ids if a pseudo return node is matched with a normal return node during CFG comparison. The initial test case added by @sim642 actually now worked without any changes, probably because the CFG creation was changed meanwhile to use an existing return node and avoid the creation of pseudo-return nodes when possible. 
So I created the test case `02-cfg-comparison/02-added-return-after-exit` where the problem was still observable. To fix it, I adjusted the comparison of nodes to only match two return nodes if either both are pseudo-return nodes or both are not. I removed the cfg comparison option from the test's configuration, because with #841 all incremental tests will be tested with both, ast and cfg comparison.

Closes #574