### PR TITLE
Support for machines where `float128` is not the same size as `long double`

### DIFF
--- a/goblint.opam
+++ b/goblint.opam
@@ -74,7 +74,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 # also remember to generate/adjust goblint.opam.locked!
 available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
-  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#c03ade107208546ef59cd14dcefa7b55f1506494" ]
+  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#8d10ae6d16e6e582c94466c6bffd2d366011668b" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # TODO: add back after release, only pinned for CI stability

--- a/goblint.opam
+++ b/goblint.opam
@@ -74,7 +74,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 # also remember to generate/adjust goblint.opam.locked!
 available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
-  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#8d10ae6d16e6e582c94466c6bffd2d366011668b" ]
+  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#4ef5a0865ce81c740c93da73e20a4f26daab3f1b" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # TODO: add back after release, only pinned for CI stability

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -128,7 +128,7 @@ conflicts: [
 pin-depends: [
   [
     "goblint-cil.2.0.1"
-    "git+https://github.com/goblint/cil.git#c03ade107208546ef59cd14dcefa7b55f1506494"
+    "git+https://github.com/goblint/cil.git#8d10ae6d16e6e582c94466c6bffd2d366011668b"
   ]
   [
     "apron.v0.9.13"

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -128,7 +128,7 @@ conflicts: [
 pin-depends: [
   [
     "goblint-cil.2.0.1"
-    "git+https://github.com/goblint/cil.git#8d10ae6d16e6e582c94466c6bffd2d366011668b"
+    "git+https://github.com/goblint/cil.git#4ef5a0865ce81c740c93da73e20a4f26daab3f1b"
   ]
   [
     "apron.v0.9.13"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -2,7 +2,7 @@
 # also remember to generate/adjust goblint.opam.locked!
 available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
-  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#8d10ae6d16e6e582c94466c6bffd2d366011668b" ]
+  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#4ef5a0865ce81c740c93da73e20a4f26daab3f1b" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # TODO: add back after release, only pinned for CI stability

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -2,7 +2,7 @@
 # also remember to generate/adjust goblint.opam.locked!
 available: os-distribution != "alpine" & arch != "arm64"
 pin-depends: [
-  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#c03ade107208546ef59cd14dcefa7b55f1506494" ]
+  [ "goblint-cil.2.0.1" "git+https://github.com/goblint/cil.git#8d10ae6d16e6e582c94466c6bffd2d366011668b" ]
   # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
   [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
   # TODO: add back after release, only pinned for CI stability

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -782,8 +782,8 @@ struct
       | Const (CInt (num,ikind,str)) ->
         (match str with Some x -> M.tracel "casto" "CInt (%s, %a, %s)\n" (Cilint.string_of_cilint num) d_ikind ikind x | None -> ());
         `Int (ID.cast_to ikind (IntDomain.of_const (num,ikind,str)))
-      | Const (CReal (_, (FFloat | FDouble | FLongDouble as fkind), Some str)) -> `Float (FD.of_string fkind str) (* prefer parsing from string due to higher precision *)
-      | Const (CReal (num, (FFloat | FDouble | FLongDouble as fkind), None)) -> `Float (FD.of_const fkind num)
+      | Const (CReal (_,fkind, Some str)) when not (Cilfacade.isComplexFKind fkind) -> `Float (FD.of_string fkind str) (* prefer parsing from string due to higher precision *)
+      | Const (CReal (num, fkind, None)) when not (Cilfacade.isComplexFKind fkind) -> `Float (FD.of_const fkind num)
       (* String literals *)
       | Const (CStr (x,_)) -> `Address (AD.from_string x) (* normal 8-bit strings, type: char* *)
       | Const (CWStr (xs,_) as c) -> (* wide character strings, type: wchar_t* *)

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -201,12 +201,24 @@ let typeOfRealAndImagComponents t =
       | FFloat -> FFloat      (* [float] *)
       | FDouble -> FDouble     (* [double] *)
       | FLongDouble -> FLongDouble (* [long double] *)
+      | FFloat128 -> FFloat128 (* [float128] *)
       | FComplexFloat -> FFloat
       | FComplexDouble -> FDouble
       | FComplexLongDouble -> FLongDouble
+      | FComplexFloat128 -> FComplexFloat128
     in
     TFloat (newfkind fkind, attrs)
   | _ -> raise (TypeOfError RealImag_NonNumerical)
+
+let isComplexFKind = function
+  | FFloat
+  | FDouble
+  | FLongDouble
+  | FFloat128 -> false
+  | FComplexFloat
+  | FComplexDouble
+  | FComplexLongDouble
+  | FComplexFloat128 -> true
 
 let rec typeOf (e: exp) : typ =
   match e with


### PR DESCRIPTION
After the necessary adjustments in CIL this also does the adaptations in Goblint. Note that we can use the existing domain for `long double` also for `float128`, as it is designed to be sound for any precision `>= 64bit` .

This should bring us further towards support for some ARM machines.

TODO:

- [x] Update pin once https://github.com/goblint/cil/pull/119 is merged