### PR TITLE
Simplify solution querying

### DIFF
--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -709,3 +709,12 @@ sig
   module LHT: BatHashtbl.S with type key = EQSys.LVar.t
   module GHT: BatHashtbl.S with type key = EQSys.GVar.t
 end
+
+module type SpecSysSol =
+sig
+  module SpecSys: SpecSys
+  open SpecSys
+
+  val gh: EQSys.G.t GHT.t
+  val lh: SpecSys.Spec.D.t LHT.t (* explicit SpecSys to avoid spurious module cycle *)
+end

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -699,6 +699,12 @@ struct
 end
 
 
+module type FileCfg =
+sig
+  val file: Cil.file
+  module Cfg: MyCFG.CfgBidir
+end
+
 module type SpecSys =
 sig
   module Spec: Spec

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -699,12 +699,6 @@ struct
 end
 
 
-module type FileCfg =
-sig
-  val file: Cil.file
-  module Cfg: MyCFG.CfgBidir
-end
-
 module type SpecSys =
 sig
   module Spec: Spec

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -697,3 +697,15 @@ struct
   let threadenter ctx lval f args = [ctx.local]
   let threadspawn ctx lval f args fctx = ctx.local
 end
+
+
+module type SpecSys =
+sig
+  module Spec: Spec
+  module EQSys: GlobConstrSys with module LVar = VarF (Spec.C)
+                              and module GVar = GVarF (Spec.V)
+                              and module D = Spec.D
+                              and module G = GVarG (Spec.G) (Spec.C)
+  module LHT: BatHashtbl.S with type key = EQSys.LVar.t
+  module GHT: BatHashtbl.S with type key = EQSys.GVar.t
+end

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -618,8 +618,8 @@ let sprint_fundec_html_dot (module Cfg : CfgBidir) live fd =
   fprint_fundec_html_dot (module Cfg) live fd Format.str_formatter;
   Format.flush_str_formatter ()
 
