### PR TITLE
Use `Z` instead of `Big_int_Z` and `Cilint`

### DIFF
--- a/.semgrep/cilint.yml
+++ b/.semgrep/cilint.yml
@@ -1,0 +1,62 @@
+rules:
+  - id: cilint-to_string
+    pattern: Cilint.string_of_cilint
+    fix: Z.to_string
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: cilint-compare
+    pattern: Cilint.compare_cilint
+    fix: Z.compare
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: cilint-zero
+    pattern: Cilint.zero_cilint
+    fix: Z.zero
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: cilint-is-zero
+    pattern: Cilint.is_zero_cilint $X
+    fix: Z.equal $X Z.zero
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: cilint-to_int
+    pattern: Cilint.int_of_cilint
+    fix: Z.to_int
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: cilint-of_big_int
+    pattern: Cilint.cilint_of_big_int $X
+    fix: $X
+    message: Cilint is Z
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: cilint-to_big_int
+    pattern: Cilint.big_int_of_cilint $X
+    fix: $X
+    message: Cilint is Z
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: cilint-t
+    pattern: Cilint.cilint
+    fix: Z.t
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: cilint-open
+    pattern: open Cilint
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING

--- a/.semgrep/zarith.yml
+++ b/.semgrep/zarith.yml
@@ -194,3 +194,9 @@ rules:
     message: use Z instead
     languages: [ocaml]
     severity: WARNING
+
+  - id: big_int_z
+    pattern: Big_int_Z.$X
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING

--- a/.semgrep/zarith.yml
+++ b/.semgrep/zarith.yml
@@ -174,9 +174,16 @@ rules:
     languages: [ocaml]
     severity: WARNING
 
-  - id: big_int_z-compare-lt
-    pattern: Big_int_Z.lt_big_int $X $Y
-    fix: Z.compare $X $Y < 0
+  - id: big_int_z-lt
+    pattern: Big_int_Z.lt_big_int
+    fix: Z.lt
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-gt
+    pattern: Big_int_Z.gt_big_int
+    fix: Z.gt
     message: use Z instead
     languages: [ocaml]
     severity: WARNING

--- a/.semgrep/zarith.yml
+++ b/.semgrep/zarith.yml
@@ -213,3 +213,34 @@ rules:
     message: use Z instead
     languages: [ocaml]
     severity: WARNING
+
+  - id: z-add-one
+    pattern-either:
+      - pattern: Z.add $X Z.one
+      - pattern: Z.add Z.one $X
+      - pattern: Z.add Z.one @@ $X
+    fix: Z.succ $X
+    message: use Z.succ instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: z-sub-one
+    pattern: Z.sub $X Z.one
+    fix: Z.pred $X
+    message: use Z.pred instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: z-of_int-0
+    pattern: Z.of_int 0
+    fix: Z.zero
+    message: use Z.zero instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: z-of_int-1
+    pattern: Z.of_int 1
+    fix: Z.one
+    message: use Z.one instead
+    languages: [ocaml]
+    severity: WARNING

--- a/.semgrep/zarith.yml
+++ b/.semgrep/zarith.yml
@@ -200,3 +200,9 @@ rules:
     message: use Z instead
     languages: [ocaml]
     severity: WARNING
+
+  - id: big_int_z-open
+    pattern: open Big_int_Z
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING

--- a/.semgrep/zarith.yml
+++ b/.semgrep/zarith.yml
@@ -1,0 +1,196 @@
+rules:
+  - id: big_int_z-zero
+    pattern: Big_int_Z.zero_big_int
+    fix: Z.zero
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-to_float
+    pattern: Big_int_Z.float_of_big_int
+    fix: Z.to_float
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-of_int
+    pattern: Big_int_Z.big_int_of_int
+    fix: Z.of_int
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-t
+    pattern: Big_int_Z.big_int
+    fix: Z.t
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-mul
+    pattern: Big_int_Z.mult_big_int
+    fix: Z.mul
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-of_int64
+    pattern: Big_int_Z.big_int_of_int64
+    fix: Z.of_int64
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-to_int
+    pattern: Big_int_Z.int_of_big_int
+    fix: Z.to_int
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-to_int32
+    pattern: Big_int_Z.int32_of_big_int
+    fix: Z.to_int32
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-of_int32
+    pattern: Big_int_Z.big_int_of_int32
+    fix: Z.of_int32
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-to_int64
+    pattern: Big_int_Z.int64_of_big_int
+    fix: Z.to_int64
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-one
+    pattern: Big_int_Z.unit_big_int
+    fix: Z.one
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-neg
+    pattern: Big_int_Z.minus_big_int
+    fix: Z.neg
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-abs
+    pattern: Big_int_Z.abs_big_int
+    fix: Z.abs
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-add
+    pattern: Big_int_Z.add_big_int
+    fix: Z.add
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-sub
+    pattern: Big_int_Z.sub_big_int
+    fix: Z.sub
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-ediv
+    pattern: Big_int_Z.div_big_int
+    fix: Z.ediv
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-gcd
+    pattern: Big_int_Z.gcd_big_int
+    fix: Z.gcd
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-compare
+    pattern: Big_int_Z.compare_big_int
+    fix: Z.compare
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-of_string
+    pattern: Big_int_Z.big_int_of_string
+    fix: Z.of_string
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-to_string
+    pattern: Big_int_Z.string_of_big_int
+    fix: Z.to_string
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-logand
+    pattern: Big_int_Z.and_big_int
+    fix: Z.logand
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-logor
+    pattern: Big_int_Z.or_big_int
+    fix: Z.logor
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-logxor
+    pattern: Big_int_Z.xor_big_int
+    fix: Z.logxor
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-shift_left
+    pattern: Big_int_Z.shift_left_big_int
+    fix: Z.shift_left
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-shift_right
+    pattern: Big_int_Z.shift_right_big_int
+    fix: Z.shift_right
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-compare-lt
+    pattern: Big_int_Z.lt_big_int $X $Y
+    fix: Z.compare $X $Y < 0
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-equal
+    pattern: Big_int_Z.eq_big_int
+    fix: Z.equal
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING
+
+  - id: big_int_z-pow-int
+    pattern: Big_int_Z.power_int_positive_int $X $Y
+    fix: Z.pow (Z.of_int $X) $Y
+    message: use Z instead
+    languages: [ocaml]
+    severity: WARNING

--- a/bench/zarith/benchZarith.ml
+++ b/bench/zarith/benchZarith.ml
@@ -8,8 +8,8 @@ open Benchmark.Tree
 
 
 let () =
