### PR TITLE
Add race detection configurations for chrony, zstd, figlet

### DIFF
--- a/conf/custom/chrony-incrpostsolver.json
+++ b/conf/custom/chrony-incrpostsolver.json
@@ -1,0 +1,114 @@
+{
+  "ana": {
+    "activated": [
+      "expRelation",
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "escape",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "mallocWrapper",
+      "mhp",
+      "symb_locks",
+      "var_eq",
+      "mallocFresh",
+      "race"
+    ],
+    "ctx_insens": [
+      "var_eq"
+    ],
+    "base": {
+      "privatization": "none",
+      "context": {
+        "non-ptr": false
+      }
+    },
+    "thread": {
+      "domain": "plain",
+      "include-node": false
+    },
+    "race": {
+      "free": false
+    },
+    "dead-code": {
+      "lines": true
+    },
+    "int": {
+      "interval": true,
+      "def_exc": true
+    },
+    "malloc": {
+      "wrappers": [
+        "Malloc",
+        "Realloc",
+        "Malloc2",
+        "Realloc2",
+        "ARR_CreateInstance",
+        "realloc_array",
+        "ARR_GetNewElement"
+      ]
+    }
+  },
+  "sem": {
+    "unknown_function": {
+      "spawn": false,
+      "invalidate": {
+        "globals": false,
+        "args": false
+      }
+    }
+  },
+  "solvers": {
+    "td3": {
+      "restart": {
+        "wpoint": {
+          "enabled": false
+        }
+      }
+    }
+  },
+  "exp": {
+    "earlyglobs": true
+  },
+  "cil": {
+    "merge": {
+      "inlines": false
+    }
+  },
+  "dbg": {
+    "timing": {
+      "enabled": true
+    }
+  },
+  "warn": {
+    "assert": false,
+    "behavior": false,
+    "integer": false,
+    "cast": false,
+    "race": true,
+    "deadcode": true,
+    "analyzer": false,
+    "unsound": true,
+    "imprecise": false,
+    "unknown": false,
+    "error": false,
+    "warning": true,
+    "info": false,
+    "debug": false,
+    "success": true
+  },
+  "incremental": {
+    "postsolver": {
+      "enabled": true
+    },
+    "restart": {
+      "sided": {
+        "enabled": false
+      },
+      "write-only": true
+    }
+  }
+}

--- a/conf/custom/chrony-incrpostsolver.json
+++ b/conf/custom/chrony-incrpostsolver.json
@@ -101,9 +101,6 @@
     "success": true
   },
   "incremental": {
-    "reluctant": {
-      "compare": "equal"
-    },
     "postsolver": {
       "enabled": true
     },

--- a/conf/custom/chrony-incrpostsolver.json
+++ b/conf/custom/chrony-incrpostsolver.json
@@ -101,6 +101,9 @@
     "success": true
   },
   "incremental": {
+    "reluctant": {
+      "compare": "equal"
+    },
     "postsolver": {
       "enabled": true
     },

--- a/conf/custom/chrony.json
+++ b/conf/custom/chrony.json
@@ -104,6 +104,9 @@
     "reluctant": {
       "compare": "equal"
     },
+    "postsolver": {
+      "enabled": false
+    },
     "restart": {
       "sided": {
         "enabled": false

--- a/conf/custom/chrony.json
+++ b/conf/custom/chrony.json
@@ -107,7 +107,8 @@
     "restart": {
       "sided": {
         "enabled": false
-      }
+      },
+      "write-only": true
     }
   }
 }

