### PR TITLE
Handle def_exc range in comparison operators

### DIFF
--- a/docs/developer-guide/firstanalysis.md
+++ b/docs/developer-guide/firstanalysis.md
@@ -17,15 +17,15 @@ int main() {
   int unknown;
 
   if (unknown) {
-    x = 5;
+    x = -5;
   } else {
-    x = 7;
+    x = -7;
   }
 
   // The above code branches on an uninitialized variable.
-  // The value of x could be either 5 or 7.
+  // The value of x could be either -5 or -7.
 
-  assert(x > 0); // TODO: Thus, this assertion should hold!
+  assert(x < 0); // TODO: Thus, this assertion should hold!
 
   return 0;
 }
@@ -53,7 +53,7 @@ It may still be useful to use Goblint's HTML output to [see the result](../user-
 We first need to design the abstract domain. It may help if you have read some theoretical tutorial on abstract domains. Our first sign lattice will simply contain the elements `{-, 0, +}` with top and bottom added. These elements are defined in the module `Signs` and then we define the sign lattice `SL` by adding bottom and top elements. This is done by the functor `Lattice.Flat`. You should look at the following functions and fix their problems.
 
 1. `of_int i` should abstract integers to their best representation in our abstract domain. Our sign domain can distinguish positive, negative and zero values, so do it right!
-2. `gt x y` should answer true if the value represented by `x` is definitely greater than the value represented by `y`. There seems to be a crucial case missing here in the otherwise excellent implementation...
+2. `lt x y` should answer true if the value represented by `x` is definitely less than the value represented by `y`. There seems to be a crucial case missing here in the otherwise excellent implementation...
 
 We will represent the abstract state of the program as a map from variables to the newly created sign domain.
 

--- a/src/analyses/tutorials/signs.ml
+++ b/src/analyses/tutorials/signs.ml
@@ -26,8 +26,8 @@ struct
     else if compare_cilint i zero_cilint > 0 then Zero
     else Zero
 
-  let gt x y = match x, y with
-    | Pos, Neg | Zero, Neg -> true (* TODO: Maybe something missing? *)
+  let lt x y = match x, y with
+    | Neg, Pos | Neg, Zero -> true (* TODO: Maybe something missing? *)
     | _ -> false
 
 end
@@ -39,8 +39,8 @@ struct
   include Lattice.Flat (Signs) (Printable.DefaultNames)
   let of_int i = `Lifted (Signs.of_int i)
 
-  let gt x y = match x, y with
-    | `Lifted x, `Lifted y -> Signs.gt x y
+  let lt x y = match x, y with
+    | `Lifted x, `Lifted y -> Signs.lt x y
     | _ -> false
 end
 
@@ -75,7 +75,7 @@ struct
 
   (* Here we return true if we are absolutely certain that an assertion holds! *)
   let assert_holds (d: D.t) (e:exp) = match e with
-    | BinOp (Gt, e1, e2, _) -> SL.gt (eval d e1) (eval d e2)
+    | BinOp (Lt, e1, e2, _) -> SL.lt (eval d e1) (eval d e2)
     | _ -> false
 
   (* We should now provide this information to Goblint. Assertions are integer expressions,

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1456,6 +1456,7 @@ struct
     | `Definite x -> BigInt.to_bool x
     | `Excluded (s,r) when S.mem BI.zero s -> Some true
     | _ -> None
+  let top_bool = `Excluded (S.empty (), R.of_interval range_ikind (0L, 1L))
 
   let of_interval ?(suppress_ovwarn=false) ik (x,y) = if BigInt.compare x y = 0 then of_int ik x else top_of ik
 
@@ -1569,10 +1570,32 @@ struct
     | _ -> lift2_inj BigInt.mul ik x y
   let div ?no_ov ik x y = lift2 BigInt.div ik x y
   let rem ik x y = lift2 BigInt.rem ik x y
