### PR TITLE
Add `cfg/lookup` request to server mode

### DIFF
--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -62,7 +62,7 @@ let of_id s =
   let id = int_of_string (Str.string_after s ix) in
   let prefix = Str.string_before s ix in
   match ix with
-  | 0 -> Statement { dummyStmt with sid = id }
+  | 0 -> Statement (Option.get (Cilfacade.find_stmt_sid id))
   | _ ->
     let fundec = Cilfacade.find_varinfo_fundec {dummyFunDec.svar with vid = id} in
     match prefix with

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -317,6 +317,33 @@ let () =
   end);
 
   register (module struct
+    let name = "cfg/lookup"
+    type params = {
+      node: string;
+    } [@@deriving of_yojson]
+    type response = {
+      next: (Edge.t list * string) list;
+      prev: (Edge.t list * string) list;
+    } [@@deriving to_yojson]
+    let process {node} serv =
+      let node = Node.of_id node in
+      let module Cfg = (val !MyCFG.current_cfg) in
+      let next =
+        Cfg.next node
+        |> List.map (fun (edges, to_node) ->
+            (List.map snd edges, Node.show_id to_node)
+          )
+      in
+      let prev =
+        Cfg.prev node
+        |> List.map (fun (edges, to_node) ->
+            (List.map snd edges, Node.show_id to_node)
+          )
+      in
+      {next; prev}
+  end);
+
+  register (module struct
     let name = "node_state"
     type params = { nid: string }  [@@deriving of_yojson]
     type response = Yojson.Safe.t [@@deriving to_yojson]

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -322,11 +322,14 @@ let () =
       node: string;
     } [@@deriving of_yojson]
     type response = {
+      node: string;
+      location: CilType.Location.t;
       next: (Edge.t list * string) list;
       prev: (Edge.t list * string) list;
     } [@@deriving to_yojson]
-    let process {node} serv =
-      let node = Node.of_id node in
+    let process ({node = node_id}: params) serv =
+      let node = Node.of_id node_id in
+      let location = Node.location node in
       let module Cfg = (val !MyCFG.current_cfg) in
       let next =
         Cfg.next node
@@ -340,7 +343,7 @@ let () =
             (List.map snd edges, Node.show_id to_node)
           )
       in
-      {next; prev}
+      {node = node_id; location; next; prev}
   end);
 
   register (module struct


### PR DESCRIPTION
This request allows programmatic traversal of the CFG for abstract debugging (as opposed to dumping a function's CFG in GraphViz format). The method allows two kinds of lookups:
1. by source code location,
2. by node ID.

In both cases the method returns:
1. node ID and location (useful for lookups by location);
2. next and previous nodes in the CFG.

### Example session
```console
$ rlwrap ./goblint --enable server.enabled --enable server.reparse ./tests/regression/04-mutex/01-simple_rc.c

{"jsonrpc":"2.0","id":0,"method":"analyze","params":{}}
{"id":0,"jsonrpc":"2.0","result":{"status":["Success"]}}

{"jsonrpc":"2.0","id":0,"method":"cfg/lookup","params":{"location":{"file":"tests/regression/04-mutex/01-simple_rc.c","line":18,"column":3,"byte":-1}}}
{"id":0,"jsonrpc":"2.0","result":{"node":"84","location":{"file":"tests/regression/04-mutex/01-simple_rc.c","line":18,"column":3,"byte":52985,"endLine":18,"endColumn":30,"endByte":53012},"next":[[[["Proc",null,"pthread_mutex_lock",["& mutex2"]]],"85"]],"prev":[[[["Proc",null,"pthread_create",["(pthread_t * __restrict  )(& id)","(pthread_attr_t const   * __restrict  )((void *)0)","& t_fun","(void * __restrict  )((void *)0)"]]],"83"]]}}

{"jsonrpc":"2.0","id":0,"method":"cfg/lookup","params":{"node":"85"}}
{"id":0,"jsonrpc":"2.0","result":{"node":"85","location":{"file":"tests/regression/04-mutex/01-simple_rc.c","line":19,"column":3,"byte":53016,"endLine":19,"endColumn":22,"endByte":53035},"next":[[[["Assign","myglobal","myglobal + 1"]],"86"]],"prev":[[[["Proc",null,"pthread_mutex_lock",["& mutex2"]]],"84"]]}}
```

/cc @FeldrinH