### PR TITLE
Handle pseudo return nodes in `Node.of_id` and improve their location

### DIFF
--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -233,12 +233,13 @@ let createCFG (file: file) =
          * lazy, so it's only added when actually needed *)
         let pseudo_return = lazy (
           if Messages.tracing then Messages.trace "cfg" "adding pseudo-return to the function %s.\n" fd.svar.vname;
-          let newst = mkStmt (Return (None, fd_loc)) in
+          let fd_end_loc = {fd_loc with line = fd_loc.endLine; byte = fd_loc.endByte; column = fd_loc.endColumn} in
+          let newst = mkStmt (Return (None, fd_end_loc)) in
           newst.sid <- get_pseudo_return_id fd;
           Cilfacade.StmtH.add Cilfacade.pseudo_return_to_fun newst fd;
           Cilfacade.IntH.replace Cilfacade.pseudo_return_stmt_sids newst.sid newst;
           let newst_node = Statement newst in
-          addEdge newst_node (fd_loc, Ret (None, fd)) (Function fd);
+          addEdge newst_node (fd_end_loc, Ret (None, fd)) (Function fd);
           newst_node
         )
         in

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -236,6 +236,7 @@ let createCFG (file: file) =
           let newst = mkStmt (Return (None, fd_loc)) in
           newst.sid <- get_pseudo_return_id fd;
           Cilfacade.StmtH.add Cilfacade.pseudo_return_to_fun newst fd;
+          Cilfacade.IntH.replace Cilfacade.pseudo_return_stmt_sids newst.sid newst;
           let newst_node = Statement newst in
           addEdge newst_node (fd_loc, Ret (None, fd)) (Function fd);
           newst_node

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -513,9 +513,13 @@ let stmt_sids: stmt IntH.t ResettableLazy.t =
       h
     )
 
+let pseudo_return_stmt_sids: stmt IntH.t = IntH.create 13
+
 (** Find [stmt] by its [sid].
     @raise Not_found *)
-let find_stmt_sid sid = IntH.find (ResettableLazy.force stmt_sids) sid
+let find_stmt_sid sid =
+  try IntH.find pseudo_return_stmt_sids sid
+  with Not_found -> IntH.find (ResettableLazy.force stmt_sids) sid
 
 
 let reset_lazy () =

--- a/tests/regression/00-sanity/01-assert.t
+++ b/tests/regression/00-sanity/01-assert.t
@@ -3,8 +3,8 @@
   [Warning][Assert] Assertion "unknown == 4" is unknown. (01-assert.c:11:3-11:33)
   [Error][Assert] Assertion "fail" will fail. (01-assert.c:12:3-12:25)
   [Warning][Deadcode] Function 'main' has dead code:
-    on lines 13..15 (01-assert.c:13-15)
+    on lines 13..14 (01-assert.c:13-14)
   [Warning][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
-    dead: 3
-    total lines: 10
+    dead: 2
+    total lines: 9

--- a/tests/regression/00-sanity/01-assert.t
+++ b/tests/regression/00-sanity/01-assert.t
@@ -3,8 +3,8 @@
   [Warning][Assert] Assertion "unknown == 4" is unknown. (01-assert.c:11:3-11:33)
   [Error][Assert] Assertion "fail" will fail. (01-assert.c:12:3-12:25)
   [Warning][Deadcode] Function 'main' has dead code:
-    on lines 13..14 (01-assert.c:13-14)
+    on lines 13..15 (01-assert.c:13-15)
   [Warning][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
-    dead: 2
-    total lines: 9
+    dead: 3
+    total lines: 10


### PR DESCRIPTION
Closes #997.

### Changes
1. Adds `Cilfacade.pseudo_return_stmt_sids`, which maps pseudo return node statement IDs to the statements themselves. This allows `Cilfacade.find_stmt_sid`, which is used by `Node.of_id` to work for pseudo return nodes.
2. Previously pseudo return nodes were given the location of the entire function definition, which starts already before the function's return type. This PR changes their location to be the end location of the function definition (with 0-width range), corresponding to the `}`. Since `Locator` uses nodes from the CFG, this already includes pseudo return nodes, but now with more reasonable locations for both lookup and display.

There is one unexpected point though as indicated by the change to the cram test: our LLoC counting can increase because the pseudo return node at its new location is on a separate line. Not sure if this weird or fine.