### PR TITLE
Clear TD3 `sides` when not reusing `wpoint` incrementally 

### DIFF
--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -74,11 +74,15 @@ module Base =
       dep = HM.create 10;
     }
 
-    let print_data data str =
+    let print_data data =
+      Printf.printf "|rho|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|sides|=%d\n|side_dep|=%d\n|side_infl|=%d\n|var_messages|=%d\n|rho_write|=%d\n|dep|=%d\n"
+        (HM.length data.rho) (HM.length data.stable) (HM.length data.infl) (HM.length data.wpoint) (HM.length data.sides) (HM.length data.side_dep) (HM.length data.side_infl) (HM.length data.var_messages) (HM.length data.rho_write) (HM.length data.dep);
+      Hooks.print_data ()
+
+    let print_data_verbose data str =
       if GobConfig.get_bool "dbg.verbose" then (
-        Printf.printf "%s:\n|rho|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|sides|=%d\n|side_dep|=%d\n|side_infl|=%d\n|var_messages|=%d\n|rho_write|=%d\n|dep|=%d\n"
-          str (HM.length data.rho) (HM.length data.stable) (HM.length data.infl) (HM.length data.wpoint) (HM.length data.sides) (HM.length data.side_dep) (HM.length data.side_infl) (HM.length data.var_messages) (HM.length data.rho_write) (HM.length data.dep);
-        Hooks.print_data ()
+        Printf.printf "%s:\n" str;
+        print_data data
       )
 
     let verify_data data =
@@ -243,14 +247,13 @@ module Base =
       let dep = data.dep in
 
       let () = print_solver_stats := fun () ->
-          Printf.printf "|rho|=%d\n|called|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|sides|=%d\n|side_dep|=%d\n|side_infl|=%d\n|var_messages|=%d\n|rho_write|=%d\n|dep|=%d\n"
-            (HM.length rho) (HM.length called) (HM.length stable) (HM.length infl) (HM.length wpoint) (HM.length sides) (HM.length side_dep) (HM.length side_infl) (HM.length var_messages) (HM.length rho_write) (HM.length dep);
-          Hooks.print_data ();
+          print_data data;
+          Printf.printf "|called|=%d\n" (HM.length called);
           print_context_stats rho
       in
 
       if GobConfig.get_bool "incremental.load" then (
-        print_data data "Loaded data for incremental analysis";
+        print_data_verbose data "Loaded data for incremental analysis";
         verify_data data
       );
 
@@ -734,7 +737,7 @@ module Base =
         delete_marked rho_write;
         HM.iter (fun x w -> delete_marked w) rho_write;
 
-        print_data data "Data after clean-up";
+        print_data_verbose data "Data after clean-up";
 
         (* TODO: reluctant doesn't call destabilize on removed functions or old copies of modified functions (e.g. after removing write), so those globals don't get restarted *)
 
@@ -836,7 +839,7 @@ module Base =
       );
 
       stop_event ();
-      print_data data "Data after solve completed";
+      print_data_verbose data "Data after solve completed";
 
       if GobConfig.get_bool "dbg.print_wpoints" then (
         Printf.printf "\nWidening points:\n";
@@ -1024,7 +1027,7 @@ module Base =
       let module Post = PostSolver.MakeIncrList (MakeIncrListArg) in
       Post.post st (stable_reluctant_vs @ vs) rho;
 
-      print_data data "Data after postsolve";
+      print_data_verbose data "Data after postsolve";
 
       verify_data data;
       (rho, {st; infl; sides; rho; wpoint; stable; side_dep; side_infl; var_messages; rho_write; dep})

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -379,6 +379,7 @@ module Base =
                 HM.replace restarted_wpoint y ();
             )
           );
+          if tracing then trace "sol2" "eval adding wpoint %a from %a\n" S.Var.pretty_trace y S.Var.pretty_trace x;
           HM.replace wpoint y ();
         );
         let tmp = simple_solve l x y in
@@ -426,7 +427,12 @@ module Base =
           HM.replace rho y tmp;
           if side_widen <> "cycle" then destabilize y;
           (* make y a widening point if ... This will only matter for the next side _ y.  *)
-          let wpoint_if e = if e then HM.replace wpoint y () in
+          let wpoint_if e =
+            if e then (
+              if tracing then trace "sol2" "side adding wpoint %a from %a\n" S.Var.pretty_trace y (Pretty.docOpt (S.Var.pretty_trace ())) x;
+              HM.replace wpoint y ()
+            )
+          in
           match side_widen with
           | "always" -> (* Any side-effect after the first one will be widened which will unnecessarily lose precision. *)
             wpoint_if true

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -75,8 +75,16 @@ module Base =
     }
 
     let print_data data =
