### PR TITLE
Add option to assume thread uniqueness

### DIFF
--- a/src/cdomains/threadIdDomain.ml
+++ b/src/cdomains/threadIdDomain.ml
@@ -1,5 +1,6 @@
 open GoblintCil
 open FlagHelper
+open Prelude
 
 module type S =
 sig
@@ -65,7 +66,11 @@ struct
     | ({vname = "main"; _}, None) -> true
     | _ -> false
 
-  let is_unique _ = false (* TODO: should this consider main unique? *)
+  let is_unique =
+    (* TODO: should this consider main unique? *)
+    let unique = lazy (GobConfig.get_string_list "ana.thread.force-unique" |> Set.String.of_list) in
+    function ({vname; _}, _) -> Set.String.mem vname (Lazy.force unique)
+  
   let may_create _ _ = true
   let is_must_parent _ _ = false
 end

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -914,6 +914,13 @@
                 "Whether the node at which a thread is created is part of its threadid",
               "type": "boolean",
               "default" : true
+            },
+            "force-unique": {
+              "title": "ana.thread.force-unique",
+              "description": "List of thread ids (function names) that should be assumed unique",
+              "type": "array",
+              "items": { "type": "string" },
+              "default": []
             }
           },
           "additionalProperties": false

--- a/tests/regression/40-threadid/11-symb_thread_id.c
+++ b/tests/regression/40-threadid/11-symb_thread_id.c
@@ -1,0 +1,21 @@
+// PARAM: --set ana.thread.domain plain --set ana.thread.force-unique[+] t_fun
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal[10];
+
+void *t_fun(void *arg) {
+  int i = (int) arg;
+  myglobal[i]=42; // NORACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id[10];
+  int i;
+  for (i=0; i<10; i++)
+    pthread_create(&id[i], NULL, t_fun, (void *) i);
+  for (i=0; i<10; i++)
+    pthread_join (id[i], NULL);
+  return 0;
+}


### PR DESCRIPTION
I'm considering adding some options to allow some unsound behavior from Goblint. Mainly, this is useful to assess what features would help in reducing false alarms. Assume we, e.g., implemented symbolic thread ids to handle indexed thread-local data, how much would that help? This pull request allows specifying a list of thead ids by function name that will be assumed unique. With this feature, we can get down to a single (relevant) warning on `smtprc` using [this conf](https://github.com/goblint/bench/blob/master/gobpie-demos/smtprc/smtprc.json). It also focuses on high-confidence races, which I think is okay for a demo on fixing bugs.

There are two questions before we merge. This does not work with histories, and I'm not sure it should override the history judgement, but I think it probably should because the main use-case for this override would be that there is some additional thread-id component (such as the argument) that makes the thread unique and histories do not take that into account either. 

Finally, I'm thinking maybe one should just have a thread mode that just assumes all threads are unique. (Or maybe we have that already, and I could just use that...)