### PR TITLE
Add `arg/lookup` request to server mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ _opam/
 cfgs/
 cfg.dot
 cilcfg.*.dot
+arg.dot
 
 *.graphml
 goblint.bc.js

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -662,6 +662,17 @@ struct
     if get_bool "exp.arg" then (
       let module ArgTool = ArgTools.Make (R) in
       let module Arg = (val ArgTool.create entrystates) in
+      if get_bool "exp.argdot" then (
+        let module ArgDot = ArgTools.Dot (Arg) in
+        let oc = Stdlib.open_out "arg.dot" in
+        Fun.protect (fun () ->
+            let ppf = Format.formatter_of_out_channel oc in
+            ArgDot.dot ppf;
+            Format.pp_print_flush ppf ()
+          ) ~finally:(fun () ->
+            Stdlib.close_out oc
+          )
+      );
       ArgTools.current_arg := Some (module Arg);
     );
 

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -663,10 +663,6 @@ struct
       let module ArgTool = ArgTools.Make (R) in
       let module Arg = (val ArgTool.create entrystates) in
       ArgTools.current_arg := Some (module Arg);
-      ignore (Pretty.printf "ARG main: %s\n" (Arg.Node.to_string Arg.main_entry));
-      Arg.iter_nodes (fun n ->
-          ignore (Pretty.printf "%s\n" (Arg.Node.to_string n))
-        )
     );
 
     (* Before SV-COMP, so result can depend on YAML witness validation. *)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -659,6 +659,16 @@ struct
     in
     Timing.wrap "warn_global" (GHT.iter warn_global) gh;
 
+    if get_bool "exp.arg" then (
+      let module ArgTool = ArgTools.Make (R) in
+      let module Arg = (val ArgTool.create entrystates) in
+      ArgTools.current_arg := Some (module Arg);
+      ignore (Pretty.printf "ARG main: %s\n" (Arg.Node.to_string Arg.main_entry));
+      Arg.iter_nodes (fun n ->
+          ignore (Pretty.printf "%s\n" (Arg.Node.to_string n))
+        )
+    );
+
     (* Before SV-COMP, so result can depend on YAML witness validation. *)
     if get_string "witness.yaml.validate" <> "" then (
       let module YWitness = YamlWitness.Validator (R) in

--- a/src/framework/edge.ml
+++ b/src/framework/edge.ml
@@ -29,7 +29,7 @@ type t =
     * appeared *)
   | Skip
   (** This is here for historical reasons. I never use Skip edges! *)
-[@@deriving eq, ord, hash, to_yojson]
+[@@deriving eq, ord, hash]
 
 
 let pretty () = function
@@ -55,3 +55,56 @@ let pretty_plain () = function
   | ASM _ -> text "ASM ..."
   | Skip -> text "Skip"
   | VDecl v -> dprintf "VDecl '%a %s;'" d_type v.vtype v.vname