--- a/conf/custom/chrony.json
+++ b/conf/custom/chrony.json
@@ -1,9 +1,21 @@
 {
   "ana": {
     "activated": [
-      "expRelation", "base", "threadid", "threadflag", "threadreturn",
-      "escape", "mutexEvents", "mutex", "access", "mallocWrapper", "mhp",
-      "symb_locks", "var_eq", "mallocFresh"
+      "expRelation",
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "escape",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "mallocWrapper",
+      "mhp",
+      "symb_locks",
+      "var_eq",
+      "mallocFresh",
+      "race"
     ],
     "ctx_insens": [
       "var_eq"
@@ -18,17 +30,26 @@
       "domain": "plain",
       "include-node": false
     },
-    "malloc": {
-      "wrappers": [
-        "ZSTD_customMalloc",
-        "ZSTD_customCalloc"
-      ]
-    },
     "race": {
       "free": false
     },
     "dead-code": {
       "lines": true
+    },
+    "int": {
+      "interval": true,
+      "def_exc": true
+    },
+    "malloc": {
+      "wrappers": [
+        "Malloc",
+        "Realloc",
+        "Malloc2",
+        "Realloc2",
+        "ARR_CreateInstance",
+        "realloc_array",
+        "ARR_GetNewElement"
+      ]
     }
   },
   "sem": {
@@ -37,16 +58,6 @@
       "invalidate": {
         "globals": false,
         "args": false
-      }
-    }
-  },
-  "incremental": {
-    "reluctant": {
-      "compare": "leq"
-    },
-    "restart": {
-      "sided": {
-        "enabled": false
       }
     }
   },
@@ -60,15 +71,7 @@
     }
   },
   "exp": {
-    "earlyglobs": true,
-    "extraspecials": [
-      "ZSTD_customMalloc",
-      "ZSTD_customCalloc",
-      "ZSTD_customFree"
-    ]
-  },
-  "pre": {
-    "cppflags": ["-DZSTD_NO_INTRINSICS", "-D_FORTIFY_SOURCE=0", "-DGOBLINT_NO_ASSERT", "-DGOBLINT_NO_BSEARCH"]
+    "earlyglobs": true
   },
   "cil": {
     "merge": {
@@ -88,7 +91,7 @@
     "race": true,
     "deadcode": true,
     "analyzer": false,
-    "unsound": false,
+    "unsound": true,
     "imprecise": false,
     "unknown": false,
     "error": false,
@@ -96,5 +99,15 @@
     "info": false,
     "debug": false,
     "success": true
+  },
+  "incremental": {
+    "reluctant": {
+      "compare": "equal"
+    },
+    "restart": {
+      "sided": {
+        "enabled": false
+      }
+    }
   }
 }

