### PR TITLE
Autotuner for `longjmp`

### DIFF
--- a/src/goblint.ml
+++ b/src/goblint.ml
@@ -58,6 +58,8 @@ let main () =
         else
           None
       in
+      (* This is run independant of the autotuner being enabled or not be sound for programs with longjmp *)
+      AutoTune.activateLongjmpAnalysesWhenRequired ();
       if get_bool "ana.autotune.enabled" then AutoTune.chooseConfig file;
       file |> do_analyze changeInfo;
       do_html_output ();

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -332,7 +332,7 @@
           "default": [
             "expRelation", "base", "threadid", "threadflag", "threadreturn",
             "escape", "mutexEvents", "mutex", "access", "race", "mallocWrapper", "mhp",
-            "assert","activeLongjmp","activeSetjmp","taintPartialContexts","modifiedSinceLongjmp","poisonVariables","expsplit","vla"
+            "assert"
           ]
         },
         "path_sens": {


### PR DESCRIPTION
Rather than disabling the analyses not needed if longjmp is not called, this now enables them if there may be calls. This allows enabling some of these analyses regardless.

TODO:

-  [ ] Dynamic calls are not recognized properly yet (see failing tests)