-  let lt ik = lift2 BigInt.lt ik
-  let gt ik = lift2 BigInt.gt ik
-  let le ik = lift2 BigInt.le ik
-  let ge ik = lift2 BigInt.ge ik
+
+  (* Comparison handling copied from Enums. *)
+  let handle_bot x y f = match x, y with
+    | `Bot, `Bot -> `Bot
+    | `Bot, _
+    | _, `Bot -> raise (ArithmeticOnIntegerBot (Printf.sprintf "%s op %s" (show x) (show y)))
+    | _, _ -> f ()
+
+  let lt ik x y =
+    handle_bot x y (fun () ->
+      match minimal x, maximal x, minimal y, maximal y with
+      | _, Some x2, Some y1, _ when BigInt.compare x2 y1 < 0 -> of_bool ik true
+      | Some x1, _, _, Some y2 when BigInt.compare x1 y2 >= 0 -> of_bool ik false
+      | _, _, _, _ -> top_bool)
+
+  let gt ik x y = lt ik y x
+
+  let le ik x y =
+    handle_bot x y (fun () ->
+      match minimal x, maximal x, minimal y, maximal y with
+      | _, Some x2, Some y1, _ when BigInt.compare x2 y1 <= 0 -> of_bool ik true
+      | Some x1, _, _, Some y2 when BigInt.compare x1 y2 > 0 -> of_bool ik false
+      | _, _, _, _ -> top_bool)
+
+  let ge ik x y = le ik y x
+
   let bitnot = lift1 BigInt.bitnot
   let bitand = lift2 BigInt.bitand
   let bitor  = lift2 BigInt.bitor

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1580,19 +1580,19 @@ struct
 
   let lt ik x y =
     handle_bot x y (fun () ->
-      match minimal x, maximal x, minimal y, maximal y with
-      | _, Some x2, Some y1, _ when BigInt.compare x2 y1 < 0 -> of_bool ik true
-      | Some x1, _, _, Some y2 when BigInt.compare x1 y2 >= 0 -> of_bool ik false
-      | _, _, _, _ -> top_bool)
+        match minimal x, maximal x, minimal y, maximal y with
+        | _, Some x2, Some y1, _ when BigInt.compare x2 y1 < 0 -> of_bool ik true
+        | Some x1, _, _, Some y2 when BigInt.compare x1 y2 >= 0 -> of_bool ik false
+        | _, _, _, _ -> top_bool)
 
   let gt ik x y = lt ik y x
 
   let le ik x y =
     handle_bot x y (fun () ->
-      match minimal x, maximal x, minimal y, maximal y with
-      | _, Some x2, Some y1, _ when BigInt.compare x2 y1 <= 0 -> of_bool ik true
-      | Some x1, _, _, Some y2 when BigInt.compare x1 y2 > 0 -> of_bool ik false
-      | _, _, _, _ -> top_bool)
+        match minimal x, maximal x, minimal y, maximal y with
+        | _, Some x2, Some y1, _ when BigInt.compare x2 y1 <= 0 -> of_bool ik true
+        | Some x1, _, _, Some y2 when BigInt.compare x1 y2 > 0 -> of_bool ik false
+        | _, _, _, _ -> top_bool)
 
   let ge ik x y = le ik y x
 

--- a/tests/regression/01-cpa/59-def_exc-cmp-range.c
+++ b/tests/regression/01-cpa/59-def_exc-cmp-range.c
@@ -1,0 +1,16 @@
+// PARAM: --enable ana.int.def_exc --disable ana.int.interval --enable ana.sv-comp.functions
+// Copied from 56-witness/28-mine-tutorial-ex4.8
+#include <goblint.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+int main() {
+  int v = 0;
+  while (__VERIFIER_nondet_bool() == 0) {
+    __goblint_check(0 <= v);
+    __goblint_check(v <= 1);
+    if (v == 0)
+      v = 1;
+    // ...
+  }
+  return 0;
+}

--- a/tests/regression/01-cpa/71-widen-sides.c
+++ b/tests/regression/01-cpa/71-widen-sides.c
@@ -3,13 +3,13 @@
 
 int further(int n) {
     // Even sides-local can not save us here :(
-    __goblint_check(n <= 1); //TODO
+    __goblint_check(n <= 2); //TODO
 }
 
 
 int fun(int n, const char* arg) {
     // Fails with solvers.td3.side_widen sides, needs sides-local
-    __goblint_check(n <= 1);
+    __goblint_check(n <= 2);
     further(n);
 }
 
@@ -26,5 +26,5 @@ int main() {
     doIt("two");
 
     // In the setting with solvers.td3.side_widen sides, widening happens and the bound is lost
-    fun(1, "org");
+    fun(2, "org");
 }

--- a/tests/regression/56-witness/28-mine-tutorial-ex4.8.c
+++ b/tests/regression/56-witness/28-mine-tutorial-ex4.8.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.int.interval --enable ana.sv-comp.functions --set ana.activated[+] unassume --set witness.yaml.unassume 28-mine-tutorial-ex4.8.yml
+// PARAM: --disable ana.int.def_exc --enable ana.int.interval --enable ana.sv-comp.functions --set ana.activated[+] unassume --set witness.yaml.unassume 28-mine-tutorial-ex4.8.yml
 #include <goblint.h>
 extern _Bool __VERIFIER_nondet_bool();
 int main() {

--- a/tests/regression/99-tutorials/01-first.c
+++ b/tests/regression/99-tutorials/01-first.c
@@ -6,15 +6,15 @@ int main() {
   int unknown;
 
   if (unknown) {
-    x = 5;
+    x = -5;
   } else {
-    x = 7;
+    x = -7;
   }
 
   // The above code branches on an uninitialized variable.
-  // The value of x could be either 5 or 7.
+  // The value of x could be either -5 or -7.
 
-  __goblint_check(x > 0); // TODO: Thus, this assertion should hold!
+  __goblint_check(x < 0); // TODO: Thus, this assertion should hold!
 
   return 0;
 }

--- a/tests/regression/99-tutorials/02-first-extend.c
+++ b/tests/regression/99-tutorials/02-first-extend.c
@@ -6,15 +6,15 @@ int main() {
   int unknown;
 
   if (unknown) {
-    x = 5;
+    x = -5;
   } else {
     x = 0;
   }
 
   // The above code branches on an uninitialized variable.
-  // The value of x could be either 5 or 0.
+  // The value of x could be either -5 or 0.
 
-  __goblint_check(x > -1); // TODO: Thus, this assertion should hold!
+  __goblint_check(x < 1); // TODO: Thus, this assertion should hold!
 
   return 0;
 }


### PR DESCRIPTION
Closes #971.

This also required changing the signs tutorial (and one side widen test), because def_exc range can represent unsigned (non-negative) values and thus would make comparisons pass.