### PR TITLE
Remove custom `SetDomain` operations

### DIFF
--- a/bench/basic/benchSet.ml
+++ b/bench/basic/benchSet.ml
@@ -1,0 +1,53 @@
+(* dune exec bench/basic/benchSet.exe -- -a *)
+
+open Benchmark
+open Benchmark.Tree
+
+module IS = Set.Make (Int)
+
+let set1 = IS.of_seq (Seq.init 1024 (fun i -> i))
+let set2 = IS.of_seq (Seq.init 1024 (fun i -> i + 1))
+let set3 = IS.of_seq (Seq.init 1024 (fun i -> i - 1))
+
+let equal1 (x, y) = IS.equal x y
+let equal2 (x, y) = IS.for_all (fun i -> IS.exists (Int.equal i) y) x
+
+let equal1' (x, y) = IS.cardinal x = IS.cardinal y && IS.equal x y
+let equal2' (x, y) = IS.cardinal x = IS.cardinal y && IS.for_all (fun i -> IS.exists (Int.equal i) y) x
+
+
+let () =
+  register (
+    "equal" @>>> [
+      "1-1" @> lazy (
+        let args = (set1, set1) in
+        throughputN 1 [
+          ("equal1", equal1, args);
+          ("equal2", equal2, args);
+          ("equal1'", equal1', args);
+          ("equal2'", equal2', args);
+        ]
+      );
+      "1-2" @> lazy (
+        let args = (set1, set2) in
+        throughputN 1 [
+          ("equal1", equal1, args);
+          ("equal2", equal2, args);
+          ("equal1'", equal1', args);
+          ("equal2'", equal2', args);
+        ]
+      );
+      "1-3" @> lazy (
+        let args = (set1, set3) in
+        throughputN 1 [
+          ("equal1", equal1, args);
+          ("equal2", equal2, args);
+          ("equal1'", equal1', args);
+          ("equal2'", equal2', args);
+        ]
+      );
+    ]
+  )
+
+let () =
+  run_global ()

--- a/bench/basic/benchSet.ml
+++ b/bench/basic/benchSet.ml
@@ -49,5 +49,46 @@ let () =
     ]
   )
 
+
+let map1 (f, x) = IS.map f x
+let map2 (f, x) =
+  let add_to_it e x = IS.add (f e) x in
+  IS.fold add_to_it x IS.empty
+
+let () =
+  register (
+    "map" @>>> [
+      "inc" @> lazy (
+        let args = ((fun x -> x + 1), set1) in
+        throughputN 1 [
+          ("map1", map1, args);
+          ("map2", map2, args);
+        ]
+      );
+      "flip" @> lazy (
+        let args = ((fun x -> 2048 - x), set1) in
+        throughputN 1 [
+          ("map1", map1, args);
+          ("map2", map2, args);
+        ]
+      );
+      "const" @> lazy (
+        let args = ((fun x -> 42), set1) in
+        throughputN 1 [
+          ("map1", map1, args);
+          ("map2", map2, args);
+        ]
+      );
+      "shuffle" @> lazy (
+        let args = ((fun x -> (31 * x + 42) mod 37), set1) in
+        throughputN 1 [
+          ("map1", map1, args);
+          ("map2", map2, args);
+        ]
+      );
+    ]
+  )
+
+
 let () =
   run_global ()

--- a/bench/basic/benchSet.ml
+++ b/bench/basic/benchSet.ml
@@ -5,7 +5,7 @@ open Benchmark.Tree
 
 module IS = Set.Make (Int)
 
-let set1 = IS.of_seq (Seq.init 1024 (fun i -> i))
+let set1 = IS.of_seq (Seq.init 1024 Fun.id)
 let set2 = IS.of_seq (Seq.init 1024 (fun i -> i + 1))
 let set3 = IS.of_seq (Seq.init 1024 (fun i -> i - 1))
 

--- a/bench/basic/dune
+++ b/bench/basic/dune
@@ -1,4 +1,4 @@
-(executable
- (name benchTuple4)
+(executables
+ (names benchTuple4 benchSet)
  (optional) ; TODO: for some reason this doesn't work: `dune build` still tries to compile if benchmark missing (https://github.com/ocaml/dune/issues/4065)
  (libraries benchmark batteries.unthreaded))

--- a/src/domains/setDomain.ml
+++ b/src/domains/setDomain.ml
@@ -187,10 +187,6 @@ struct
     end
     )
 
-  let equal x y =
-    cardinal x = cardinal y
-    && for_all (fun e -> exists (Base.equal e) y) x
-
   let hash x = fold (fun x y -> y + Base.hash x) x 0
 
   let relift x = map Base.relift x

--- a/src/domains/setDomain.ml
+++ b/src/domains/setDomain.ml
@@ -174,10 +174,6 @@ struct
   let top () = unsupported "Make.top"
   let is_top _ = false
 
-  let map f s =
-    let add_to_it x s = add (f x) s in
-    fold add_to_it s (empty ())
-
   include Print (Base) (
     struct
       type nonrec t = t


### PR DESCRIPTION
`Set.Make` from the standard library already comes with `equal` and `map` implemented directly on the internal binary tree. These are more efficient than our hand-written replacements that have been around for a decade. It's possible that back then they weren't in the standard library yet.

Includes benchmarks for the multiple versions of the two functions.

### `equal`
The standard library `equal` (as `equal1` in benchmark) beats the removed implementation (as `equal2'` in benchmark) **316.. 79346 times**! The speedup varies wildly depending on whether the compared sets are equal or where the difference is (in the first element or in the last element).
Our implementation was so horrible because an `exists` in a `for_all`  constitutes as pairwise checking of set elements.

The benchmark also shows that the `cardinal`ity check before full comparison does improve the standard library.

```
*** Run benchmarks for path "equal.1-1"

Throughputs for "equal1", "equal2", "equal1'", "equal2'" each running for at least 1 CPU second:
 equal1:  1.07 WALL ( 1.06 usr +  0.00 sys =  1.07 CPU) @ 130907.93/s (n=139781)
 equal2:  1.03 WALL ( 1.03 usr +  0.00 sys =  1.03 CPU) @ 406.16/s (n=419)
equal1':  1.05 WALL ( 1.05 usr +  0.00 sys =  1.05 CPU) @ 76708.04/s (n=80399)
equal2':  1.07 WALL ( 1.07 usr +  0.00 sys =  1.07 CPU) @ 411.81/s (n=439)
            Rate  equal2 equal2' equal1'  equal1
 equal2    406/s      --     -1%    -99%   -100%
equal2'    412/s      1%      --    -99%   -100%
equal1'  76708/s  18786%  18527%      --    -41%
 equal1 130908/s  32131%  31688%     71%      --
**********************************************************************
*** Run benchmarks for path "equal.1-2"

Throughputs for "equal1", "equal2", "equal1'", "equal2'" each running for at least 1 CPU second:
 equal1:  1.04 WALL ( 1.04 usr +  0.00 sys =  1.04 CPU) @ 32610002.51/s (n=33963285)
 equal2:  1.00 WALL ( 1.00 usr +  0.00 sys =  1.00 CPU) @ 101939.55/s (n=102352)
equal1':  1.04 WALL ( 1.04 usr +  0.00 sys =  1.04 CPU) @ 173465.93/s (n=181062)
equal2':  1.06 WALL ( 1.06 usr +  0.00 sys =  1.06 CPU) @ 66505.95/s (n=70539)
              Rate equal2'  equal2 equal1'  equal1
equal2'    66506/s      --    -35%    -62%   -100%
 equal2   101940/s     53%      --    -41%   -100%
equal1'   173466/s    161%     70%      --    -99%
 equal1 32610003/s  48933%  31890%  18699%      --
**********************************************************************
*** Run benchmarks for path "equal.1-3"

Throughputs for "equal1", "equal2", "equal1'", "equal2'" each running for at least 1 CPU second:
 equal1:  1.05 WALL ( 1.05 usr +  0.00 sys =  1.05 CPU) @ 33438517.91/s (n=35200895)
 equal2:  1.05 WALL ( 1.05 usr +  0.00 sys =  1.05 CPU) @ 404.30/s (n=423)
equal1':  1.04 WALL ( 1.04 usr +  0.00 sys =  1.04 CPU) @ 173868.53/s (n=180849)
equal2':  1.07 WALL ( 1.07 usr +  0.00 sys =  1.07 CPU) @ 421.42/s (n=450)
              Rate   equal2  equal2'  equal1'   equal1
 equal2      404/s       --      -4%    -100%    -100%
equal2'      421/s       4%       --    -100%    -100%
equal1'   173869/s   42905%   41158%       --     -99%
 equal1 33438518/s 8270716% 7934630%   19132%       --
*********************************************************************
```

### `map`
The improvement for `map` is not as impressive, but in many cases it's still there. Our implementation (as `map2` in benchmark) only beats the standard library (as `map1` in the benchmark) slightly in some contrived cases.
The standard implementation exploits the case when the function happens to be monotonic (at every binary tree level) to avoid rebalancing.

Nevertheless, it's better for maintenance to not have our own version of something that already exists.

```
*** Run benchmarks for path "map.const"

Throughputs for "map1", "map2" each running for at least 1 CPU second:
map1:  1.04 WALL ( 1.04 usr +  0.00 sys =  1.04 CPU) @ 77777.16/s (n=80964)
map2:  1.07 WALL ( 1.07 usr +  0.00 sys =  1.07 CPU) @ 87047.20/s (n=93115)
        Rate map1 map2
map1 77777/s   -- -11%
map2 87047/s  12%   --
**********************************************************************
*** Run benchmarks for path "map.flip"

Throughputs for "map1", "map2" each running for at least 1 CPU second:
map1:  1.02 WALL ( 1.02 usr +  0.00 sys =  1.02 CPU) @ 18294.26/s (n=18613)
map2:  1.04 WALL ( 1.04 usr +  0.00 sys =  1.04 CPU) @ 10597.32/s (n=11046)
        Rate map2 map1
map2 10597/s   -- -42%
map1 18294/s  73%   --
**********************************************************************
*** Run benchmarks for path "map.inc"

Throughputs for "map1", "map2" each running for at least 1 CPU second:
map1:  1.06 WALL ( 1.06 usr +  0.00 sys =  1.06 CPU) @ 71151.84/s (n=75738)
map2:  1.01 WALL ( 1.01 usr +  0.00 sys =  1.01 CPU) @ 9838.61/s (n=9954)
        Rate map2 map1
map2  9839/s   -- -86%
map1 71152/s 623%   --
**********************************************************************
*** Run benchmarks for path "map.shuffle"

Throughputs for "map1", "map2" each running for at least 1 CPU second:
map1:  1.06 WALL ( 1.06 usr +  0.00 sys =  1.06 CPU) @ 9425.65/s (n=9975)
map2:  1.06 WALL ( 1.06 usr +  0.00 sys =  1.06 CPU) @ 31483.75/s (n=33365)
        Rate map1 map2
map1  9426/s   -- -70%
map2 31484/s 234%   --
```

### sv-benchmarks
Ignoring noise, sv-benchmarks also shows this PR having an improvement:
![image](https://user-images.githubusercontent.com/378740/225009559-dd6d9849-acb1-4162-a107-51e1ba8844fc.png)
Surprisingly, there are benchmarks where this speeds analysis up over 2 times!