--- a/conf/custom/chrony.json
+++ b/conf/custom/chrony.json
@@ -101,9 +101,6 @@
     "success": true
   },
   "incremental": {
-    "reluctant": {
-      "compare": "equal"
-    },
     "postsolver": {
       "enabled": false
     },

--- a/conf/custom/figlet-incrpostsolver.json
+++ b/conf/custom/figlet-incrpostsolver.json
@@ -1,0 +1,103 @@
+{
+  "ana": {
+    "activated": [
+      "expRelation",
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "escape",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "mallocWrapper",
+      "mhp",
+      "symb_locks",
+      "var_eq",
+      "mallocFresh",
+      "race"
+    ],
+    "ctx_insens": [
+      "var_eq"
+    ],
+    "base": {
+      "privatization": "none",
+      "context": {
+        "non-ptr": false
+      }
+    },
+    "thread": {
+      "domain": "plain",
+      "include-node": false
+    },
+    "race": {
+      "free": false
+    },
+    "dead-code": {
+      "lines": true
+    },
+    "int": {
+      "interval": true,
+      "def_exc": true
+    }
+  },
+  "sem": {
+    "unknown_function": {
+      "spawn": false,
+      "invalidate": {
+        "globals": false,
+        "args": false
+      }
+    }
+  },
+  "solvers": {
+    "td3": {
+      "restart": {
+        "wpoint": {
+          "enabled": false
+        }
+      }
+    }
+  },
+  "exp": {
+    "earlyglobs": true
+  },
+  "cil": {
+    "merge": {
+      "inlines": false
+    }
+  },
+  "dbg": {
+    "timing": {
+      "enabled": true
+    }
+  },
+  "warn": {
+    "assert": false,
+    "behavior": false,
+    "integer": false,
+    "cast": false,
+    "race": true,
+    "deadcode": true,
+    "analyzer": false,
+    "unsound": true,
+    "imprecise": false,
+    "unknown": false,
+    "error": false,
+    "warning": true,
+    "info": false,
+    "debug": false,
+    "success": true
+  },
+  "incremental": {
+    "postsolver": {
+      "enabled": true
+    },
+    "restart": {
+      "sided": {
+        "enabled": false
+      },
+      "write-only": true
+    }
+  }
+}

--- a/conf/custom/figlet-incrpostsolver.json
+++ b/conf/custom/figlet-incrpostsolver.json
@@ -90,9 +90,6 @@
     "success": true
   },
   "incremental": {
-    "reluctant": {
-      "compare": "equal"
-    },
     "postsolver": {
       "enabled": true
     },

--- a/conf/custom/figlet-incrpostsolver.json
+++ b/conf/custom/figlet-incrpostsolver.json
@@ -90,6 +90,9 @@
     "success": true
   },
   "incremental": {
+    "reluctant": {
+      "compare": "equal"
+    },
     "postsolver": {
       "enabled": true
     },

--- a/conf/custom/figlet.json
+++ b/conf/custom/figlet.json
@@ -1,0 +1,102 @@
+{
+  "ana": {
+    "activated": [
+      "expRelation",
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "escape",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "mallocWrapper",
+      "mhp",
+      "symb_locks",
+      "var_eq",
+      "mallocFresh",
+      "race"
+    ],
+    "ctx_insens": [
+      "var_eq"
+    ],
+    "base": {
+      "privatization": "none",
+      "context": {
+        "non-ptr": false
+      }
+    },
+    "thread": {
+      "domain": "plain",
+      "include-node": false
+    },
+    "race": {
+      "free": false
+    },
+    "dead-code": {
+      "lines": true
+    },
+    "int": {
+      "interval": true,
+      "def_exc": true
+    }
+  },
+  "sem": {
+    "unknown_function": {
+      "spawn": false,
+      "invalidate": {
+        "globals": false,
+        "args": false
+      }
+    }
+  },
+  "solvers": {
+    "td3": {
+      "restart": {
+        "wpoint": {
+          "enabled": false
+        }
+      }
+    }
+  },
+  "exp": {
+    "earlyglobs": true
+  },
+  "cil": {
+    "merge": {
+      "inlines": false
+    }
+  },
+  "dbg": {
+    "timing": {
+      "enabled": true
+    }
+  },
+  "warn": {
+    "assert": false,
+    "behavior": false,
+    "integer": false,
+    "cast": false,
+    "race": true,
+    "deadcode": true,
+    "analyzer": false,
+    "unsound": true,
+    "imprecise": false,
+    "unknown": false,
+    "error": false,
+    "warning": true,
+    "info": false,
+    "debug": false,
+    "success": true
+  },
+  "incremental": {
+    "reluctant": {
+      "compare": "equal"
+    },
+    "restart": {
+      "sided": {
+        "enabled": false
+      }
+    }
+  }
+}

--- a/conf/custom/figlet.json
+++ b/conf/custom/figlet.json
@@ -90,9 +90,6 @@
     "success": true
   },
   "incremental": {
-    "reluctant": {
-      "compare": "equal"
-    },
     "postsolver": {
       "enabled": false
     },

--- a/conf/custom/figlet.json
+++ b/conf/custom/figlet.json
@@ -96,7 +96,8 @@
     "restart": {
       "sided": {
         "enabled": false
-      }
+      },
+      "write-only": true
     }
   }
 }

--- a/conf/custom/figlet.json
+++ b/conf/custom/figlet.json
@@ -93,6 +93,9 @@
     "reluctant": {
       "compare": "equal"
     },