-let dead_code_cfg (file:file) (module Cfg : CfgBidir) live =
-  iterGlobals file (fun glob ->
+let dead_code_cfg (module FileCfg: MyCFG.FileCfg) live =
+  iterGlobals FileCfg.file (fun glob ->
       match glob with
       | GFun (fd,loc) ->
         (* ignore (Printf.printf "fun: %s\n" fd.svar.vname); *)
@@ -630,7 +630,7 @@ let dead_code_cfg (file:file) (module Cfg : CfgBidir) live =
         let fname = Fpath.(file_dir / dot_file_name) in
         let out = open_out (Fpath.to_string fname) in
         let ppf = Format.formatter_of_out_channel out in
-        fprint_fundec_html_dot (module Cfg : CfgBidir) live fd ppf;
+        fprint_fundec_html_dot (module FileCfg.Cfg) live fd ppf;
         Format.pp_print_flush ppf ();
         close_out out
       | _ -> ()

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1192,17 +1192,14 @@ struct
   let asm ctx = S.asm (conv ctx)
 end
 
-module CompareGlobSys
-    (S:Spec)
-    (Sys:GlobConstrSys with module LVar = VarF (S.C)
-                        and module GVar = GVarF (S.V)
-                        and module D = S.D
-                        and module G = GVarG (S.G) (S.C))
-    (LH:Hashtbl.S with type key=Sys.LVar.t)
-    (GH:Hashtbl.S with type key=Sys.GVar.t)
-=
+module CompareGlobSys (SpecSys: SpecSys) =
 struct
-  open S
+  open SpecSys
+  module Sys = EQSys
+  module LH = LHT
+  module GH = GHT
+
+  open Spec
   module G = Sys.G
 
   module PP = Hashtbl.Make (Node)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -45,7 +45,7 @@ let current_node_state_json : (Node.t -> Yojson.Safe.t) ref = ref (fun _ -> asse
 module AnalyzeCFG (Cfg:CfgBidir) (Spec:Spec) (Inc:Increment) =
 struct
 
-  module SpecSys: SpecSys =
+  module SpecSys: SpecSys with module Spec = Spec =
   struct
     (* Must be created in module, because cannot be wrapped in a module later. *)
     module Spec = Spec

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -594,8 +594,6 @@ struct
       lh, gh
     in
 
-    Generic.write_cfgs := CfgTools.dead_code_cfg (module FileCfg);
-
     (* Use "normal" constraint solving *)
     let timeout_reached () =
       M.error "Timeout reached!";

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -604,6 +604,15 @@ struct
     in
     let timeout = get_string "dbg.timeout" |> Goblintutil.seconds_of_duration_string in
     let lh, gh = Goblintutil.timeout solve_and_postprocess () (float_of_int timeout) timeout_reached in
+    let module SpecSysSol: SpecSysSol =
+    struct
+      module SpecSys = SpecSys
+      let lh = lh
+      let gh = gh
+    end
+    in
+    let module R: ResultQuery.SpecSysSol2 = ResultQuery.Make (SpecSysSol) in
+
     let local_xml = solver2source_result lh in
     current_node_state_json := (fun node -> LT.to_yojson (Result.find local_xml node));
 
@@ -631,8 +640,8 @@ struct
       WResult.write lh gh entrystates;
 
     if get_bool "witness.yaml.enabled" then (
-      let module YWitness = YamlWitness.Make (struct let file = file end) (Cfg) (SpecSys) in
-      YWitness.write lh gh
+      let module YWitness = YamlWitness.Make (struct let file = file end) (Cfg) (R) in
+      YWitness.write ()
     );
 
     if get_string "witness.yaml.validate" <> "" then (

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -313,7 +313,7 @@ struct
 
     (* real beginning of the [analyze] function *)
     if get_bool "ana.sv-comp.enabled" then
-      Witness.init (module Cfg) file; (* TODO: move this out of analyze_loop *)
+      Witness.init (module FileCfg); (* TODO: move this out of analyze_loop *)
 
     GU.global_initialization := true;
     GU.earlyglobs := get_bool "exp.earlyglobs";
@@ -594,7 +594,7 @@ struct
       lh, gh
     in
 
-    Generic.write_cfgs := CfgTools.dead_code_cfg file (module Cfg:CfgBidir);
+    Generic.write_cfgs := CfgTools.dead_code_cfg (module FileCfg);
 
     (* Use "normal" constraint solving *)
     let timeout_reached () =
@@ -627,7 +627,7 @@ struct
     in
 
     if get_bool "exp.cfgdot" then
-      CfgTools.dead_code_cfg file (module Cfg : CfgBidir) liveness;
+      CfgTools.dead_code_cfg (module FileCfg) liveness;
 
     let warn_global g v =
       (* ignore (Pretty.printf "warn_global %a %a\n" EQSys.GVar.pretty_trace g EQSys.G.pretty v); *)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -627,7 +627,7 @@ struct
       (* ignore (Pretty.printf "warn_global %a %a\n" EQSys.GVar.pretty_trace g EQSys.G.pretty v); *)
       match g with
       | `Left g -> (* Spec global *)
-        Query.ask_global gh (WarnGlobal (Obj.repr g))
+        R.ask_global (WarnGlobal (Obj.repr g))
       | `Right _ -> (* contexts global *)
         ()
     in

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -59,3 +59,10 @@ let dummy_func = emptyFunction "__goblint_dummy_init" (* TODO get rid of this? *
 let dummy_node = FunctionEntry Cil.dummyFunDec
 
 let all_array_index_exp : exp = CastE(TInt(Cilfacade.ptrdiff_ikind (),[]), unknown_exp)
+
+
+module type FileCfg =
+sig
+  val file: Cil.file
+  module Cfg: CfgBidir
+end

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -76,7 +76,7 @@ sig
   val nh: Spec.D.t NH.t Lazy.t
 end
 
-module Make (SpecSysSol: SpecSysSol): SpecSysSol2 =
+module Make (SpecSysSol: SpecSysSol): SpecSysSol2 with module SpecSys = SpecSysSol.SpecSys =
 struct
   include SpecSysSol
   open SpecSys

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -68,6 +68,7 @@ module NH = BatHashtbl.Make (Node)
 
 module type SpecSysSol2 =
 sig
+  module FileCfg: FileCfg
   module SpecSys: SpecSys
   open SpecSys
 
@@ -80,8 +81,9 @@ sig
   val ask_global: 'a Queries.t -> 'a Queries.result
 end
 
-module Make (SpecSysSol: SpecSysSol): SpecSysSol2 with module SpecSys = SpecSysSol.SpecSys =
+module Make (FileCfg: FileCfg) (SpecSysSol: SpecSysSol): SpecSysSol2 with module SpecSys = SpecSysSol.SpecSys =
 struct
+  module FileCfg = FileCfg
   include SpecSysSol
   open SpecSys
 

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -75,8 +75,8 @@ sig
   val lh: Spec.D.t LHT.t
   val nh: Spec.D.t NH.t Lazy.t
 
-  val ask_local: EQSys.LVar.t -> Spec.D.t -> 'a Queries.t -> 'a Queries.result
-  val ask_local_node: Node.t -> Spec.D.t -> 'a Queries.t -> 'a Queries.result
+  val ask_local: EQSys.LVar.t -> ?local:Spec.D.t -> 'a Queries.t -> 'a Queries.result
+  val ask_local_node: Node.t -> ?local:Spec.D.t -> 'a Queries.t -> 'a Queries.result
   val ask_global: 'a Queries.t -> 'a Queries.result
 end
 
@@ -96,7 +96,17 @@ struct
 
   module Query = Query (SpecSys)
 
-  let ask_local lvar local q = Query.ask_local gh lvar local q
-  let ask_local_node node local q = Query.ask_local_node gh node local q
+  let ask_local lvar ?local q =
+    let local = match local with
+      | Some local -> local
+      | None -> try LHT.find lh lvar with Not_found -> Spec.D.bot ()
+    in
+    Query.ask_local gh lvar local q
+  let ask_local_node node ?local q =
+    let local = match local with
+      | Some local -> local
+      | None -> try NH.find (Lazy.force nh) node with Not_found -> Spec.D.bot ()
+    in
+    Query.ask_local_node gh node local q
   let ask_global q = Query.ask_global gh q
 end

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -68,7 +68,7 @@ module NH = BatHashtbl.Make (Node)
 
 module type SpecSysSol2 =
 sig
-  module FileCfg: FileCfg
+  module FileCfg: MyCFG.FileCfg
   module SpecSys: SpecSys
   open SpecSys
 
@@ -81,7 +81,7 @@ sig
   val ask_global: 'a Queries.t -> 'a Queries.result
 end
 
-module Make (FileCfg: FileCfg) (SpecSysSol: SpecSysSol): SpecSysSol2 with module SpecSys = SpecSysSol.SpecSys =
+module Make (FileCfg: MyCFG.FileCfg) (SpecSysSol: SpecSysSol): SpecSysSol2 with module SpecSys = SpecSysSol.SpecSys =
 struct
   module FileCfg = FileCfg
   include SpecSysSol

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -1,13 +1,9 @@
 open Analyses
 
-module Query
-    (Spec : Spec)
-    (EQSys : GlobConstrSys with module LVar = VarF (Spec.C)
-                            and module GVar = GVarF (Spec.V)
-                            and module D = Spec.D
-                            and module G = GVarG (Spec.G) (Spec.C))
-    (GHT : BatHashtbl.S with type key = EQSys.GVar.t) =
+module Query (SpecSys: SpecSys) =
 struct
+  open SpecSys
+
   let ask_local (gh: EQSys.G.t GHT.t) (lvar:EQSys.LVar.t) local =
     (* build a ctx for using the query system *)
     let rec ctx =

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -1,0 +1,68 @@
+open Analyses
+
+module Query
+    (Spec : Spec)
+    (EQSys : GlobConstrSys with module LVar = VarF (Spec.C)
+                            and module GVar = GVarF (Spec.V)
+                            and module D = Spec.D
+                            and module G = GVarG (Spec.G) (Spec.C))
+    (GHT : BatHashtbl.S with type key = EQSys.GVar.t) =
+struct
+  let ask_local (gh: EQSys.G.t GHT.t) (lvar:EQSys.LVar.t) local =
+    (* build a ctx for using the query system *)
+    let rec ctx =
+      { ask    = (fun (type a) (q: a Queries.t) -> Spec.query ctx q)
+      ; emit   = (fun _ -> failwith "Cannot \"emit\" in witness context.")
+      ; node   = fst lvar
+      ; prev_node = MyCFG.dummy_node
+      ; control_context = (fun () -> Obj.magic (snd lvar)) (* magic is fine because Spec is top-level Control Spec *)
+      ; context = (fun () -> snd lvar)
+      ; edge    = MyCFG.Skip
+      ; local  = local
+      ; global = (fun g -> try EQSys.G.spec (GHT.find gh (EQSys.GVar.spec g)) with Not_found -> Spec.G.bot ()) (* see 29/29 on why fallback is needed *)
+      ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in witness context.")
+      ; split  = (fun d es   -> failwith "Cannot \"split\" in witness context.")
+      ; sideg  = (fun v g    -> failwith "Cannot \"sideg\" in witness context.")
+      }
+    in
+    Spec.query ctx
+
+  let ask_local_node (gh: EQSys.G.t GHT.t) (n: Node.t) local =
+    (* build a ctx for using the query system *)
+    let rec ctx =
+      { ask    = (fun (type a) (q: a Queries.t) -> Spec.query ctx q)
+      ; emit   = (fun _ -> failwith "Cannot \"emit\" in witness context.")
+      ; node   = n
+      ; prev_node = MyCFG.dummy_node
+      ; control_context = (fun () -> ctx_failwith "No context in witness context.")
+      ; context = (fun () -> ctx_failwith "No context in witness context.")
+      ; edge    = MyCFG.Skip
+      ; local  = local
+      ; global = (fun g -> try EQSys.G.spec (GHT.find gh (EQSys.GVar.spec g)) with Not_found -> Spec.G.bot ()) (* TODO: how can be missing? *)
+      ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in witness context.")
+      ; split  = (fun d es   -> failwith "Cannot \"split\" in witness context.")
+      ; sideg  = (fun v g    -> failwith "Cannot \"sideg\" in witness context.")
+      }
+    in
+    Spec.query ctx
+
+  let ask_global (gh: EQSys.G.t GHT.t) =
+    (* copied from Control for WarnGlobal *)
+    (* build a ctx for using the query system *)
+    let rec ctx =
+      { ask    = (fun (type a) (q: a Queries.t) -> Spec.query ctx q)
+      ; emit   = (fun _ -> failwith "Cannot \"emit\" in query context.")
+      ; node   = MyCFG.dummy_node (* TODO maybe ask should take a node (which could be used here) instead of a location *)
+      ; prev_node = MyCFG.dummy_node
+      ; control_context = (fun () -> ctx_failwith "No context in query context.")
+      ; context = (fun () -> ctx_failwith "No context in query context.")
+      ; edge    = MyCFG.Skip
+      ; local  = Spec.startstate GoblintCil.dummyFunDec.svar (* bot and top both silently raise and catch Deadcode in DeadcodeLifter *) (* TODO: is this startstate bad? *)
+      ; global = (fun v -> EQSys.G.spec (try GHT.find gh (EQSys.GVar.spec v) with Not_found -> EQSys.G.bot ())) (* TODO: how can be missing? *)
+      ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
+      ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
+      ; sideg  = (fun v g    -> failwith "Cannot \"split\" in query context.")
+      }
+    in
+    Spec.query ctx
+end

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -74,6 +74,10 @@ sig
   val gh: EQSys.G.t GHT.t
   val lh: Spec.D.t LHT.t
   val nh: Spec.D.t NH.t Lazy.t
+
+  val ask_local: EQSys.LVar.t -> Spec.D.t -> 'a Queries.t -> 'a Queries.result
+  val ask_local_node: Node.t -> Spec.D.t -> 'a Queries.t -> 'a Queries.result
+  val ask_global: 'a Queries.t -> 'a Queries.result
 end
 
 module Make (SpecSysSol: SpecSysSol): SpecSysSol2 with module SpecSys = SpecSysSol.SpecSys =
@@ -89,4 +93,10 @@ struct
         ) lh;
       nh
     )
+
+  module Query = Query (SpecSys)
+
+  let ask_local lvar local q = Query.ask_local gh lvar local q
+  let ask_local_node node local q = Query.ask_local_node gh node local q
+  let ask_global q = Query.ask_global gh q
 end

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -62,3 +62,31 @@ struct
     in
     Spec.query ctx
 end
+
+
+module NH = BatHashtbl.Make (Node)
+
+module type SpecSysSol2 =
+sig
+  module SpecSys: SpecSys
+  open SpecSys
+
+  val gh: EQSys.G.t GHT.t
+  val lh: Spec.D.t LHT.t
+  val nh: Spec.D.t NH.t Lazy.t
+end
+
+module Make (SpecSysSol: SpecSysSol): SpecSysSol2 =
+struct
+  include SpecSysSol
+  open SpecSys
+
+  let nh: Spec.D.t NH.t Lazy.t = lazy (
+      let nh = NH.create 113 in
+      LHT.iter (fun (n, _) d ->
+          let d' = try Spec.D.join (NH.find nh n) d with Not_found -> d in
+          NH.replace nh n d'
+        ) lh;
+      nh
+    )
+end

--- a/src/solvers/generic.ml
+++ b/src/solvers/generic.ml
@@ -2,9 +2,6 @@ open Prelude
 open GobConfig
 open Analyses
 
-let write_cfgs : ((MyCFG.node -> bool) -> unit) ref = ref (fun _ -> ())
-
-
 module LoadRunSolver: GenericEqBoxSolver =
   functor (S: EqConstrSys) (VH: Hashtbl.S with type key = S.v) ->
   struct

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -254,13 +254,11 @@ let print_svcomp_result (s: string): unit =
 let print_task_result (module TaskResult:TaskResult): unit =
   print_svcomp_result (Result.to_string TaskResult.result)
 
-let init (module Cfg: CfgBidir) file =
+let init (module FileCfg: MyCFG.FileCfg) =
   (* TODO: toggle analyses based on specification *)
   let module Task = struct
-    let file = file
+    include FileCfg
     let specification = Svcomp.Specification.of_option ()
-
-    module Cfg = Cfg
   end
   in
   Printf.printf "SV-COMP specification: %s\n" (Svcomp.Specification.to_string Task.specification);

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -6,12 +6,11 @@ open GobConfig
 module type WitnessTaskResult = TaskResult with module Arg.Edge = MyARG.InlineEdge
 
 let write_file filename (module Task:Task) (module TaskResult:WitnessTaskResult): unit =
-  let module Cfg = Task.Cfg in
-  let module Invariant = WitnessUtil.Invariant (struct let file = Task.file end) (Cfg) in
+  let module Invariant = WitnessUtil.Invariant (Task) in
 
   let module TaskResult =
     (val if get_bool "witness.stack" then
-        (module StackTaskResult (Cfg) (TaskResult) : WitnessTaskResult)
+        (module StackTaskResult (Task.Cfg) (TaskResult) : WitnessTaskResult)
       else
         (module TaskResult)
     )
@@ -268,8 +267,7 @@ let init (module Cfg: CfgBidir) file =
   Svcomp.task := Some (module Task)
 
 open Analyses
-module Result (Cfg : CfgBidir)
-              (R: ResultQuery.SpecSysSol2) =
+module Result (R: ResultQuery.SpecSysSol2) =
 struct
   open R
   open SpecSys
@@ -366,7 +364,7 @@ struct
     let module Arg =
     struct
       open MyARG
-      module ArgIntra = UnCilTernaryIntra (UnCilLogicIntra (CfgIntra (Cfg)))
+      module ArgIntra = UnCilTernaryIntra (UnCilLogicIntra (CfgIntra (FileCfg.Cfg)))
       include Intra (ArgIntra) (Arg)
     end
     in

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -282,9 +282,8 @@ struct
       fun nc -> LHT.find_default lh nc (Spec.D.bot ())
     in
     let ask_indices lvar =
-      let local = get lvar in
       let indices = ref [] in
-      ignore ((ask_local lvar local) (Queries.IterVars (fun i ->
+      ignore (ask_local lvar (Queries.IterVars (fun i ->
           indices := i :: !indices
         )));
       !indices
@@ -333,7 +332,7 @@ struct
       let prev = NHT.create 100 in
       let next = NHT.create 100 in
       LHT.iter (fun lvar local ->
-          ignore ((ask_local lvar local) (Queries.IterPrevVars (fun i (prev_node, prev_c_obj, j) edge ->
+          ignore (ask_local lvar ~local (Queries.IterPrevVars (fun i (prev_node, prev_c_obj, j) edge ->
               let lvar' = (fst lvar, snd lvar, i) in
               let prev_lvar: NHT.key = (prev_node, Obj.obj prev_c_obj, j) in
               NHT.modify_def [] lvar' (fun prevs -> (edge, prev_lvar) :: prevs) prev;
@@ -374,7 +373,7 @@ struct
 
     let find_invariant (n, c, i) =
       let context = {Invariant.default_context with path = Some i} in
-      ask_local (n, c) (get (n, c)) (Invariant context)
+      ask_local (n, c) (Invariant context)
     in
 
     match Task.specification with

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -281,7 +281,6 @@ struct
     let get: node * Spec.C.t -> Spec.D.t =
       fun nc -> LHT.find_default lh nc (Spec.D.bot ())
     in
-    let ask_local lvar = Query.ask_local gh lvar in (* eta-expanad for query polymorphism *)
     let ask_indices lvar =
       let local = get lvar in
       let indices = ref [] in

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -258,14 +258,9 @@ let print_task_result (module TaskResult:TaskResult): unit =
 
 open Analyses
 module Result (Cfg : CfgBidir)
-              (Spec : Spec)
-              (EQSys : GlobConstrSys with module LVar = VarF (Spec.C)
-                                  and module GVar = GVarF (Spec.V)
-                                  and module D = Spec.D
-                                  and module G = GVarG (Spec.G) (Spec.C))
-              (LHT : BatHashtbl.S with type key = EQSys.LVar.t)
-              (GHT : BatHashtbl.S with type key = EQSys.GVar.t) =
+              (SpecSys: SpecSys) =
 struct
+  open SpecSys
   open Svcomp
   let init file =
     (* TODO: toggle analyses based on specification *)
@@ -279,7 +274,7 @@ struct
     Printf.printf "SV-COMP specification: %s\n" (Svcomp.Specification.to_string Task.specification);
     Svcomp.task := Some (module Task)
 
-  module Query = ResultQuery.Query (Spec) (EQSys) (GHT)
+  module Query = ResultQuery.Query (SpecSys)
 
   let determine_result lh gh entrystates (module Task:Task): (module WitnessTaskResult) =
     let get: node * Spec.C.t -> Spec.D.t =

--- a/src/witness/witnessUtil.ml
+++ b/src/witness/witnessUtil.ml
@@ -51,13 +51,15 @@ sig
   val file: Cil.file
 end
 
-module Invariant (File: File) (Cfg: MyCFG.CfgBidir) =
+module Invariant (FileCfg: Analyses.FileCfg) =
 struct
+  open FileCfg
+
   let emit_loop_head = GobConfig.get_bool "witness.invariant.loop-head"
   let emit_after_lock = GobConfig.get_bool "witness.invariant.after-lock"
   let emit_other = GobConfig.get_bool "witness.invariant.other"
 
-  let loop_heads = find_loop_heads (module Cfg) File.file
+  let loop_heads = find_loop_heads (module Cfg) file
 
   let is_after_lock to_node =
     List.exists (fun (edges, from_node) ->

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -122,9 +122,9 @@ let yaml_entries_to_file yaml_entries file =
 module Make
     (File: WitnessUtil.File)
     (Cfg: MyCFG.CfgBidir)
-    (SpecSysSol: ResultQuery.SpecSysSol2) =
+    (R: ResultQuery.SpecSysSol2) =
 struct
-  open SpecSysSol
+  open R
   open SpecSys
 
   module NH = BatHashtbl.Make (Node)
@@ -362,8 +362,9 @@ struct
   include Lattice.Chain (ChainParams)
 end
 
-module Validator (SpecSys: SpecSys) =
+module Validator (R: ResultQuery.SpecSysSol2) =
 struct
+  open R
   open SpecSys
 
   module Locator = WitnessUtil.Locator (EQSys.LVar)
@@ -383,7 +384,7 @@ struct
     synthetic = false;
   }
 
-  let validate lh gh (file: Cil.file) =
+  let validate (file: Cil.file) =
     let locator = Locator.create () in
     LHT.iter (fun ((n, _) as lvar) _ ->
         let loc = Node.location n in

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -122,20 +122,15 @@ let yaml_entries_to_file yaml_entries file =
 module Make
     (File: WitnessUtil.File)
     (Cfg: MyCFG.CfgBidir)
-    (Spec : Spec)
-    (EQSys : GlobConstrSys with module LVar = VarF (Spec.C)
-                            and module GVar = GVarF (Spec.V)
-                            and module D = Spec.D
-                            and module G = GVarG (Spec.G) (Spec.C))
-    (LHT : BatHashtbl.S with type key = EQSys.LVar.t)
-    (GHT : BatHashtbl.S with type key = EQSys.GVar.t) =
+    (SpecSys: SpecSys) =
 struct
+  open SpecSys
 
   module NH = BatHashtbl.Make (Node)
   module WitnessInvariant = WitnessUtil.Invariant (File) (Cfg)
   module FMap = BatHashtbl.Make (CilType.Fundec)
   module FCMap = BatHashtbl.Make (Printable.Prod (CilType.Fundec) (Spec.C))
-  module Query = ResultQuery.Query (Spec) (EQSys) (GHT)
+  module Query = ResultQuery.Query (SpecSys)
 
   type con_inv = {node: Node.t; context: Spec.C.t; invariant: Invariant.t; state: Spec.D.t}
 
@@ -377,20 +372,15 @@ struct
   include Lattice.Chain (ChainParams)
 end
 
-module Validator
-    (Spec : Spec)
-    (EQSys : GlobConstrSys with module LVar = VarF (Spec.C)
-                            and module GVar = GVarF (Spec.V)
-                            and module D = Spec.D
-                            and module G = GVarG (Spec.G) (Spec.C))
-    (LHT : BatHashtbl.S with type key = EQSys.LVar.t)
-    (GHT : BatHashtbl.S with type key = EQSys.GVar.t) =
+module Validator (SpecSys: SpecSys) =
 struct
+  open SpecSys
+
   module Locator = WitnessUtil.Locator (EQSys.LVar)
   module LvarS = Locator.ES
   module InvariantParser = WitnessUtil.InvariantParser
   module VR = ValidationResult
-  module Query = ResultQuery.Query (Spec) (EQSys) (GHT)
+  module Query = ResultQuery.Query (SpecSys)
 
   let loc_of_location (location: YamlWitnessType.Location.t): Cil.location = {
     file = location.file_name;

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -118,72 +118,6 @@ let yaml_entries_to_file yaml_entries file =
   let text = Yaml.to_string_exn ~len:(List.length yaml_entries * 2048 + 2048) yaml in
   Batteries.output_file ~filename:(Fpath.to_string file) ~text
 
-module Query
-    (Spec : Spec)
-    (EQSys : GlobConstrSys with module LVar = VarF (Spec.C)
-                            and module GVar = GVarF (Spec.V)
-                            and module D = Spec.D
-                            and module G = GVarG (Spec.G) (Spec.C))
-    (GHT : BatHashtbl.S with type key = EQSys.GVar.t) =
-struct
-  let ask_local (gh: EQSys.G.t GHT.t) (lvar:EQSys.LVar.t) local =
-    (* build a ctx for using the query system *)
-    let rec ctx =
-      { ask    = (fun (type a) (q: a Queries.t) -> Spec.query ctx q)
-      ; emit   = (fun _ -> failwith "Cannot \"emit\" in witness context.")
-      ; node   = fst lvar
-      ; prev_node = MyCFG.dummy_node
-      ; control_context = (fun () -> Obj.magic (snd lvar)) (* magic is fine because Spec is top-level Control Spec *)
-      ; context = (fun () -> snd lvar)
-      ; edge    = MyCFG.Skip
-      ; local  = local
-      ; global = (fun g -> try EQSys.G.spec (GHT.find gh (EQSys.GVar.spec g)) with Not_found -> Spec.G.bot ()) (* TODO: how can be missing? *)
-      ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in witness context.")
-      ; split  = (fun d es   -> failwith "Cannot \"split\" in witness context.")
-      ; sideg  = (fun v g    -> failwith "Cannot \"sideg\" in witness context.")
-      }
-    in
-    Spec.query ctx
-
-  let ask_local_node (gh: EQSys.G.t GHT.t) (n: Node.t) local =
-    (* build a ctx for using the query system *)
-    let rec ctx =
-      { ask    = (fun (type a) (q: a Queries.t) -> Spec.query ctx q)
-      ; emit   = (fun _ -> failwith "Cannot \"emit\" in witness context.")
-      ; node   = n
-      ; prev_node = MyCFG.dummy_node
-      ; control_context = (fun () -> ctx_failwith "No context in witness context.")
-      ; context = (fun () -> ctx_failwith "No context in witness context.")
-      ; edge    = MyCFG.Skip
-      ; local  = local
-      ; global = (fun g -> try EQSys.G.spec (GHT.find gh (EQSys.GVar.spec g)) with Not_found -> Spec.G.bot ()) (* TODO: how can be missing? *)
-      ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in witness context.")
-      ; split  = (fun d es   -> failwith "Cannot \"split\" in witness context.")
-      ; sideg  = (fun v g    -> failwith "Cannot \"sideg\" in witness context.")
-      }
-    in
-    Spec.query ctx
-
-  let ask_global (gh: EQSys.G.t GHT.t) =
-    (* copied from Control for WarnGlobal *)
-    (* build a ctx for using the query system *)
-    let rec ctx =
-      { ask    = (fun (type a) (q: a Queries.t) -> Spec.query ctx q)
-      ; emit   = (fun _ -> failwith "Cannot \"emit\" in query context.")
-      ; node   = MyCFG.dummy_node (* TODO maybe ask should take a node (which could be used here) instead of a location *)
-      ; prev_node = MyCFG.dummy_node
-      ; control_context = (fun () -> ctx_failwith "No context in query context.")
-      ; context = (fun () -> ctx_failwith "No context in query context.")
-      ; edge    = MyCFG.Skip
-      ; local  = Spec.startstate dummyFunDec.svar (* bot and top both silently raise and catch Deadcode in DeadcodeLifter *) (* TODO: is this startstate bad? *)
-      ; global = (fun v -> EQSys.G.spec (try GHT.find gh (EQSys.GVar.spec v) with Not_found -> EQSys.G.bot ())) (* TODO: how can be missing? *)
-      ; spawn  = (fun v d    -> failwith "Cannot \"spawn\" in query context.")
-      ; split  = (fun d es   -> failwith "Cannot \"split\" in query context.")
-      ; sideg  = (fun v g    -> failwith "Cannot \"split\" in query context.")
-      }
-    in
-    Spec.query ctx
-end
 
 module Make
     (File: WitnessUtil.File)
@@ -201,7 +135,7 @@ struct
   module WitnessInvariant = WitnessUtil.Invariant (File) (Cfg)
   module FMap = BatHashtbl.Make (CilType.Fundec)
   module FCMap = BatHashtbl.Make (Printable.Prod (CilType.Fundec) (Spec.C))
-  module Query = Query (Spec) (EQSys) (GHT)
+  module Query = ResultQuery.Query (Spec) (EQSys) (GHT)
 
   type con_inv = {node: Node.t; context: Spec.C.t; invariant: Invariant.t; state: Spec.D.t}
 
@@ -456,7 +390,7 @@ struct
   module LvarS = Locator.ES
   module InvariantParser = WitnessUtil.InvariantParser
   module VR = ValidationResult
-  module Query = Query (Spec) (EQSys) (GHT)
+  module Query = ResultQuery.Query (Spec) (EQSys) (GHT)
 
   let loc_of_location (location: YamlWitnessType.Location.t): Cil.location = {
     file = location.file_name;


### PR DESCRIPTION
### Changes
1. Deduplicate `ctx` construction for querying the solution. This was copy-pasted in `Control`, `Witness` and `YamlWitness`.
2. Extract `SpecSys` and `SpecSysSol` wrapper modules for easier passing around of `Spec`, `EQSys`, `LHT` and `GHT`. Previously passing the solution to somewhere from `Control` required at least those four functor arguments with complex argument module constraints. The solution also holds the actual solution (`lh` and `gh`) instead of passing around two arguments.
3. Add joined contexts solution (a node hashtable) to solution querying lazily. This allows the joined contexts solution to be only computed once, instead of doing the same thing multiple times in various places.

This will be useful in #914 for also getting access to per-node queries.

### TODO
- [x] Fix Gobview.