### PR TITLE
Marshal `array_map` in `Base`, only collect entries when needed

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -98,25 +98,31 @@ struct
 
   type marshal = attributes VarMap.t VarH.t
 
+  let array_domain_annotation_enabled = lazy (GobConfig.get_bool "annotation.goblint_array_domain")
+
   let add_to_array_map fundec arguments =
-    let rec pointedArrayMap = function
-      | [] -> VarMap.empty
-      | (info,value)::xs ->
-        match value with
-        | `Address t when hasAttribute "goblint_array_domain" info.vattr ->
-          let possibleVars = PreValueDomain.AD.to_var_may t in
-          List.fold_left (fun map arr -> VarMap.add arr (info.vattr) map) (pointedArrayMap xs) @@ List.filter (fun info -> isArrayType info.vtype) possibleVars
-        | _ -> pointedArrayMap xs
-    in
-    match VarH.find_option !array_map fundec.svar with
-    | Some _ -> () (*We already have something -> do not change it*)
-    | None -> VarH.add !array_map fundec.svar (pointedArrayMap arguments)
+    if Lazy.force array_domain_annotation_enabled then
+      let rec pointedArrayMap = function
+        | [] -> VarMap.empty
+        | (info,value)::xs ->
+          match value with
+          | `Address t when hasAttribute "goblint_array_domain" info.vattr ->
+            let possibleVars = PreValueDomain.AD.to_var_may t in
+            List.fold_left (fun map arr -> VarMap.add arr (info.vattr) map) (pointedArrayMap xs) @@ List.filter (fun info -> isArrayType info.vtype) possibleVars
+          | _ -> pointedArrayMap xs
+      in
+      match VarH.find_option !array_map fundec.svar with
+      | Some _ -> () (*We already have something -> do not change it*)
+      | None -> VarH.add !array_map fundec.svar (pointedArrayMap arguments)
 
   let attributes_varinfo info fundec =
-    let map = VarH.find !array_map fundec.svar in
-    match VarMap.find_opt info map with
-    | Some attr ->  Some (attr, typeAttrs (info.vtype)) (*if the function has a different domain for this array, use it*)
-    | None -> Some (info.vattr, typeAttrs (info.vtype))
+    if Lazy.force array_domain_annotation_enabled then
+      let map = VarH.find !array_map fundec.svar in
+      match VarMap.find_opt info map with
+      | Some attr ->  Some (attr, typeAttrs (info.vtype)) (*if the function has a different domain for this array, use it*)
+      | None -> Some (info.vattr, typeAttrs (info.vtype))
+    else
+      None
 
   let project_val ask array_attr p_opt value is_glob =
     let p = if GobConfig.get_bool "annotation.int.enabled" then (

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -94,7 +94,9 @@ struct
   (*There surely is a better way, because this means that often the wrong one gets chosen*)
   module VarH = Hashtbl.Make(CilType.Varinfo)
   module VarMap = Map.Make(CilType.Varinfo)
-  let array_map = VarH.create 20
+  let array_map = ref (VarH.create 20)
+
+  type marshal = attributes VarMap.t VarH.t
 
   let add_to_array_map fundec arguments =
     let rec pointedArrayMap = function
@@ -106,12 +108,12 @@ struct
           List.fold_left (fun map arr -> VarMap.add arr (info.vattr) map) (pointedArrayMap xs) @@ List.filter (fun info -> isArrayType info.vtype) possibleVars
         | _ -> pointedArrayMap xs
     in
-    match VarH.find_option array_map fundec.svar with
+    match VarH.find_option !array_map fundec.svar with
     | Some _ -> () (*We already have something -> do not change it*)
-    | None -> VarH.add array_map fundec.svar (pointedArrayMap arguments)
+    | None -> VarH.add !array_map fundec.svar (pointedArrayMap arguments)
 
   let attributes_varinfo info fundec =
-    let map = VarH.find array_map fundec.svar in
+    let map = VarH.find !array_map fundec.svar in
     match VarMap.find_opt info map with
     | Some attr ->  Some (attr, typeAttrs (info.vtype)) (*if the function has a different domain for this array, use it*)
     | None -> Some (info.vattr, typeAttrs (info.vtype))
@@ -149,12 +151,16 @@ struct
   let char_array : (lval, bytes) Hashtbl.t = Hashtbl.create 500
 
   let init marshal =
+    begin match marshal with
+      | Some marshal -> array_map := marshal
+      | None -> ()
+    end;
     return_varstore := Goblintutil.create_var @@ makeVarinfo false "RETURN" voidType;
     Priv.init ()
 
   let finalize () =
     Priv.finalize ();
-    VarH.clear array_map
+    !array_map
 
   (**************************************************************************
    * Abstract evaluation functions


### PR DESCRIPTION
This PR changes the Base so that the `array_map` is marshalled. Additionally, it ensures that entries for this map are only collected when needed, i.e. when "annotation.goblint_array_domain" is activated. Only if this configuration option is active, the array-domain should be chosen selectively. Note that the option is activated by the autotuner case it itself adds these annotations.

This PR fixes #932, but I was not able to construct a small test case that exhibits the issue of #932, so this PR does not add any regression tests. 