### PR TITLE
Fix various server mode crashes

### DIFF
--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -42,7 +42,7 @@ let spec_module: (module Spec) Lazy.t = lazy (
 let get_spec (): (module Spec) =
   Lazy.force spec_module
 
-let current_node_state_json : (Node.t -> Yojson.Safe.t) ref = ref (fun _ -> assert false)
+let current_node_state_json : (Node.t -> Yojson.Safe.t option) ref = ref (fun _ -> None)
 
 (** Given a [Cfg], a [Spec], and an [Inc], computes the solution to [MCP.Path] *)
 module AnalyzeCFG (Cfg:CfgBidir) (Spec:Spec) (Inc:Increment) =
@@ -636,7 +636,7 @@ struct
     let module R: ResultQuery.SpecSysSol2 with module SpecSys = SpecSys = ResultQuery.Make (FileCfg) (SpecSysSol) in
 
     let local_xml = solver2source_result lh in
-    current_node_state_json := (fun node -> LT.to_yojson (Result.find local_xml node));
+    current_node_state_json := (fun node -> Option.map LT.to_yojson (Result.find_option local_xml node));
 
     let liveness =
       if get_bool "ana.dead-code.lines" || get_bool "ana.dead-code.branches" then

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -57,6 +57,7 @@ let find_fundec (node: t) =
   | Function fd -> fd
   | FunctionEntry fd -> fd
 
+(** @raise Not_found *)
 let of_id s =
   let ix = Str.search_forward (Str.regexp {|[0-9]+$|}) s 0 in
   let id = int_of_string (Str.string_after s ix) in
@@ -68,5 +69,5 @@ let of_id s =
     match prefix with
     | "ret" -> Function fundec
     | "fun" -> FunctionEntry fundec
-    | _     -> invalid_arg "Node.of_id: invalid prefix"
+    | _     -> raise Not_found
 

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -420,9 +420,12 @@ let merge_parsed parsed =
     match parsed with
     | [one] -> Cilfacade.callConstructors one
     | [] ->
-      prerr_endline "No files to analyze!";
-      raise Exit
-    | xs -> Cilfacade.getMergedAST xs |> Cilfacade.callConstructors
+      raise (FrontendError "no files to analyze")
+    | xs ->
+      try
+        Cilfacade.getMergedAST xs |> Cilfacade.callConstructors
+      with Errormsg.Error ->
+        raise (FrontendError "Errormsg.Error")
   in
 
   Cilfacade.rmTemps merged_AST;

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -473,7 +473,7 @@ let do_analyze change_info merged_AST =
     (* we first find the functions to analyze: *)
     if get_bool "dbg.verbose" then print_endline "And now...  the Goblin!";
     let (stf,exf,otf as funs) = Cilfacade.getFuns merged_AST in
-    if stf@exf@otf = [] then failwith "No suitable function to start from.";
+    if stf@exf@otf = [] then raise (FrontendError "no suitable function to start from");
     if get_bool "dbg.verbose" then ignore (Pretty.printf "Startfuns: %a\nExitfuns: %a\nOtherfuns: %a\n"
                                              L.pretty stf L.pretty exf L.pretty otf);
     (* and here we run the analysis! *)

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -397,7 +397,13 @@ let parse_preprocessed preprocessed =
     in
     Errormsg.transformLocation := transformLocation;
 
-    Cilfacade.getAST preprocessed_file
+    try
+      Cilfacade.getAST preprocessed_file
+    with
+    | Frontc.ParseError s ->
+      raise (FrontendError (Format.sprintf "Frontc.ParseError: %s" s))
+    | Errormsg.Error ->
+      raise (FrontendError "Errormsg.Error")
   in
   List.map get_ast_and_record_deps preprocessed
 

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -39,8 +39,12 @@ let current_file = ref dummyFile
     @raise GoblintCil.Errormsg.Error *)
 let parse fileName =
   let fileName_str = Fpath.to_string fileName in
