### PR TITLE
Add `global-state` request to server mode

### DIFF
--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -161,12 +161,13 @@ struct
 
   let hash     = unop_fold (fun a n (module S : Printable.S) x -> hashmul a @@ S.hash (obj x)) 0
 
-  let name () =
+  (* let name () =
     let domain_name (n, (module D: Printable.S)) =
       let analysis_name = find_spec_name n in
       analysis_name ^ ":(" ^ D.name () ^ ")"
     in
-    IO.to_string (List.print ~first:"[" ~last:"]" ~sep:", " String.print) (map domain_name @@ domain_list ())
+    IO.to_string (List.print ~first:"[" ~last:"]" ~sep:", " String.print) (map domain_name @@ domain_list ()) *)
+  let name () = "MCP.C"
 
   let printXml f xs =
     let print_one a n (module S : Printable.S) x : unit =
@@ -317,6 +318,7 @@ struct
   open Obj
 
   include DomVariantPrintable (PrintableOfLatticeSpec (DLSpec))
+  let name () = "MCP.G"
 
   let binop_map' (f: int -> (module Lattice.S) -> Obj.t -> Obj.t -> 'a) (n1, d1) (n2, d2) =
     assert (n1 = n2);
@@ -346,7 +348,10 @@ struct
 end
 
 module DomVariantLattice (DLSpec : DomainListLatticeSpec) =
-  Lattice.Lift (DomVariantLattice0 (DLSpec)) (Printable.DefaultNames)
+struct
+  include Lattice.Lift (DomVariantLattice0 (DLSpec)) (Printable.DefaultNames)
+  let name () = "MCP.G"
+end
 
 module LocalDomainListSpec : DomainListLatticeSpec =
 struct

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -98,6 +98,7 @@ struct
         let printXml f c = BatPrintf.fprintf f "<value>%a</value>" printXml c (* wrap in <value> for HTML printing *)
       end
       )
+    let name () = "contexts"
   end
 
   include Lattice.Lift2 (G) (CSet) (Printable.DefaultNames)

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -477,6 +477,8 @@ module FromSpec (S:Spec) (Cfg:CfgBackward) (I: Increment)
                            and module GVar = GVarF (S.V)
                            and module D = S.D
                            and module G = GVarG (S.G) (S.C)
+
+    val iter_vars: (LVar.t -> D.t) -> (GVar.t -> G.t) -> VarQuery.t -> LVar.t VarQuery.f -> GVar.t VarQuery.f -> unit
   end
 =
 struct

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1220,11 +1220,16 @@ struct
       | `Right _ -> true
   end
 
-  module EM = MapDomain.MapBot (Basetype.CilExp) (Basetype.Bools)
+  module EM =
+  struct
+    include MapDomain.MapBot (Basetype.CilExp) (Basetype.Bools)
+    let name () = "branches"
+  end
 
   module G =
   struct
     include Lattice.Lift2 (S.G) (EM) (Printable.DefaultNames)
+    let name () = "deadbranch"
 
     let s = function
       | `Bot -> S.G.bot ()

--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -596,6 +596,33 @@ let () =
   end);
 
   register (module struct
+    let name = "global-state"
+    type params = {
+      vid: int option [@default None];
+      node: string option [@default None];
+    } [@@deriving of_yojson]
+    type response = Yojson.Safe.t [@@deriving to_yojson]
+    let process (params: params) serv =
+      let vq_opt = match params.vid, params.node with
+        | None, None ->
+          None
+        | Some vid, None ->
+          let vi = {Cil.dummyFunDec.svar with vid} in (* Equal to actual varinfo by vid. *)
+          Some (VarQuery.Global vi)
+        | None, Some node_id ->
+          let node = try
+              Node.of_id node_id
+            with Not_found ->
+              Response.Error.(raise (make ~code:RequestFailed ~message:"not analyzed or non-existent node" ()))
+          in
+          Some (VarQuery.Node {node; fundec = None})
+        | Some _, Some _ ->
+          Response.Error.(raise (make ~code:RequestFailed ~message:"requires at most one of vid and node" ()))
+      in
+      !Control.current_varquery_global_state_json vq_opt
+  end);
+
+  register (module struct
     let name = "exp_eval"
     type params = ExpressionEvaluation.query [@@deriving of_yojson]
     type response =


### PR DESCRIPTION
Builds on #1012.

This request allows getting the entire global state (not too practical), but also filtering by constraint variable queries (e.g. by variable `vid` or node). The latter could be useful for displaying relevant global invariant states in the abstract debugger, relating to the current node or global variables in multi-threaded mode.