+
+let to_yojson e =
+  let fields = match e with
+    | Assign (lval, exp) ->
+      [
+        ("type", `String "assign");
+        ("lval", CilType.Lval.to_yojson lval);
+        ("exp", CilType.Exp.to_yojson exp);
+      ]
+    | Test (exp, branch) ->
+      [
+        ("type", `String "branch");
+        ("exp", CilType.Exp.to_yojson exp);
+        ("branch", `Bool branch);
+      ]
+    | Proc (lval, function_, args) ->
+      [
+        ("type", `String "call");
+        ("lval", [%to_yojson: CilType.Lval.t option] lval);
+        ("function", CilType.Exp.to_yojson function_);
+        ("args", [%to_yojson: CilType.Exp.t list] args);
+      ]
+    | Entry function_ ->
+      [
+        ("type", `String "entry");
+        ("function", CilType.Fundec.to_yojson function_);
+      ]
+    | Ret (exp, function_) ->
+      [
+        ("type", `String "return");
+        ("function", CilType.Fundec.to_yojson function_);
+        ("exp", [%to_yojson: CilType.Exp.t option] exp);
+      ]
+    | ASM (instructions, output, input) ->
+      [
+        ("type", `String "asm");
+        ("instructions", [%to_yojson: string list] instructions);
+        ("output", asm_out_to_yojson output);
+        ("input", asm_in_to_yojson input);
+      ]
+    | VDecl variable ->
+      [
+        ("type", `String "declare");
+        ("variable", CilType.Varinfo.to_yojson variable);
+      ]
+    | Skip ->
+      [
+        ("type", `String "nop");
+      ]
+  in
+  `Assoc ([
+      ("string", `String (Pretty.sprint ~width:max_int (pretty () e)))
+    ] @ fields)

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1640,6 +1640,12 @@
           "description": "Construct abstract reachability graph (ARG).",
           "type": "boolean",
           "default": false
+        },
+        "argdot": {
+          "title": "exp.argdot",
+          "description": "Output ARG as dot file.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1634,6 +1634,12 @@
           "description": "Hide standard extern globals (e.g. `stdout`) from cluttering local states.",
           "type": "boolean",
           "default": true
+        },
+        "arg": {
+          "title": "exp.arg",
+          "description": "Construct abstract reachability graph (ARG).",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -117,7 +117,7 @@ let serve serv =
 
 let arg_wrapper: (module ArgWrapper) ResettableLazy.t =
   ResettableLazy.from_fun (fun () ->
-      let module Arg = (val (Option.get !ArgTools.current_arg)) in
+      let module Arg = (val (Option.get_exn !ArgTools.current_arg Response.Error.(E (make ~code:RequestFailed ~message:"not analyzed or arg disabled" ())))) in
       let module Locator = WitnessUtil.Locator (Arg.Node) in
       let module StringH = Hashtbl.Make (Printable.Strings) in
 
@@ -469,7 +469,7 @@ let () =
           begin try
               [ArgWrapper.find_node node_id]
             with Not_found ->
-              Response.Error.(raise (make ~code:RequestFailed ~message:"not analyzed or non-existent node" ()))
+              Response.Error.(raise (make ~code:RequestFailed ~message:"non-existent node" ()))
           end
         | None, Some location ->
           let nodes_opt =

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -455,6 +455,8 @@ let () =
       let module ArgWrapper = (val (ResettableLazy.force serv.arg_wrapper)) in
       let open ArgWrapper in
       let n: Arg.Node.t = match params.node, params.location with
+        | None, None ->
+          Arg.main_entry
         | Some node_id, None ->
           let found = ref None in
           begin try
@@ -475,8 +477,8 @@ let () =
             Locator.ES.choose_opt nodes
           in
           Option.get_exn node_opt Response.Error.(E (make ~code:RequestFailed ~message:"cannot find node for location" ()))
-        | _, _ ->
-          Response.Error.(raise (make ~code:RequestFailed ~message:"requires node xor location" ()))
+        | Some _, Some _ ->
+          Response.Error.(raise (make ~code:RequestFailed ~message:"requires node nand location" ()))
       in
       let node = Arg.Node.cfgnode n in
       let node_id = Node.show_id node in

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -453,6 +453,8 @@ let () =
     type one_response = {
       node: string;
       cfg_node: string;
+      context: string;
+      path: string;
       location: CilType.Location.t;
       next: (MyARG.inline_edge * string) list;
       prev: (MyARG.inline_edge * string) list;
@@ -496,7 +498,15 @@ let () =
             (edge, Arg.Node.to_string to_node)
           )
       in
-      {node = Arg.Node.to_string n; cfg_node = cfg_node_id; location; next; prev}
+      {
+        node = Arg.Node.to_string n;
+        cfg_node = cfg_node_id;
+        context = string_of_int (Arg.Node.context_id n);
+        path = string_of_int (Arg.Node.path_id n);
+        location;
+        next;
+        prev
+      }
   end);
 
   register (module struct

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -459,6 +459,10 @@ let () =
     type edge_node = {
       edge: MyARG.inline_edge;
       node: string;
+      cfg_node: string;
+      context: string;
+      path: string;
+      location: CilType.Location.t;
     } [@@deriving to_yojson]
     type one_response = {
       node: string;
@@ -502,13 +506,29 @@ let () =
       let next =
         Arg.next n
         |> List.map (fun (edge, to_node) ->
-            {edge; node = Arg.Node.to_string to_node}
+            let cfg_to_node = Arg.Node.cfgnode to_node in
+            {
+              edge;
+              node = Arg.Node.to_string to_node;
+              cfg_node = Node.show_id cfg_to_node;
+              context = string_of_int (Arg.Node.context_id to_node);
+              path = string_of_int (Arg.Node.path_id to_node);
+              location = Node.location cfg_to_node;
+            }
           )
       in
       let prev =
         Arg.prev n
         |> List.map (fun (edge, to_node) ->
-            {edge; node = Arg.Node.to_string to_node}
+            let cfg_to_node = Arg.Node.cfgnode to_node in
+            {
+              edge;
+              node = Arg.Node.to_string to_node;
+              cfg_node = Node.show_id cfg_to_node;
+              context = string_of_int (Arg.Node.context_id to_node);
+              path = string_of_int (Arg.Node.path_id to_node);
+              location = Node.location cfg_to_node;
+            }
           )
       in
       {

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -131,6 +131,8 @@ let arg_wrapper: (module ArgWrapper) ResettableLazy.t =
           StringH.replace ids (Arg.Node.to_string n) n;
         );
 
+      (* TODO: lookup  by CFG node *)
+
       let module ArgWrapper =
       struct
         module Arg = Arg
@@ -456,7 +458,7 @@ let () =
       context: string;
       path: string;
       location: CilType.Location.t;
-      next: (MyARG.inline_edge * string) list;
+      next: (MyARG.inline_edge * string) list; (* TODO: tuple to record *)
       prev: (MyARG.inline_edge * string) list;
     } [@@deriving to_yojson]
     type response = one_response list [@@deriving to_yojson]
@@ -471,7 +473,7 @@ let () =
           begin try
               [ArgWrapper.find_node node_id]
             with Not_found ->
-              Response.Error.(raise (make ~code:RequestFailed ~message:"non-existent node" ()))
+              Response.Error.(raise (make ~code:RequestFailed ~message:"non-existent node" ())) (* TODO: empty list *)
           end
         | None, Some location ->
           let nodes_opt =
@@ -479,7 +481,7 @@ let () =
             let+ nodes = Locator.find_opt locator location in
             Locator.ES.elements nodes
           in
-          Option.get_exn nodes_opt Response.Error.(E (make ~code:RequestFailed ~message:"cannot find node for location" ()))
+          Option.get_exn nodes_opt Response.Error.(E (make ~code:RequestFailed ~message:"cannot find node for location" ())) (* TODO: empty list *)
         | Some _, Some _ ->
           Response.Error.(raise (make ~code:RequestFailed ~message:"requires node nand location" ()))
       in

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -473,7 +473,7 @@ let () =
           begin try
               [ArgWrapper.find_node node_id]
             with Not_found ->
-              Response.Error.(raise (make ~code:RequestFailed ~message:"non-existent node" ())) (* TODO: empty list *)
+              [] (* non-existent node *)
           end
         | None, Some location ->
           let nodes_opt =
@@ -481,7 +481,7 @@ let () =
             let+ nodes = Locator.find_opt locator location in
             Locator.ES.elements nodes
           in
-          Option.get_exn nodes_opt Response.Error.(E (make ~code:RequestFailed ~message:"cannot find node for location" ())) (* TODO: empty list *)
+          Option.default [] nodes_opt (* cannot find node for location *)
         | Some _, Some _ ->
           Response.Error.(raise (make ~code:RequestFailed ~message:"requires node nand location" ()))
       in

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -452,16 +452,22 @@ let () =
       node: string option [@default None];
       location: CilType.Location.t option [@default None];
     } [@@deriving of_yojson]
+
+    type edge_node = {
+      edge: MyARG.inline_edge;
+      node: string;
+    } [@@deriving to_yojson]
     type one_response = {
       node: string;
       cfg_node: string;
       context: string;
       path: string;
       location: CilType.Location.t;
-      next: (MyARG.inline_edge * string) list; (* TODO: tuple to record *)
-      prev: (MyARG.inline_edge * string) list;
+      next: edge_node list;
+      prev: edge_node list;
     } [@@deriving to_yojson]
     type response = one_response list [@@deriving to_yojson]
+
     let process (params: params) serv =
       let module ArgWrapper = (val (ResettableLazy.force serv.arg_wrapper)) in
       let open ArgWrapper in
@@ -491,13 +497,13 @@ let () =
       let next =
         Arg.next n
         |> List.map (fun (edge, to_node) ->
-            (edge, Arg.Node.to_string to_node)
+            {edge; node = Arg.Node.to_string to_node}
           )
       in
       let prev =
         Arg.prev n
         |> List.map (fun (edge, to_node) ->
-            (edge, Arg.Node.to_string to_node)
+            {edge; node = Arg.Node.to_string to_node}
           )
       in
       {

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -447,6 +447,7 @@ let () =
     } [@@deriving of_yojson]
     type response = {
       node: string;
+      cfg_node: string;
       location: CilType.Location.t;
       next: (MyARG.inline_edge * string) list;
       prev: (MyARG.inline_edge * string) list;
@@ -480,9 +481,9 @@ let () =
         | Some _, Some _ ->
           Response.Error.(raise (make ~code:RequestFailed ~message:"requires node nand location" ()))
       in
-      let node = Arg.Node.cfgnode n in
-      let node_id = Node.show_id node in
-      let location = Node.location node in
+      let cfg_node = Arg.Node.cfgnode n in
+      let cfg_node_id = Node.show_id cfg_node in
+      let location = Node.location cfg_node in
       let next =
         Arg.next n
         |> List.map (fun (edge, to_node) ->
@@ -495,7 +496,7 @@ let () =
             (edge, Arg.Node.to_string to_node)
           )
       in
-      {node = node_id; location; next; prev}
+      {node = Arg.Node.to_string n; cfg_node = cfg_node_id; location; next; prev}
   end);
 
   register (module struct

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -127,7 +127,7 @@ let arg_wrapper: (module ArgWrapper) ResettableLazy.t =
       let cfg_nodes = StringH.create 113 in
       Arg.iter_nodes (fun n ->
           let cfgnode = Arg.Node.cfgnode n in
-          let loc = Node.location cfgnode in
+          let loc = UpdateCil.getLoc cfgnode in
           if not loc.synthetic then
             Locator.add locator loc n;
           StringH.replace ids (Arg.Node.to_string n) n;
@@ -230,7 +230,7 @@ let node_locator: Locator.t ResettableLazy.t =
       let rec iter_node node =
         if not (NH.mem reachable node) then begin
           NH.replace reachable node ();
-          let loc = Node.location node in
+          let loc = UpdateCil.getLoc node in
           if not loc.synthetic then
             Locator.add locator loc node;
           List.iter (fun (_, prev_node) ->
@@ -431,7 +431,7 @@ let () =
           Response.Error.(raise (make ~code:RequestFailed ~message:"requires node xor location" ()))
       in
       let node_id = Node.show_id node in
-      let location = Node.location node in
+      let location = UpdateCil.getLoc node in
       let module Cfg = (val !MyCFG.current_cfg) in
       let next =
         Cfg.next node
@@ -502,7 +502,7 @@ let () =
       in
       let cfg_node = Arg.Node.cfgnode n in
       let cfg_node_id = Node.show_id cfg_node in
-      let location = Node.location cfg_node in
+      let location = UpdateCil.getLoc cfg_node in
       let next =
         Arg.next n
         |> List.map (fun (edge, to_node) ->
@@ -513,7 +513,7 @@ let () =
               cfg_node = Node.show_id cfg_to_node;
               context = string_of_int (Arg.Node.context_id to_node);
               path = string_of_int (Arg.Node.path_id to_node);
-              location = Node.location cfg_to_node;
+              location = UpdateCil.getLoc cfg_to_node;
             }
           )
       in
@@ -527,7 +527,7 @@ let () =
               cfg_node = Node.show_id cfg_to_node;
               context = string_of_int (Arg.Node.context_id to_node);
               path = string_of_int (Arg.Node.path_id to_node);
-              location = Node.location cfg_to_node;
+              location = UpdateCil.getLoc cfg_to_node;
             }
           )
       in

--- a/src/witness/argTools.ml
+++ b/src/witness/argTools.ml
@@ -42,6 +42,13 @@ struct
     let equal (n1, c1, i1) (n2, c2, i2) =
       EQSys.LVar.equal (n1, c1) (n2, c2) && i1 = i2
 
+    let compare (n1, c1, i1) (n2, c2, i2) =
+      let r = EQSys.LVar.compare (n1, c1) (n2, c2) in
+      if r <> 0 then
+        r
+      else
+        Int.compare i1 i2
+
     let hash (n, c, i) = 31 * EQSys.LVar.hash (n, c) + i
 
     let cfgnode (n, c, i) = n

--- a/src/witness/argTools.ml
+++ b/src/witness/argTools.ml
@@ -46,6 +46,8 @@ struct
     let hash (n, c, i) = 31 * EQSys.LVar.hash (n, c) + i
 
     let cfgnode (n, c, i) = n
+    let context_id (n, c, i) = Spec.C.tag c
+    let path_id (n, c, i) = i
 
     let to_string (n, c, i) =
       (* copied from NodeCtxStackGraphMlWriter *)

--- a/src/witness/argTools.ml
+++ b/src/witness/argTools.ml
@@ -13,6 +13,8 @@ sig
   val iter_nodes: (Node.t -> unit) -> unit
 end
 
+let current_arg: (module BiArg) option ref = ref None
+
 module Make (R: ResultQuery.SpecSysSol2) =
 struct
   open R
@@ -113,6 +115,7 @@ struct
 
       let prev = witness_prev
       let iter_nodes f =
+        f main_entry;
         NHT.iter (fun n _ ->
             f n
           ) witness_prev_map

--- a/src/witness/argTools.ml
+++ b/src/witness/argTools.ml
@@ -1,0 +1,120 @@
+open MyCFG
+open Graphml
+open Svcomp
+open GobConfig
+
+module type WitnessTaskResult = TaskResult with module Arg.Edge = MyARG.InlineEdge
+
+module type BiArg =
+sig
+  include MyARG.S with module Edge = MyARG.InlineEdge
+
+  val prev: Node.t -> (Edge.t * Node.t) list
+end
+
+module Make (R: ResultQuery.SpecSysSol2) =
+struct
+  open R
+  open SpecSys
+  open Svcomp
+
+  module Query = ResultQuery.Query (SpecSys)
+
+  let get: node * Spec.C.t -> Spec.D.t =
+    fun nc -> LHT.find_default lh nc (Spec.D.bot ())
+
+  let ask_indices lvar =
+    let indices = ref [] in
+    ignore (ask_local lvar (Queries.IterVars (fun i ->
+        indices := i :: !indices
+      )));
+    !indices
+
+  module CfgNode = Node
+
+  module Node =
+  struct
+    type t = MyCFG.node * Spec.C.t * int
+
+    let equal (n1, c1, i1) (n2, c2, i2) =
+      EQSys.LVar.equal (n1, c1) (n2, c2) && i1 = i2
+
+    let hash (n, c, i) = 31 * EQSys.LVar.hash (n, c) + i
+
+    let cfgnode (n, c, i) = n
+
+    let to_string (n, c, i) =
+      (* copied from NodeCtxStackGraphMlWriter *)
+      let c_tag = Spec.C.tag c in
+      let i_str = string_of_int i in
+      match n with
+      | Statement stmt  -> Printf.sprintf "s%d(%d)[%s]" stmt.sid c_tag i_str
+      | Function f      -> Printf.sprintf "ret%d%s(%d)[%s]" f.svar.vid f.svar.vname c_tag i_str
+      | FunctionEntry f -> Printf.sprintf "fun%d%s(%d)[%s]" f.svar.vid f.svar.vname c_tag i_str
+
+    (* TODO: less hacky way (without ask_indices) to move node *)
+    let is_live (n, c, i) = not (Spec.D.is_bot (get (n, c)))
+    let move_opt (n, c, i) to_n =
+      match ask_indices (to_n, c) with
+      | [] -> None
+      | [to_i] ->
+        let to_node = (to_n, c, to_i) in
+        BatOption.filter is_live (Some to_node)
+      | _ :: _ :: _ ->
+        failwith "Node.move_opt: ambiguous moved index"
+    let equal_node_context (n1, c1, i1) (n2, c2, i2) =
+      EQSys.LVar.equal (n1, c1) (n2, c2)
+  end
+
+  module NHT = BatHashtbl.Make (Node)
+
+  let create entrystates: (MyARG.inline_edge * Node.t) list NHT.t * (module BiArg with type Node.t = MyCFG.node * Spec.C.t * int) =
+    let (witness_prev_map, witness_prev, witness_next) =
+      let prev = NHT.create 100 in
+      let next = NHT.create 100 in
+      LHT.iter (fun lvar local ->
+          ignore (ask_local lvar ~local (Queries.IterPrevVars (fun i (prev_node, prev_c_obj, j) edge ->
+              let lvar' = (fst lvar, snd lvar, i) in
+              let prev_lvar: NHT.key = (prev_node, Obj.obj prev_c_obj, j) in
+              NHT.modify_def [] lvar' (fun prevs -> (edge, prev_lvar) :: prevs) prev;
+              NHT.modify_def [] prev_lvar (fun nexts -> (edge, lvar') :: nexts) next
+            )))
+        ) lh;
+
+      (prev,
+        (fun n ->
+          NHT.find_default prev n []), (* main entry is not in prev at all *)
+        (fun n ->
+          NHT.find_default next n [])) (* main return is not in next at all *)
+    in
+    let witness_main =
+      let lvar = WitnessUtil.find_main_entry entrystates in
+      let main_indices = ask_indices lvar in
+      (* TODO: get rid of this hack for getting index of entry state *)
+      assert (List.compare_length_with main_indices 1 = 0);
+      let main_index = List.hd main_indices in
+      (fst lvar, snd lvar, main_index)
+    in
+
+    let module Arg =
+    struct
+      module Node = Node
+      module Edge = MyARG.InlineEdge
+      let main_entry = witness_main
+      let next = witness_next
+    end
+    in
+    let module Arg =
+    struct
+      open MyARG
+      module ArgIntra = UnCilTernaryIntra (UnCilLogicIntra (CfgIntra (FileCfg.Cfg)))
+      include Intra (ArgIntra) (Arg)
+
+      let prev = witness_prev
+    end
+    in
+    (witness_prev_map, (module Arg: BiArg with type Node.t = MyCFG.node * Spec.C.t * int))
+
+  let create entrystates =
+    Timing.wrap "arg create" create entrystates
+end

--- a/src/witness/argTools.ml
+++ b/src/witness/argTools.ml
@@ -1,9 +1,4 @@
 open MyCFG
-open Graphml
-open Svcomp
-open GobConfig
-
-module type WitnessTaskResult = TaskResult with module Arg.Edge = MyARG.InlineEdge
 
 module type BiArg =
 sig
@@ -19,7 +14,6 @@ module Make (R: ResultQuery.SpecSysSol2) =
 struct
   open R
   open SpecSys
-  open Svcomp
 
   module Query = ResultQuery.Query (SpecSys)
 

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -36,7 +36,7 @@ type inline_edge =
   | InlineEntry of CilType.Exp.t list
   | InlineReturn of CilType.Lval.t option
   | InlinedEdge of Edge.t
-[@@deriving eq, ord, hash, to_yojson]
+[@@deriving eq, ord, hash]
 
 let pretty_inline_edge () = function
   | CFGEdge e -> Edge.pretty_plain () e
@@ -44,6 +44,28 @@ let pretty_inline_edge () = function
   | InlineReturn None -> Pretty.dprintf "InlineReturn"
   | InlineReturn (Some ret) -> Pretty.dprintf "InlineReturn '%a'" Cil.d_lval ret
   | InlinedEdge e -> Pretty.dprintf "Inlined %a" Edge.pretty_plain e
+
+let inline_edge_to_yojson = function
+  | CFGEdge e ->
+    `Assoc [
+      ("cfg", Edge.to_yojson e)
+    ]
+  | InlineEntry args ->
+    `Assoc [
+      ("entry", `Assoc [
+          ("args", [%to_yojson: CilType.Exp.t list] args);
+        ]);
+    ]
+  | InlineReturn lval ->
+    `Assoc [
+      ("return", `Assoc [
+          ("lval", [%to_yojson: CilType.Lval.t option] lval);
+        ]);
+    ]
+  | InlinedEdge e ->
+    `Assoc [
+      ("inlined", Edge.to_yojson e)
+    ]
 
 module InlineEdgePrintable: Printable.S with type t = inline_edge =
 struct

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -35,6 +35,7 @@ type inline_edge =
   | CFGEdge of Edge.t
   | InlineEntry of CilType.Exp.t list
   | InlineReturn of CilType.Lval.t option
+  | InlinedEdge of Edge.t
 [@@deriving eq, ord, hash, to_yojson]
 
 let pretty_inline_edge () = function
@@ -42,6 +43,7 @@ let pretty_inline_edge () = function
   | InlineEntry args -> Pretty.dprintf "InlineEntry '(%a)'" (Pretty.d_list ", " Cil.d_exp) args
   | InlineReturn None -> Pretty.dprintf "InlineReturn"
   | InlineReturn (Some ret) -> Pretty.dprintf "InlineReturn '%a'" Cil.d_lval ret
+  | InlinedEdge e -> Pretty.dprintf "Inlined %a" Edge.pretty_plain e
 
 module InlineEdgePrintable: Printable.S with type t = inline_edge =
 struct

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -4,6 +4,7 @@ open GoblintCil
 module type Node =
 sig
   include Hashtbl.HashedType
+  include Set.OrderedType with type t := t
 
   val cfgnode: t -> MyCFG.node
   val to_string: t -> string
@@ -78,7 +79,7 @@ end
 module StackNode (Node: Node):
   Node with type t = Node.t list =
 struct
-  type t = Node.t list [@@deriving eq, hash]
+  type t = Node.t list [@@deriving eq, ord, hash]
 
   let cfgnode nl = Node.cfgnode (List.hd nl)
   let to_string nl =

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -7,6 +7,8 @@ sig
   include Set.OrderedType with type t := t
 
   val cfgnode: t -> MyCFG.node
+  val context_id: t -> int
+  val path_id: t -> int
   val to_string: t -> string
 
   val move_opt: t -> MyCFG.node -> t option
@@ -82,6 +84,8 @@ struct
   type t = Node.t list [@@deriving eq, ord, hash]
 
   let cfgnode nl = Node.cfgnode (List.hd nl)
+  let context_id nl = Node.context_id (List.hd nl)
+  let path_id nl = Node.path_id (List.hd nl)
   let to_string nl =
     nl
     |> List.map Node.to_string

--- a/src/witness/violation.ml
+++ b/src/witness/violation.ml
@@ -94,8 +94,13 @@ let find_path (type node) (module Arg:ViolationArg with type Node.t = node) (mod
         else if not (NHT.mem itered_nodes node) then begin
           NHT.replace itered_nodes node ();
           List.iter (fun (edge, prev_node) ->
-              if not (NHT.mem itered_nodes prev_node) then
-                NHT.replace next_nodes prev_node (edge, node)
+              match edge with
+              | MyARG.CFGEdge _
+              | InlineEntry _
+              | InlineReturn _ ->
+                if not (NHT.mem itered_nodes prev_node) then
+                  NHT.replace next_nodes prev_node (edge, node)
+              | InlinedEdge _ -> ()
             ) (Arg.prev node);
           bfs curs' (List.map snd (Arg.prev node) @ nexts)
         end

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -231,11 +231,20 @@ let write_file filename (module Task:Task) (module TaskResult:WitnessTaskResult)
           (* TODO: keep control (Test) edges to dead (sink) nodes for violation witness? *)
         in
         List.iter (fun (edge, to_node) ->
-            write_node to_node;
-            write_edge node edge to_node
+            match edge with
+            | MyARG.CFGEdge _
+            | InlineEntry _
+            | InlineReturn _ ->
+              write_node to_node;
+              write_edge node edge to_node
+            | InlinedEdge _ -> ()
           ) edge_to_nodes;
         List.iter (fun (edge, to_node) ->
-            iter_node to_node
+            match edge with
+            | MyARG.CFGEdge _
+            | InlineEntry _
+            | InlineReturn _ -> iter_node to_node
+            | InlinedEdge _ -> ()
           ) edge_to_nodes
       end
     end

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -271,100 +271,12 @@ struct
   open Svcomp
 
   module Query = ResultQuery.Query (SpecSys)
+  module ArgTool = ArgTools.Make (R)
+  module NHT = ArgTool.NHT
 
   let determine_result entrystates (module Task:Task): (module WitnessTaskResult) =
-    let get: node * Spec.C.t -> Spec.D.t =
-      fun nc -> LHT.find_default lh nc (Spec.D.bot ())
-    in
-    let ask_indices lvar =
-      let indices = ref [] in
-      ignore (ask_local lvar (Queries.IterVars (fun i ->
-          indices := i :: !indices
-        )));
-      !indices
-    in
-
-    let module CfgNode = Node in
-
-    let module Node =
-    struct
-      type t = MyCFG.node * Spec.C.t * int
-
-      let equal (n1, c1, i1) (n2, c2, i2) =
-        EQSys.LVar.equal (n1, c1) (n2, c2) && i1 = i2
-
-      let hash (n, c, i) = 31 * EQSys.LVar.hash (n, c) + i
-
-      let cfgnode (n, c, i) = n
-
-      let to_string (n, c, i) =
-        (* copied from NodeCtxStackGraphMlWriter *)
-        let c_tag = Spec.C.tag c in
-        let i_str = string_of_int i in
-        match n with
-        | Statement stmt  -> Printf.sprintf "s%d(%d)[%s]" stmt.sid c_tag i_str
-        | Function f      -> Printf.sprintf "ret%d%s(%d)[%s]" f.svar.vid f.svar.vname c_tag i_str
-        | FunctionEntry f -> Printf.sprintf "fun%d%s(%d)[%s]" f.svar.vid f.svar.vname c_tag i_str
-
-      (* TODO: less hacky way (without ask_indices) to move node *)
-      let is_live (n, c, i) = not (Spec.D.is_bot (get (n, c)))
-      let move_opt (n, c, i) to_n =
-        match ask_indices (to_n, c) with
-        | [] -> None
-        | [to_i] ->
-          let to_node = (to_n, c, to_i) in
-          BatOption.filter is_live (Some to_node)
-        | _ :: _ :: _ ->
-          failwith "Node.move_opt: ambiguous moved index"
-      let equal_node_context (n1, c1, i1) (n2, c2, i2) =
-        EQSys.LVar.equal (n1, c1) (n2, c2)
-    end
-    in
-
-    let module NHT = BatHashtbl.Make (Node) in
-
-    let (witness_prev_map, witness_prev, witness_next) =
-      let prev = NHT.create 100 in
-      let next = NHT.create 100 in
-      LHT.iter (fun lvar local ->
-          ignore (ask_local lvar ~local (Queries.IterPrevVars (fun i (prev_node, prev_c_obj, j) edge ->
-              let lvar' = (fst lvar, snd lvar, i) in
-              let prev_lvar: NHT.key = (prev_node, Obj.obj prev_c_obj, j) in
-              NHT.modify_def [] lvar' (fun prevs -> (edge, prev_lvar) :: prevs) prev;
-              NHT.modify_def [] prev_lvar (fun nexts -> (edge, lvar') :: nexts) next
-            )))
-        ) lh;
-
-      (prev,
-        (fun n ->
-          NHT.find_default prev n []), (* main entry is not in prev at all *)
-        (fun n ->
-          NHT.find_default next n [])) (* main return is not in next at all *)
-    in
-    let witness_main =
-      let lvar = WitnessUtil.find_main_entry entrystates in
-      let main_indices = ask_indices lvar in
-      (* TODO: get rid of this hack for getting index of entry state *)
-      assert (List.compare_length_with main_indices 1 = 0);
-      let main_index = List.hd main_indices in
-      (fst lvar, snd lvar, main_index)
-    in
-
-    let module Arg =
-    struct
-      module Node = Node
-      module Edge = MyARG.InlineEdge
-      let main_entry = witness_main
-      let next = witness_next
-    end
-    in
-    let module Arg =
-    struct
-      open MyARG
-      module ArgIntra = UnCilTernaryIntra (UnCilLogicIntra (CfgIntra (FileCfg.Cfg)))
-      include Intra (ArgIntra) (Arg)
-    end
-    in
+    let (witness_prev_map, arg_module) = ArgTool.create entrystates in
+    let module Arg = (val arg_module) in
 
     let find_invariant (n, c, i) =
       let context = {Invariant.default_context with path = Some i} in
@@ -418,7 +330,6 @@ struct
         struct
           include Arg
 
-          let prev = witness_prev
           let violations = violations
         end
         in

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -275,8 +275,7 @@ struct
   module NHT = ArgTool.NHT
 
   let determine_result entrystates (module Task:Task): (module WitnessTaskResult) =
-    let (witness_prev_map, arg_module) = ArgTool.create entrystates in
-    let module Arg = (val arg_module) in
+    let module Arg = (val ArgTool.create entrystates) in
 
     let find_invariant (n, c, i) =
       let context = {Invariant.default_context with path = Some i} in
@@ -319,12 +318,13 @@ struct
           |> List.exists (fun (_, to_n) -> is_violation to_n)
         in
         let violations =
-          NHT.fold (fun lvar _ acc ->
+          (* TODO: fold_nodes?s *)
+          let acc = ref [] in
+          Arg.iter_nodes (fun lvar ->
               if is_violation lvar then
-                lvar :: acc
-              else
-                acc
-            ) witness_prev_map []
+                acc := lvar :: !acc
+            );
+          !acc
         in
         let module ViolationArg =
         struct

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -238,6 +238,7 @@ struct
           let yr =
             if should_inline f then
               step_ctx ctx x' (InlineEntry a)
+              (* TODO: keep inlined Proc edge as well *)
             else
               R.bot ()
           in

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -239,7 +239,6 @@ struct
           let yr =
             if should_inline f then
               step_ctx ctx x' (InlineEntry (l, f, a))
-              (* TODO: keep inlined Proc edge as well *)
             else
               R.bot ()
           in

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -137,6 +137,7 @@ struct
     with Ctx_failure _ ->
       R.bot ()
   let step_ctx_edge ctx x = step_ctx ctx x (CFGEdge ctx.edge)
+  let step_ctx_inlined_edge ctx x = step_ctx ctx x (InlinedEdge ctx.edge)
 
   let map ctx f g =
     (* we now use Sync for every tf such that threadspawn after tf could look up state before tf *)
@@ -258,7 +259,9 @@ struct
         if should_inline f then
           let nosync = (Sync.singleton x (SyncSet.singleton x)) in
           (* returns already post-sync in FromSpec *)
-          step (Function f) (Option.get fc) x (InlineReturn l) nosync (* fc should be Some outside of MCP *)
+          let returnr = step (Function f) (Option.get fc) x (InlineReturn l) nosync in (* fc should be Some outside of MCP *)
+          let procr = step_ctx_inlined_edge ctx cd in
+          R.join procr returnr
         else
           step_ctx_edge ctx cd
       in

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -238,7 +238,7 @@ struct
           (* R.bot () isn't right here? doesn't actually matter? *)
           let yr =
             if should_inline f then
-              step_ctx ctx x' (InlineEntry a)
+              step_ctx ctx x' (InlineEntry (l, f, a))
               (* TODO: keep inlined Proc edge as well *)
             else
               R.bot ()
@@ -259,7 +259,7 @@ struct
         if should_inline f then
           let nosync = (Sync.singleton x (SyncSet.singleton x)) in
           (* returns already post-sync in FromSpec *)
-          let returnr = step (Function f) (Option.get fc) x (InlineReturn l) nosync in (* fc should be Some outside of MCP *)
+          let returnr = step (Function f) (Option.get fc) x (InlineReturn (l, f, a)) nosync in (* fc should be Some outside of MCP *)
           let procr = step_ctx_inlined_edge ctx cd in
           R.join procr returnr
         else


### PR DESCRIPTION
This is analogous to #988, but for traversing the ARG (abstract reachability graph) instead of the CFG. The option `exp.arg` is added to enable ARG construction outside of SV-COMP witness mode.

As opposed to `cfg/lookup`, this request has two extensions:
1. If neither `node` nor `location` are given, the entry node of the ARG is returned.
2. Returns a JSON array instead of a single result. This is necessary when looking up by location to return ARG nodes for all contexts and paths at the same node. In other cases a singleton array is returned.