### PR TITLE
Value Domain: Rm code duplication caused by "smart" operations

### DIFF
--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -558,7 +558,6 @@ struct
         | `Lifted f -> (`Lifted f, join_elem x y) (* f = g *)
         | x -> (x, `Top)) (* f <> g *)
     | (`Array x, `Array y) -> `Array (CArrays.smart_join x_eval_int y_eval_int x y)
-    | (`Blob x, `Blob y) -> `Blob (Blobs.join x y)
     | _ -> join x y  (* Others can not contain array -> normal join  *)
 
   let rec smart_widen x_eval_int y_eval_int x y:t =


### PR DESCRIPTION
The "smart" `leq`, `join`, and `widen` that are needed for the partitioned array domain contained a lot of code duplication, and implementations even started to diverge (different error messages).

This removes duplication by delegating to the standard `leq`, `join`, `widen` for the cases where no special handling is needed.