### PR TITLE
Fix address set meet

### DIFF
--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -388,6 +388,11 @@ struct
   module Offset = struct
     type t = NoOffset | Field of CilType.Fieldinfo.t * t | Index of unit * t  [@@deriving eq, ord, hash]
 
+    let rec show = function
+      | NoOffset -> ""
+      | Field (f, o) -> "." ^ f.fname ^ show o
+      | Index ((), o) -> "[?]" ^ show o ^ ")"
+
     let is_first_field x = match x.fcomp.cfields with
       | [] -> false
       | f :: _ -> CilType.Fieldinfo.equal f x
@@ -442,15 +447,14 @@ struct
     type elt = t
     type t = r [@@deriving eq, ord, hash]
 
-    let show x = failwith ""
+    let show = function
+      | MyAddr (v, o) -> v.vname ^ (Offset.show o)
+      | MyNullPtr -> "NULL"
+      | MyUnknownPtr -> "?"
+      | MyStrPtr (Some s) -> s
+      | MyStrPtr None -> "(unknown string)"
 
-    let pretty _= failwith ""
-
-    let printXml _ = failwith ""
-
-    let to_yojson _ = failwith ""
-
-    let arbitrary _ = failwith ""
+    include Printable.SimpleShow (struct type nonrec t = t let show = show end)
 
     let rec of_elt_offset: Offs.t -> Offset.t =
       function
@@ -464,6 +468,7 @@ struct
       | StrPtr a -> MyStrPtr a
       | NullPtr -> MyNullPtr
 
+    let arbitrary _ = failwith "arbitrary not implemented for Lval.R"
   end
 end
 

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -442,7 +442,7 @@ struct
     | ReprAddr of CilType.Varinfo.t * ReprOffset.t (** Pointer to offset of a variable. *)
     | ReprNullPtr (** NULL pointer. *)
     | ReprUnknownPtr (** Unknown pointer. Could point to globals, heap and escaped variables. *)
-    | ReprMyStrPtr of string option [@@deriving eq, ord, hash]
+    | ReprStrPtr of string option [@@deriving eq, ord, hash]
 
   (** Representatives for lvalue sublattices as defined by {!NormalLat}. *)
   module R: DisjointDomain.Representative with type elt = t =
@@ -455,8 +455,8 @@ struct
       | ReprAddr (v, o) -> v.vname ^ (ReprOffset.show o)
       | ReprNullPtr -> "NULL"
       | ReprUnknownPtr -> "?"
-      | ReprMyStrPtr (Some s) -> "\"" ^ s ^ "\""
-      | ReprMyStrPtr None -> "(unknown string)"
+      | ReprStrPtr (Some s) -> "\"" ^ s ^ "\""
+      | ReprStrPtr None -> "(unknown string)"
 
     include Printable.SimpleShow (struct type nonrec t = t let show = show end)
 
