### PR TITLE
Autotune: Conditionally activate congruence integer domain

### DIFF
--- a/conf/svcomp23.json
+++ b/conf/svcomp23.json
@@ -67,6 +67,7 @@
         "mallocWrappers",
         "noRecursiveIntervals",
         "enums",
+        "congruence",
         "octagon",
         "wideningThresholds"
       ]

--- a/conf/svcomp23.json
+++ b/conf/svcomp23.json
@@ -67,7 +67,6 @@
         "mallocWrappers",
         "noRecursiveIntervals",
         "enums",
-        "congruence",
         "octagon",
         "wideningThresholds"
       ]

--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -315,6 +315,21 @@ class octagonFunctionVisitor(list, amount) = object
 
 end
 
+let congruenceOption factors file =
+  let locals, globals = factors.integralVars in
+  let cost = (locals + globals) * (factors.instructions / 12) + 5 * factors.functionCalls in
+  let value = 5 * locals + globals in
+  let activate () =
+    print_endline @@ "Congruence: " ^ string_of_int cost;
+    set_bool "ana.int.congruence" true;
+    print_endline "Enabled congruence domain.";
+  in
+  {
+    value;
+    cost;
+    activate;
+  }
+
 let apronOctagonOption factors file =
   let locals =
     if List.mem "specification" (get_string_list "ana.autotune.activated" ) && get_string "ana.specification" <> "" then
@@ -429,6 +444,7 @@ let chooseConfig file =
   print_endline @@ "File: " ^ string_of_int fileCompplexity;
 
   let options = [] in
+  let options = if isActivated "congruence" then (congruenceOption factors file)::options else options in
   let options = if isActivated "octagon" then (apronOctagonOption factors file)::options else options in
   let options = if isActivated "wideningThresholds" then (wideningOption factors file)::options else options in
 

--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -413,7 +413,16 @@ let chooseFromOptions costTarget options =
 let isActivated a = get_bool "ana.autotune.enabled" && List.mem a @@ get_string_list "ana.autotune.activated"
 
 let chooseConfig file =
-  if isActivated "congruence" then
+  let factors = collectFactors visitCilFileSameGlobals file in
+  let fileCompplexity = estimateComplexity factors file in
+
+  print_endline "Collected factors:";
+  printFactors factors;
+  print_endline "";
+  print_endline "Complexity estimates:";
+  print_endline @@ "File: " ^ string_of_int fileCompplexity;
+
+  if fileCompplexity < totalTarget && isActivated "congruence" then
     addModAttributes file;
 
   if isActivated "noRecursiveIntervals" then
@@ -433,15 +442,6 @@ let chooseConfig file =
 
   if isActivated "arrayDomain" then
     selectArrayDomains file;
-
-  let factors = collectFactors visitCilFileSameGlobals file in
-  let fileCompplexity = estimateComplexity factors file in
-
-  print_endline "Collected factors:";
-  printFactors factors;
-  print_endline "";
-  print_endline "Complexity estimates:";
-  print_endline @@ "File: " ^ string_of_int fileCompplexity;
 
   let options = [] in
   let options = if isActivated "congruence" then (congruenceOption factors file)::options else options in


### PR DESCRIPTION
This PR extends the autotuner to be able to enable the congruence domain for a whole program. Previously, the autotuner only activated the congruence domain for functions that contain the `%`-operator (remainder)  or  were called by such functions. 

However, the congruence domain may be useful even in some cases when the program does not contain the remainder operator. Therefore the congruence domain is activated on a program when there is still some "autotuner fuel" left for the configuration. This should enable the domain on small programs. 

The formulas for computing the `cost` and `value` option were chosen as something that seemed sensible, but were not fine-tuned.
 
 This PR also adds the `congruence` option to the autotuner in the `svcomp23.json` configuration. That means that the autotuner may activate the `congruence` domain, on a function level or for a whole program. 