### PR TITLE
Fix incremental invariant parser for server mode

### DIFF
--- a/src/util/server.ml
+++ b/src/util/server.ml
@@ -691,8 +691,7 @@ let () =
                 let fundec = Node.find_fundec cfg_node in
                 let loc = UpdateCil.getLoc cfg_node in
 
-                (* Disable CIL check because incremental reparsing causes physically non-equal varinfos in this exp. *)
-                begin match InvariantParser.parse_cil ~check:false (ResettableLazy.force serv.invariant_parser) ~fundec ~loc exp_cabs with
+                begin match InvariantParser.parse_cil (ResettableLazy.force serv.invariant_parser) ~fundec ~loc exp_cabs with
                   | Ok exp -> exp
                   | Error e ->
                     Response.Error.(raise (make ~code:RequestFailed ~message:"CIL couldn't parse expression (undefined variables or side effects)" ()))
@@ -732,8 +731,7 @@ let () =
             let fundec = Node.find_fundec cfg_node in
             let loc = UpdateCil.getLoc cfg_node in
 
-            (* Disable CIL check because incremental reparsing causes physically non-equal varinfos in this exp. *)
-            begin match InvariantParser.parse_cil ~check:false (ResettableLazy.force serv.invariant_parser) ~fundec ~loc exp_cabs with
+            begin match InvariantParser.parse_cil (ResettableLazy.force serv.invariant_parser) ~fundec ~loc exp_cabs with
               | Ok exp ->
                 let x = Arg.query n (EvalInt exp) in
                 {


### PR DESCRIPTION
This hopefully fixes the following issue.

## Issue
```c
// repro.c
int global = 32;

int main() {
    int local = 3;
}
```

```yaml
// goblint.json
{
  "files": ["repro.c"]
}
```

After reanalysis `arg/eval-int` will return `top` for the expression `global`.

Note: running analysis with `reset=false` you need to analyze, comment out `global`, reanalyze, comment in `global` and reanalyze again to get the issue to happen. Running analysis with `reset=true` you just need to analyze twice.

_Originally posted by @FeldrinH in https://github.com/goblint/analyzer/issues/1008#issuecomment-1476588559_
            