### PR TITLE
Handle annihilators in interval `logor` and `logand`

### DIFF
--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -655,18 +655,20 @@ struct
     else
       narrow ik x y
 
-  let log f ik i1 i2 =
+  let log f annihilator ik i1 i2 =
     match is_bot i1, is_bot i2 with
     | true, true -> bot_of ik
     | true, _
     | _   , true -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (show i1) (show i2)))
     | _ ->
       match to_bool i1, to_bool i2 with
+      | Some x, _ when x = annihilator -> of_bool ik annihilator
+      | _, Some y when y = annihilator -> of_bool ik annihilator
       | Some x, Some y -> of_bool ik (f x y)
       | _              -> top_of ik
 
-  let logor = log (||)
-  let logand = log (&&)
+  let logor = log (||) true
+  let logand = log (&&) false
 
   let log1 f ik i1 =
     if is_bot i1 then

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -655,7 +655,7 @@ struct
     else
       narrow ik x y
 
-  let log f annihilator ik i1 i2 =
+  let log f ~annihilator ik i1 i2 =
     match is_bot i1, is_bot i2 with
     | true, true -> bot_of ik
     | true, _
@@ -667,8 +667,8 @@ struct
       | Some x, Some y -> of_bool ik (f x y)
       | _              -> top_of ik
 
-  let logor = log (||) true
-  let logand = log (&&) false
+  let logor = log (||) ~annihilator:true
+  let logand = log (&&) ~annihilator:false
 
   let log1 f ik i1 =
     if is_bot i1 then

--- a/tests/regression/56-witness/07-base-lor-interval.c
+++ b/tests/regression/56-witness/07-base-lor-interval.c
@@ -1,0 +1,11 @@
+// PARAM: --enable ana.int.interval --set witness.yaml.validate 07-base-lor-interval.yml
+#include <goblint.h>
+
+int main() {
+  int r; // rand
+  int x;
+  __goblint_assume(x >= 2);
+  ; // SUCCESS (witness)
+  ; // SUCCESS (witness)
+  return 0;
+}

--- a/tests/regression/56-witness/07-base-lor-interval.yml
+++ b/tests/regression/56-witness/07-base-lor-interval.yml
@@ -1,0 +1,60 @@
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: b000a41c-b7eb-4187-92ea-40530a44479c
+    creation_time: 2023-01-24T09:33:20Z
+    producer:
+      name: Goblint
+      version: heads/yaml-witness-unassume-bench-0-g22403e387-dirty
+      command_line: '''/home/simmo/dev/goblint/sv-comp/goblint/goblint'' ''07-base-lor-interval.c''
+        ''--enable'' ''ana.int.interval'' ''--enable'' ''witness.yaml.enabled'' ''--enable''
+        ''witness.invariant.other'' ''--disable'' ''witness.invariant.accessed'' ''--set''
+        ''dbg.debug'' ''true'' ''--enable'' ''dbg.timing.enabled'' ''--set'' ''goblint-dir''
+        ''.goblint-56-07'''
+    task:
+      input_files:
+      - 07-base-lor-interval.c
+      input_file_hashes:
+        07-base-lor-interval.c: 6aaf25a17ef6c1a6b16300f34c4ef196baeb5a505a0e863ca0340e6060ef84e4
+      data_model: LP64
+      language: C
+  location:
+    file_name: 07-base-lor-interval.c
+    file_hash: 6aaf25a17ef6c1a6b16300f34c4ef196baeb5a505a0e863ca0340e6060ef84e4
+    line: 8
+    column: 2
+    function: main
+  location_invariant:
+    string: r || 2 <= x
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: b000a41c-b7eb-4187-92ea-40530a44479c
+    creation_time: 2023-01-24T09:33:20Z
+    producer:
+      name: Goblint
+      version: heads/yaml-witness-unassume-bench-0-g22403e387-dirty
+      command_line: '''/home/simmo/dev/goblint/sv-comp/goblint/goblint'' ''07-base-lor-interval.c''
+        ''--enable'' ''ana.int.interval'' ''--enable'' ''witness.yaml.enabled'' ''--enable''
+        ''witness.invariant.other'' ''--disable'' ''witness.invariant.accessed'' ''--set''
+        ''dbg.debug'' ''true'' ''--enable'' ''dbg.timing.enabled'' ''--set'' ''goblint-dir''
+        ''.goblint-56-07'''
+    task:
+      input_files:
+      - 07-base-lor-interval.c
+      input_file_hashes:
+        07-base-lor-interval.c: 6aaf25a17ef6c1a6b16300f34c4ef196baeb5a505a0e863ca0340e6060ef84e4
+      data_model: LP64
+      language: C
+  location:
+    file_name: 07-base-lor-interval.c
+    file_hash: 6aaf25a17ef6c1a6b16300f34c4ef196baeb5a505a0e863ca0340e6060ef84e4
+    line: 9
+    column: 2
+    function: main
+  location_invariant:
+    string: 2 <= x || r
+    type: assertion
+    format: C


### PR DESCRIPTION
If `2 <= x` is true according to intervals, but `r` is unknown, then `r || 2 <= x` should still be true. However, previously it was unknown as annihilators for `logor` and `logand` were not specially handled in the interval domain.

This only concerns witness expressions since `LOr` and `LAnd` do not appear in normal analysis.