### PR TITLE
Add `cil/varinfos` request to server mode

### DIFF
--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -445,6 +445,8 @@ let varinfo_roles: varinfo_role VarinfoH.t ResettableLazy.t =
             VarinfoH.replace h fd.svar Function; (* function itself can be used as a variable (function pointer) *)
             List.iter (fun vi -> VarinfoH.replace h vi (Formal fd)) fd.sformals;
             List.iter (fun vi -> VarinfoH.replace h vi (Local fd)) fd.slocals
+          | GVarDecl (vi, _) when Cil.isFunctionType vi.vtype ->
+            VarinfoH.replace h vi Function
           | GVar (vi, _, _)
           | GVarDecl (vi, _) ->
             VarinfoH.replace h vi Global


### PR DESCRIPTION
This returns a list of data for all `varinfo`s known to CIL, including:
1. `vid` to be used for other requests since name is not globally unique,
2. `original_name` to be used for mapping to actual code names (or detecting temporaries if missing),
3. `role` and `function` for determining the scope.

This is provided as a list and a client may construct suitably grouped mappings from it.