### PR TITLE
Fix Apron reading globals with offsets

### DIFF
--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -66,8 +66,8 @@ struct
     let v_ins = VH.create 10 in
     let visitor = object
       inherit nopCilVisitor
-      method! vvrbl (v: varinfo) =
-        if v.vglob || ThreadEscape.has_escaped ask v then (
+      method! vlval = function
+        | (Var v, NoOffset) when v.vglob || ThreadEscape.has_escaped ask v ->
           let v_in =
             if VH.mem v_ins v then
               VH.find v_ins v
@@ -76,9 +76,8 @@ struct
               VH.replace v_ins v v_in;
               v_in
           in
-          ChangeTo v_in
-        )
-        else
+          ChangeTo (Var v_in, NoOffset)
+        | _ ->
           SkipChildren
     end
     in

--- a/src/util/xmlUtil.ml
+++ b/src/util/xmlUtil.ml
@@ -8,5 +8,5 @@ let escape (x:string):string =
   Str.global_replace (Str.regexp ">") "&gt;" |>
   Str.global_replace (Str.regexp "\"") "&quot;" |>
   Str.global_replace (Str.regexp "'") "&apos;" |>
-  Str.global_replace (Str.regexp "[\x0b\001\x0c\x0f\x0e]") "" |> (* g2html just cannot handle from some kernel benchmarks, even when escaped... *)
+  Str.global_replace (Str.regexp "[\x0b\001\x0c\x0f\x0e\x05]") "" |> (* g2html just cannot handle from some kernel benchmarks, even when escaped... *)
   Str.global_replace (Str.regexp "[\x1b]") "" (* g2html cannot handle from chrony *)

--- a/tests/regression/46-apron2/28-sv-comp-unroll-term.c
+++ b/tests/regression/46-apron2/28-sv-comp-unroll-term.c
@@ -1,0 +1,34 @@
+// SKIP PARAM: --set ana.activated[+] apron --enable ana.sv-comp.enabled --set ana.specification "CHECK( init(main()), LTL(G ! call(reach_error())) )" --set sem.int.signed_overflow assume_none
+
+// Minimized from sv-benchmarks/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--staging--speakup--speakup_spkout.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+// using loop unrolling of 1.
+// Used to not terminate.
+
+struct speakup_info_t {
+  int port_tts;
+};
+struct speakup_info_t speakup_info;
+
+unsigned char inb(int port) {
+  unsigned char value;
+  return value;
+}
+
+void synth_flush(void) {
+  int timeout = 100000;
+  int __cil_tmp4;
+  while (1) {
+    __cil_tmp4 = speakup_info.port_tts + 5;
+    inb(__cil_tmp4);
+    timeout --;
+    if (!timeout)
+      return;
+  }
+}
+
+int main() {
+  synth_flush();
+  while (1)
+    synth_flush();
+  return 0;
+}

--- a/tests/regression/46-apron2/29-read-var-offset.c
+++ b/tests/regression/46-apron2/29-read-var-offset.c
@@ -1,0 +1,15 @@
+// SKIP PARAM: --set ana.activated[+] apron
+#include <assert.h>
+
+struct s {
+  int x;
+  int y;
+};
+
+struct s g;
+
+int main() {
+  assert(g.x < 10);
+  // Manually check that Apron environment doesn't contain just "g" after read from int offset.
+  return 0;
+}


### PR DESCRIPTION
This fixes the case where enabling loop unrolling heuristic for `sv-benchmarks/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--staging--speakup--speakup_spkout.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out` caused its analysis time to jump from 0.3s to a 15min timeout.

After minimization of the program and options, the bug in Apron analysis is "obvious", but getting a spurious variable in an Apron environment to cause the jump in analysis time requires a fairly intricate combination of options:
1. Loops unrolled at least once.
2. Signed overflow disabled.
3. SV-COMP witness functor enabled.
4. Apron enabled.
5. Def_exc enabled.

The bug was simply that reading an int field of a struct, e.g. `g.x` added `g` as an int variable to the Apron environment.
This causes incomparable differences between Apron states, which causes some def_exc exclusion sets not to be joined in witness functor dependencies, which in turn causes the exclusion sets to grow instead of collapsing via a join/widen at some point.
The original program has a loop counting down from 100000, which takes a while if exclusion sets count down from that one by one.

Integer fields of structs are quite common, so this could be happening in many benchmarks, but with smaller constant bounds the slowdown would not be as drastic.