### PR TITLE
Improve `threadJoins` when it is used context-insensitively

### DIFF
--- a/src/analyses/threadJoins.ml
+++ b/src/analyses/threadJoins.ml
@@ -87,6 +87,9 @@ struct
     | Queries.MustJoinedThreads -> (ctx.local:ConcDomain.MustThreadSet.t) (* type annotation needed to avoid "would escape the scope of its equation" *)
     | _ ->  Queries.Result.top q
 
+  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au =
+    D.union ctx.local au
+
   let startstate v = D.top ()
   let exitstate  v = D.top ()
 end

--- a/tests/regression/51-threadjoins/06-ctxinsens.c
+++ b/tests/regression/51-threadjoins/06-ctxinsens.c
@@ -1,0 +1,28 @@
+//PARAM: --set ana.activated[+] threadJoins --set ana.ctx_insens[+] threadJoins
+#include <pthread.h>
+
+int g = 10;
+
+void *t_fun(void *arg) {
+  g++; //NORACE
+  return NULL;
+}
+
+void benign() { 
+  // Causes must-joined set to be empty here!
+}
+
+int main(void) {
+  int t;
+
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  
+  benign();
+  pthread_join(id, NULL);
+  benign();
+  g++; //NORACE
+
+
+  return 0;
+}


### PR DESCRIPTION
Join set of must-joined TIDs in `combine` instead of just taking it from the callee.
This can improve, e.g., race warnings when the `threadJoins` analysis is used context-insensitively.

Closes #968 