### PR TITLE
Fix: not found global should be added not removed

### DIFF
--- a/src/incremental/compareCIL.ml
+++ b/src/incremental/compareCIL.ml
@@ -198,7 +198,7 @@ let compareCilFiles ?(eq=eq_glob) (oldAST: file) (newAST: file) =
       | ForceReanalyze f ->
         changes.exclude_from_rel_destab <- VarinfoSet.add f.svar changes.exclude_from_rel_destab;
         append_to_changed ~unchangedHeader:false;
-    with Not_found -> changes.removed <- current_global::changes.removed (* Global could not be found in old map -> added *)
+    with Not_found -> changes.added <- current_global::changes.added (* Global could not be found in old map -> added *)
   in
 
   (*  For each function in the new file, check whether a function with the same name


### PR DESCRIPTION
When investigating issue #954, I detected, that there is a mistake in the comparison of globals in that globals that are not found in the old map are declared to be `removed`, but should actually be `added`. This fixes the first case described in #954. ~~It remains to check whether this also fixes the second one described or possibly even  affects #955.~~

Closes #954, closes #955.