### PR TITLE
ArrayDomain: `normalize` after `widen` and `join`

### DIFF
--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -236,7 +236,7 @@ struct
     | Joint x -> Val.is_top x
     | _-> false
 
-  let join (x:t) (y:t) =
+  let join (x:t) (y:t) = normalize @@
     match x, y with
     | Joint x, Joint y -> Joint (Val.join x y)
     | Partitioned (e,(xl, xm, xr)), Joint y -> Partitioned (e,(Val.join xl y, Val.join xm y, Val.join xr y))
@@ -245,7 +245,7 @@ struct
       if CilType.Exp.equal e e' then Partitioned (e,(Val.join xl yl, Val.join xm ym, Val.join xr yr))
       else Joint (Val.join (join_of_all_parts x) (join_of_all_parts y))
 
-  let widen (x:t) (y:t) = match x,y with
+  let widen (x:t) (y:t) = normalize @@ match x,y with
     | Joint x, Joint y -> Joint (Val.widen x y)
     | Partitioned (e,(xl, xm, xr)), Joint y -> Partitioned (e,(Val.widen xl y, Val.widen xm y, Val.widen xr y))
     | Joint x, Partitioned (e,(yl, ym, yr)) -> Partitioned (e,(Val.widen x yl, Val.widen x ym, Val.widen x yr))

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -668,7 +668,7 @@ struct
   let smart_widen = smart_widen_with_length None
   let smart_leq = smart_leq_with_length None
 
-  let meet x y = match x,y with
+  let meet x y = normalize @@ match x,y with
     | Joint x, Joint y -> Joint (Val.meet x y)
     | Joint x, Partitioned (e, (xl, xm, xr))
     | Partitioned (e, (xl, xm, xr)), Joint x ->
@@ -682,7 +682,7 @@ struct
         (* TODO: do smart things if the relationship between e1e and e2e is known *)
         x
 
-  let narrow x y = match x,y with
+  let narrow x y = normalize @@ match x,y with
     | Joint x, Joint y -> Joint (Val.narrow x y)
     | Joint x, Partitioned (e, (xl, xm, xr))
     | Partitioned (e, (xl, xm, xr)), Joint x ->

--- a/tests/regression/22-partitioned_arrays/20-more-fixpoint.c
+++ b/tests/regression/22-partitioned_arrays/20-more-fixpoint.c
@@ -1,0 +1,37 @@
+// PARAM: --set ana.base.arrays.domain partitioned 
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <assert.h>
+
+pthread_mutex_t m;
+
+int arr[2];
+void g() {
+  int x = arr;
+  if (!(arr[0] <= arr[0])) {x = 5;}
+}
+
+void f(int i) {
+  pthread_mutex_lock(&m);
+  arr[i]++;
+  pthread_mutex_unlock(&m);
+}
+
+void* nop(void* unused) {
+  return NULL;
+}
+
+int main(void) {
+  pthread_t tid1;
+  pthread_create(&tid1, NULL, &nop, NULL);
+
+  f(1);
+  
+  pthread_mutex_lock(&m);
+  arr[1]--;
+  g();
+  pthread_mutex_unlock(&m);
+
+  return 0;
+}

--- a/tests/regression/22-partitioned_arrays/20-more-fixpoint.c
+++ b/tests/regression/22-partitioned_arrays/20-more-fixpoint.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.base.arrays.domain partitioned 
+// PARAM: --set ana.base.arrays.domain partitioned
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
@@ -8,7 +8,7 @@ pthread_mutex_t m;
 
 int arr[2];
 void g() {
-  int x = arr;
+  int x = 8;
   if (!(arr[0] <= arr[0])) {x = 5;}
 }
 
@@ -27,7 +27,7 @@ int main(void) {
   pthread_create(&tid1, NULL, &nop, NULL);
 
   f(1);
-  
+
   pthread_mutex_lock(&m);
   arr[1]--;
   g();


### PR DESCRIPTION
In an sv-comp pre-run, we had an issue where a fixpoint was not reached due to missing normalization upon `widen` and `join`. This fixes the issue.
I'd suggest we wait until we have the definitive sv-comp version before merging this, in case it has non-local effects.

Follow-up to #902 