### PR TITLE
Add custom location marks to exception backtraces

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -7,7 +7,7 @@
   (name goblint_lib)
   (public_name goblint.lib)
   (modules :standard \ goblint mainspec privPrecCompare apronPrecCompare messagesCompare)
-  (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc cpu arg-complete fpath yaml yaml.unix uuidm goblint_timing catapult
+  (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc cpu arg-complete fpath yaml yaml.unix uuidm goblint_timing catapult goblint_backtrace
     ; Conditionally compile based on whether apron optional dependency is installed or not.
     ; Alternative dependencies seem like the only way to optionally depend on optional dependencies.
     ; See: https://dune.readthedocs.io/en/stable/concepts.html#alternative-dependencies.

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -687,11 +687,11 @@ struct
       | Skip           -> tf_skip var edge prev_node
     end getl sidel getg sideg d
 
-  type Goblint_backtrace.mark += Location of location
+  type Goblint_backtrace.mark += TfLocation of location
 
   let () = Goblint_backtrace.register_mark_printer (function
-      | Location loc ->
-        Some (CilType.Location.show loc)
+      | TfLocation loc ->
+        Some ("transfer function at " ^ CilType.Location.show loc)
       | _ -> None (* for other marks *)
     )
 
@@ -700,7 +700,7 @@ struct
     let old_loc2 = !Tracing.next_loc in
     Tracing.current_loc := f;
     Tracing.next_loc := t;
-    Goblint_backtrace.protect ~mark:(fun () -> Location f) ~finally:(fun () ->
+    Goblint_backtrace.protect ~mark:(fun () -> TfLocation f) ~finally:(fun () ->
         Tracing.current_loc := old_loc;
         Tracing.next_loc := old_loc2
       ) (fun () ->

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -687,12 +687,20 @@ struct
       | Skip           -> tf_skip var edge prev_node
     end getl sidel getg sideg d
 
+  type Goblint_backtrace.mark += Location of location
+
+  let () = Goblint_backtrace.register_mark_printer (function
+      | Location loc ->
+        Some (CilType.Location.show loc)
+      | _ -> None (* for other marks *)
+    )
+
   let tf var getl sidel getg sideg prev_node (_,edge) d (f,t) =
     let old_loc  = !Tracing.current_loc in
     let old_loc2 = !Tracing.next_loc in
     Tracing.current_loc := f;
     Tracing.next_loc := t;
-    Fun.protect ~finally:(fun () ->
+    Goblint_backtrace.protect ~mark:(fun () -> Location f) ~finally:(fun () ->
         Tracing.current_loc := old_loc;
         Tracing.next_loc := old_loc2
       ) (fun () ->

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -299,7 +299,9 @@ struct
       in
       let with_externs = do_extern_inits ctx file in
       (*if (get_bool "dbg.verbose") then Printf.printf "Number of init. edges : %d\nWorking:" (List.length edges);    *)
+      let old_loc = !Tracing.current_loc in
       let result : Spec.D.t = List.fold_left transfer_func with_externs edges in
+      Tracing.current_loc := old_loc;
       if M.tracing then M.trace "global_inits" "startstate: %a\n" Spec.D.pretty result;
       result, !funs
     in

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -461,8 +461,7 @@ let do_analyze change_info merged_AST =
       with e ->
         let backtrace = Printexc.get_raw_backtrace () in (* capture backtrace immediately, otherwise the following loses it (internal exception usage without raise_notrace?) *)
         Goblintutil.should_warn := true; (* such that the `about to crash` message gets printed *)
-        let loc = !Tracing.current_loc in
-        Messages.error ~category:Analyzer ~loc:(Messages.Location.CilLocation loc) "About to crash!";
+        Messages.error ~category:Analyzer "About to crash!";
         (* trigger Generic.SolverStats...print_stats *)
         Goblintutil.(self_signal (signal_of_string (get_string "dbg.solver-signal")));
         do_stats ();

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -461,7 +461,11 @@ let do_analyze change_info merged_AST =
       with e ->
         let backtrace = Printexc.get_raw_backtrace () in (* capture backtrace immediately, otherwise the following loses it (internal exception usage without raise_notrace?) *)
         Goblintutil.should_warn := true; (* such that the `about to crash` message gets printed *)
-        Messages.error ~category:Analyzer "About to crash!";
+        let pretty_mark () = match Goblint_backtrace.find_marks e with
+          | m :: _ -> Pretty.dprintf " at mark %s" (Goblint_backtrace.mark_to_string m)
+          | [] -> Pretty.nil
+        in
+        Messages.error ~category:Analyzer "About to crash%t!" pretty_mark;
         (* trigger Generic.SolverStats...print_stats *)
         Goblintutil.(self_signal (signal_of_string (get_string "dbg.solver-signal")));
         do_stats ();

--- a/src/util/backtrace/dune
+++ b/src/util/backtrace/dune
@@ -1,0 +1,5 @@
+(include_subdirs no)
+
+(library
+ (name goblint_backtrace)
+ (public_name goblint.backtrace))

--- a/src/util/backtrace/goblint_backtrace.ml
+++ b/src/util/backtrace/goblint_backtrace.ml
@@ -1,0 +1,75 @@
+type mark = ..
+
+exception Marked of mark * exn
+
+let mark m e =
+  if Printexc.backtrace_status () then
+    Marked (m, e)
+  else
+    e
+
+(* Copied & modified from Fun. *)
+let protect ~mark:(m: unit -> mark) ~(finally: unit -> unit) work =
+  let finally_no_exn () =
+    try
+      finally ()
+    with e ->
+      let bt = Printexc.get_raw_backtrace () in
+      Printexc.raise_with_backtrace (mark (m ()) (Fun.Finally_raised e)) bt
+  in
+  match work () with
+  | result ->
+    finally_no_exn ();
+    result
+  | exception work_exn ->
+    let work_bt = Printexc.get_raw_backtrace () in
+    finally_no_exn ();
+    Printexc.raise_with_backtrace (mark (m ()) work_exn) work_bt
+
+
+let rec unmark = function
+  | Marked (_, e) -> unmark e
+  | e -> e
+
+let () = Printexc.register_printer (function
+    | Marked _ as e ->
+      Some (Printexc.to_string (unmark e))
+    | _ -> None (* for other exceptions *)
+  )
+
+let mark_printers: (mark -> string option) list ref = ref []
+
+let register_mark_printer f =
+  mark_printers := f :: !mark_printers
+
+let apply_mark_printers m =
+  List.find_map (fun f ->
+      match f m with
+      | Some s -> Some s
+      | None
+      | exception _ -> None
+    ) !mark_printers
+
+let mark_to_string_default m =
+  Obj.Extension_constructor.(name (of_val m))
+
+let mark_to_string m =
+  match apply_mark_printers m with
+  | Some s -> s
+  | None -> mark_to_string_default m
+
+let rec print_marktrace oc e =
+  match e with
+  | Marked (m, e) ->
+    print_marktrace oc e;
+    Printf.fprintf oc "Marked with %s\n" (mark_to_string m)
+  | e -> ()
+
+let () =
+  Printexc.set_uncaught_exception_handler (fun e bt ->
+      (* Copied & modified from Printexc.default_uncaught_exception_handler. *)
+      Printf.eprintf "Fatal error: exception %s\n" (Printexc.to_string e);
+      print_marktrace stderr e;
+      Printexc.print_raw_backtrace stderr bt;
+      flush stderr
+    )

--- a/src/util/backtrace/goblint_backtrace.ml
+++ b/src/util/backtrace/goblint_backtrace.ml
@@ -1,21 +1,31 @@
 type mark = ..
 
-exception Marked of mark * exn
+module Exn =
+struct
+  type t = exn
+  let equal = (==)
+  let hash = Hashtbl.hash
+end
 
-let mark m e =
+module EWH = Ephemeron.K1.Make (Exn)
+
+let marks: mark EWH.t = EWH.create 10
+
+let add_mark e m =
   if Printexc.backtrace_status () then
-    Marked (m, e)
-  else
-    e
+    EWH.add marks e m
+
 
 (* Copied & modified from Fun. *)
-let protect ~mark:(m: unit -> mark) ~(finally: unit -> unit) work =
+let protect ~(mark: unit -> mark) ~(finally: unit -> unit) work =
   let finally_no_exn () =
     try
       finally ()
     with e ->
       let bt = Printexc.get_raw_backtrace () in
-      Printexc.raise_with_backtrace (mark (m ()) (Fun.Finally_raised e)) bt
+      let finally_exn = Fun.Finally_raised e in
+      add_mark finally_exn (mark ());
+      Printexc.raise_with_backtrace finally_exn bt
   in
   match work () with
   | result ->
@@ -24,18 +34,9 @@ let protect ~mark:(m: unit -> mark) ~(finally: unit -> unit) work =
   | exception work_exn ->
     let work_bt = Printexc.get_raw_backtrace () in
     finally_no_exn ();
-    Printexc.raise_with_backtrace (mark (m ()) work_exn) work_bt
+    add_mark work_exn (mark ());
+    Printexc.raise_with_backtrace work_exn work_bt
 
-
-let rec unmark = function
-  | Marked (_, e) -> unmark e
-  | e -> e
-
-let () = Printexc.register_printer (function
-    | Marked _ as e ->
-      Some (Printexc.to_string (unmark e))
-    | _ -> None (* for other exceptions *)
-  )
 
 let mark_printers: (mark -> string option) list ref = ref []
 
@@ -58,12 +59,11 @@ let mark_to_string m =
   | Some s -> s
   | None -> mark_to_string_default m
 
-let rec print_marktrace oc e =
-  match e with
-  | Marked (m, e) ->
-    print_marktrace oc e;
-    Printf.fprintf oc "Marked with %s\n" (mark_to_string m)
-  | e -> ()
+let print_marktrace oc e =
+  let ms = List.rev (EWH.find_all marks e) in
+  List.iter (fun m ->
+      Printf.fprintf oc "Marked with %s\n" (mark_to_string m)
+    ) ms
 
 let () =
   Printexc.set_uncaught_exception_handler (fun e bt ->

--- a/src/util/backtrace/goblint_backtrace.ml
+++ b/src/util/backtrace/goblint_backtrace.ml
@@ -12,8 +12,7 @@ module EWH = Ephemeron.K1.Make (Exn)
 let marks: mark EWH.t = EWH.create 10
 
 let add_mark e m =
-  if Printexc.backtrace_status () then
-    EWH.add marks e m
+  EWH.add marks e m
 
 
 (* Copied & modified from Fun. *)
@@ -59,8 +58,11 @@ let mark_to_string m =
   | Some s -> s
   | None -> mark_to_string_default m
 
+let find_marks e =
+  List.rev (EWH.find_all marks e)
+
 let print_marktrace oc e =
-  let ms = List.rev (EWH.find_all marks e) in
+  let ms = find_marks e in
   List.iter (fun m ->
       Printf.fprintf oc "Marked with %s\n" (mark_to_string m)
     ) ms
@@ -69,7 +71,8 @@ let () =
   Printexc.set_uncaught_exception_handler (fun e bt ->
       (* Copied & modified from Printexc.default_uncaught_exception_handler. *)
       Printf.eprintf "Fatal error: exception %s\n" (Printexc.to_string e);
-      print_marktrace stderr e;
+      if Printexc.backtrace_status () then
+        print_marktrace stderr e;
       Printexc.print_raw_backtrace stderr bt;
       flush stderr
     )

--- a/src/util/backtrace/goblint_backtrace.mli
+++ b/src/util/backtrace/goblint_backtrace.mli
@@ -28,3 +28,6 @@ val print_marktrace: out_channel -> exn -> unit
 (** Print trace of marks of an exception.
 
     Used by default for uncaught exceptions. *)
+
+val find_marks: exn -> mark list
+(** Find all marks of an exception. *)

--- a/src/util/backtrace/goblint_backtrace.mli
+++ b/src/util/backtrace/goblint_backtrace.mli
@@ -1,0 +1,30 @@
+(** Backtraces with custom marks. *)
+
+(** {2 Mark definition} *)
+
+type mark = ..
+(** Extensible type of marks. *)
+
+val register_mark_printer: (mark -> string option) -> unit
+(** Register printing function for custom mark.
+    The function should return [None] for other marks. *)
+
+val mark_to_string: mark -> string
+(** Convert mark to string using registered printers, or {!mark_to_string_default} if unhandled. *)
+
+val mark_to_string_default: mark -> string
+(** Convert mark to default string. *)
+
+
+(** {2 Mark usage} *)
+
+val add_mark: exn -> mark -> unit
+(** Add mark to exception. *)
+
+val protect: mark:(unit -> mark) -> finally:(unit -> unit) -> (unit -> 'a) -> 'a
+(** {!Fun.protect} with additional [~mark] addition to all exceptions. *)
+
+val print_marktrace: out_channel -> exn -> unit
+(** Print trace of marks of an exception.
+
+    Used by default for uncaught exceptions. *)


### PR DESCRIPTION
## Problem
In 023b7c19d1973f9ffb822f19787af6a3c760136d, `current_loc` was explicitly added back to the "About to crash" error. Actually `Messages.error` already uses `current_node` unless specified otherwise. That's why in #533 I removed the explicit location specification.

But that error didn't have a location (from a node) because there is no current node at that point. _Some_ `current_loc` is always present, so it seems like that works on the "About to crash" error, but it actually doesn't.

Even when an exception is raised in a transfer function, using `current_loc` for "About to crash" just gives it the last global variable definition location! That is because it is set by the simulated global initializer transfer functions: https://github.com/goblint/analyzer/blob/4828e7b40860c84ce5b9fe072cf484202805dff4/src/framework/control.ml#L276-L280
But unlike actual transfer functions, this forgets to unset the current location after calling `Spec.assign` and thus the last global initializer location simply leaks to the rest.

Therefore, `current_loc` for "About to crash" is plain incorrect and even misleading.

## Solution
This PR proposes a solution to the above problem by allowing raised exceptions to be _marked_ with some custom data.

Arbitrary custom data can be added and a printer for it registered (just like exceptions themselves). An exception handler can then add such custom mark to the exception as it is reraised.
In this particular case, this is done in `FromSpec`, where we manage `current_loc` during actual transfer function evaluation.

Uncaught exception printing is extended to also print all the marks added to the exception. The marks actually stack, so you don't just get the innermost `current_loc` for where the exception occurred, but the entire stack of `current_loc`s, which is analogous to the entire stack of OCaml transfer function calls.
In case `-v` is not used, the first mark is also added to the "About to crash" error.

