### PR TITLE
Add missing accesses to VLA lengths

### DIFF
--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -56,6 +56,16 @@ struct
 
   (** Transfer functions: *)
 
+  let vdecl ctx v =
+    let rec distribute_access_typ = function
+      | TArray (et, len, _) ->
+        Option.may (access_one_top ctx Read false) len;
+        distribute_access_typ et
+      | _ -> ()
+    in
+    distribute_access_typ v.vtype;
+    ctx.local
+
   let assign ctx lval rval : D.t =
     (* ignore global inits *)
     if !GU.global_initialization then ctx.local else begin

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -57,13 +57,7 @@ struct
   (** Transfer functions: *)
 
   let vdecl ctx v =
-    let rec distribute_access_typ = function
-      | TArray (et, len, _) ->
-        Option.may (access_one_top ctx Read false) len;
-        distribute_access_typ et
-      | _ -> ()
-    in
-    distribute_access_typ v.vtype;
+    access_one_top ctx Read false (SizeOf v.vtype);
     ctx.local
 
   let assign ctx lval rval : D.t =

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -282,11 +282,30 @@ and distribute_access_exp f = function
     distribute_access_exp f b;
     distribute_access_exp f t;
     distribute_access_exp f e
+
+  | SizeOf t ->
+    distribute_access_type f t
+
   | Const _
-  | SizeOf _
   | SizeOfStr _
   | AlignOf _
   | AddrOfLabel _ ->
+    ()
+
+and distribute_access_type f = function
+  | TArray (et, len, _) ->
+    Option.may (distribute_access_exp f) len;
+    distribute_access_type f et
+
+  | TVoid _
+  | TInt _
+  | TFloat _
+  | TPtr _
+  | TFun _
+  | TNamed _
+  | TComp _
+  | TEnum _
+  | TBuiltin_va_list _ ->
     ()
 
 let add side e kind conf vo oo a =

--- a/tests/regression/04-mutex/68-vla_rc.c
+++ b/tests/regression/04-mutex/68-vla_rc.c
@@ -1,0 +1,17 @@
+#include <pthread.h>
+#include <stdio.h>
+
+int g;
+
+void *t_fun(void *arg) {
+  g=g+1; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  int a[g]; // RACE!
+  int b[2][g]; // RACE!
+  return 0;
+}

--- a/tests/regression/04-mutex/69-sizeof_rc.c
+++ b/tests/regression/04-mutex/69-sizeof_rc.c
@@ -1,0 +1,17 @@
+#include <pthread.h>
+#include <stdio.h>
+
+int g;
+
+void *t_fun(void *arg) {
+  g=g+1; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  int a = sizeof(int[g]); // RACE!
+  int b = sizeof(int[2][g]); // RACE!
+  return 0;
+}


### PR DESCRIPTION
While thinking about VLAs for #970 I realized that our access/race analysis does not implement the `vdecl` transfer function. This meant that we missed races if the VLA length was a racy variable.

Moreover, `sizeof` on types evaluates the expressions in array type lengths in case of VLAs, so those also constitute read accesses.