+  Errormsg.hadErrors := false; (* reset because CIL doesn't *)
   let cabs2cil = Timing.wrap ~args:[("file", `String fileName_str)] "FrontC" Frontc.parse fileName_str in
-  Timing.wrap ~args:[("file", `String fileName_str)] "Cabs2cil" cabs2cil ()
+  let file = Timing.wrap ~args:[("file", `String fileName_str)] "Cabs2cil" cabs2cil () in
+  if !E.hadErrors then
+    E.s (E.error "There were parsing errors in %s" fileName_str);
+  file
 
 let print (fileAST: file) =
   dumpFile defaultCilPrinter stdout "stdout" fileAST
@@ -96,6 +100,7 @@ end
 
 (** @raise GoblintCil.Errormsg.Error *)
 let getMergedAST fileASTs =
+  Errormsg.hadErrors := false; (* reset because CIL doesn't *)
   let merged = Timing.wrap "mergeCIL"  (Mergecil.merge fileASTs) "stdout" in
   if !E.hadErrors then
     E.s (E.error "There were errors during merging\n");

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -35,6 +35,8 @@ let init () =
 
 let current_file = ref dummyFile
 
+(** @raise GoblintCil.FrontC.ParseError
+    @raise GoblintCil.Errormsg.Error *)
 let parse fileName =
   let fileName_str = Fpath.to_string fileName in
   let cabs2cil = Timing.wrap ~args:[("file", `String fileName_str)] "FrontC" Frontc.parse fileName_str in
@@ -60,6 +62,8 @@ let do_preprocess ast =
   iterGlobals ast (function GFun (fd,_) -> List.iter (f fd) !visitors | _ -> ())
 
 
+(** @raise GoblintCil.FrontC.ParseError
+    @raise GoblintCil.Errormsg.Error *)
 let getAST fileName =
   let fileAST = parse fileName in
   (*  rmTemps fileAST; *)
@@ -90,6 +94,7 @@ class addConstructors cons = object
   method! vtype _ = SkipChildren
 end
 
+(** @raise GoblintCil.Errormsg.Error *)
 let getMergedAST fileASTs =
   let merged = Timing.wrap "mergeCIL"  (Mergecil.merge fileASTs) "stdout" in
   if !E.hadErrors then

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -324,10 +324,13 @@ let () =
     type params = { nid: string }  [@@deriving of_yojson]
     type response = Yojson.Safe.t [@@deriving to_yojson]
     let process { nid } serv =
-      let n = Node.of_id nid in
-      match !Control.current_node_state_json n with
-      | Some json -> json
-      | None -> Response.Error.(raise (make ~code:InvalidRequest ~message:"not analyzed, non-existent or dead node" ()))
+      match Node.of_id nid with
+      | n ->
+        begin match !Control.current_node_state_json n with
+          | Some json -> json
+          | None -> Response.Error.(raise (make ~code:InvalidRequest ~message:"not analyzed, non-existent or dead node" ()))
+        end
+      | exception Not_found -> Response.Error.(raise (make ~code:InvalidRequest ~message:"not analyzed or non-existent node" ()))
   end);
 
   register (module struct

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -302,7 +302,10 @@ let () =
     let name = "functions"
     type params = unit [@@deriving of_yojson]
     type response = Function.t list [@@deriving to_yojson]
-    let process () serv = Function.getFunctionsList (Option.get serv.file).globals
+    let process () serv =
+      match serv.file with
+      | Some file -> Function.getFunctionsList file.globals
+      | None -> Response.Error.(raise (make ~code:InvalidRequest ~message:"not analyzed" ()))
   end);
 
   register (module struct

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -305,7 +305,7 @@ let () =
     let process () serv =
       match serv.file with
       | Some file -> Function.getFunctionsList file.globals
-      | None -> Response.Error.(raise (make ~code:InvalidRequest ~message:"not analyzed" ()))
+      | None -> Response.Error.(raise (make ~code:RequestFailed ~message:"not analyzed" ()))
   end);
 
   register (module struct
@@ -328,9 +328,9 @@ let () =
       | n ->
         begin match !Control.current_node_state_json n with
           | Some json -> json
-          | None -> Response.Error.(raise (make ~code:InvalidRequest ~message:"not analyzed, non-existent or dead node" ()))
+          | None -> Response.Error.(raise (make ~code:RequestFailed ~message:"not analyzed, non-existent or dead node" ()))
         end
-      | exception Not_found -> Response.Error.(raise (make ~code:InvalidRequest ~message:"not analyzed or non-existent node" ()))
+      | exception Not_found -> Response.Error.(raise (make ~code:RequestFailed ~message:"not analyzed or non-existent node" ()))
   end);
 
   register (module struct

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -324,10 +324,10 @@ let () =
     type params = { nid: string }  [@@deriving of_yojson]
     type response = Yojson.Safe.t [@@deriving to_yojson]
     let process { nid } serv =
-      let f = !Control.current_node_state_json in
       let n = Node.of_id nid in
-      let json = f n in
-      json
+      match !Control.current_node_state_json n with
+      | Some json -> json
+      | None -> Response.Error.(raise (make ~code:InvalidRequest ~message:"not analyzed, non-existent or dead node" ()))
   end);
 
   register (module struct


### PR DESCRIPTION
Closes #983. Instead of crashing, JSON-RPC errors are returned instead.

For preprocessing, parsing and merging errors, this introduces the `FrontendError` exception, which (hopefully) is safe to catch in server mode in order to continue.

/cc @FeldrinH