@@ -467,9 +467,9 @@ struct
       | `Index (_,o) -> Index ((), of_elt_offset o) (* all indices to same bucket *)
     let of_elt = function
       | Addr (v, o) -> ReprAddr (v, of_elt_offset o) (* addrs grouped by var and part of offset *)
-      | StrPtr _ when GobConfig.get_bool "ana.base.limit-string-addresses" -> ReprMyStrPtr None (* all strings together if limited *)
+      | StrPtr _ when GobConfig.get_bool "ana.base.limit-string-addresses" -> ReprStrPtr None (* all strings together if limited *)
       | UnknownPtr -> ReprUnknownPtr
-      | StrPtr a -> ReprMyStrPtr a
+      | StrPtr a -> ReprStrPtr a
       | NullPtr -> ReprNullPtr
 
     let arbitrary _ = failwith "arbitrary not implemented for Lval.R"

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -451,7 +451,7 @@ struct
       | MyAddr (v, o) -> v.vname ^ (Offset.show o)
       | MyNullPtr -> "NULL"
       | MyUnknownPtr -> "?"
-      | MyStrPtr (Some s) -> s
+      | MyStrPtr (Some s) -> "\"" ^ s ^ "\""
       | MyStrPtr None -> "(unknown string)"
 
     include Printable.SimpleShow (struct type nonrec t = t let show = show end)

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -429,7 +429,7 @@ struct
       | Field _, Index _ -> -1
       | Index _, Field _ ->  1
   end
-  type elttype =
+  type r =
     | MyAddr of CilType.Varinfo.t * Offset.t (** Pointer to offset of a variable. *)
     | MyNullPtr (** NULL pointer. *)
     | MyUnknownPtr (** Unknown pointer. Could point to globals, heap and escaped variables. *)
@@ -440,9 +440,9 @@ struct
   struct
     include Normal (Idx)
     type elt = t
-    type t = elttype [@@deriving eq, ord, hash]
+    type t = r [@@deriving eq, ord, hash]
 
-    let show x = ""
+    let show x = failwith ""
 
     let pretty _= failwith ""
 

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -386,6 +386,10 @@ module NormalLatRepr (Idx: IntDomain.Z) =
 struct
   include NormalLat (Idx)
   module Offset = struct
+
+    (* Offset type for representative without abstract values for index offsets.
+       Reason: The offset in the representative (used for buckets) should not depend on the integer domains,
+       since different integer domains may be active at different program points. *)
     type t = NoOffset | Field of CilType.Fieldinfo.t * t | Index of unit * t  [@@deriving eq, ord, hash]
 
     let rec show = function

--- a/tests/regression/29-svcomp/31-dd-address-meet.c
+++ b/tests/regression/29-svcomp/31-dd-address-meet.c
@@ -1,5 +1,6 @@
 // PARAM: --enable annotation.int.enabled
 #include <stdlib.h>
+#include <goblint.h>
 struct slotvec {
    size_t size ;
    char *val ;
@@ -9,7 +10,7 @@ static struct slotvec slotvec0 = {sizeof(slot0), slot0};
 
 static void install_signal_handlers(void)
 {
-  { if(!(slotvec0.val == & slot0[0LL])) { reach_error(); abort(); } };
+  { if(!(slotvec0.val == & slot0[0LL])) {  reach_error(); abort(); } };
 }
 
 int main(int argc , char **argv )
@@ -17,5 +18,8 @@ int main(int argc , char **argv )
   // Goblint used to consider both branches in this condition to be dead, because the meet on addresses with different active int domains was broken
   { if(!(slotvec0.val == & slot0[0LL])) { reach_error(); abort(); } };
   install_signal_handlers();
+
+  // Should be reachable
+  __goblint_check(1);
   return 0;
 }

--- a/tests/regression/29-svcomp/31-dd-address-meet.c
+++ b/tests/regression/29-svcomp/31-dd-address-meet.c
@@ -1,4 +1,5 @@
 // PARAM: --enable annotation.int.enabled
+// This option enables ALL int domains for globals
 #include <stdlib.h>
 #include <goblint.h>
 struct slotvec {

--- a/tests/regression/29-svcomp/31-dd-address-meet.c
+++ b/tests/regression/29-svcomp/31-dd-address-meet.c
@@ -1,0 +1,21 @@
+// PARAM: --enable annotation.int.enabled
+#include <stdlib.h>
+struct slotvec {
+   size_t size ;
+   char *val ;
+};
+static char slot0[256] ;
+static struct slotvec slotvec0 = {sizeof(slot0), slot0};
+
+static void install_signal_handlers(void)
+{
+  { if(!(slotvec0.val == & slot0[0LL])) { reach_error(); abort(); } };
+}
+
+int main(int argc , char **argv )
+{
+  // Goblint used to consider both branches in this condition to be dead, because the meet on addresses with different active int domains was broken
+  { if(!(slotvec0.val == & slot0[0LL])) { reach_error(); abort(); } };
+  install_signal_handlers();
+  return 0;
+}


### PR DESCRIPTION
The meet of addresses is currently unsound when different integer domains may be activated within an analysis run. This is demonstrated by this [example](https://github.com/goblint/analyzer/blob/d35bc54f50531b0f4c98951df55bbcf04b7be04c/tests/regression/29-svcomp/31-dd-address-meet.c). Here, the abstract representation of the address pointed to by `slotvec0.val` contains an offset where all int domains are active, as all int domains are activated for global variables with the `annotation.int.enabled` setting. At the point of the comparison however, only `def_exc` is active. Therefore the abstract addresses are kept in different buckets and the meet that is performed yields `bottom`.

This issue also appears on sv-comp when the congruence auto-tuning is enabled, and for *some* functions the congruence domain is activated, and for others not. 


This PR fixes this issue by not keeping the `index` information in the representative that is used to split address sets.

(Closes #925) 


