### PR TITLE
Warnings and Dead Code Handling for `noreturn`

### DIFF
--- a/goblint.opam
+++ b/goblint.opam
@@ -73,7 +73,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 # also remember to generate/adjust goblint.opam.locked!
 available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
-  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#5a3b7bb7f4d9b67678826ab7698f8a9048891553" ]
+  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#c03ade107208546ef59cd14dcefa7b55f1506494" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # TODO: add back after release, only pinned for CI stability

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -127,7 +127,7 @@ conflicts: [
 pin-depends: [
   [
     "goblint-cil.2.0.1"
-    "git+https://github.com/goblint/cil.git#5a3b7bb7f4d9b67678826ab7698f8a9048891553"
+    "git+https://github.com/goblint/cil.git#c03ade107208546ef59cd14dcefa7b55f1506494"
   ]
   [
     "apron.v0.9.13"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -2,7 +2,7 @@
 # also remember to generate/adjust goblint.opam.locked!
 available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
-  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#5a3b7bb7f4d9b67678826ab7698f8a9048891553" ]
+  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#c03ade107208546ef59cd14dcefa7b55f1506494" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # TODO: add back after release, only pinned for CI stability

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1767,6 +1767,8 @@ struct
     set_many ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local inits
 
   let return ctx exp fundec: store =
+    if Cil.hasAttribute "noreturn" fundec.svar.vattr then
+      M.warn ~category:(Behavior (Undefined Other)) "Function declared 'noreturn' should not return";
     let st: store = ctx.local in
     match fundec.svar.vname with
     | "__goblint_dummy_init" ->
@@ -2273,6 +2275,8 @@ struct
       in
       let return_val = project_val (Analyses.ask_of_ctx ctx) (attributes_varinfo (return_varinfo ()) callerFundec) (Some p) return_val (is_privglob (return_varinfo ())) in
       let cpa' = project (Analyses.ask_of_ctx ctx) (Some p) nst.cpa callerFundec in
+
+      if get_bool "sem.noreturn.dead_code" && Cil.hasAttribute "noreturn" f.svar.vattr then raise Deadcode;
 
       let st = { nst with cpa = cpa'; weak = st.weak } in (* keep weak from caller *)
       match lval with

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2017,7 +2017,7 @@ struct
     let st: store = ctx.local in
     let gs = ctx.global in
     let desc = LF.find f in
-    match desc.special args, f.vname with
+    let st = match desc.special args, f.vname with
     | Memset { dest; ch; count; }, _ ->
       (* TODO: check count *)
       let eval_ch = eval_rv (Analyses.ask_of_ctx ctx) gs st ch in
@@ -2243,6 +2243,8 @@ struct
 
         (* List.map (fun f -> f (fun lv -> (fun x -> set ~ctx:(Some ctx) ctx.ask ctx.global st (eval_lv ctx.ask ctx.global st lv) (Cilfacade.typeOfLval lv) x))) (LF.effects_for f.vname args) |> BatList.fold_left D.meet st *)
       end
+    in
+    if get_bool "sem.noreturn.dead_code" && Cil.hasAttribute "noreturn" f.vattr then raise Deadcode else st
 
   let combine ctx (lval: lval option) fexp (f: fundec) (args: exp list) fc (after: D.t) : D.t =
     let combine_one (st: D.t) (fun_st: D.t) =

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1768,7 +1768,7 @@ struct
 
   let return ctx exp fundec: store =
     if Cil.hasAttribute "noreturn" fundec.svar.vattr then
-      M.warn ~category:(Behavior (Undefined Other)) "Function declared 'noreturn' should not return";
+      M.warn ~category:(Behavior (Undefined Other)) "Function declared 'noreturn' could return";
     let st: store = ctx.local in
     match fundec.svar.vname with
     | "__goblint_dummy_init" ->

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -232,6 +232,7 @@ let createCFG (file: file) =
         (* Return node to be used for infinite loop connection to end of function
          * lazy, so it's only added when actually needed *)
         let pseudo_return = lazy (
+          if Messages.tracing then Messages.trace "cfg" "adding pseudo-return to the function %s.\n" fd.svar.vname;
           let newst = mkStmt (Return (None, fd_loc)) in
           newst.sid <- get_pseudo_return_id fd;
           Cilfacade.StmtH.add Cilfacade.pseudo_return_to_fun newst fd;

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -26,6 +26,7 @@ let init_options () =
 let init () =
   initCIL ();
   removeBranchingOnConstants := false;
+  addReturnOnNoreturnFallthrough := true;
   lowerConstants := true;
   Mergecil.ignore_merge_conflicts := true;
   (* lineDirectiveStyle := None; *)

--- a/src/util/messageCategory.ml
+++ b/src/util/messageCategory.ml
@@ -12,6 +12,7 @@ type undefined_behavior =
   | NullPointerDereference
   | UseAfterFree
   | Uninitialized
+  | Other
 [@@deriving eq, ord, hash]
 
 type behavior =
@@ -104,6 +105,7 @@ struct
       | NullPointerDereference -> ["NullPointerDereference"]
       | UseAfterFree -> ["UseAfterFree"]
       | Uninitialized -> ["Uninitialized"]
+      | Other -> ["Other"]
   end
 
   let from_string_list (s: string list): category =
@@ -211,6 +213,7 @@ let behaviorName = function
     |NullPointerDereference -> "NullPointerDereference"
     |UseAfterFree -> "UseAfterFree"
     |Uninitialized -> "Uninitialized"
+    |Other -> "Other"
     | ArrayOutOfBounds aob -> match aob with
       | PastEnd -> "PastEnd"
       | BeforeStart -> "BeforeStart"

--- a/src/util/messageCategory.ml
+++ b/src/util/messageCategory.ml
@@ -63,6 +63,7 @@ struct
     let nullpointer_dereference: category = create @@ NullPointerDereference
     let use_after_free: category = create @@ UseAfterFree
     let uninitialized: category = create @@ Uninitialized
+    let other: category = create @@ Other
 
     module ArrayOutOfBounds =
     struct
@@ -97,6 +98,7 @@ struct
         | "nullpointer_dereference" -> nullpointer_dereference
         | "use_after_free" -> use_after_free
         | "uninitialized" -> uninitialized
+        | "other" -> other
         | _ -> Unknown
 
     let path_show (e: t) =

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1269,7 +1269,7 @@
               "description":
                 "For the purposes of detecting dead code, assume that functions marked noreturn don't return.",
               "type": "boolean",
-              "default": true
+              "default": false
             }
           },
           "additionalProperties": false

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1259,6 +1259,21 @@
           },
           "additionalProperties": false
         },
+        "noreturn": {
+          "title": "sem.noreturn",
+          "description": "Handling of C11 _Noreturn function specifier.",
+          "type": "object",
+          "properties": {
+            "dead_code": {
+              "title": "sem.noreturn.dead_code",
+              "description":
+                "For the purposes of detecting dead code, assume that functions marked noreturn don't return.",
+              "type": "boolean",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
         "int": {
           "title": "sem.int",
           "type": "object",

--- a/tests/regression/64-noreturn/00-noreturn-deadcode-off.c
+++ b/tests/regression/64-noreturn/00-noreturn-deadcode-off.c
@@ -1,0 +1,57 @@
+//PARAM: --disable sem.noreturn.dead_code
+// tests for warnings about functions marked noreturn, that may return during program execution
+#include <stdnoreturn.h>
+#include <stdio.h>
+
+
+noreturn void empty() {
+
+} // WARN
+
+noreturn void aborts() {
+  abort();
+} // NOWARN!
+
+
+noreturn void foo(int x) {
+  if (x < 0) {
+    return 7; // WARN
+  }
+  abort();
+}
+
+noreturn void bar(int x) {
+  if (x < 0) {
+    return 7; // NOWARN!
+  }
+  abort();
+}
+
+
+int main() {
+  // switch over an unknown int, otherwise the first call
+  // to a function that aborts will dead-code the rest of main
+  int unknown;
+  scanf("%d", &unknown);
+  switch (unknown) {
+    case 0:
+      empty();
+      break;
+
+    case 1:
+      aborts();
+      break;
+
+    case 3:
+      foo(-1);
+      break;
+
+    case 4:
+      foo(1);
+      break;
+
+    case 5:
+      bar(1);
+      break;
+  }
+}

--- a/tests/regression/64-noreturn/01-noreturn-deadcode-on.c
+++ b/tests/regression/64-noreturn/01-noreturn-deadcode-on.c
@@ -28,6 +28,11 @@ noreturn void chain2() {
 } // NOWARN!
 
 
+// declared but undefined functions can also have noreturn attribute
+
+noreturn void no_definition(void);
+
+
 int main() {
   // switch over an unknown int, otherwise the first call
   // to a function that aborts will dead-code the rest of main
@@ -46,6 +51,11 @@ int main() {
 
     case 2:
       chain2();
+      break;
+
+    case 3:
+      no_definition();
+      __goblint_check(0); // NOWARN (unreachable)
       break;
   }
 }

--- a/tests/regression/64-noreturn/01-noreturn-deadcode-on.c
+++ b/tests/regression/64-noreturn/01-noreturn-deadcode-on.c
@@ -4,8 +4,6 @@
 #include <stdio.h>
 
 
-void no_op() {}
-
 noreturn void does_not_return() {
   abort();
 }
@@ -38,12 +36,12 @@ int main() {
   switch (unknown) {
     case 0:
       does_not_return();
-      no_op(); // TODO WARN (test script can't handle dead code warnings)
+      __goblint_check(0); // NOWARN (unreachable)
       break;
 
     case 1:
       does_return();
-      no_op(); // TODO WARN (still detect as dead, since we "trust" the noreturn annotation)
+      __goblint_check(0); // NOWARN (unreachable)
       break;
 
     case 2:

--- a/tests/regression/64-noreturn/01-noreturn-deadcode-on.c
+++ b/tests/regression/64-noreturn/01-noreturn-deadcode-on.c
@@ -1,0 +1,53 @@
+//PARAM: --enable sem.noreturn.dead_code
+// test that (calls of) functions marked noreturn are detected as dead
+#include <stdnoreturn.h>
+#include <stdio.h>
+
+
+void no_op() {}
+
+noreturn void does_not_return() {
+  abort();
+}
+
+noreturn void does_return() {
+
+} // WARN
+
+
+// with nested calls to noreturn functions, only warn that the innermost function returns
+
+noreturn void chain0() {
+
+} // WARN
+
+noreturn void chain1() {
+  chain0();
+} // NOWARN!
+
+noreturn void chain2() {
+  chain1();
+} // NOWARN!
+
+
+int main() {
+  // switch over an unknown int, otherwise the first call
+  // to a function that aborts will dead-code the rest of main
+  int unknown;
+  scanf("%d", &unknown);
+  switch (unknown) {
+    case 0:
+      does_not_return();
+      no_op(); // TODO WARN (test script can't handle dead code warnings)
+      break;
+
+    case 1:
+      does_return();
+      no_op(); // TODO WARN (still detect as dead, since we "trust" the noreturn annotation)
+      break;
+
+    case 2:
+      chain2();
+      break;
+  }
+}


### PR DESCRIPTION
Resolves  #501.

Changes:
- on return of a function, warn if the function is marked `noreturn`,
- after call of a function, raise `Deadcode` if the option `sem.noreturn.dead_code` is enabled.

Added an `Other` variant to `undefined_behavior` for the message category, but could also just as well be category `Unknown`.

---

However, from what I can tell there's an issue here with how CIL handles `noreturn`. Here are the CFGs generated for the following function, once marked with `noreturn` and once unmarked:

```c
void without_noreturn(int x) {
  if (x)
    abort();
}

noreturn void with_noreturn(int x) {
  if (x)
    abort();
}
```

CFG for `without_noreturn`

![image](https://user-images.githubusercontent.com/17551908/208772055-e2e8827f-1e44-4aef-a1ec-e9434c7a463d.png)


CFG for `with_noreturn`

![image](https://user-images.githubusercontent.com/17551908/208770870-3ec4dcaf-3d59-44ba-805d-3665de410da2.png)


My guess is that reaching the end of a `noreturn` function is undefined behaviour, so CIL is allowed to do this.