+    "postsolver": {
+      "enabled": false
+    },
     "restart": {
       "sided": {
         "enabled": false

--- a/conf/custom/zstd-race-incrpostsolver.json
+++ b/conf/custom/zstd-race-incrpostsolver.json
@@ -1,0 +1,121 @@
+{
+  "ana": {
+    "activated": [
+      "expRelation",
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "escape",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "mallocWrapper",
+      "mhp",
+      "symb_locks",
+      "var_eq",
+      "mallocFresh",
+      "race"
+    ],
+    "ctx_insens": [
+      "var_eq"
+    ],
+    "base": {
+      "privatization": "none",
+      "context": {
+        "non-ptr": false
+      }
+    },
+    "thread": {
+      "domain": "plain",
+      "include-node": false
+    },
+    "malloc": {
+      "wrappers": [
+        "ZSTD_customMalloc",
+        "ZSTD_customCalloc"
+      ]
+    },
+    "race": {
+      "free": false
+    },
+    "dead-code": {
+      "lines": true
+    }
+  },
+  "sem": {
+    "unknown_function": {
+      "spawn": false,
+      "invalidate": {
+        "globals": false,
+        "args": false
+      }
+    }
+  },
+  "solvers": {
+    "td3": {
+      "restart": {
+        "wpoint": {
+          "enabled": false
+        }
+      }
+    }
+  },
+  "exp": {
+    "earlyglobs": true,
+    "extraspecials": [
+      "ZSTD_customMalloc",
+      "ZSTD_customCalloc",
+      "ZSTD_customFree"
+    ]
+  },
+  "pre": {
+    "cppflags": [
+      "-DZSTD_NO_INTRINSICS",
+      "-D_FORTIFY_SOURCE=0",
+      "-DGOBLINT_NO_ASSERT",
+      "-DGOBLINT_NO_BSEARCH"
+    ]
+  },
+  "cil": {
+    "merge": {
+      "inlines": false
+    }
+  },
+  "dbg": {
+    "timing": {
+      "enabled": true
+    }
+  },
+  "warn": {
+    "assert": false,
+    "behavior": false,
+    "integer": false,
+    "cast": false,
+    "race": true,
+    "deadcode": true,
+    "analyzer": false,
+    "unsound": true,
+    "imprecise": false,
+    "unknown": false,
+    "error": false,
+    "warning": true,
+    "info": false,
+    "debug": false,
+    "success": true
+  },
+  "incremental": {
+    "postsolver": {
+      "enabled": true
+    },
+    "restart": {
+      "sided": {
+        "enabled": false
+      },
+      "write-only": true
+    },
+    "reluctant": {
+      "compare": "leq"
+    }
+  }
+}

--- a/conf/custom/zstd-race-incrpostsolver.json
+++ b/conf/custom/zstd-race-incrpostsolver.json
@@ -41,6 +41,10 @@
     },
     "dead-code": {
       "lines": true
+    },
+    "int": {
+      "interval": true,
+      "def_exc": true
     }
   },
   "sem": {

--- a/conf/custom/zstd-race-incrpostsolver.json
+++ b/conf/custom/zstd-race-incrpostsolver.json
@@ -109,9 +109,6 @@
     "success": true
   },
   "incremental": {
-    "reluctant": {
-      "compare": "equal"
-    },
     "postsolver": {
       "enabled": true
     },

--- a/conf/custom/zstd-race-incrpostsolver.json
+++ b/conf/custom/zstd-race-incrpostsolver.json
@@ -105,6 +105,9 @@
     "success": true
   },
   "incremental": {
+    "reluctant": {
+      "compare": "equal"
+    },
     "postsolver": {
       "enabled": true
     },
@@ -113,9 +116,6 @@
         "enabled": false
       },
       "write-only": true
-    },
-    "reluctant": {
-      "compare": "leq"
     }
   }
 }

--- a/conf/custom/zstd-race.json
+++ b/conf/custom/zstd-race.json
@@ -112,6 +112,9 @@
     "reluctant": {
       "compare": "equal"
     },
+    "postsolver": {
+      "enabled": false
+    },
     "restart": {
       "sided": {
         "enabled": false

--- a/conf/custom/zstd-race.json
+++ b/conf/custom/zstd-race.json
@@ -115,7 +115,8 @@
     "restart": {
       "sided": {
         "enabled": false
-      }
+      },
+      "write-only": true
     }
   }
 }

