### PR TITLE
Add missing library functions for Concrat benchmarks

### DIFF
--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -109,6 +109,10 @@ let posix_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("timer_gettime", unknown [drop "timerid" []; drop "curr_value" [w_deep]]);
     ("timer_getoverrun", unknown [drop "timerid" []]);
     ("lstat", unknown [drop "pathname" [r]; drop "statbuf" [w]]);
+    ("getpwnam", unknown [drop "name" [r]]);
+    ("strndup", unknown [drop "s" [r]; drop "n" []]);
+    ("freeaddrinfo", unknown [drop "res" [f_deep]]);
+    ("getgid", unknown []);
   ]
 
 (** Pthread functions. *)
@@ -201,6 +205,7 @@ let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("svcerr_systemerr", unknown [drop "xprt" [r_deep; w_deep]]);
     ("svc_sendreply", unknown [drop "xprt" [r_deep; w_deep]; drop "outproc" [s]; drop "out" [r]]);
     ("shutdown", unknown [drop "socket" []; drop "how" []]);
+    ("getaddrinfo_a", unknown [drop "mode" []; drop "list" [w_deep]; drop "nitems" []; drop "sevp" [r; w; s]]);
   ]
 
 let linux_userspace_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -101,6 +101,12 @@ let posix_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("shm_open", unknown [drop "name" [r]; drop "oflag" []; drop "mode" []]);
     ("sched_get_priority_max", unknown [drop "policy" []]);
     ("mprotect", unknown [drop "addr" []; drop "len" []; drop "prot" []]);
+    ("ftime", unknown [drop "tp" [w]]);
+    ("timer_create", unknown [drop "clockid" []; drop "sevp" [r; w; s]; drop "timerid" [w]]);
+    ("timer_settime", unknown [drop "timerid" []; drop "flags" []; drop "new_value" [r_deep]; drop "old_value" [w_deep]]);
+    ("timer_gettime", unknown [drop "timerid" []; drop "curr_value" [w_deep]]);
+    ("timer_getoverrun", unknown [drop "timerid" []]);
+    ("lstat", unknown [drop "pathname" [r]; drop "statbuf" [w]]);
   ]
 
 (** Pthread functions. *)
@@ -119,6 +125,8 @@ let pthread_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("pthread_setcanceltype", unknown [drop "type" []; drop "oldtype" [w]]);
     ("pthread_detach", unknown [drop "thread" []]);
     ("pthread_attr_setschedpolicy", unknown [drop "attr" [r; w]; drop "policy" []]);
+    ("pthread_condattr_init", unknown [drop "attr" [w]]);
+    ("pthread_condattr_setclock", unknown [drop "attr" [w]; drop "clock_id" []]);
   ]
 
 (** GCC builtin functions.

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -44,6 +44,7 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("setbuf", unknown [drop "stream" [w]; drop "buf" [w]]);
     ("swprintf", unknown (drop "wcs" [w] :: drop "maxlen" [] :: drop "fmt" [r] :: VarArgs (drop' [])));
     ("assert", special [__ "exp" []] @@ fun exp -> Assert { exp; check = true; refine = get_bool "sem.assert.refine" }); (* only used if assert is used without include, e.g. in transformed files *)
+    ("difftime", unknown [drop "time1" []; drop "time2" []]);
   ]
 
 (** C POSIX library functions.
@@ -88,6 +89,7 @@ let posix_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("getsockopt", unknown [drop "sockfd" []; drop "level" []; drop "optname" []; drop "optval" [w]; drop "optlen" [w]]);
     ("gethostbyaddr", unknown [drop "addr" [r_deep]; drop "len" []; drop "type" []]);
     ("gethostbyaddr_r", unknown [drop "addr" [r_deep]; drop "len" []; drop "type" []; drop "ret" [w_deep]; drop "buf" [w]; drop "buflen" []; drop "result" [w]; drop "h_errnop" [w]]);
+    ("sigaction", unknown [drop "signum" []; drop "act" [r_deep; s_deep]; drop "oldact" [w_deep]]);
   ]
 
 (** Pthread functions. *)
@@ -104,6 +106,7 @@ let pthread_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("pthread_key_delete", unknown [drop "key" [f]]);
     ("pthread_cancel", unknown [drop "thread" []]);
     ("pthread_setcanceltype", unknown [drop "type" []; drop "oldtype" [w]]);
+    ("pthread_detach", unknown [drop "thread" []]);
   ]
 
 (** GCC builtin functions.
@@ -173,6 +176,10 @@ let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("svcerr_decode", unknown [drop "xprt" [r_deep; w_deep]]);
     ("svcerr_systemerr", unknown [drop "xprt" [r_deep; w_deep]]);
     ("svc_sendreply", unknown [drop "xprt" [r_deep; w_deep]; drop "outproc" [s]; drop "out" [r]]);
+  ]
+
+let linux_userspace_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
+    ("prctl", unknown [drop "option" []; drop "arg2" []; drop "arg3" []; drop "arg4" []; drop "arg5" []]);
   ]
 
 let big_kernel_lock = AddrOf (Cil.var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType)))
