### PR TITLE
Fix Unreached Fixpoint in Reluctant Incremental Analysis

### DIFF
--- a/conf/zstd-race.json
+++ b/conf/zstd-race.json
@@ -41,9 +41,6 @@
     }
   },
   "incremental": {
-    "reluctant": {
-      "compare": "leq"
-    },
     "restart": {
       "sided": {
         "enabled": false

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -727,9 +727,21 @@ module Base =
               solve x Widen;
               if not (op (HM.find rho x) old_rho) then (
                 print_endline "Destabilization required...";
-                HM.replace infl x old_infl;
+
+                let infl_x = HM.find_default infl x (VS.empty) in
+
+                let print_set vs s =
+                  print_endline s;
+                  VS.iter (fun v -> ignore @@ Pretty.printf "%a\n" S.Var.pretty_trace v) vs
+                in
+                ignore @@ Pretty.printf "infl_x: %d, old_infl: %d, intersction: %d\n" (VS.cardinal infl_x) (VS.cardinal old_infl) (VS.cardinal (VS.inter infl_x old_infl));
+                print_set infl_x "new infl:";
+                print_set old_infl "old infl:";
+
+                let infl_new = VS.union infl_x old_infl in
+
+                HM.replace infl x infl_new;
                 destabilize x;
-                HM.replace stable x ()
               )
               else (
                 print_endline "Destabilization not required...";

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -721,13 +721,12 @@ module Base =
         if reluctant then (
           (* solve on the return node of changed functions. Only destabilize the function's return node if the analysis result changed *)
           print_endline "Separately solving changed functions...";
-          let op = if GobConfig.get_string "incremental.reluctant.compare" = "leq" then S.Dom.leq else S.Dom.equal in
           HM.iter (fun x (old_rho, old_infl) -> HM.replace infl x old_infl) old_ret;
           HM.iter (fun x (old_rho, old_infl) ->
               ignore @@ Pretty.printf "test for %a\n" Node.pretty_trace (S.Var.node x);
               solve x Widen;
               VS.iter (fun k -> ignore @@ Pretty.printf "in infl after solving: %a\n" Node.pretty_trace (S.Var.node k)) (HM.find_default infl x VS.empty);
-              if not (op (HM.find rho x) old_rho) then (
+              if not (S.Dom.equal (HM.find rho x) old_rho) then (
                 print_endline "Further destabilization happened ...";
               )
               else (

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -728,19 +728,9 @@ module Base =
               if not (op (HM.find rho x) old_rho) then (
                 print_endline "Destabilization required...";
 
-                let infl_x = HM.find_default infl x (VS.empty) in
-
-                let print_set vs s =
-                  print_endline s;
-                  VS.iter (fun v -> ignore @@ Pretty.printf "%a\n" S.Var.pretty_trace v) vs
-                in
-                ignore @@ Pretty.printf "infl_x: %d, old_infl: %d, intersction: %d\n" (VS.cardinal infl_x) (VS.cardinal old_infl) (VS.cardinal (VS.inter infl_x old_infl));
-                print_set infl_x "new infl:";
-                print_set old_infl "old infl:";
-
-                let infl_new = VS.union infl_x old_infl in
-
-                HM.replace infl x infl_new;
+                let infl_new = HM.find_default infl x (VS.empty) in
+                let infl_combined = VS.union infl_new old_infl in
+                HM.replace infl x infl_combined;
                 destabilize x;
               )
               else (

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -721,7 +721,7 @@ module Base =
         if reluctant then (
           (* solve on the return node of changed functions. Only destabilize the function's return node if the analysis result changed *)
           print_endline "Separately solving changed functions...";
-          HM.iter (fun x (old_rho, old_infl) -> HM.replace infl x old_infl) old_ret;
+          HM.iter (fun x (old_rho, old_infl) -> HM.replace rho x old_rho; HM.replace infl x old_infl) old_ret;
           HM.iter (fun x (old_rho, old_infl) ->
               ignore @@ Pretty.printf "test for %a\n" Node.pretty_trace (S.Var.node x);
               solve x Widen;

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1053,14 +1053,6 @@
                 "Destabilize nodes in changed functions reluctantly",
               "type": "boolean",
               "default": false
-            },
-            "compare": {
-              "title": "incremental.reluctant.compare",
-              "description":
-                "In order to reuse the function's old abstract value the new abstract value must be leq (focus on efficiency) or equal (focus on precision) compared to the old.",
-              "type": "string",
-              "enum": ["leq", "equal"],
-              "default": "equal"
             }
           },
           "additionalProperties": false

--- a/tests/incremental/00-basic/15-reluctant-test.c
+++ b/tests/incremental/00-basic/15-reluctant-test.c
@@ -28,7 +28,8 @@ int main(){
 		g = 4;
 		int i = bar();
 
-
+		// At first unreachable, then UNKNOWN!
+		__goblint_check(i == 4);
 	}
 	return x;
 }

--- a/tests/incremental/00-basic/15-reluctant-test.c
+++ b/tests/incremental/00-basic/15-reluctant-test.c
@@ -1,0 +1,34 @@
+#include <goblint.h>
+// This test used to resulted in an unreachd fixpoint in the incremental implementation.
+
+int g = 3;
+
+int bar(){
+	int x = foo();
+	return x;
+}
+
+int foo(){
+	int top;
+	int r = 0;
+	if(top){
+		r = g;
+	} else {
+		// bar();
+		// r = 5;
+	}
+	return r;
+}
+
+int main(){
+	int x;
+
+	x = foo();
+	if(x == 5){
+		g = 4;
+		int i = bar();
+
+
+	}
+	return x;
+}

--- a/tests/incremental/00-basic/15-reluctant-test.c
+++ b/tests/incremental/00-basic/15-reluctant-test.c
@@ -1,5 +1,5 @@
 #include <goblint.h>
-// This test used to resulted in an unreachd fixpoint in the incremental implementation.
+// This test used to resulted in an unreached fixpoint in the incremental implementation.
 
 int g = 3;
 

--- a/tests/incremental/00-basic/15-reluctant-test.c
+++ b/tests/incremental/00-basic/15-reluctant-test.c
@@ -28,8 +28,7 @@ int main(){
 		g = 4;
 		int i = bar();
 
-		// At first unreachable, then UNKNOWN!
-		__goblint_check(i == 4);
+
 	}
 	return x;
 }

--- a/tests/incremental/00-basic/15-reluctant-test.json
+++ b/tests/incremental/00-basic/15-reluctant-test.json
@@ -1,0 +1,15 @@
+{
+	"ana": {
+		"int": {
+			"enums": true
+		}
+	},
+	"incremental": {
+		"reluctant": {
+			"enabled": true
+		}
+	},
+	"exp": {
+		"earlyglobs": true
+	}
+}

--- a/tests/incremental/00-basic/15-reluctant-test.patch
+++ b/tests/incremental/00-basic/15-reluctant-test.patch
@@ -1,0 +1,25 @@
+diff --git tests/incremental/00-basic/15-reluctant-test.c tests/incremental/00-basic/15-reluctant-test.c
+index eb4c59f6b..5be065852 100644
+--- tests/incremental/00-basic/15-reluctant-test.c
++++ tests/incremental/00-basic/15-reluctant-test.c
+@@ -14,8 +14,8 @@ int foo(){
+ 	if(top){
+ 		r = g;
+ 	} else {
+-		// bar();
+-		// r = 5;
++		bar();
++		r = 5;
+ 	}
+ 	return r;
+ }
+@@ -28,7 +28,7 @@ int main(){
+ 		g = 4;
+ 		int i = bar();
+ 
+-
++		__goblint_check(i == 4); //UNKNOWN!
+ 	}
+ 	return x;
+ }
+\ No newline at end of file

--- a/tests/incremental/00-basic/15-reluctant-test.patch
+++ b/tests/incremental/00-basic/15-reluctant-test.patch
@@ -1,5 +1,3 @@
-diff --git tests/incremental/00-basic/15-reluctant-test.c tests/incremental/00-basic/15-reluctant-test.c
-index eb4c59f6b..5be065852 100644
 --- tests/incremental/00-basic/15-reluctant-test.c
 +++ tests/incremental/00-basic/15-reluctant-test.c
 @@ -14,8 +14,8 @@ int foo(){
@@ -16,10 +14,9 @@ index eb4c59f6b..5be065852 100644
 @@ -28,7 +28,7 @@ int main(){
  		g = 4;
  		int i = bar();
- 
+
 -
-+		__goblint_check(i == 4); //UNKNOWN!
++    __goblint_check(i == 4); //UNKNOWN!
  	}
  	return x;
  }
-\ No newline at end of file

--- a/tests/incremental/00-basic/15-reluctant-test.patch
+++ b/tests/incremental/00-basic/15-reluctant-test.patch
@@ -1,5 +1,5 @@
 diff --git tests/incremental/00-basic/15-reluctant-test.c tests/incremental/00-basic/15-reluctant-test.c
-index df4739354..a9117d577 100644
+index eb4c59f6b..5be065852 100644
 --- tests/incremental/00-basic/15-reluctant-test.c
 +++ tests/incremental/00-basic/15-reluctant-test.c
 @@ -14,8 +14,8 @@ int foo(){
@@ -13,11 +13,11 @@ index df4739354..a9117d577 100644
  	}
  	return r;
  }
-@@ -29,7 +29,7 @@ int main(){
+@@ -28,7 +28,7 @@ int main(){
+ 		g = 4;
  		int i = bar();
  
- 		// At first unreachable, then UNKNOWN!
--		__goblint_check(i == 4);
+-
 +		__goblint_check(i == 4); //UNKNOWN!
  	}
  	return x;

--- a/tests/incremental/00-basic/15-reluctant-test.patch
+++ b/tests/incremental/00-basic/15-reluctant-test.patch
@@ -1,5 +1,5 @@
 diff --git tests/incremental/00-basic/15-reluctant-test.c tests/incremental/00-basic/15-reluctant-test.c
-index eb4c59f6b..5be065852 100644
+index df4739354..a9117d577 100644
 --- tests/incremental/00-basic/15-reluctant-test.c
 +++ tests/incremental/00-basic/15-reluctant-test.c
 @@ -14,8 +14,8 @@ int foo(){
@@ -13,11 +13,11 @@ index eb4c59f6b..5be065852 100644
  	}
  	return r;
  }
-@@ -28,7 +28,7 @@ int main(){
- 		g = 4;
+@@ -29,7 +29,7 @@ int main(){
  		int i = bar();
  
--
+ 		// At first unreachable, then UNKNOWN!
+-		__goblint_check(i == 4);
 +		__goblint_check(i == 4); //UNKNOWN!
  	}
  	return x;


### PR DESCRIPTION
This PR targets issue #949. This PR changes the behavior of reluctant incremental analysis for in case the abstract value of a reluctantly analyzed unknown `x` changed. 

The sets `infl x` from the previous analysis and the set `infl x` after the call to `solve x` by the reluctant analysis are joined before calling `destabilize x`. Unlike previously, this does not add `x` to the `stable` set after the call to destabilize.