-  let pow2_pow n = Big_int_Z.power_int_positive_int 2 n in
-  let pow2_lsl n = Big_int_Z.shift_left_big_int Big_int_Z.unit_big_int n in
+  let pow2_pow n = Z.pow (Z.of_int 2) n in
+  let pow2_lsl n = Z.shift_left Z.one n in
 
 
   register (

--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -190,8 +190,8 @@ struct
     | ik when not (IntDomain.should_ignore_overflow ik) -> (* don't add type bounds for signed when assume_none *)
       let (type_min, type_max) = IntDomain.Size.range ik in
       (* TODO: don't go through CIL exp? *)
-      let e1 = BinOp (Le, Lval (Cil.var x), (Cil.kintegerCilint ik (Cilint.cilint_of_big_int type_max)), intType) in
-      let e2 = BinOp (Ge, Lval (Cil.var x), (Cil.kintegerCilint ik (Cilint.cilint_of_big_int type_min)), intType) in
+      let e1 = BinOp (Le, Lval (Cil.var x), (Cil.kintegerCilint ik type_max), intType) in
+      let e2 = BinOp (Ge, Lval (Cil.var x), (Cil.kintegerCilint ik type_min), intType) in
       let rel = RD.assert_inv rel e1 false (no_overflow ask e1) in (* TODO: how can be overflow when asserting type bounds? *)
       let rel = RD.assert_inv rel e2 false (no_overflow ask e2) in
       rel

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -780,7 +780,7 @@ struct
       (* seems like constFold already converts CChr to CInt *)
       | Const (CChr x) -> eval_rv a gs st (Const (charConstToInt x)) (* char becomes int, see Cil doc/ISO C 6.4.4.4.10 *)
       | Const (CInt (num,ikind,str)) ->
-        (match str with Some x -> M.tracel "casto" "CInt (%s, %a, %s)\n" (Cilint.string_of_cilint num) d_ikind ikind x | None -> ());
+        (match str with Some x -> M.tracel "casto" "CInt (%s, %a, %s)\n" (Z.to_string num) d_ikind ikind x | None -> ());
         `Int (ID.cast_to ikind (IntDomain.of_const (num,ikind,str)))
       | Const (CReal (_,fkind, Some str)) when not (Cilfacade.isComplexFKind fkind) -> `Float (FD.of_string fkind str) (* prefer parsing from string due to higher precision *)
       | Const (CReal (num, fkind, None)) when not (Cilfacade.isComplexFKind fkind) -> `Float (FD.of_const fkind num)
@@ -944,7 +944,7 @@ struct
               true
             else
               match Cil.getInteger (sizeOf t), Cil.getInteger (sizeOf at) with
-              | Some i1, Some i2 -> Cilint.compare_cilint i1 i2 <= 0
+              | Some i1, Some i2 -> Z.compare i1 i2 <= 0
               | _ ->
                 if contains_vla t || contains_vla (get_type_addr (x, o)) then
                   begin
@@ -1644,7 +1644,7 @@ struct
       in
       match last_index lval, stripCasts rval with
       | Some (lv, i), Const(CChr c) when c<>'\000' -> (* "abc" <> "abc\000" in OCaml! *)
-        let i = Cilint.int_of_cilint i in
+        let i = Z.to_int i in
         (* ignore @@ printf "%a[%i] = %c\n" d_lval lv i c; *)
         let s = try Hashtbl.find char_array lv with Not_found -> Bytes.empty in (* current string for lv or empty string *)
         if i >= Bytes.length s then ((* optimized b/c Out_of_memory *)

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -362,8 +362,8 @@ struct
                   let top_ik = ID.top_of ikind in
                   match ID.minimal b, ID.maximal b with
                   | Some lb, Some ub ->
-                    let starting = if Z.equal lb x then ID.starting ikind (Z.add lb Z.one) else top_ik in
-                    let ending = if Z.equal ub x then ID.ending ikind (Z.sub ub Z.one) else top_ik in
+                    let starting = if Z.equal lb x then ID.starting ikind (Z.succ lb) else top_ik in
+                    let ending = if Z.equal ub x then ID.ending ikind (Z.pred ub) else top_ik in
                     ID.meet starting ending
                   | _ ->
                     top_ik

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -4,7 +4,6 @@
 
 open Prelude.Ana
 open Analyses
-open Cilint
 
 module Spec : Analyses.MCPSpec =
 struct
@@ -57,13 +56,13 @@ struct
       begin
         (* Compare the cilint first in the hope that it is cheaper than the LVal comparison *)
         match e1, e2 with
-        | BinOp(PlusA, Lval l1, Const(CInt(i,_,_)), _), Lval l2 when (compare_cilint i zero_cilint > 0 && lvalsEq l1 l2) ->
+        | BinOp(PlusA, Lval l1, Const(CInt(i,_,_)), _), Lval l2 when (Z.compare i Z.zero > 0 && lvalsEq l1 l2) ->
           Queries.ID.of_bool (Cilfacade.get_ikind t) false  (* c > 0 => (! x+c < x) *)
-        | Lval l1, BinOp(PlusA, Lval l2, Const(CInt(i,_,_)), _) when (compare_cilint i zero_cilint < 0 && lvalsEq l1 l2) ->
+        | Lval l1, BinOp(PlusA, Lval l2, Const(CInt(i,_,_)), _) when (Z.compare i Z.zero < 0 && lvalsEq l1 l2) ->
           Queries.ID.of_bool (Cilfacade.get_ikind t) false  (* c < 0 => (! x < x+c )*)
-        | BinOp(MinusA, Lval l1, Const(CInt(i,_,_)), _), Lval l2 when (compare_cilint i zero_cilint < 0 && lvalsEq l1 l2) ->
+        | BinOp(MinusA, Lval l1, Const(CInt(i,_,_)), _), Lval l2 when (Z.compare i Z.zero < 0 && lvalsEq l1 l2) ->
           Queries.ID.of_bool (Cilfacade.get_ikind t) false  (* c < 0 => (! x-c < x) *)
-        | Lval l1, BinOp(MinusA, Lval l2, Const(CInt(i,_,_)), _) when (compare_cilint i zero_cilint > 0 && lvalsEq l1 l2) ->
+        | Lval l1, BinOp(MinusA, Lval l2, Const(CInt(i,_,_)), _) when (Z.compare i Z.zero > 0 && lvalsEq l1 l2) ->
           Queries.ID.of_bool (Cilfacade.get_ikind t) false  (* c > 0 => (! x < x-c) *)
         | _ ->
           Queries.ID.top ()
@@ -74,7 +73,7 @@ struct
         | BinOp(PlusA, Lval l1, Const(CInt(i,_,_)), _), Lval l2
         | Lval l2, BinOp(PlusA, Lval l1, Const(CInt(i,_,_)), _)
         | BinOp(MinusA, Lval l1, Const(CInt(i,_,_)), _), Lval l2
-        | Lval l2, BinOp(MinusA, Lval l1, Const(CInt(i,_,_)), _) when compare_cilint i zero_cilint <> 0 && (lvalsEq l1 l2) ->
+        | Lval l2, BinOp(MinusA, Lval l1, Const(CInt(i,_,_)), _) when Z.compare i Z.zero <> 0 && (lvalsEq l1 l2) ->
           Queries.ID.of_bool (Cilfacade.get_ikind t) false
         | _ ->
           Queries.ID.top ()

--- a/src/analyses/fileUse.ml
+++ b/src/analyses/fileUse.ml
@@ -84,7 +84,7 @@ struct
       | Lval lval, Const (CInt(i, kind, str)) ->
         (* ignore(printf "branch(%s==%i, %B)\n" v.vname (Int64.to_int i) tv); *)
         let k = D.key_from_lval lval in
-        if Cilint.compare_cilint i Cilint.zero_cilint = 0 && tv then (
+        if Z.compare i Z.zero = 0 && tv then (
           (* ignore(printf "error-branch\n"); *)
           D.error k m
         )else

--- a/src/analyses/spec.ml
+++ b/src/analyses/spec.ml
@@ -291,7 +291,7 @@ struct
         let binop = BinOp (Eq, Lval lval, Const (CInt(i, kind, str)), Cil.intType) in
         let key = D.key_from_lval lval in
         let value = D.find key m in
-        if Cilint.is_zero_cilint i && tv then (
+        if Z.equal i Z.zero && tv then (
           M.debug ~category:Analyzer "error-branch";
           (* D.remove key m *)
         )else(

--- a/src/analyses/tutorials/signs.ml
+++ b/src/analyses/tutorials/signs.ml
@@ -2,7 +2,6 @@
 
 open Prelude.Ana
 open Analyses
-open Cilint
 
 module Signs =
 struct
@@ -22,8 +21,8 @@ struct
 
   (* TODO: An attempt to abstract integers, but it's just a little wrong... *)
   let of_int i =
-    if compare_cilint i zero_cilint < 0 then Zero
-    else if compare_cilint i zero_cilint > 0 then Zero
+    if Z.compare i Z.zero < 0 then Zero
+    else if Z.compare i Z.zero > 0 then Zero
     else Zero
 
   let lt x y = match x, y with

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -486,9 +486,6 @@ struct
             else if Cil.isConstant e && Cil.isConstant i' then
               match Cil.getInteger e, Cil.getInteger i' with
               | Some (e'': Cilint.cilint), Some i'' ->
-                let (i'': BI.t) = Cilint.big_int_of_cilint  i'' in
-                let (e'': BI.t) = Cilint.big_int_of_cilint  e'' in
-
                 if BI.equal  i'' (BI.add e'' BI.one) then
                   (* If both are integer constants and they are directly adjacent, we change partitioning to maintain information *)
                   Partitioned (i', (Val.join xl xm, a, xr))

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -138,8 +138,8 @@ struct
         | hd::tl ->
           begin
             match Z.gt i max_i, Z.lt i min_i with
-            | false,true -> subjoin tl (Z.add i Z.one)
-            | false,false -> Val.join hd (subjoin tl (Z.add i Z.one))
+            | false,true -> subjoin tl (Z.succ i)
+            | false,false -> Val.join hd (subjoin tl (Z.succ i))
             | _,_ -> Val.bot ()
           end in
       subjoin xl Z.zero in
@@ -154,13 +154,13 @@ struct
       let rec weak_update l i = match l with
         | [] -> []
         | hd::tl ->
-          if Z.lt i min_i then hd::(weak_update tl (Z.add i Z.one))
+          if Z.lt i min_i then hd::(weak_update tl (Z.succ i))
           else if Z.gt i max_i then (hd::tl)
-          else (Val.join hd v)::(weak_update tl (Z.add i Z.one)) in
+          else (Val.join hd v)::(weak_update tl (Z.succ i)) in
       let rec full_update l i = match l with
         | [] -> []
         | hd::tl ->
-          if Z.lt i min_i then hd::(full_update tl (Z.add i Z.one))
+          if Z.lt i min_i then hd::(full_update tl (Z.succ i))
           else v::tl in
       if Z.equal min_i max_i then full_update xl Z.zero
       else weak_update xl Z.zero in

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -135,8 +135,8 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
   let of_int x =
     match IntDomain.IntDomTuple.minimal x, IntDomain.IntDomTuple.maximal x with
     | Some l, Some h when l >= Float_t.to_big_int Float_t.lower_bound && h <= Float_t.to_big_int Float_t.upper_bound ->
-      let l' = Float_t.of_float Down (Big_int_Z.float_of_big_int l) in
-      let h' = Float_t.of_float Up (Big_int_Z.float_of_big_int h) in
+      let l' = Float_t.of_float Down (Z.to_float l) in
+      let h' = Float_t.of_float Up (Z.to_float h) in
       if not (Float_t.is_finite l' && Float_t.is_finite h') then
         Top
       else
@@ -353,7 +353,7 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
       | _ -> (0, 1)
     in
     IntDomain.IntDomTuple.of_interval IBool
-      (Big_int_Z.big_int_of_int a, Big_int_Z.big_int_of_int b)
+      (Z.of_int a, Z.of_int b)
 
 
   let eval_neg = function
@@ -555,7 +555,7 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
       | _ -> (0, 0)
     in
     IntDomain.IntDomTuple.of_interval IBool
-      (Big_int_Z.big_int_of_int l, Big_int_Z.big_int_of_int u)
+      (Z.of_int l, Z.of_int u)
 
   let ne a b =
     Messages.warn
@@ -575,7 +575,7 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
       | _ -> (1, 1)
     in
     IntDomain.IntDomTuple.of_interval IBool
-      (Big_int_Z.big_int_of_int l, Big_int_Z.big_int_of_int u)
+      (Z.of_int l, Z.of_int u)
 
   let unordered op1 op2 =
     let a, b =
@@ -585,10 +585,10 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
       | Top, _ | _, Top -> (0,1) (*neither of the arguments is Top/Bot/NaN*)
       | _ -> (0, 0)
     in
-    IntDomain.IntDomTuple.of_interval IBool (Big_int_Z.big_int_of_int a, Big_int_Z.big_int_of_int b)
+    IntDomain.IntDomTuple.of_interval IBool (Z.of_int a, Z.of_int b)
 
-  let true_nonZero_IInt = IntDomain.IntDomTuple.of_excl_list IInt [(Big_int_Z.big_int_of_int 0)]
-  let false_zero_IInt = IntDomain.IntDomTuple.of_int IInt (Big_int_Z.big_int_of_int 0)
+  let true_nonZero_IInt = IntDomain.IntDomTuple.of_excl_list IInt [(Z.of_int 0)]
+  let false_zero_IInt = IntDomain.IntDomTuple.of_int IInt (Z.of_int 0)
   let unknown_IInt = IntDomain.IntDomTuple.top_of IInt
 
   let eval_isnormal = function

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -587,8 +587,8 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
     in
     IntDomain.IntDomTuple.of_interval IBool (Z.of_int a, Z.of_int b)
 
-  let true_nonZero_IInt = IntDomain.IntDomTuple.of_excl_list IInt [(Z.of_int 0)]
-  let false_zero_IInt = IntDomain.IntDomTuple.of_int IInt (Z.of_int 0)
+  let true_nonZero_IInt = IntDomain.IntDomTuple.of_excl_list IInt [Z.zero]
+  let false_zero_IInt = IntDomain.IntDomTuple.of_int IInt Z.zero
   let unknown_IInt = IntDomain.IntDomTuple.top_of IInt
 
   let eval_isnormal = function

--- a/src/cdomains/floatOps/floatOps.ml
+++ b/src/cdomains/floatOps/floatOps.ml
@@ -42,9 +42,9 @@ let big_int_of_float f =
   let x, n = Float.frexp f in
   let shift = min 52 n in
   let x' = x *. Float.pow 2. (Float.of_int shift) in
-  Big_int_Z.mult_big_int
-    (Big_int_Z.big_int_of_int64 (Int64.of_float x'))
-    (Big_int_Z.power_int_positive_int 2 (n - shift))
+  Z.mul
+    (Z.of_int64 (Int64.of_float x'))
+    (Z.pow (Z.of_int 2) (n - shift))
 
 module CDouble = struct
   type t = float [@@deriving eq, ord, to_yojson]

--- a/src/cdomains/floatOps/floatOps.ml
+++ b/src/cdomains/floatOps/floatOps.ml
@@ -15,7 +15,7 @@ module type CFloatType = sig
 
   val of_float: round_mode -> float -> t
   val to_float: t -> float option
-  val to_big_int: t -> Big_int_Z.big_int
+  val to_big_int: t -> Z.t
 
   val is_finite: t -> bool
   val pred: t -> t

--- a/src/cdomains/floatOps/floatOps.mli
+++ b/src/cdomains/floatOps/floatOps.mli
@@ -15,7 +15,7 @@ module type CFloatType = sig
 
   val of_float: round_mode -> float -> t
   val to_float: t -> float option
-  val to_big_int: t -> Big_int_Z.big_int
+  val to_big_int: t -> Z.t
 
   val is_finite: t -> bool
   val pred: t -> t

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -422,8 +422,8 @@ module Size = struct (* size in bits as int, range as int64 *)
     let c = card t in
     (* let z = add (rem (sub x a) c) a in (* might lead to overflows itself... *)*)
     let y = Z.erem x c in
-    let y = if Z.compare y b > 0 then Z.sub y c
-      else if Z.compare y a < 0 then Z.add y c
+    let y = if Z.gt y b then Z.sub y c
+      else if Z.lt y a then Z.add y c
       else y
     in
     if M.tracing then M.tracel "cast_int" "Cast %s to range [%s, %s] (%s) = %s (%s in int64)\n" (Z.to_string x) (Z.to_string a) (Z.to_string b) (Z.to_string c) (Z.to_string y) (if is_int64_big_int y then "fits" else "does not fit");

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -408,7 +408,7 @@ module Size = struct (* size in bits as int, range as int64 *)
   let range ik =
     let a,b = bits ik in
     let x = if isSigned ik then Z.neg (Z.shift_left Z.one a) (* -2^a *) else Z.zero in
-    let y = Z.sub (Z.shift_left Z.one b) Z.one in (* 2^b - 1 *)
+    let y = Z.pred (Z.shift_left Z.one b) in (* 2^b - 1 *)
     x,y
 
   let is_cast_injective ~from_type ~to_type =

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -323,7 +323,7 @@ module IntDomTuple : sig
   val ikind: t -> ikind
 end
 
-val of_const: Cilint.cilint * Cil.ikind * string option -> IntDomTuple.t
+val of_const: Z.t * Cil.ikind * string option -> IntDomTuple.t
 
 
 module Size : sig

--- a/src/cdomains/symbLocksDomain.ml
+++ b/src/cdomains/symbLocksDomain.ml
@@ -54,7 +54,7 @@ struct
 
   let eq_const c1 c2 =
     match c1, c2 with
-    | CInt (i1,_,_), CInt (i2,_,_)     -> Cilint.compare_cilint i1 i2 = 0
+    | CInt (i1,_,_), CInt (i2,_,_)     -> Z.compare i1 i2 = 0
     |	CStr (s1,_)        , CStr (s2,_)         -> s1=s2
     |	CWStr (s1,_)       , CWStr (s2,_)        -> s1=s2
     |	CChr c1        , CChr c2         -> c1=c2

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -108,7 +108,7 @@ struct
 
   let array_length_idx default length =
     let l = BatOption.bind length (fun e -> Cil.getInteger (Cil.constFold true e)) in
-    BatOption.map_default (fun x-> IndexDomain.of_int (Cilfacade.ptrdiff_ikind ()) @@ Cilint.big_int_of_cilint x) default l
+    BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) default l
 
   let rec bot_value ?(varAttr=[]) (t: typ): t =
     match t with
@@ -981,7 +981,7 @@ struct
               let new_value_at_index = do_update_offset ask `Bot offs value exp l' o' v t in
               let new_array_value =  CArrays.set ask x' (e, idx) new_value_at_index in
               let len_ci = BatOption.bind len (fun e -> Cil.getInteger @@ Cil.constFold true e) in
-              let len_id = BatOption.map (fun ci -> IndexDomain.of_int (Cilfacade.ptrdiff_ikind ()) @@ Cilint.big_int_of_cilint ci) len_ci in
+              let len_id = BatOption.map (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) len_ci in
               let newl = BatOption.default (ID.starting (Cilfacade.ptrdiff_ikind ()) Z.zero) len_id in
               let new_array_value = CArrays.update_length newl new_array_value in
               `Array new_array_value

--- a/src/domains/myCheck.ml
+++ b/src/domains/myCheck.ml
@@ -41,7 +41,7 @@ struct
     in
     set_shrink shrink int64
 
-  let big_int: Big_int_Z.big_int arbitrary =
+  let big_int: Z.t arbitrary =
     let open Big_int_Z in
     let shrink x yield =
       let y = ref x in

--- a/src/domains/myCheck.ml
+++ b/src/domains/myCheck.ml
@@ -42,14 +42,13 @@ struct
     set_shrink shrink int64
 
   let big_int: Z.t arbitrary =
-    let open Big_int_Z in
     let shrink x yield =
       let y = ref x in
-      let two_big_int = big_int_of_int 2 in
-      while not (eq_big_int !y zero_big_int) do y := div_big_int !y two_big_int; yield !y; done;
+      let two_big_int = Z.of_int 2 in
+      while not (Z.equal !y Z.zero) do y := Z.ediv !y two_big_int; yield !y; done;
       ()
     in
-    set_print string_of_big_int @@ set_shrink shrink @@ QCheck.map big_int_of_int64 int64
+    set_print Z.to_string @@ set_shrink shrink @@ QCheck.map Z.of_int64 int64
 
   let sequence (arbs: 'a arbitrary list): 'a list arbitrary =
     let gens = List.map gen arbs in

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -40,7 +40,7 @@ let compare_name (a: string) (b: string) =
 
 let rec eq_constant ~(rename_mapping: rename_mapping) ~(acc: (typ * typ) list) (a: constant) (b: constant) =
   match a, b with
-  | CInt (val1, kind1, str1), CInt (val2, kind2, str2) -> Cilint.compare_cilint val1 val2 = 0 && kind1 = kind2 (* Ignore string representation, i.e. 0x2 == 2 *)
+  | CInt (val1, kind1, str1), CInt (val2, kind2, str2) -> Z.compare val1 val2 = 0 && kind1 = kind2 (* Ignore string representation, i.e. 0x2 == 2 *)
   | CEnum (exp1, str1, enuminfo1), CEnum (exp2, str2, enuminfo2) -> eq_exp exp1 exp2 ~rename_mapping ~acc (* Ignore name and enuminfo  *)
   | a, b -> a = b
 

--- a/src/util/intOps.ml
+++ b/src/util/intOps.ml
@@ -219,16 +219,8 @@ struct
   let add = Z.add
   let sub = Z.sub
   let mul = Z.mul
-
-  (* If the first operand of a div is negative, Zarith rounds the result away from zero.
-     We thus always transform this into a division with a non-negative first operand.
-  *)
-  let div a b = if Z.lt a zero then Z.neg (Z.ediv (Z.neg a) b) else Z.ediv a b
-
-  (* Z.erem computes the Euclidian Modulus, but what we want here is the remainder, as returned by mod on ints
-     -1 rem 5 == -1, whereas -1 Euclid-Mod 5 == 4
-  *)
-  let rem a b = Z.sub a (mul b (div a b))
+  let div = Z.div
+  let rem = Z.rem
 
   let gcd x y = abs @@ Z.gcd x y
   let compare = Z.compare

--- a/src/util/intOps.ml
+++ b/src/util/intOps.ml
@@ -53,8 +53,8 @@ sig
   val to_int64 : t -> int64
   val of_string : string -> t (* TODO: unused *)
   val to_string : t -> string
-  val of_bigint : Big_int_Z.big_int -> t
-  val to_bigint : t -> Big_int_Z.big_int
+  val of_bigint : Z.t -> t
+  val to_bigint : t -> Z.t
 end
 
 module type IntOps =
@@ -206,9 +206,9 @@ struct
   let to_bigint = Z.of_int64
 end
 
-module BigIntOpsBase : IntOpsBase with type t = Big_int_Z.big_int =
+module BigIntOpsBase : IntOpsBase with type t = Z.t =
 struct
-  type t = Big_int_Z.big_int
+  type t = Z.t
   let zero = Z.zero
   let one = Z.one
   let upper_bound = None
@@ -225,7 +225,7 @@ struct
   *)
   let div a b = if Z.compare a zero < 0 then Z.neg (Z.ediv (Z.neg a) b) else Z.ediv a b
 
-  (* Big_int_Z.mod_big_int computes the Euclidian Modulus, but what we want here is the remainder, as returned by mod on ints
+  (* Z.erem computes the Euclidian Modulus, but what we want here is the remainder, as returned by mod on ints
      -1 rem 5 == -1, whereas -1 Euclid-Mod 5 == 4
   *)
   let rem a b = Z.sub a (mul b (div a b))

--- a/src/util/intOps.ml
+++ b/src/util/intOps.ml
@@ -112,8 +112,8 @@ struct
   let to_int64 = Int64.of_int
   let of_string = int_of_string
   let to_string = string_of_int
-  let of_bigint = Big_int_Z.int_of_big_int
-  let to_bigint = Big_int_Z.big_int_of_int
+  let of_bigint = Z.to_int
+  let to_bigint = Z.of_int
 end
 
 module Int32OpsBase : IntOpsBase with type t = int32 =
@@ -157,8 +157,8 @@ struct
   let to_int64 = Int64.of_int32
   let of_string = Int32.of_string
   let to_string = Int32.to_string
-  let of_bigint = Big_int_Z.int32_of_big_int
-  let to_bigint = Big_int_Z.big_int_of_int32
+  let of_bigint = Z.to_int32
+  let to_bigint = Z.of_int32
 end
 
 module Int64OpsBase : IntOpsBase with type t = int64 =
@@ -202,37 +202,37 @@ struct
   let to_int64 x = x
   let of_string = Int64.of_string
   let to_string = Int64.to_string
-  let of_bigint = Big_int_Z.int64_of_big_int
-  let to_bigint = Big_int_Z.big_int_of_int64
+  let of_bigint = Z.to_int64
+  let to_bigint = Z.of_int64
 end
 
 module BigIntOpsBase : IntOpsBase with type t = Big_int_Z.big_int =
 struct
   type t = Big_int_Z.big_int
-  let zero = Big_int_Z.zero_big_int
-  let one = Big_int_Z.unit_big_int
+  let zero = Z.zero
+  let one = Z.one
   let upper_bound = None
   let lower_bound = None
 
-  let neg = Big_int_Z.minus_big_int
-  let abs = Big_int_Z.abs_big_int
-  let add = Big_int_Z.add_big_int
-  let sub = Big_int_Z.sub_big_int
-  let mul = Big_int_Z.mult_big_int
+  let neg = Z.neg
+  let abs = Z.abs
+  let add = Z.add
+  let sub = Z.sub
+  let mul = Z.mul
 
   (* If the first operand of a div is negative, Zarith rounds the result away from zero.
      We thus always transform this into a division with a non-negative first operand.
   *)
-  let div a b = if Big_int_Z.lt_big_int a zero then Big_int_Z.minus_big_int (Big_int_Z.div_big_int (Big_int_Z.minus_big_int a) b) else Big_int_Z.div_big_int a b
+  let div a b = if Z.compare a zero < 0 then Z.neg (Z.ediv (Z.neg a) b) else Z.ediv a b
 
   (* Big_int_Z.mod_big_int computes the Euclidian Modulus, but what we want here is the remainder, as returned by mod on ints
      -1 rem 5 == -1, whereas -1 Euclid-Mod 5 == 4
   *)
-  let rem a b = Big_int_Z.sub_big_int a (mul b (div a b))
+  let rem a b = Z.sub a (mul b (div a b))
 
-  let gcd x y = abs @@ Big_int_Z.gcd_big_int x y
-  let compare = Big_int_Z.compare_big_int
-  let equal = Big_int_Z.eq_big_int
+  let gcd x y = abs @@ Z.gcd x y
+  let compare = Z.compare
+  let equal = Z.equal
   let hash = Z.hash
 
   let top_range _ _ = false
@@ -240,21 +240,21 @@ struct
   let max = Z.max
   let min = Z.min
 
-  let of_int = Big_int_Z.big_int_of_int
-  let to_int = Big_int_Z.int_of_big_int
-  let of_int64 x = Big_int_Z.big_int_of_int64 x
-  let to_int64 x = Big_int_Z.int64_of_big_int x
-  let of_string = Big_int_Z.big_int_of_string
-  let to_string = Big_int_Z.string_of_big_int
+  let of_int = Z.of_int
+  let to_int = Z.to_int
+  let of_int64 x = Z.of_int64 x
+  let to_int64 x = Z.to_int64 x
+  let of_string = Z.of_string
+  let to_string = Z.to_string
   let of_bigint x = x
   let to_bigint x = x
 
-  let shift_left = Big_int_Z.shift_left_big_int
-  let shift_right = Big_int_Z.shift_right_big_int
+  let shift_left = Z.shift_left
+  let shift_right = Z.shift_right
   let bitnot x = sub (neg x) one
-  let bitand = Big_int_Z.and_big_int
-  let bitor = Big_int_Z.or_big_int
-  let bitxor = Big_int_Z.xor_big_int
+  let bitand = Z.logand
+  let bitor = Z.logor
+  let bitxor = Z.logxor
 
 end
 

--- a/src/util/intOps.ml
+++ b/src/util/intOps.ml
@@ -223,7 +223,7 @@ struct
   (* If the first operand of a div is negative, Zarith rounds the result away from zero.
      We thus always transform this into a division with a non-negative first operand.
   *)
-  let div a b = if Z.compare a zero < 0 then Z.neg (Z.ediv (Z.neg a) b) else Z.ediv a b
+  let div a b = if Z.lt a zero then Z.neg (Z.ediv (Z.neg a) b) else Z.ediv a b
 
   (* Z.erem computes the Euclidian Modulus, but what we want here is the remainder, as returned by mod on ints
      -1 rem 5 == -1, whereas -1 Euclid-Mod 5 == 4

--- a/src/util/intOps.ml
+++ b/src/util/intOps.ml
@@ -222,7 +222,7 @@ struct
   let div = Z.div
   let rem = Z.rem
 
-  let gcd x y = abs @@ Z.gcd x y
+  let gcd = Z.gcd
   let compare = Z.compare
   let equal = Z.equal
   let hash = Z.hash

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -106,12 +106,12 @@ class findAssignmentConstDiff((diff: Z.t option ref), var) = object
     | Set ((Var v, NoOffset), BinOp (PlusA, Lval (Var v2, NoOffset), Const (CInt (cint,_,_)), _ ),_,_) when v.vid = var.vid && v2.vid = var.vid ->
       ( match !diff with
         | Some _ -> raise WrongOrMultiple
-        | _ -> diff := Some (Cilint.big_int_of_cilint cint); SkipChildren
+        | _ -> diff := Some cint; SkipChildren
       )
     | Set ((Var v, NoOffset), BinOp (MinusA, Lval (Var v2, NoOffset), Const (CInt (cint,_,_)), _ ),_,_) when v.vid = var.vid && v2.vid = var.vid ->
       ( match !diff with
         | Some _ -> raise WrongOrMultiple
-        | _ -> diff := Some (Z.neg (Cilint.big_int_of_cilint cint)); SkipChildren
+        | _ -> diff := Some (Z.neg cint); SkipChildren
       )
     | Set ((Var v, NoOffset), _,_,_) when v.vid = var.vid  -> raise WrongOrMultiple
     | _ -> SkipChildren
@@ -134,7 +134,7 @@ type assignment =
   | Other
 
 let classifyInstruction var = function
-  | Set (((Var info), NoOffset), Const(CInt (i,_,_)), _,_) when info.vid = var.vid -> Const (Cilint.big_int_of_cilint i)
+  | Set (((Var info), NoOffset), Const(CInt (i,_,_)), _,_) when info.vid = var.vid -> Const i
   | Set (((Var info), NoOffset), _                       , _,_) when info.vid = var.vid -> Other
   | _ -> NoAssign
 
@@ -232,11 +232,11 @@ let rec loopIterations start diff comp =
   in
   match comp with
   | BinOp (op, (Const _ as c), var, t) -> loopIterations start diff (BinOp (flip op, var, c, t))
-  | BinOp (Lt, _, (Const (CInt (cint,_,_) )), _) -> if Z.lt diff Z.zero then None else loopIterations' (Cilint.big_int_of_cilint cint) false
-  | BinOp (Gt, _, (Const (CInt (cint,_,_) )), _) -> if Z.gt diff Z.zero then None else loopIterations' (Cilint.big_int_of_cilint cint) false
-  | BinOp (Le, _, (Const (CInt (cint,_,_) )), _) -> if Z.lt diff Z.zero then None else loopIterations' (Z.succ @@ Cilint.big_int_of_cilint cint) false
-  | BinOp (Ge, _, (Const (CInt (cint,_,_) )), _) -> if Z.gt diff Z.zero then None else loopIterations' (Z.pred @@ Cilint.big_int_of_cilint cint ) false
-  | BinOp (Ne, _, (Const (CInt (cint,_,_) )), _) -> loopIterations' (Cilint.big_int_of_cilint cint) true
+  | BinOp (Lt, _, (Const (CInt (cint,_,_) )), _) -> if Z.lt diff Z.zero then None else loopIterations' cint false
+  | BinOp (Gt, _, (Const (CInt (cint,_,_) )), _) -> if Z.gt diff Z.zero then None else loopIterations' cint false
+  | BinOp (Le, _, (Const (CInt (cint,_,_) )), _) -> if Z.lt diff Z.zero then None else loopIterations' (Z.succ @@ cint) false
+  | BinOp (Ge, _, (Const (CInt (cint,_,_) )), _) -> if Z.gt diff Z.zero then None else loopIterations' (Z.pred @@ cint) false
+  | BinOp (Ne, _, (Const (CInt (cint,_,_) )), _) -> loopIterations' cint true
   | _ -> failwith "unexpected comparison in loopIterations"
 
 let ( >>= ) = Option.bind

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -227,14 +227,14 @@ let rec loopIterations start diff comp =
          else if shouldBeExact then
            None
          else
-           Some (Z.add roundedDown Z.one)
+           Some (Z.succ roundedDown)
        )
   in
   match comp with
   | BinOp (op, (Const _ as c), var, t) -> loopIterations start diff (BinOp (flip op, var, c, t))
   | BinOp (Lt, _, (Const (CInt (cint,_,_) )), _) -> if Z.lt diff Z.zero then None else loopIterations' (Cilint.big_int_of_cilint cint) false
   | BinOp (Gt, _, (Const (CInt (cint,_,_) )), _) -> if Z.gt diff Z.zero then None else loopIterations' (Cilint.big_int_of_cilint cint) false
-  | BinOp (Le, _, (Const (CInt (cint,_,_) )), _) -> if Z.lt diff Z.zero then None else loopIterations' (Z.add Z.one @@ Cilint.big_int_of_cilint cint) false
+  | BinOp (Le, _, (Const (CInt (cint,_,_) )), _) -> if Z.lt diff Z.zero then None else loopIterations' (Z.succ @@ Cilint.big_int_of_cilint cint) false
   | BinOp (Ge, _, (Const (CInt (cint,_,_) )), _) -> if Z.gt diff Z.zero then None else loopIterations' (Z.pred @@ Cilint.big_int_of_cilint cint ) false
   | BinOp (Ne, _, (Const (CInt (cint,_,_) )), _) -> loopIterations' (Cilint.big_int_of_cilint cint) true
   | _ -> failwith "unexpected comparison in loopIterations"

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -234,8 +234,8 @@ let rec loopIterations start diff comp =
   | BinOp (op, (Const _ as c), var, t) -> loopIterations start diff (BinOp (flip op, var, c, t))
   | BinOp (Lt, _, (Const (CInt (cint,_,_) )), _) -> if Z.lt diff Z.zero then None else loopIterations' cint false
   | BinOp (Gt, _, (Const (CInt (cint,_,_) )), _) -> if Z.gt diff Z.zero then None else loopIterations' cint false
-  | BinOp (Le, _, (Const (CInt (cint,_,_) )), _) -> if Z.lt diff Z.zero then None else loopIterations' (Z.succ @@ cint) false
-  | BinOp (Ge, _, (Const (CInt (cint,_,_) )), _) -> if Z.gt diff Z.zero then None else loopIterations' (Z.pred @@ cint) false
+  | BinOp (Le, _, (Const (CInt (cint,_,_) )), _) -> if Z.lt diff Z.zero then None else loopIterations' (Z.succ cint) false
+  | BinOp (Ge, _, (Const (CInt (cint,_,_) )), _) -> if Z.gt diff Z.zero then None else loopIterations' (Z.pred cint) false
   | BinOp (Ne, _, (Const (CInt (cint,_,_) )), _) -> loopIterations' cint true
   | _ -> failwith "unexpected comparison in loopIterations"
 

--- a/src/util/wideningThresholds.ml
+++ b/src/util/wideningThresholds.ml
@@ -7,7 +7,6 @@ module Thresholds = Set.Make(Z)
 (* differentiating between upper and lower bounds, because e.g. expr > 10 is definitely true for an interval [11, x] and definitely false for an interval [x, 10] *)
 (* apron octagons use thresholds for c in inequalities +/- x +/- y <= c *)
 let addThreshold t_ref z = t_ref := Thresholds.add z !t_ref
-let one = Z.of_int 1
 
 class extractThresholdsFromConditionsVisitor(upper_thresholds,lower_thresholds, octagon_thresholds) = object
   inherit nopCilVisitor
@@ -19,9 +18,9 @@ class extractThresholdsFromConditionsVisitor(upper_thresholds,lower_thresholds, 
     | BinOp (Lt, _, (Const (CInt(i,_,_))), (TInt _))
     | BinOp (Gt, (Const (CInt(i,_,_))), _, (TInt _)) ->
       addThreshold upper_thresholds @@ i;
-      addThreshold lower_thresholds @@ Z.sub i one;
+      addThreshold lower_thresholds @@ Z.pred i;
 
-      let negI = Z.add one @@ Z.neg i in
+      let negI = Z.succ @@ Z.neg i in
       addThreshold octagon_thresholds @@ i; (* upper, just large enough: x + Y <= i *)
       addThreshold octagon_thresholds @@ negI; (* lower, just small enough: -X -Y  <= -i+1 -> X + Y >= i-1 -> X + Y >= i-1 *)
       addThreshold octagon_thresholds @@ Z.add i i; (* double upper: X + X <= 2i -> X <= i *)
@@ -33,11 +32,11 @@ class extractThresholdsFromConditionsVisitor(upper_thresholds,lower_thresholds, 
     | BinOp (Gt, _, (Const (CInt(i,_,_))), (TInt _))
     | BinOp (Le, _, (Const (CInt(i,_,_))), (TInt _))
     | BinOp (Ge, (Const (CInt(i,_,_))), _, (TInt _)) ->
-      let i = Z.add i one in (* The same as above with i+1 because for integers expr <= 10 <=> expr < 11 *)
+      let i = Z.succ i in (* The same as above with i+1 because for integers expr <= 10 <=> expr < 11 *)
       addThreshold upper_thresholds @@ i;
-      addThreshold lower_thresholds @@ Z.sub i one;
+      addThreshold lower_thresholds @@ Z.pred i;
 
-      let negI = Z.add one @@ Z.neg i in
+      let negI = Z.succ @@ Z.neg i in
       addThreshold octagon_thresholds @@ i;
       addThreshold octagon_thresholds @@ negI;
       addThreshold octagon_thresholds @@ Z.add i i;

--- a/unittest/cdomains/floatDomainTest.ml
+++ b/unittest/cdomains/floatDomainTest.ml
@@ -24,9 +24,9 @@ struct
   let fi_zero = FI.of_const 0.
   let fi_one = FI.of_const 1.
   let fi_neg_one = FI.of_const (-.1.)
-  let itb_true = IT.of_int IBool (Z.of_int 1)
-  let itb_false = IT.of_int IBool (Z.of_int 0)
-  let itb_unknown = IT.of_interval IBool (Z.of_int 0, Z.of_int 1)
+  let itb_true = IT.of_int IBool Z.one
+  let itb_false = IT.of_int IBool Z.zero
+  let itb_unknown = IT.of_interval IBool (Z.zero, Z.one)
 
   let assert_equal v1 v2 =
     assert_equal ~cmp:FI.equal ~printer:FI.show v1 v2
@@ -139,7 +139,7 @@ struct
       cast (IT.of_int IInt Z.zero) fi_zero;
       cast (IT.of_int IInt Z.one) fi_one;
       (* no IChar because char has unknown signedness (particularly, unsigned on arm64) *)
-      cast (IT.of_interval IUChar (Z.of_int 0, Z.of_int 128)) (FI.of_interval (0., 128.));
+      cast (IT.of_interval IUChar (Z.zero, Z.of_int 128)) (FI.of_interval (0., 128.));
       cast (IT.of_interval ISChar (Z.of_int (-8), Z.of_int (-1))) (FI.of_interval (-. 8., - 1.));
       cast (IT.of_interval IUInt (Z.of_int 2, Z.of_int 100)) (FI.of_interval (2., 100.));
       cast (IT.of_interval IInt (Z.of_int (- 100), Z.of_int 100)) (FI.of_interval (-. 100., 100.));
@@ -171,7 +171,7 @@ struct
       cast IBool fi_zero (IT.of_bool IBool false);
 
       (* no IChar because char has unknown signedness (particularly, unsigned on arm64) *)
-      cast IUChar (FI.of_interval (0.123, 128.999)) (IT.of_interval IUChar (Z.of_int 0, Z.of_int 128));
+      cast IUChar (FI.of_interval (0.123, 128.999)) (IT.of_interval IUChar (Z.zero, Z.of_int 128));
       cast ISChar (FI.of_interval (-. 8.0000000, 127.)) (IT.of_interval ISChar (Z.of_int (-8), Z.of_int 127));
       cast IUInt (FI.of_interval (2., 100.)) (IT.of_interval IUInt (Z.of_int 2, Z.of_int 100));
       cast IInt (FI.of_interval (-. 100.2, 100.1)) (IT.of_interval IInt (Z.of_int (- 100), Z.of_int 100));

--- a/unittest/cdomains/floatDomainTest.ml
+++ b/unittest/cdomains/floatDomainTest.ml
@@ -24,9 +24,9 @@ struct
   let fi_zero = FI.of_const 0.
   let fi_one = FI.of_const 1.
   let fi_neg_one = FI.of_const (-.1.)
-  let itb_true = IT.of_int IBool (Big_int_Z.big_int_of_int 1)
-  let itb_false = IT.of_int IBool (Big_int_Z.big_int_of_int 0)
-  let itb_unknown = IT.of_interval IBool (Big_int_Z.big_int_of_int 0, Big_int_Z.big_int_of_int 1)
+  let itb_true = IT.of_int IBool (Z.of_int 1)
+  let itb_false = IT.of_int IBool (Z.of_int 0)
+  let itb_unknown = IT.of_interval IBool (Z.of_int 0, Z.of_int 1)
 
   let assert_equal v1 v2 =
     assert_equal ~cmp:FI.equal ~printer:FI.show v1 v2
@@ -126,7 +126,7 @@ struct
 
   let test_FI_casti2f_specific _ =
     let cast_bool a b =
-      assert_equal b (FI.of_int (IT.of_int IBool (Big_int_Z.big_int_of_int a))) in
+      assert_equal b (FI.of_int (IT.of_int IBool (Z.of_int a))) in
     begin
       cast_bool 0 fi_zero;
       cast_bool 1 fi_one
@@ -136,24 +136,24 @@ struct
       GobConfig.set_bool "ana.int.interval" true;
       cast (IT.top_of IInt) (FI.of_interval (-2147483648.,2147483647.));
       cast (IT.top_of IBool) (FI.of_interval (0., 1.));
-      cast (IT.of_int IInt Big_int_Z.zero_big_int) fi_zero;
-      cast (IT.of_int IInt Big_int_Z.unit_big_int) fi_one;
+      cast (IT.of_int IInt Z.zero) fi_zero;
+      cast (IT.of_int IInt Z.one) fi_one;
       (* no IChar because char has unknown signedness (particularly, unsigned on arm64) *)
-      cast (IT.of_interval IUChar (Big_int_Z.big_int_of_int 0, Big_int_Z.big_int_of_int 128)) (FI.of_interval (0., 128.));
-      cast (IT.of_interval ISChar (Big_int_Z.big_int_of_int (-8), Big_int_Z.big_int_of_int (-1))) (FI.of_interval (-. 8., - 1.));
-      cast (IT.of_interval IUInt (Big_int_Z.big_int_of_int 2, Big_int_Z.big_int_of_int 100)) (FI.of_interval (2., 100.));
-      cast (IT.of_interval IInt (Big_int_Z.big_int_of_int (- 100), Big_int_Z.big_int_of_int 100)) (FI.of_interval (-. 100., 100.));
-      cast (IT.of_interval IUShort (Big_int_Z.big_int_of_int 2, Big_int_Z.big_int_of_int 100)) (FI.of_interval (2., 100.));
-      cast (IT.of_interval IShort (Big_int_Z.big_int_of_int (- 100), Big_int_Z.big_int_of_int 100)) (FI.of_interval (-. 100., 100.));
+      cast (IT.of_interval IUChar (Z.of_int 0, Z.of_int 128)) (FI.of_interval (0., 128.));
+      cast (IT.of_interval ISChar (Z.of_int (-8), Z.of_int (-1))) (FI.of_interval (-. 8., - 1.));
+      cast (IT.of_interval IUInt (Z.of_int 2, Z.of_int 100)) (FI.of_interval (2., 100.));
+      cast (IT.of_interval IInt (Z.of_int (- 100), Z.of_int 100)) (FI.of_interval (-. 100., 100.));
+      cast (IT.of_interval IUShort (Z.of_int 2, Z.of_int 100)) (FI.of_interval (2., 100.));
+      cast (IT.of_interval IShort (Z.of_int (- 100), Z.of_int 100)) (FI.of_interval (-. 100., 100.));
 
-      cast (IT.of_interval IULong (Big_int_Z.zero_big_int, Big_int_Z.big_int_of_int64 Int64.max_int)) (FI.of_interval (0., 9223372036854775807.));
-      cast (IT.of_interval IULong (Big_int_Z.zero_big_int, Big_int_Z.big_int_of_int64 (9223372036854775806L))) (FI.of_interval (0., 9223372036854775807.));
-      cast (IT.of_interval ILong (Big_int_Z.big_int_of_int64 Int64.min_int, Big_int_Z.zero_big_int)) (FI.of_interval (-. 9223372036854775808., 0.));
-      cast (IT.of_interval ILong (Big_int_Z.big_int_of_int (- 100), Big_int_Z.big_int_of_int 100)) (FI.of_interval (-. 100., 100.));
-      cast (IT.of_interval IULongLong (Big_int_Z.zero_big_int, Big_int_Z.big_int_of_int64 Int64.max_int)) (FI.of_interval (0., 9223372036854775807.));
-      cast (IT.of_interval IULongLong (Big_int_Z.zero_big_int, Big_int_Z.big_int_of_int64 (9223372036854775806L))) (FI.of_interval (0., 9223372036854775807.));
-      cast (IT.of_interval ILongLong (Big_int_Z.big_int_of_int64 Int64.min_int, Big_int_Z.zero_big_int)) (FI.of_interval (-. 9223372036854775808., 0.));
-      cast (IT.of_interval ILongLong (Big_int_Z.big_int_of_int (- 100), Big_int_Z.big_int_of_int 100)) (FI.of_interval (-. 100., 100.));
+      cast (IT.of_interval IULong (Z.zero, Z.of_int64 Int64.max_int)) (FI.of_interval (0., 9223372036854775807.));
+      cast (IT.of_interval IULong (Z.zero, Z.of_int64 (9223372036854775806L))) (FI.of_interval (0., 9223372036854775807.));
+      cast (IT.of_interval ILong (Z.of_int64 Int64.min_int, Z.zero)) (FI.of_interval (-. 9223372036854775808., 0.));
+      cast (IT.of_interval ILong (Z.of_int (- 100), Z.of_int 100)) (FI.of_interval (-. 100., 100.));
+      cast (IT.of_interval IULongLong (Z.zero, Z.of_int64 Int64.max_int)) (FI.of_interval (0., 9223372036854775807.));
+      cast (IT.of_interval IULongLong (Z.zero, Z.of_int64 (9223372036854775806L))) (FI.of_interval (0., 9223372036854775807.));
+      cast (IT.of_interval ILongLong (Z.of_int64 Int64.min_int, Z.zero)) (FI.of_interval (-. 9223372036854775808., 0.));
+      cast (IT.of_interval ILongLong (Z.of_int (- 100), Z.of_int 100)) (FI.of_interval (-. 100., 100.));
       GobConfig.set_bool "ana.int.interval" false;
     end
 
@@ -164,26 +164,26 @@ struct
       GobConfig.set_bool "ana.int.interval" true;
       cast IInt (FI.of_interval (-2147483648.,2147483647.)) (IT.top_of IInt);
       cast IInt (FI.of_interval (-9999999999.,9999999999.)) (IT.top_of IInt);
-      cast IInt (FI.of_interval (-10.1,20.9)) (IT.of_interval IInt ( Big_int_Z.big_int_of_int (-10),  Big_int_Z.big_int_of_int 20));
+      cast IInt (FI.of_interval (-10.1,20.9)) (IT.of_interval IInt ( Z.of_int (-10),  Z.of_int 20));
       cast IBool (FI.of_interval (0.,1.)) (IT.top_of IBool);
       cast IBool (FI.of_interval (-9999999999.,9999999999.)) (IT.top_of IBool);
       cast IBool fi_one (IT.of_bool IBool true);
       cast IBool fi_zero (IT.of_bool IBool false);
 
       (* no IChar because char has unknown signedness (particularly, unsigned on arm64) *)
-      cast IUChar (FI.of_interval (0.123, 128.999)) (IT.of_interval IUChar (Big_int_Z.big_int_of_int 0, Big_int_Z.big_int_of_int 128));
-      cast ISChar (FI.of_interval (-. 8.0000000, 127.)) (IT.of_interval ISChar (Big_int_Z.big_int_of_int (-8), Big_int_Z.big_int_of_int 127));
-      cast IUInt (FI.of_interval (2., 100.)) (IT.of_interval IUInt (Big_int_Z.big_int_of_int 2, Big_int_Z.big_int_of_int 100));
-      cast IInt (FI.of_interval (-. 100.2, 100.1)) (IT.of_interval IInt (Big_int_Z.big_int_of_int (- 100), Big_int_Z.big_int_of_int 100));
-      cast IUShort (FI.of_interval (2., 100.)) (IT.of_interval IUShort (Big_int_Z.big_int_of_int 2, Big_int_Z.big_int_of_int 100));
-      cast IShort (FI.of_interval (-. 100., 100.)) (IT.of_interval IShort (Big_int_Z.big_int_of_int (- 100), Big_int_Z.big_int_of_int 100));
+      cast IUChar (FI.of_interval (0.123, 128.999)) (IT.of_interval IUChar (Z.of_int 0, Z.of_int 128));
+      cast ISChar (FI.of_interval (-. 8.0000000, 127.)) (IT.of_interval ISChar (Z.of_int (-8), Z.of_int 127));
+      cast IUInt (FI.of_interval (2., 100.)) (IT.of_interval IUInt (Z.of_int 2, Z.of_int 100));
+      cast IInt (FI.of_interval (-. 100.2, 100.1)) (IT.of_interval IInt (Z.of_int (- 100), Z.of_int 100));
+      cast IUShort (FI.of_interval (2., 100.)) (IT.of_interval IUShort (Z.of_int 2, Z.of_int 100));
+      cast IShort (FI.of_interval (-. 100., 100.)) (IT.of_interval IShort (Z.of_int (- 100), Z.of_int 100));
 
-      cast IULong (FI.of_interval (0., 9223372036854775808.)) (IT.of_interval IULong (Big_int_Z.zero_big_int, Big_int_Z.big_int_of_string "9223372036854775808"));
-      cast ILong (FI.of_interval (-. 9223372036854775808., 0.)) (IT.of_interval ILong (Big_int_Z.big_int_of_string "-9223372036854775808", Big_int_Z.zero_big_int));
-      cast ILong (FI.of_interval (-. 100.99999, 100.99999)) (IT.of_interval ILong (Big_int_Z.big_int_of_int (- 100), Big_int_Z.big_int_of_int 100));
-      cast IULongLong (FI.of_interval (0., 9223372036854775808.)) (IT.of_interval IULongLong (Big_int_Z.zero_big_int, Big_int_Z.big_int_of_string "9223372036854775808"));
-      cast ILongLong (FI.of_interval (-. 9223372036854775808., 0.)) (IT.of_interval ILongLong ((Big_int_Z.big_int_of_string "-9223372036854775808"), Big_int_Z.zero_big_int));
-      cast ILongLong  (FI.of_interval (-. 100., 100.)) (IT.of_interval ILongLong (Big_int_Z.big_int_of_int (- 100), Big_int_Z.big_int_of_int 100));
+      cast IULong (FI.of_interval (0., 9223372036854775808.)) (IT.of_interval IULong (Z.zero, Z.of_string "9223372036854775808"));
+      cast ILong (FI.of_interval (-. 9223372036854775808., 0.)) (IT.of_interval ILong (Z.of_string "-9223372036854775808", Z.zero));
+      cast ILong (FI.of_interval (-. 100.99999, 100.99999)) (IT.of_interval ILong (Z.of_int (- 100), Z.of_int 100));
+      cast IULongLong (FI.of_interval (0., 9223372036854775808.)) (IT.of_interval IULongLong (Z.zero, Z.of_string "9223372036854775808"));
+      cast ILongLong (FI.of_interval (-. 9223372036854775808., 0.)) (IT.of_interval ILongLong ((Z.of_string "-9223372036854775808"), Z.zero));
+      cast ILongLong  (FI.of_interval (-. 100., 100.)) (IT.of_interval ILongLong (Z.of_int (- 100), Z.of_int 100));
       GobConfig.set_bool "ana.int.interval" false;
     end
 

--- a/unittest/cdomains/lvalTest.ml
+++ b/unittest/cdomains/lvalTest.ml
@@ -9,9 +9,9 @@ let ikind = IntDomain.PtrDiffIkind.ikind ()
 
 let a_var = Cil.makeGlobalVar "a" Cil.intPtrType
 let a_lv = LV.from_var a_var
-let i_0 = ID.of_int ikind (Z.of_int 0)
+let i_0 = ID.of_int ikind Z.zero
 let a_lv_0 = LV.from_var_offset (a_var, `Index (i_0, `NoOffset))
-let i_1 = ID.of_int ikind (Z.of_int 1)
+let i_1 = ID.of_int ikind Z.one
 let a_lv_1 = LV.from_var_offset (a_var, `Index (i_1, `NoOffset))
 let i_top = ID.join i_0 i_1
 let a_lv_top = LV.from_var_offset (a_var, `Index (i_top, `NoOffset))
@@ -48,7 +48,7 @@ let test_join_0 _ =
 
 let test_leq_not_0 _ =
   assert_leq a_lv_1 a_lv_not_0;
-  OUnit.assert_equal ~printer:[%show: [`Eq | `Neq | `Top]] `Neq (ID.equal_to (Z.of_int 0) i_not_0);
+  OUnit.assert_equal ~printer:[%show: [`Eq | `Neq | `Top]] `Neq (ID.equal_to Z.zero i_not_0);
   OUnit.assert_equal ~printer:[%show: [`MustZero | `MustNonzero | `MayZero]] `MustNonzero (LV.Offs.cmp_zero_offset (`Index (i_not_0, `NoOffset)));
   assert_not_leq a_lv a_lv_not_0;
   assert_not_leq a_lv_0 a_lv_not_0

--- a/unittest/mainTest.ml
+++ b/unittest/mainTest.ml
@@ -9,7 +9,8 @@ let all_tests = ("" >:::
     CompilationDatabaseTest.tests;
     LibraryDslTest.tests;
     (* etc *)
-    "domaintest" >::: QCheck_ounit.to_ounit2_test_list Maindomaintest.all_testsuite
+    "domaintest" >::: QCheck_ounit.to_ounit2_test_list Maindomaintest.all_testsuite;
+    IntOpsTest.tests;
   ])
 
 let () = run_test_tt_main all_tests

--- a/unittest/util/intOpsTest.ml
+++ b/unittest/util/intOpsTest.ml
@@ -10,17 +10,13 @@ let old_div a b = if Z.lt a Z.zero then Z.neg (Z.ediv (Z.neg a) b) else Z.ediv a
 let old_rem a b = Z.sub a (Z.mul b (old_div a b))
 
 let test_bigint_div =
-  QCheck.(Test.make ~name:"div"
-    (pair MyCheck.Arbitrary.big_int MyCheck.Arbitrary.big_int)
-    (fun (x, y) ->
+  QCheck.(Test.make ~name:"div" (pair MyCheck.Arbitrary.big_int MyCheck.Arbitrary.big_int) (fun (x, y) ->
       assume (Z.compare y Z.zero <> 0);
       Z.equal (Z.div x y) (old_div x y)
     ))
 
 let test_bigint_rem =
-  QCheck.(Test.make ~name:"rem"
-    (pair MyCheck.Arbitrary.big_int MyCheck.Arbitrary.big_int)
-    (fun (x, y) ->
+  QCheck.(Test.make ~name:"rem" (pair MyCheck.Arbitrary.big_int MyCheck.Arbitrary.big_int) (fun (x, y) ->
       assume (Z.compare y Z.zero <> 0);
       Z.equal (Z.rem x y) (old_rem x y)
     ))

--- a/unittest/util/intOpsTest.ml
+++ b/unittest/util/intOpsTest.ml
@@ -1,0 +1,34 @@
+open OUnit2
+open Goblint_lib
+
+(* If the first operand of a div is negative, Zarith rounds the result away from zero.
+    We thus always transform this into a division with a non-negative first operand. *)
+let old_div a b = if Z.lt a Z.zero then Z.neg (Z.ediv (Z.neg a) b) else Z.ediv a b
+
+(* Z.erem computes the Euclidian Modulus, but what we want here is the remainder, as returned by mod on ints
+   -1 rem 5 == -1, whereas -1 Euclid-Mod 5 == 4 *)
+let old_rem a b = Z.sub a (Z.mul b (old_div a b))
+
+let test_bigint_div =
+  QCheck.(Test.make ~name:"div"
+    (pair MyCheck.Arbitrary.big_int MyCheck.Arbitrary.big_int)
+    (fun (x, y) ->
+      assume (Z.compare y Z.zero <> 0);
+      Z.equal (Z.div x y) (old_div x y)
+    ))
+
+let test_bigint_rem =
+  QCheck.(Test.make ~name:"rem"
+    (pair MyCheck.Arbitrary.big_int MyCheck.Arbitrary.big_int)
+    (fun (x, y) ->
+      assume (Z.compare y Z.zero <> 0);
+      Z.equal (Z.rem x y) (old_rem x y)
+    ))
+
+let tests =
+  "intOpsTest" >::: [
+    "bigint" >::: QCheck_ounit.to_ounit2_test_list [
+      test_bigint_div;
+      test_bigint_rem;
+    ]
+  ]


### PR DESCRIPTION
`Big_int_Z` is just an old compatibility wrapper for `Z` except all the function names redundantly contain `big_int` as well.
`Cilint` is now just a wrapper for `Z` too except all the function names redundantly contain `cilint` as well.

This just makes much of the bigint handling code much more readable by using `Z` directly.