### PR TITLE
Prevent modification of options while the solver runs

### DIFF
--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -238,7 +238,6 @@ struct
   let exitstate  v = D.empty ()
 
   let init marshal =
-    set_bool "sem.malloc.fail" true;
     return_addr_ :=  Addr.from_var (Goblintutil.create_var @@ makeVarinfo false "RETURN" voidType)
 end
 

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -691,7 +691,7 @@ let rec analyze_loop (module CFG : CfgBidir) file fs change_info =
   try
     let (module Spec) = get_spec () in
     let module A = AnalyzeCFG (CFG) (Spec) (struct let increment = change_info end) in
-    A.analyze file fs
+    GobConfig.with_immutable_conf (fun () -> A.analyze file fs)
   with Refinement.RestartAnalysis ->
     (* Tail-recursively restart the analysis again, when requested.
         All solving starts from scratch.
@@ -706,8 +706,7 @@ let compute_cfg file =
 
 (** The main function to perform the selected analyses. *)
 let analyze change_info (file: file) fs =
-  GobConfig.with_immutable_conf @@ fun () ->
-    if (get_bool "dbg.verbose") then print_endline "Generating the control flow graph.";
-    let (module CFG) = compute_cfg file in
-    MyCFG.current_cfg := (module CFG);
-    analyze_loop (module CFG) file fs change_info
+  if (get_bool "dbg.verbose") then print_endline "Generating the control flow graph.";
+  let (module CFG) = compute_cfg file in
+  MyCFG.current_cfg := (module CFG);
+  analyze_loop (module CFG) file fs change_info

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -706,7 +706,8 @@ let compute_cfg file =
 
 (** The main function to perform the selected analyses. *)
 let analyze change_info (file: file) fs =
-  if (get_bool "dbg.verbose") then print_endline "Generating the control flow graph.";
-  let (module CFG) = compute_cfg file in
-  MyCFG.current_cfg := (module CFG);
-  analyze_loop (module CFG) file fs change_info
+  GobConfig.with_immutable_conf @@ fun () ->
+    if (get_bool "dbg.verbose") then print_endline "Generating the control flow graph.";
+    let (module CFG) = compute_cfg file in
+    MyCFG.current_cfg := (module CFG);
+    analyze_loop (module CFG) file fs change_info

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -126,6 +126,7 @@ let check_arguments () =
   let warn m = eprint_color ("{yellow}Option warning: "^m) in
   if get_bool "allfuns" && not (get_bool "exp.earlyglobs") then (set_bool "exp.earlyglobs" true; warn "allfuns enables exp.earlyglobs.\n");
   if not @@ List.mem "escape" @@ get_string_list "ana.activated" then warn "Without thread escape analysis, every local variable whose address is taken is considered escaped, i.e., global!";
+  if List.mem "malloc_null" @@ get_string_list "ana.activated" && not @@ get_bool "sem.malloc.fail" then (set_bool "sem.malloc.fail" true; warn "The malloc_null analysis enables sem.malloc.fail.");
   if get_bool "ana.base.context.int" && not (get_bool "ana.base.context.non-ptr") then (set_bool "ana.base.context.int" false; warn "ana.base.context.int implicitly disabled by ana.base.context.non-ptr");
   (* order matters: non-ptr=false, int=true -> int=false cascades to interval=false with warning *)
   if get_bool "ana.base.context.interval" && not (get_bool "ana.base.context.int") then (set_bool "ana.base.context.interval" false; warn "ana.base.context.interval implicitly disabled by ana.base.context.int");

--- a/src/util/gobConfig.ml
+++ b/src/util/gobConfig.ml
@@ -124,7 +124,7 @@ struct
     in
     String.concat "" (helper p)
 
-  (** raise when an attempt is made to the configuration while it is immutable *)
+  (** raise when an attempt is made to modify the configuration while it is immutable *)
   exception Immutable of path
 
   let () =

--- a/src/util/gobConfig.ml
+++ b/src/util/gobConfig.ml
@@ -75,7 +75,17 @@ sig
   (** Merge configurations from a JSON object with current. *)
   val merge : Yojson.Safe.t -> unit
 
-  val json_conf: Yojson.Safe.t ref
+  (* TODO: can bypass immutability by directly setting value *)
+  val json_conf : Yojson.Safe.t ref
+
+  (* TODO: completely lock this down? *)
+  (* val set_immutable : bool -> unit *)
+
+  (* Check whether modification of configuration is currently allowed. *)
+  val is_immutable : unit -> bool
+
+  (* Call the given function with modification to configuration disabled. *)
+  val with_immutable_conf : (unit -> 'a) -> 'a
 end
 
 (** The implementation of the [gobConfig] module. *)
@@ -98,19 +108,26 @@ struct
              | Select of string * path (** we need to select an field *)
              | Index  of index  * path (** we need to select an array index *)
 
-  (** Path printing. *)
-  let rec print_path' ch = function
-    | Here -> ()
-    | Select (s,p)    -> fprintf ch ".%s%a"  s print_path' p
-    | Index (Int i,p) -> fprintf ch "[%d]%a" i print_path' p
-    | Index (App ,p) -> fprintf ch "[+]%a"    print_path' p
-    | Index (Rem ,p) -> fprintf ch "[-]%a"    print_path' p
-    | Index (New  ,p) -> fprintf ch "[*]%a"    print_path' p
 
-  (** Path printing where you can ignore the first dot. *)
-  let[@warning "-unused-value-declaration"] print_path ch = function
-    | Select (s,p) -> fprintf ch "%s%a" s print_path' p
-    | pth -> print_path' ch pth
+  let show_path p =
+    let rec helper = function
+      | Here             -> []
+      | Select (s, p)    -> Printf.sprintf ".%s" s :: helper p
+      | Index (Int i, p) -> Printf.sprintf "[%d]" i :: helper p
+      | Index (App, p)   -> "[+]" :: helper p
+      | Index (Rem, p)   -> "[-]" :: helper p
+      | Index (New, p)   -> "[*]" :: helper p
+    in
+    String.concat "" (helper p)
+
+  (** raise when an attempt is made to the configuration while it is immutable *)
+  exception Immutable of path
+
+  let () =
+    Printexc.register_printer @@
+      function
+        | Immutable p -> Some (Printf.sprintf "Immutable(%s)" (show_path p))
+        | _ -> None
 
   (** Helper function [split c1 c2 xs] that splits [xs] on [c1] or [c2] *)
   let split c1 c2 xs =
@@ -215,8 +232,23 @@ struct
       | _ -> None (* for other exceptions *)
     )
 
-  (** The main function to write new values into the conf. *)
-  let set_value v o orig_pth =
+  (** (Global) flag to disallow modification of the configuration. *)
+  let immutable = ref false
+
+  let set_immutable = (:=) immutable
+
+  let is_immutable () = !immutable
+
+  let with_immutable_conf f =
+    (* allow nesting *)
+    if is_immutable () then f ()
+    else (
+      set_immutable true;
+      Fun.protect ~finally:(fun () -> set_immutable false) f
+    )
+
+  (** The main function to write new values into the conf. Use [set_value] to properly invalidate cache and check immutability. *)
+  let unsafe_set_value v o orig_pth =
     let rec set_value v o pth =
       match o, pth with
       | `Assoc m, Select (key,pth) ->
@@ -304,22 +336,25 @@ struct
   let get_string_list = List.map Yojson.Safe.Util.to_string % get_list
 
   (** Helper functions for writing values. *)
-  let set_path_string st v =
+  (* let set_path_string st v =
+    set_value v json_conf (parse_path st) *)
+
+  (** Sets a value, preventing changes when the configuration is immutable and invalidating the cache. *)
+  let set_value v o pth =
+    if is_immutable () then raise (Immutable pth);
+    drop_memo ();
+    unsafe_set_value v o pth
+
+  (** Helper function for writing values. Handles the tracing. *)
+  let set_path_string ?(show_trace = true) st v =
+    if show_trace && tracing then trace "conf" "Setting '%s' to %a.\n" st GobYojson.pretty v;
     set_value v json_conf (parse_path st)
 
-  (** Helper functions for writing values. Handels the tracing. *)
-  let set_path_string_trace st v =
-    drop_memo ();
-    if tracing then trace "conf" "Setting '%s' to %a.\n" st GobYojson.pretty v;
-    set_path_string st v
-
   (** Convenience functions for writing values. *)
-  let set_int    st i = set_path_string_trace st (`Int i)
-  let set_bool   st i = set_path_string_trace st (`Bool i)
-  let set_string st i = set_path_string_trace st (`String i)
-  let set_list   st l =
-    drop_memo ();
-    set_value (`List l) json_conf (parse_path st)
+  let set_int    st i = set_path_string st (`Int i)
+  let set_bool   st i = set_path_string st (`Bool i)
+  let set_string st i = set_path_string st (`String i)
+  let set_list   st l = set_path_string ~show_trace:false st (`List l)
 
   (** The ultimate convenience function for writing values. *)
   let one_quote = Str.regexp "\'"
@@ -328,7 +363,7 @@ struct
       try
         let s' = Str.global_replace one_quote "\"" s in
         let v = Yojson.Safe.from_string s' in
-        set_path_string_trace st v
+        set_path_string st v
       with Yojson.Json_error _ | TypeError _ ->
         set_string st s
     with e ->

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -239,7 +239,7 @@ let () =
     type response = unit [@@deriving to_yojson]
     let process () _ =
       try
-        GobConfig.json_conf := Options.defaults;
+        GobConfig.set_conf Options.defaults;
         Maingoblint.parse_arguments ();
       with exn -> (* TODO: Be more specific in what we catch. *)
         Response.Error.(raise (of_exn exn))


### PR DESCRIPTION
Raises an exception if a configuration value is changed while the solver is running. This should never occur.

Draft PR, to be discussed.

Resolves #653.