### PR TITLE
Make Address Representatives Use Unit-domain for Index-Offsets

### DIFF
--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -408,7 +408,7 @@ struct
        since different integer domains may be active at different program points. *)
     include Normal (UnitIdxDomain)
 
-    let rec of_elt_offset (*: (fieldinfo, Idx.t) offs -> (fieldinfo, UnitIdxDomain.t) offs *) =
+    let rec of_elt_offset: (fieldinfo, Idx.t) offs -> (fieldinfo, UnitIdxDomain.t) offs =
       function
       | `NoOffset -> `NoOffset
       | `Field (f,o) -> `Field (f, of_elt_offset o)
@@ -417,7 +417,7 @@ struct
     let of_elt (x: elt): t = match x with
       | Addr (v, o) -> Addr (v, of_elt_offset o) (* addrs grouped by var and part of offset *)
       | StrPtr _ when GobConfig.get_bool "ana.base.limit-string-addresses" -> StrPtr None (* all strings together if limited *)
-      | StrPtr x -> StrPtr x
+      | StrPtr x -> StrPtr x (* everything else is kept separate, including strings if not limited *)
       | NullPtr -> NullPtr
       | UnknownPtr -> UnknownPtr
   end

--- a/tests/regression/29-svcomp/31-dd-address-meet.c
+++ b/tests/regression/29-svcomp/31-dd-address-meet.c
@@ -1,5 +1,6 @@
 // PARAM: --enable annotation.int.enabled
 #include <stdlib.h>
+#include <goblint.h>
 struct slotvec {
    size_t size ;
    char *val ;
@@ -9,7 +10,7 @@ static struct slotvec slotvec0 = {sizeof(slot0), slot0};
 
 static void install_signal_handlers(void)
 {
-  { if(!(slotvec0.val == & slot0[0LL])) { reach_error(); abort(); } };
+  { if(!(slotvec0.val == & slot0[0LL])) {  reach_error(); abort(); } };
 }
 
 int main(int argc , char **argv )
@@ -17,5 +18,8 @@ int main(int argc , char **argv )
   // Goblint used to consider both branches in this condition to be dead, because the meet on addresses with different active int domains was broken
   { if(!(slotvec0.val == & slot0[0LL])) { reach_error(); abort(); } };
   install_signal_handlers();
+
+  // Should be reachable
+  __goblint_check(1);
   return 0;
 }


### PR DESCRIPTION
This PR makes the `NormalLatRepr` use the `Unit`-domain for the index-offset of representatives. This way, the active integer domains do not have an impact on the representative that addresses are grouped with.

Fixes #925. This is the more elegant alternative to #924. I created it separately here because we are already benchmarking #924 and might want to merge #924 first to make it part of the Goblint version submitted to sv-comp.

When we merge #924 first, I will adapt this PR to be able to be merged.