@@ -331,6 +338,7 @@ let library_descs = Hashtbl.of_list (List.concat [
     pthread_descs_list;
     gcc_descs_list;
     glibc_desc_list;
+    linux_userspace_descs_list;
     linux_descs_list;
     goblint_descs_list;
     zstd_descs_list;

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -48,7 +48,7 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("system", unknown [drop "command" [r]]);
     ("wcscat", unknown [drop "dest" [r; w]; drop "src" [r]]);
     ("abs", unknown [drop "j" []]);
-    ("localtime_r", unknown [drop "timep" [r]]);
+    ("localtime_r", unknown [drop "timep" [r]; drop "result" [w]]);
     ("strsep", unknown [drop "stringp" [r_deep; w]; drop "delim" [r]]);
     ("strcasestr", unknown [drop "haystack" [r]; drop "needle" [r]]);
   ]

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -133,6 +133,7 @@ let pthread_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("pthread_attr_setschedpolicy", unknown [drop "attr" [r; w]; drop "policy" []]);
     ("pthread_condattr_init", unknown [drop "attr" [w]]);
     ("pthread_condattr_setclock", unknown [drop "attr" [w]; drop "clock_id" []]);
+    ("pthread_mutexattr_destroy", unknown [drop "attr" [f]]);
   ]
 
 (** GCC builtin functions.

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -45,6 +45,9 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("swprintf", unknown (drop "wcs" [w] :: drop "maxlen" [] :: drop "fmt" [r] :: VarArgs (drop' [])));
     ("assert", special [__ "exp" []] @@ fun exp -> Assert { exp; check = true; refine = get_bool "sem.assert.refine" }); (* only used if assert is used without include, e.g. in transformed files *)
     ("difftime", unknown [drop "time1" []; drop "time2" []]);
+    ("system", unknown [drop "command" [r]]);
+    ("wcscat", unknown [drop "dest" [r; w]; drop "src" [r]]);
+    ("abs", unknown [drop "j" []]);
   ]
 
 (** C POSIX library functions.
@@ -90,6 +93,11 @@ let posix_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("gethostbyaddr", unknown [drop "addr" [r_deep]; drop "len" []; drop "type" []]);
     ("gethostbyaddr_r", unknown [drop "addr" [r_deep]; drop "len" []; drop "type" []; drop "ret" [w_deep]; drop "buf" [w]; drop "buflen" []; drop "result" [w]; drop "h_errnop" [w]]);
     ("sigaction", unknown [drop "signum" []; drop "act" [r_deep; s_deep]; drop "oldact" [w_deep]]);
+    ("tcgetattr", unknown [drop "fd" []; drop "termios_p" [r_deep]]);
+    ("tcsetattr", unknown [drop "fd" []; drop "optional_actions" []; drop "termios_p" [w_deep]]);
+    ("access", unknown [drop "pathname" [r]; drop "mode" []]);
+    ("ttyname", unknown [drop "fd" []]);
+    ("shm_open", unknown [drop "name" [r]; drop "oflag" []; drop "mode" []]);
   ]
 
 (** Pthread functions. *)
@@ -180,6 +188,7 @@ let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
 
 let linux_userspace_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("prctl", unknown [drop "option" []; drop "arg2" []; drop "arg3" []; drop "arg4" []; drop "arg5" []]);
+    ("__ctype_tolower_loc", unknown []);
   ]
 
 let big_kernel_lock = AddrOf (Cil.var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType)))
@@ -329,6 +338,30 @@ let svcomp_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__VERIFIER_atomic_begin", special [] @@ Lock { lock = verifier_atomic; try_ = false; write = true; return_on_success = true });
     ("__VERIFIER_atomic_end", special [] @@ Unlock verifier_atomic);
     ("__VERIFIER_nondet_loff_t", unknown []); (* cannot give it in sv-comp.c without including stdlib or similar *)
