### PR TITLE
Base.invariant: Refine congruence information on `x % 2 != c`

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1794,7 +1794,18 @@ struct
             ID.meet a'' t
           | _, _ -> a''
         in
-        meet_bin a''' b'
+        let a,b = meet_bin a''' b' in
+        (* Special handling for case a % 2 != c *)
+        let a = if PrecisionUtil.(is_congruence_active (int_precision_from_node_or_config ())) then
+            let two = BI.of_int 2 in
+            match ID.to_int b, ID.to_excl_list c with
+            | Some b, Some ([v], _) when BI.equal b two ->
+              let k = if BI.equal (BI.abs (BI.rem v two)) (BI.zero) then BI.one else BI.zero in
+              ID.meet (ID.of_congruence ikind (k, b)) a
+            | _, _ -> a
+          else a
+        in
+        a, b
       | Eq | Ne as op ->
         let both x = x, x in
         let m = ID.meet a b in

--- a/src/util/precisionUtil.ml
+++ b/src/util/precisionUtil.ml
@@ -22,6 +22,8 @@ let int_precision_from_node (): int_precision =
   | Some n -> int_precision_from_fundec (Node.find_fundec n)
   | _ -> max_int_precision (* In case a Node is None we have to handle Globals, i.e. we activate all IntDomains (TODO: verify this assumption) *)
 
+let is_congruence_active (_, _, _, c: int_precision): bool = c
+
 let float_precision_from_node (): float_precision =
   match !MyCFG.current_node with
   | Some n -> float_precision_from_fundec (Node.find_fundec n)

--- a/tests/regression/37-congruence/12-invariant-ineq.c
+++ b/tests/regression/37-congruence/12-invariant-ineq.c
@@ -1,0 +1,65 @@
+//PARAM: --enable ana.int.congruence --enable ana.int.interval --enable annotation.int.enabled
+#include <goblint.h>
+
+#define LIMIT 1000000
+
+int foo() __attribute__ ((goblint_precision("def_exc","interval", "no-congruence")));
+int foo(){
+	unsigned int top;
+	if(top > LIMIT){
+		top = LIMIT;
+	}
+
+	if(top % 2 == 1){
+		__goblint_check(top % 2 == 1); //UNKNOWN
+	}
+
+	if(top % 2 != 0){
+		__goblint_check(top % 2 != 0); //UNKNOWN
+	}
+}
+
+int main(){
+	foo();
+	unsigned int top;
+
+	if(top > LIMIT){
+		top = LIMIT;
+	}
+
+	if(top % 2 == 1){
+		__goblint_check(top % 2 == 1);
+	}
+
+	if(top % 2 != 0){
+		__goblint_check(top % 2 != 0);
+	}
+
+	if(top % 2 != 1){
+		__goblint_check(top % 2 != 1);
+	}
+
+	if(top % 3 != 0){
+		__goblint_check(top % 3 != 0); //TODO
+	}
+
+	unsigned int r;
+	if(top > 0 && top < 10) {
+		r = 3 * top;
+		r = r;
+	} else {
+		r = 3;
+		r = r;
+	}
+
+	if(r % 3 != 0) {
+		// Unreachable
+		__goblint_check(0); //NOWARN
+	}
+
+	if(r % 3 != 1) { } else {
+		// Unreachable
+		__goblint_check(0); //NOWARN
+	}
+	return 0;
+}

--- a/tests/regression/37-congruence/12-invariant-ineq.c
+++ b/tests/regression/37-congruence/12-invariant-ineq.c
@@ -46,10 +46,8 @@ int main(){
 	unsigned int r;
 	if(top > 0 && top < 10) {
 		r = 3 * top;
-		r = r;
 	} else {
 		r = 3;
-		r = r;
 	}
 
 	if(r % 3 != 0) {


### PR DESCRIPTION
This PR adds a special check in `Base.invariant` for the case that the condition is of the form `x % 2 != c`, i.e. a remainder computation with divisor `2` where one result value can be excluded. In this case of a inequality, the information obtained is now expressed in the congruence domain.

We should decide whether we want to merge this, since this yields some benefit in precision, but only in very particular cases. The motivating example like `sv-benchmarks/c/array-examples/sanfoundry_24-1.i` is not resolved by this, since the expression that is asserted over there is an access to an array. 

Closes #892