### PR TITLE
Add `arg/dot`, `arg/state`, `arg/eval` and `arg/eval-int` requests to server mode

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1261,6 +1261,9 @@ struct
         | `Bot -> Queries.Result.bot q (* TODO: remove *)
         | _ -> Queries.Result.top q
       end
+    | Q.EvalValueYojson e ->
+      let v = eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local e in
+      `Lifted (VD.to_yojson v)
     | Q.BlobSize e -> begin
         let p = eval_rv_address (Analyses.ask_of_ctx ctx) ctx.global ctx.local e in
         (* ignore @@ printf "BlobSize %a MayPointTo %a\n" d_plainexp e VD.pretty p; *)

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -307,6 +307,8 @@ struct
              (* TODO: only query others that actually respond to EvalInt *)
              (* 2x speed difference on SV-COMP nla-digbench-scaling/ps6-ll_valuebound5.c *)
              f (Result.top ()) (!base_id, spec !base_id, assoc !base_id ctx.local) *)
+          | Queries.DYojson ->
+            `Lifted (D.to_yojson ctx.local)
           | _ ->
             let r = fold_left (f ~q) (Result.top ()) @@ spec_list ctx.local in
             do_sideg ctx !sides;

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -473,7 +473,6 @@ struct
   let is_top_env = A.is_top Man.mgr
   let is_bot_env = A.is_bottom Man.mgr
 
-  let to_yojson x = failwith "TODO implement to_yojson"
   let invariant _ = []
   let tag _ = failwith "Std: no tag"
   let arbitrary () = failwith "no arbitrary"
@@ -493,6 +492,20 @@ struct
     (* there is no A.compare, but polymorphic compare should delegate to Abstract0 and Environment compare's implemented in Apron's C *)
     Stdlib.compare x y
   let printXml f x = BatPrintf.fprintf f "<value>\n<map>\n<key>\nconstraints\n</key>\n<value>\n%s</value>\n<key>\nenv\n</key>\n<value>\n%s</value>\n</map>\n</value>\n" (XmlUtil.escape (Format.asprintf "%a" A.print x)) (XmlUtil.escape (Format.asprintf "%a" (Environment.print: Format.formatter -> Environment.t -> unit) (A.env x)))
+
+  let to_yojson (x: t) =
+    let constraints =
+      A.to_lincons_array Man.mgr x
+      |> SharedFunctions.Lincons1Set.of_earray
+      |> SharedFunctions.Lincons1Set.elements
+      |> List.map (fun lincons1 -> `String (SharedFunctions.Lincons1.show lincons1))
+    in
+    let env = `String (Format.asprintf "%a" (Environment.print: Format.formatter -> Environment.t -> unit) (A.env x))
+    in
+    `Assoc [
+      ("constraints", `List constraints);
+      ("env", env);
+    ]
 
   let unify x y =
     A.unify Man.mgr x y

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -49,17 +49,19 @@ sig
 end
 
 (* ZeroInit is true if malloc was used to allocate memory and it's false if calloc was used *)
-module ZeroInit = Lattice.Fake(Basetype.RawBools)
+module ZeroInit =
+struct
+  include Lattice.Fake(Basetype.RawBools)
+  let name () = "no zeroinit"
+end
 
 module Blob (Value: S) (Size: IntDomain.Z)=
 struct
-  include Lattice.Prod3 (Value) (Size) (ZeroInit)
+  include Lattice.Prod3 (struct include Value let name () = "value" end) (struct include Size let name () = "size" end) (ZeroInit)
   let name () = "blob"
   type value = Value.t
   type size = Size.t
   type origin = ZeroInit.t
-  let printXml f (x, y, z) =
-    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\nsize\n</key>\n%a<key>\norigin\n</key>\n%a</map>\n</value>\n" (XmlUtil.escape (Value.name ())) Value.printXml x Size.printXml y ZeroInit.printXml z
 
   let value (a, b, c) = a
   let invalidate_value ask t (v, s, o) = Value.invalidate_value ask t v, s, o

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -620,3 +620,25 @@ let get_short_list begin_str end_str list =
 
   let str = String.concat separator cut_str_list in
   begin_str ^ str ^ end_str
+
+
+module Yojson =
+struct
+  include Std
+  type t = Yojson.Safe.t [@@deriving eq]
+  let name () = "yojson"
+
+  let compare = Stdlib.compare
+  let hash = Hashtbl.hash
+
+  let pretty = GobYojson.pretty
+
+  include SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
+
+  let to_yojson x = x (* override SimplePretty *)
+end

--- a/src/util/gobZ.ml
+++ b/src/util/gobZ.ml
@@ -1,0 +1,4 @@
+type t = Z.t
+
+let to_yojson z =
+  `Intlit (Z.to_string z)

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -409,6 +409,7 @@ let () =
     type response = {
       node: string;
       location: CilType.Location.t;
+      function_: CilType.Fundec.t [@key "function"];
       next: (Edge.t list * string) list;
       prev: (Edge.t list * string) list;
     } [@@deriving to_yojson]
@@ -432,6 +433,7 @@ let () =
       in
       let node_id = Node.show_id node in
       let location = UpdateCil.getLoc node in
+      let function_ = Node.find_fundec node in
       let module Cfg = (val !MyCFG.current_cfg) in
       let next =
         Cfg.next node
@@ -445,7 +447,7 @@ let () =
             (List.map snd edges, Node.show_id to_node)
           )
       in
-      {node = node_id; location; next; prev}
+      {node = node_id; location; function_; next; prev}
   end);
 
   register (module struct
@@ -463,6 +465,7 @@ let () =
       context: string;
       path: string;
       location: CilType.Location.t;
+      function_: CilType.Fundec.t [@key "function"];
     } [@@deriving to_yojson]
     type one_response = {
       node: string;
@@ -470,6 +473,7 @@ let () =
       context: string;
       path: string;
       location: CilType.Location.t;
+      function_: CilType.Fundec.t [@key "function"];
       next: edge_node list;
       prev: edge_node list;
     } [@@deriving to_yojson]