--- a/conf/custom/zstd-race.json
+++ b/conf/custom/zstd-race.json
@@ -41,6 +41,10 @@
     },
     "dead-code": {
       "lines": true
+    },
+    "int": {
+      "interval": true,
+      "def_exc": true
     }
   },
   "sem": {
@@ -49,16 +53,6 @@
       "invalidate": {
         "globals": false,
         "args": false
-      }
-    }
-  },
-  "incremental": {
-    "reluctant": {
-      "compare": "equal"
-    },
-    "restart": {
-      "sided": {
-        "enabled": false
       }
     }
   },
@@ -113,5 +107,15 @@
     "info": false,
     "debug": false,
     "success": true
+  },
+  "incremental": {
+    "reluctant": {
+      "compare": "equal"
+    },
+    "restart": {
+      "sided": {
+        "enabled": false
+      }
+    }
   }
 }

--- a/conf/custom/zstd-race.json
+++ b/conf/custom/zstd-race.json
@@ -54,7 +54,7 @@
   },
   "incremental": {
     "reluctant": {
-      "compare": "leq"
+      "compare": "equal"
     },
     "restart": {
       "sided": {

--- a/conf/custom/zstd-race.json
+++ b/conf/custom/zstd-race.json
@@ -1,0 +1,117 @@
+{
+  "ana": {
+    "activated": [
+      "expRelation",
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "escape",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "mallocWrapper",
+      "mhp",
+      "symb_locks",
+      "var_eq",
+      "mallocFresh",
+      "race"
+    ],
+    "ctx_insens": [
+      "var_eq"
+    ],
+    "base": {
+      "privatization": "none",
+      "context": {
+        "non-ptr": false
+      }
+    },
+    "thread": {
+      "domain": "plain",
+      "include-node": false
+    },
+    "malloc": {
+      "wrappers": [
+        "ZSTD_customMalloc",
+        "ZSTD_customCalloc"
+      ]
+    },
+    "race": {
+      "free": false
+    },
+    "dead-code": {
+      "lines": true
+    }
+  },
+  "sem": {
+    "unknown_function": {
+      "spawn": false,
+      "invalidate": {
+        "globals": false,
+        "args": false
+      }
+    }
+  },
+  "incremental": {
+    "reluctant": {
+      "compare": "leq"
+    },
+    "restart": {
+      "sided": {
+        "enabled": false
+      }
+    }
+  },
+  "solvers": {
+    "td3": {
+      "restart": {
+        "wpoint": {
+          "enabled": false
+        }
+      }
+    }
+  },
+  "exp": {
+    "earlyglobs": true,
+    "extraspecials": [
+      "ZSTD_customMalloc",
+      "ZSTD_customCalloc",
+      "ZSTD_customFree"
+    ]
+  },
+  "pre": {
+    "cppflags": [
+      "-DZSTD_NO_INTRINSICS",
+      "-D_FORTIFY_SOURCE=0",
+      "-DGOBLINT_NO_ASSERT",
+      "-DGOBLINT_NO_BSEARCH"
+    ]
+  },
+  "cil": {
+    "merge": {
+      "inlines": false
+    }
+  },
+  "dbg": {
+    "timing": {
+      "enabled": true
+    }
+  },
+  "warn": {
+    "assert": false,
+    "behavior": false,
+    "integer": false,
+    "cast": false,
+    "race": true,
+    "deadcode": true,
+    "analyzer": false,
+    "unsound": true,
+    "imprecise": false,
+    "unknown": false,
+    "error": false,
+    "warning": true,
+    "info": false,
+    "debug": false,
+    "success": true
+  }
+}

--- a/conf/custom/zstd-race.json
+++ b/conf/custom/zstd-race.json
@@ -109,9 +109,6 @@
     "success": true
   },
   "incremental": {
-    "reluctant": {
-      "compare": "equal"
-    },
     "postsolver": {
       "enabled": false
     },


### PR DESCRIPTION
This PR adds configurations for race detection for chrony and figlet. An existing configuration for zstd was moved to the `conf/custom` folder that is intended to keep project-specific configuration files. This supersedes #888, which added configurations for sqlite, which we currently are not pursuing.