### PR TITLE
Fix compilation on OCaml 5.0.0~rc1

### DIFF
--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -32,6 +32,9 @@ jobs:
           - os: ubuntu-latest
             ocaml-compiler: 4.14.x
             z3: true
+          - os: ubuntu-latest
+            ocaml-compiler: ocaml-base-compiler.5.0.0~rc1
+            apron: false
 
     # customize name to use readable string for apron instead of just a boolean
     # workaround for missing ternary operator: https://github.com/actions/runner/issues/409

--- a/src/cdomains/fileDomain.ml
+++ b/src/cdomains/fileDomain.ml
@@ -58,7 +58,7 @@ struct
 
   let fopen k loc filename mode m =
     if is_unknown k m then m else
-      let mode = match String.lowercase mode with "r" -> Val.Read | _ -> Val.Write in
+      let mode = match String.lowercase_ascii mode with "r" -> Val.Read | _ -> Val.Write in
       let v = V.make k loc (Val.Open(filename, mode)) in
       add' k v m
   let fclose k loc m =

--- a/src/util/processPool.ml
+++ b/src/util/processPool.ml
@@ -22,7 +22,7 @@ let run ~jobs ?(terminated=fun _ _ -> ()) tasks =
           Unix.open_process task.command
       in
       let pid = Unix.process_pid proc in
-      Catapult.Tracing.a_begin ~id:(string_of_int pid) "ProcessPool" ~args:[("command", `String task.command)];
+      Catapult.Tracing.a_begin ~id:(string_of_int pid) ~cat:[] "ProcessPool" ~args:[("command", `String task.command)];
       Hashtbl.replace procs pid (task, proc);
       run tasks
     | [] when Hashtbl.length procs = 0 ->
@@ -36,7 +36,7 @@ let run ~jobs ?(terminated=fun _ _ -> ()) tasks =
           close_in proc_in;
           close_out proc_out;
           Hashtbl.remove procs pid;
-          Catapult.Tracing.a_exit ~id:(string_of_int pid) "ProcessPool";
+          Catapult.Tracing.a_exit ~id:(string_of_int pid) ~cat:[] "ProcessPool";
           terminated task status
         | None -> (* unrelated process *)
           ()


### PR DESCRIPTION
So far our OCaml 5 support was blocked by batteries. Now an OCaml 5 compatible version of batteries has been released: https://github.com/ocaml/opam-repository/pull/22635.
Only one Goblint issue required fixing: the deprecated `String.lowercase` is removed in OCaml 5.

There's still one gap: Apron doesn't yet have an OCaml 5 compatible version, which is why that combination is currently excluded from the unlocked matrix.