@@ -514,6 +518,7 @@ let () =
               context = string_of_int (Arg.Node.context_id to_node);
               path = string_of_int (Arg.Node.path_id to_node);
               location = UpdateCil.getLoc cfg_to_node;
+              function_ = Node.find_fundec cfg_to_node;
             }
           )
       in
@@ -528,6 +533,7 @@ let () =
               context = string_of_int (Arg.Node.context_id to_node);
               path = string_of_int (Arg.Node.path_id to_node);
               location = UpdateCil.getLoc cfg_to_node;
+              function_ = Node.find_fundec cfg_to_node;
             }
           )
       in
@@ -537,6 +543,7 @@ let () =
         context = string_of_int (Arg.Node.context_id n);
         path = string_of_int (Arg.Node.path_id n);
         location;
+        function_ = Node.find_fundec cfg_node;
         next;
         prev
       }

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -625,7 +625,8 @@ let () =
             let fundec = Node.find_fundec cfg_node in
             let loc = UpdateCil.getLoc cfg_node in
 
-            begin match InvariantParser.parse_cil (ResettableLazy.force serv.invariant_parser) ~fundec ~loc exp_cabs with
+            (* Disable CIL check because incremental reparsing causes physically non-equal varinfos in this exp. *)
+            begin match InvariantParser.parse_cil ~check:false (ResettableLazy.force serv.invariant_parser) ~fundec ~loc exp_cabs with
               | Ok exp ->
                 let x = Arg.query n (EvalInt exp) in
                 {

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -604,7 +604,7 @@ let () =
   end);
 
   register (module struct
-    let name = "arg/eval"
+    let name = "arg/eval-int"
     type params = {
       node: string;
       exp: string;
@@ -631,7 +631,7 @@ let () =
                 {
                   raw = Queries.ID.to_yojson x;
                   int = Queries.ID.to_int x;
-                  bool = Queries.ID.to_bool x;
+                  bool = Queries.ID.to_bool x; (* Separate, because Not{0} has to_int = None, but to_bool = Some true. *)
                 }
               | Error e ->
                 Response.Error.(raise (make ~code:RequestFailed ~message:"CIL couldn't parse expression (undefined variables or side effects)" ()))

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -451,6 +451,19 @@ let () =
   end);
 
   register (module struct
+    let name = "arg/dot"
+    type params = unit [@@deriving of_yojson]
+    type response = {
+      arg: string
+    } [@@deriving to_yojson]
+    let process () serv =
+      let module ArgWrapper = (val (ResettableLazy.force serv.arg_wrapper)) in
+      let module ArgDot = ArgTools.Dot (ArgWrapper.Arg) in
+      let arg = Format.asprintf "%t" ArgDot.dot in
+      {arg}
+  end);
+
+  register (module struct
     let name = "arg/lookup"
     type params = {
       node: string option [@default None];

--- a/src/witness/argTools.ml
+++ b/src/witness/argTools.ml
@@ -6,6 +6,8 @@ sig
 
   val prev: Node.t -> (Edge.t * Node.t) list
   val iter_nodes: (Node.t -> unit) -> unit
+
+  val query: Node.t -> 'a Queries.t -> 'a Queries.result
 end
 
 module Dot (Arg: BiArg) =
@@ -147,6 +149,9 @@ struct
         NHT.iter (fun n _ ->
             f n
           ) witness_prev_map
+
+      let query ((n, c, i): Node.t) q =
+        R.ask_local (n, c) (PathQuery (i, q))
     end
     in
     (module Arg: BiArg with type Node.t = MyCFG.node * Spec.C.t * int)

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -216,6 +216,11 @@ struct
           f (I.to_int x)
         ) (fst ctx.local);
       ()
+    | Queries.PathQuery (i, q) ->
+      (* TODO: optimize indexing, using inner hashcons somehow? *)
+      (* let (d, _) = List.at (S.elements s) i in *)
+      let (d, _) = List.find (fun (x, _) -> I.to_int x = i) (Dom.bindings (fst ctx.local)) in
+      Spec.query (conv ctx d) q
     | Queries.Invariant ({path=Some i; _} as c) ->
       (* TODO: optimize indexing, using inner hashcons somehow? *)
       (* let (d, _) = List.at (S.elements s) i in *)

--- a/src/witness/witnessUtil.ml
+++ b/src/witness/witnessUtil.ml
@@ -133,7 +133,7 @@ struct
       Errormsg.log "\n"; (* CIL prints garbage without \n before *)
       Error e
 
-  let parse_cil {global_vars} ~(fundec: Cil.fundec) ~loc (inv_cabs: Cabs.expression): (Cil.exp, string) result =
+  let parse_cil {global_vars} ?(check=true) ~(fundec: Cil.fundec) ~loc (inv_cabs: Cabs.expression): (Cil.exp, string) result =
     let genv = Cabs2cil.genvironment in
     let env = Hashtbl.copy genv in
     List.iter (fun (v: Cil.varinfo) ->
@@ -157,7 +157,7 @@ struct
 
     let vars = fundec.sformals @ fundec.slocals @ global_vars in
     match inv_exp_opt with
-    | Some inv_exp when Check.checkStandaloneExp ~vars inv_exp ->
+    | Some inv_exp when not check || Check.checkStandaloneExp ~vars inv_exp ->
       Ok inv_exp
     | _ ->
       Error "parse_cil"


### PR DESCRIPTION
### Changes
1. Add `function` fields to `cfg/lookup` and `arg/lookup` responses.
2. Add `arg/dot` request, which returns the Graphviz string representation of the ARG.
3. Add `arg/state` request, which returns the JSON representation of an ARG node local state.
4. Add `arg/eval` request, which returns the JSON representation of a C expression evaluated at an ARG node.

The latter two are achieved by introducing a `PathQuery` query. The `PathQuery` generalizes the ability of `Invariant` query to only query a single path from the witness lifter. The `DYojson` query just returns `D.to_yojson` but via the query system. It is slightly hacky but allows accessing the local state representation of a particular path without bigger changes to all the `Spec` lifters.

### TODO
- [x] Rename `arg/eval` → `arg/eval-int`.