+  ]
+
+let ncurses_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
+    ("echo", unknown []);
+    ("noecho", unknown []);
+    ("wattrset", unknown [drop "win" [r_deep; w_deep]; drop "attrs" []]);
+    ("endwin", unknown []);
+    ("wgetch", unknown [drop "win" [r_deep; w_deep]]);
+    ("wmove", unknown [drop "win" [r_deep; w_deep]; drop "y" []; drop "x" []]);
+    ("waddch", unknown [drop "win" [r_deep; w_deep]; drop "ch" []]);
+    ("waddnwstr", unknown [drop "win" [r_deep; w_deep]; drop "wstr" [r]; drop "n" []]);
+    ("wattr_on", unknown [drop "win" [r_deep; w_deep]; drop "attrs" []; drop "opts" []]); (* opts argument currently not used *)
+    ("wrefresh", unknown [drop "win" [r_deep; w_deep]]);
+    ("mvprintw", unknown (drop "win" [r_deep; w_deep] :: drop "y" [] :: drop "x" [] :: drop "fmt" [r] :: VarArgs (drop' [r])));
+    ("initscr", unknown []);
+    ("curs_set", unknown [drop "visibility" []]);
+    ("wtimeout", unknown [drop "win" [r_deep; w_deep]; drop "delay" []]);
+    ("start_color", unknown []);
+    ("use_default_colors", unknown []);
+    ("wclear", unknown [drop "win" [r_deep; w_deep]]);
+    ("can_change_color", unknown []);
+    ("init_color", unknown [drop "color" []; drop "red" []; drop "green" []; drop "blue" []]);
+    ("init_pair", unknown [drop "pair" []; drop "f" [r]; drop "b" [r]]);
+    ("wbkgd", unknown [drop "win" [r_deep; w_deep]; drop "ch" []]);
   ]
 
 (* TODO: allow selecting which lists to use *)

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -49,6 +49,8 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("wcscat", unknown [drop "dest" [r; w]; drop "src" [r]]);
     ("abs", unknown [drop "j" []]);
     ("localtime_r", unknown [drop "timep" [r]]);
+    ("strsep", unknown [drop "stringp" [r_deep; w]; drop "delim" [r]]);
+    ("strcasestr", unknown [drop "haystack" [r]; drop "needle" [r]]);
   ]
 
 (** C POSIX library functions.
@@ -169,6 +171,7 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__atomic_store_n", unknown [drop "ptr" [w]; drop "val" []; drop "memorder" []]);
     ("__atomic_load_n", unknown [drop "ptr" [r]; drop "memorder" []]);
     ("__sync_fetch_and_add", unknown (drop "ptr" [r; w] :: drop "value" [] :: VarArgs (drop' [])));
+    ("__sync_fetch_and_sub", unknown (drop "ptr" [r; w] :: drop "value" [] :: VarArgs (drop' [])));
   ]
 
 let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
@@ -197,11 +200,15 @@ let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("svcerr_decode", unknown [drop "xprt" [r_deep; w_deep]]);
     ("svcerr_systemerr", unknown [drop "xprt" [r_deep; w_deep]]);
     ("svc_sendreply", unknown [drop "xprt" [r_deep; w_deep]; drop "outproc" [s]; drop "out" [r]]);
+    ("shutdown", unknown [drop "socket" []; drop "how" []]);
   ]
 
 let linux_userspace_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("prctl", unknown [drop "option" []; drop "arg2" []; drop "arg3" []; drop "arg4" []; drop "arg5" []]);
     ("__ctype_tolower_loc", unknown []);
+    ("epoll_create", unknown [drop "size" []]);
+    ("epoll_ctl", unknown [drop "epfd" []; drop "op" []; drop "fd" []; drop "event" [w]]);
+    ("epoll_wait", unknown [drop "epfd" []; drop "events" [w]; drop "maxevents" []; drop "timeout" []]);
   ]
 
 let big_kernel_lock = AddrOf (Cil.var (Goblintutil.create_var (makeGlobalVar "[big kernel lock]" intType)))

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -159,6 +159,7 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_popcountll", unknown [drop "x" []]);
     ("__atomic_store_n", unknown [drop "ptr" [w]; drop "val" []; drop "memorder" []]);
     ("__atomic_load_n", unknown [drop "ptr" [r]; drop "memorder" []]);
+    ("__sync_fetch_and_add", unknown (drop "ptr" [r; w] :: drop "value" [] :: VarArgs (drop' [])));
   ]
 
 let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -48,6 +48,7 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("system", unknown [drop "command" [r]]);
     ("wcscat", unknown [drop "dest" [r; w]; drop "src" [r]]);
     ("abs", unknown [drop "j" []]);
+    ("localtime_r", unknown [drop "timep" [r]]);
   ]
 
 (** C POSIX library functions.
@@ -98,6 +99,7 @@ let posix_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("access", unknown [drop "pathname" [r]; drop "mode" []]);
     ("ttyname", unknown [drop "fd" []]);
     ("shm_open", unknown [drop "name" [r]; drop "oflag" []; drop "mode" []]);
+    ("sched_get_priority_max", unknown [drop "policy" []]);
   ]
 
 (** Pthread functions. *)
@@ -115,6 +117,7 @@ let pthread_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("pthread_cancel", unknown [drop "thread" []]);
     ("pthread_setcanceltype", unknown [drop "type" []; drop "oldtype" [w]]);
     ("pthread_detach", unknown [drop "thread" []]);
+    ("pthread_attr_setschedpolicy", unknown [drop "attr" [r; w]; drop "policy" []]);
   ]
 
 (** GCC builtin functions.

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -403,6 +403,7 @@ let library_descs = Hashtbl.of_list (List.concat [
     zstd_descs_list;
     math_descs_list;
     svcomp_descs_list;
+    ncurses_descs_list;
   ])
 
 

--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -100,6 +100,7 @@ let posix_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("ttyname", unknown [drop "fd" []]);
     ("shm_open", unknown [drop "name" [r]; drop "oflag" []; drop "mode" []]);
     ("sched_get_priority_max", unknown [drop "policy" []]);
+    ("mprotect", unknown [drop "addr" []; drop "len" []; drop "prot" []]);
   ]
 
 (** Pthread functions. *)


### PR DESCRIPTION
Adds a bunch of missing library function specifications for https://github.com/goblint/bench/pull/53.