### PR TITLE
Fix incremental write-only restarting for side effects from deleted nodes

### DIFF
--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -712,6 +712,17 @@ module Base =
         (* delete from incremental postsolving/warning structures to remove spurious warnings *)
         delete_marked superstable;
         delete_marked var_messages;
+
+        if restart_write_only then (
+          (* restart write-only *)
+          (* before delete_marked because we also want to restart write-only side effects from deleted nodes *)
+          HM.iter (fun x w ->
+              HM.iter (fun y d ->
+                  ignore (Pretty.printf "Restarting write-only to bot %a\n" S.Var.pretty_trace y);
+                  HM.replace rho y (S.Dom.bot ());
+                ) w
+            ) rho_write
+        );
         delete_marked rho_write;
         HM.iter (fun x w -> delete_marked w) rho_write;
 
@@ -904,16 +915,6 @@ module Base =
         else
           HM.create 0 (* doesn't matter, not used *)
       in
-
-      if restart_write_only then (
-        (* restart write-only *)
-        HM.iter (fun x w ->
-            HM.iter (fun y d ->
-                ignore (Pretty.printf "Restarting write-only to bot %a\n" S.Var.pretty_trace y);
-                HM.replace rho y (S.Dom.bot ());
-              ) w
-          ) rho_write
-      );
 
       if incr_verify then (
         HM.filteri_inplace (fun x _ -> HM.mem reachable_and_superstable x) var_messages;

--- a/tests/incremental/13-restart-write/09-mutex-self-fix.c
+++ b/tests/incremental/13-restart-write/09-mutex-self-fix.c
@@ -1,0 +1,17 @@
+#include <pthread.h>
+
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+int g;
+
+void *t_fun(void *arg) {
+  g++; // RACE!
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  while (1) {
+    pthread_create(&id, NULL, t_fun, NULL);
+  }
+  return 0;
+}

--- a/tests/incremental/13-restart-write/09-mutex-self-fix.json
+++ b/tests/incremental/13-restart-write/09-mutex-self-fix.json
@@ -3,7 +3,8 @@
     "restart": {
       "sided": {
         "enabled": false
-      }
+      },
+      "write-only": true
     }
   }
 }

--- a/tests/incremental/13-restart-write/09-mutex-self-fix.json
+++ b/tests/incremental/13-restart-write/09-mutex-self-fix.json
@@ -1,0 +1,9 @@
+{
+  "incremental": {
+    "restart": {
+      "sided": {
+        "enabled": false
+      }
+    }
+  }
+}

--- a/tests/incremental/13-restart-write/09-mutex-self-fix.patch
+++ b/tests/incremental/13-restart-write/09-mutex-self-fix.patch
@@ -1,0 +1,13 @@
+--- tests/incremental/13-restart-write/09-mutex-self-fix.c
++++ tests/incremental/13-restart-write/09-mutex-self-fix.c
+@@ -4,7 +4,9 @@ pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+ int g;
+
+ void *t_fun(void *arg) {
+-  g++; // RACE!
++  pthread_mutex_lock(&A);
++  g++; // NORACE
++  pthread_mutex_unlock(&A);
+   return NULL;
+ }
+


### PR DESCRIPTION
Before this fix, the added test case failed because old accesses from the deleted node (in a completely changed function) are not restarted.

This issue was revealed when re-running some incremental restarting benchmarks. `aget_comb02.patch` with RestartGlob failed to become more precise due to this issue.