-      Printf.printf "|rho|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|sides|=%d\n|side_dep|=%d\n|side_infl|=%d\n|var_messages|=%d\n|rho_write|=%d\n|dep|=%d\n"
-        (HM.length data.rho) (HM.length data.stable) (HM.length data.infl) (HM.length data.wpoint) (HM.length data.sides) (HM.length data.side_dep) (HM.length data.side_infl) (HM.length data.var_messages) (HM.length data.rho_write) (HM.length data.dep);
+      Printf.printf "|rho|=%d\n" (HM.length data.rho);
+      Printf.printf "|stable|=%d\n" (HM.length data.stable);
+      Printf.printf "|infl|=%d\n" (HM.length data.infl);
+      Printf.printf "|wpoint|=%d\n" (HM.length data.wpoint);
+      Printf.printf "|sides|=%d\n" (HM.length data.sides);
+      Printf.printf "|side_dep|=%d\n" (HM.length data.side_dep);
+      Printf.printf "|side_infl|=%d\n" (HM.length data.side_infl);
+      Printf.printf "|var_messages|=%d\n" (HM.length data.var_messages);
+      Printf.printf "|rho_write|=%d\n" (HM.length data.rho_write);
+      Printf.printf "|dep|=%d\n" (HM.length data.dep);
       Hooks.print_data ()
 
     let print_data_verbose data str =

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -197,8 +197,10 @@ module Base =
             HM.clear data.stable;
             HM.clear data.infl
           );
-          if not reuse_wpoint then
+          if not reuse_wpoint then (
             HM.clear data.wpoint;
+            HM.clear data.sides
+          );
           data
         | None ->
           create_empty_data ()

--- a/src/solvers/td3.ml
+++ b/src/solvers/td3.ml
@@ -76,8 +76,8 @@ module Base =
 
     let print_data data str =
       if GobConfig.get_bool "dbg.verbose" then (
-        Printf.printf "%s:\n|rho|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|side_dep|=%d\n|side_infl|=%d\n|var_messages|=%d\n|rho_write|=%d\n|dep|=%d\n"
-          str (HM.length data.rho) (HM.length data.stable) (HM.length data.infl) (HM.length data.wpoint) (HM.length data.side_dep) (HM.length data.side_infl) (HM.length data.var_messages) (HM.length data.rho_write) (HM.length data.dep);
+        Printf.printf "%s:\n|rho|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|sides|=%d\n|side_dep|=%d\n|side_infl|=%d\n|var_messages|=%d\n|rho_write|=%d\n|dep|=%d\n"
+          str (HM.length data.rho) (HM.length data.stable) (HM.length data.infl) (HM.length data.wpoint) (HM.length data.sides) (HM.length data.side_dep) (HM.length data.side_infl) (HM.length data.var_messages) (HM.length data.rho_write) (HM.length data.dep);
         Hooks.print_data ()
       )
 
@@ -241,8 +241,8 @@ module Base =
       let dep = data.dep in
 
       let () = print_solver_stats := fun () ->
-          Printf.printf "|rho|=%d\n|called|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|side_dep|=%d\n|side_infl|=%d\n|var_messages|=%d\n|rho_write|=%d\n|dep|=%d\n"
-            (HM.length rho) (HM.length called) (HM.length stable) (HM.length infl) (HM.length wpoint) (HM.length side_dep) (HM.length side_infl) (HM.length var_messages) (HM.length rho_write) (HM.length dep);
+          Printf.printf "|rho|=%d\n|called|=%d\n|stable|=%d\n|infl|=%d\n|wpoint|=%d\n|sides|=%d\n|side_dep|=%d\n|side_infl|=%d\n|var_messages|=%d\n|rho_write|=%d\n|dep|=%d\n"
+            (HM.length rho) (HM.length called) (HM.length stable) (HM.length infl) (HM.length wpoint) (HM.length sides) (HM.length side_dep) (HM.length side_infl) (HM.length var_messages) (HM.length rho_write) (HM.length dep);
           Hooks.print_data ();
           print_context_stats rho
       in


### PR DESCRIPTION
Even though our default behavior is not reusing `wpoint` incrementally, we were reusing `sides`, which is used for turning global constraint variables into widening points. This meant that even when we didn't consider such variable a widening point after incremental loading, it would become one after a single side effect. This is different from the usual counting achieved via `sides`.

There's no real value in reusing `sides` if we're trying to be more accurate by not reusing `wpoint`. Reusing `sides` is not necessary for termination because variables will get re-added if necessary.
I don't know if this has any real-world improvement for incremental precision. Theoretically it is possible, although it only makes a difference if the incremental run makes just a few side effects from a particular node.

Also includes changes for debug output related to the issue. The accidental reuse was hard to notice because no stats about `sides` were being printed. I suspected a problem because for incremental runs the number of widening points was much greater than at the end of the original run.