### PR TITLE
Split `combine` into `combine_env` and `combine_assign`

### DIFF
--- a/src/analyses/abortUnless.ml
+++ b/src/analyses/abortUnless.ml
@@ -46,7 +46,10 @@ struct
     in
     [false, candidate]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     if au && lval = None then (
       (* Assert happens after evaluation of call, so if variables in `arg` are assigned to, asserting might unsoundly yield bot *)
       (* See test 62/03 *)

--- a/src/analyses/abortUnless.ml
+++ b/src/analyses/abortUnless.ml
@@ -47,16 +47,16 @@ struct
     [false, candidate]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    if au && lval = None then (
-      (* Assert happens after evaluation of call, so if variables in `arg` are assigned to, asserting might unsoundly yield bot *)
+    if au then (
+      (* Assert before combine_assign, so if variables in `arg` are assigned to, asserting doesn't unsoundly yield bot *)
       (* See test 62/03 *)
       match args with
       | [arg] -> ctx.emit (Events.Assert arg)
       | _ -> ()
     );
+    false
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     false
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -105,7 +105,10 @@ struct
   let enter ctx lv f args : (D.t * D.t) list =
     [(ctx.local,ctx.local)]
 
-  let combine ctx lv fexp f args fc al f_ask =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx lv fexp f args fc al f_ask =
     access_one_top ctx Read false fexp;
     begin match lv with
       | None      -> ()

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -106,16 +106,17 @@ struct
     [(ctx.local,ctx.local)]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    (* These should be in enter, but enter cannot emit events, nor has fexp argument *)
+    access_one_top ctx Read false fexp;
+    List.iter (access_one_top ctx Read false) args;
+    au
 
   let combine_assign ctx lv fexp f args fc al f_ask =
-    access_one_top ctx Read false fexp;
     begin match lv with
       | None      -> ()
       | Some lval -> access_one_top ~deref:true ctx Write false (AddrOf lval)
     end;
-    List.iter (access_one_top ctx Read false) args;
-    al
+    ctx.local
 
 
   let threadspawn ctx lval f args fctx =

--- a/src/analyses/activeLongjmp.ml
+++ b/src/analyses/activeLongjmp.ml
@@ -15,6 +15,9 @@ struct
 
   let context _ _ = ()
 
+  let combine_env ctx lval fexp f args fc au f_ask =
+    au
+
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     let desc = LibraryFunctions.find f in
     match desc.special arglist, f.vname with

--- a/src/analyses/activeLongjmp.ml
+++ b/src/analyses/activeLongjmp.ml
@@ -15,9 +15,6 @@ struct
 
   let context _ _ = ()
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    au
-
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     let desc = LibraryFunctions.find f in
     match desc.special arglist, f.vname with

--- a/src/analyses/activeSetjmp.ml
+++ b/src/analyses/activeSetjmp.ml
@@ -14,10 +14,7 @@ struct
 
   let should_join a b = D.equal a b
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask:Queries.ask): D.t =
+  let combine_env ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask:Queries.ask): D.t =
     ctx.local (* keep local as opposed to IdentitySpec *)
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/activeSetjmp.ml
+++ b/src/analyses/activeSetjmp.ml
@@ -14,7 +14,10 @@ struct
 
   let should_join a b = D.equal a b
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask:Queries.ask): D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask:Queries.ask): D.t =
     ctx.local (* keep local as opposed to IdentitySpec *)
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -350,7 +350,10 @@ struct
         st'
     end
 
-  let combine ctx r fe f args fc fun_st (f_ask : Queries.ask) =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local (* TODO *)
+
+  let combine_assign ctx r fe f args fc fun_st (f_ask : Queries.ask) =
     let st = ctx.local in
     let reachable_from_args = List.fold (fun ls e -> Queries.LS.join ls (ctx.ask (ReachableFrom e))) (Queries.LS.empty ()) args in
     let fundec = Node.find_fundec ctx.node in

--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -350,10 +350,7 @@ struct
         st'
     end
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local (* TODO *)
-
-  let combine_assign ctx r fe f args fc fun_st (f_ask : Queries.ask) =
+  let combine_env ctx r fe f args fc fun_st (f_ask : Queries.ask) =
     let st = ctx.local in
     let reachable_from_args = List.fold (fun ls e -> Queries.LS.join ls (ctx.ask (ReachableFrom e))) (Queries.LS.empty ()) args in
     let fundec = Node.find_fundec ctx.node in
@@ -394,7 +391,10 @@ struct
     in
     let unify_rel = RD.unify new_rel new_fun_rel in (* TODO: unify_with *)
     if M.tracing then M.tracel "combine" "relation unifying %a %a = %a\n" RD.pretty new_rel RD.pretty new_fun_rel RD.pretty unify_rel;
-    let unify_st = {fun_st with rel = unify_rel} in
+    {fun_st with rel = unify_rel}
+
+  let combine_assign ctx r fe f args fc fun_st (f_ask : Queries.ask) =
+    let unify_st = ctx.local in
     if RD.Tracked.type_tracked (Cilfacade.fundec_return_type f) then (
       let unify_st' = match r with
         | Some lv ->

--- a/src/analyses/assert.ml
+++ b/src/analyses/assert.ml
@@ -27,7 +27,10 @@ struct
   let enter ctx (lval: lval option) (fd:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, ctx.local]
 
-  let combine ctx (lval:lval option) fexp (fd:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (fd:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     au
 
   let assert_fn ctx e check refine =

--- a/src/analyses/assert.ml
+++ b/src/analyses/assert.ml
@@ -4,34 +4,11 @@ open GobConfig
 
 module Spec : Analyses.MCPSpec =
 struct
-  include Analyses.DefaultSpec (* TODO: IdentitySpec/UnitAnalysis *)
+  include UnitAnalysis.Spec
 
   let name () = "assert"
-  module D = Lattice.Unit
-  module G = Lattice.Unit
-  module C = Lattice.Unit
 
   (* transfer functions *)
-  let assign ctx (lval:lval) (rval:exp) : D.t =
-    ctx.local
-
-  let branch ctx (exp:exp) (tv:bool) : D.t =
-    ctx.local
-
-  let body ctx (f:fundec) : D.t =
-    ctx.local
-
-  let return ctx (exp:exp option) (f:fundec) : D.t =
-    ctx.local
-
-  let enter ctx (lval: lval option) (fd:fundec) (args:exp list) : (D.t * D.t) list =
-    [ctx.local, ctx.local]
-
-  let combine_env ctx lval fexp f args fc au f_ask =
-    au
-
-  let combine_assign ctx (lval:lval option) fexp (fd:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    ctx.local
 
   let assert_fn ctx e check refine =
 
@@ -80,11 +57,6 @@ struct
     match desc.special args, f.vname with
     | Assert { exp; check; refine }, _ -> assert_fn ctx exp check refine
     | _, _ -> ctx.local
-
-  let startstate v = D.bot ()
-  let threadenter ctx lval f args = [D.top ()]
-  let threadspawn ctx lval f args fctx = ctx.local
-  let exitstate  v = D.top ()
 end
 
 let _ =

--- a/src/analyses/assert.ml
+++ b/src/analyses/assert.ml
@@ -4,7 +4,7 @@ open GobConfig
 
 module Spec : Analyses.MCPSpec =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec/UnitAnalysis *)
 
   let name () = "assert"
   module D = Lattice.Unit
@@ -28,10 +28,10 @@ struct
     [ctx.local, ctx.local]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    au
 
   let combine_assign ctx (lval:lval option) fexp (fd:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    au
+    ctx.local
 
   let assert_fn ctx e check refine =
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2330,7 +2330,10 @@ struct
             end
         else st) tainted_lvs local_st
 
-  let combine ctx (lval: lval option) fexp (f: fundec) (args: exp list) fc (after: D.t) (f_ask: Q.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local (* TODO *)
+
+  let combine_assign ctx (lval: lval option) fexp (f: fundec) (args: exp list) fc (after: D.t) (f_ask: Q.ask) : D.t =
     let combine_one (st: D.t) (fun_st: D.t) =
       if M.tracing then M.tracel "combine" "%a\n%a\n" CPA.pretty st.cpa CPA.pretty fun_st.cpa;
       (* This function does miscellaneous things, but the main task was to give the

--- a/src/analyses/condVars.ml
+++ b/src/analyses/condVars.ml
@@ -139,7 +139,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, D.bot ()]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     (* combine caller's state with globals from callee *)
     (* TODO (precision): globals with only global vars are kept, the rest is lost -> collect which globals are assigned to *)
     (* D.merge (fun k s1 s2 -> match s2 with Some ss2 when (fst k).vglob && D.only_global_exprs ss2 -> s2 | _ when (fst k).vglob -> None | _ -> s1) ctx.local au *)

--- a/src/analyses/condVars.ml
+++ b/src/analyses/condVars.ml
@@ -139,15 +139,15 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, D.bot ()]
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au (f_ask: Queries.ask) =
     (* combine caller's state with globals from callee *)
     (* TODO (precision): globals with only global vars are kept, the rest is lost -> collect which globals are assigned to *)
     (* D.merge (fun k s1 s2 -> match s2 with Some ss2 when (fst k).vglob && D.only_global_exprs ss2 -> s2 | _ when (fst k).vglob -> None | _ -> s1) ctx.local au *)
     let tainted = TaintPartialContexts.conv_varset (f_ask.f Queries.MayBeTainted) in
     D.only_untainted ctx.local tainted (* tainted globals might have changed... *)
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+    ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     (* TODO: shouldn't there be some kind of invalidadte, depending on the effect of the special function? *)

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -7,7 +7,7 @@ open Analyses
 
 module Spec : Analyses.MCPSpec =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec/UnitAnalysis *)
   module D = Lattice.Unit
   module C = Lattice.Unit
 
@@ -99,10 +99,10 @@ struct
     [ctx.local, ctx.local]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    au
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    au
+    ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     ctx.local

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -7,9 +7,7 @@ open Analyses
 
 module Spec : Analyses.MCPSpec =
 struct
-  include Analyses.DefaultSpec (* TODO: IdentitySpec/UnitAnalysis *)
-  module D = Lattice.Unit
-  module C = Lattice.Unit
+  include UnitAnalysis.Spec
 
   let name () = "expRelation"
 
@@ -79,38 +77,6 @@ struct
           Queries.ID.top ()
       end
     | _ -> Queries.Result.top q
-
-
-  (* below here is all the usual stuff an analysis requires, we don't do anything here *)
-  (* transfer functions *)
-  let assign ctx (lval:lval) (rval:exp) : D.t =
-    ctx.local
-
-  let branch ctx (exp:exp) (tv:bool) : D.t =
-    ctx.local
-
-  let body ctx (f:fundec) : D.t =
-    ctx.local
-
-  let return ctx (exp:exp option) (f:fundec) : D.t =
-    ctx.local
-
-  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
-    [ctx.local, ctx.local]
-
-  let combine_env ctx lval fexp f args fc au f_ask =
-    au
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    ctx.local
-
-  let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
-    ctx.local
-
-  let startstate v = D.bot ()
-  let threadenter ctx lval f args = [D.top ()]
-  let threadspawn ctx lval f args fctx = ctx.local
-  let exitstate  v = D.top ()
 end
 
 let _ =

--- a/src/analyses/expRelation.ml
+++ b/src/analyses/expRelation.ml
@@ -98,7 +98,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     au
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/expsplit.ml
+++ b/src/analyses/expsplit.ml
@@ -46,7 +46,10 @@ struct
   let return ctx (exp:exp option) (f:fundec) =
     emit_splits_ctx ctx
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
     let d = D.join ctx.local au in
     emit_splits ctx d
 

--- a/src/analyses/expsplit.ml
+++ b/src/analyses/expsplit.ml
@@ -47,11 +47,11 @@ struct
     emit_splits_ctx ctx
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
     let d = D.join ctx.local au in
     emit_splits ctx d
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
+    emit_splits_ctx ctx
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) =
     let d = match (LibraryFunctions.find f).special arglist, f.vname with

--- a/src/analyses/expsplit.ml
+++ b/src/analyses/expsplit.ml
@@ -48,10 +48,10 @@ struct
 
   let combine_env ctx lval fexp f args fc au f_ask =
     let d = D.join ctx.local au in
-    emit_splits ctx d
+    emit_splits ctx d (* Update/preserve splits for globals in combined environment. *)
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
-    emit_splits_ctx ctx
+    emit_splits_ctx ctx (* Update/preserve splits over assigned variable. *)
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) =
     let d = match (LibraryFunctions.find f).special arglist, f.vname with

--- a/src/analyses/extractPthread.ml
+++ b/src/analyses/extractPthread.ml
@@ -1056,8 +1056,10 @@ module Spec : Analyses.MCPSpec = struct
     (* set predecessor set to start node of function *)
     [ (d_caller, d_callee) ]
 
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
 
-  let combine ctx (lval : lval option) fexp (f : fundec) (args : exp list) fc (au : D.t) (f_ask: Queries.ask) : D.t =
+  let combine_assign ctx (lval : lval option) fexp (f : fundec) (args : exp list) fc (au : D.t) (f_ask: Queries.ask) : D.t =
     if D.any_is_bot ctx.local || D.any_is_bot au
     then ctx.local
     else

--- a/src/analyses/fileUse.ml
+++ b/src/analyses/fileUse.ml
@@ -164,14 +164,14 @@ struct
     ) else m
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     let m = ctx.local in
     (* pop the last location off the stack *)
     let m = D.edit_callstack List.tl m in (* TODO could it be problematic to keep this in the caller instead of callee domain? if we only add the stack for the callee in enter, then there would be no need to pop a location anymore... *)
     (* TODO add all globals from au to m (since we remove formals and locals on return, we can just add everything except special vars?) *)
-    let m = D.without_special_vars au |> D.add_all m in
+    D.without_special_vars au |> D.add_all m
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+    let m = ctx.local in
     let return_val = D.find_option return_var au in
     match lval, return_val with
     | Some lval, Some v ->

--- a/src/analyses/fileUse.ml
+++ b/src/analyses/fileUse.ml
@@ -163,7 +163,10 @@ struct
       D.extend_value unclosed_var (mustOpen, mayOpen) m
     ) else m
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     let m = ctx.local in
     (* pop the last location off the stack *)
     let m = D.edit_callstack List.tl m in (* TODO could it be problematic to keep this in the caller instead of callee domain? if we only add the stack for the callee in enter, then there would be no need to pop a location anymore... *)

--- a/src/analyses/locksetAnalysis.ml
+++ b/src/analyses/locksetAnalysis.ml
@@ -17,6 +17,12 @@ struct
   module D = D
   module C = D
 
+  let combine_env ctx lval fexp f args fc au f_ask =
+    au
+
+  let combine_assign ctx lval fexp f args fc au f_ask =
+    ctx.local
+
   let startstate v = D.empty ()
   let threadenter ctx lval f args = [D.empty ()]
   let exitstate  v = D.empty ()

--- a/src/analyses/locksetAnalysis.ml
+++ b/src/analyses/locksetAnalysis.ml
@@ -17,12 +17,6 @@ struct
   module D = D
   module C = D
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    au
-
-  let combine_assign ctx lval fexp f args fc au f_ask =
-    ctx.local
-
   let startstate v = D.empty ()
   let threadenter ctx lval f args = [D.empty ()]
   let exitstate  v = D.empty ()

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -519,11 +519,11 @@ struct
     do_spawns ctx !spawns;
     map (fun xs -> (topo_sort_an @@ map fst xs, topo_sort_an @@ map snd xs)) @@ n_cartesian_product css
 
-  let combine (ctx:(D.t, G.t, C.t, V.t) ctx) r fe f a fc fd f_ask =
+  let combine_env (ctx:(D.t, G.t, C.t, V.t) ctx) r fe f a fc fd f_ask =
     let spawns = ref [] in
     let sides  = ref [] in
     let emits = ref [] in
-    let ctx'' = outer_ctx "combine" ~spawns ~sides ~emits ctx in
+    let ctx'' = outer_ctx "combine_env" ~spawns ~sides ~emits ctx in
     (* Like spec_list2 but for three lists. Tail recursion like map3_rev would have.
        Due to context-insensitivity, second list is optional and may only contain a subset of analyses
        in the same order, so some skipping needs to happen to align the three lists.
@@ -539,8 +539,37 @@ struct
       | _, _, _ -> invalid_arg "MCP.spec_list3_rev_acc"
     in
     let f post_all (n,(module S:MCPSpec),(d,fc,fd)) =
-      let ctx' : (S.D.t, S.G.t, S.C.t, S.V.t) ctx = inner_ctx "combine" ~post_all ctx'' n d in
-      n, repr @@ S.combine ctx' r fe f a (Option.map obj fc) (obj fd) f_ask
+      let ctx' : (S.D.t, S.G.t, S.C.t, S.V.t) ctx = inner_ctx "combine_env" ~post_all ctx'' n d in
+      n, repr @@ S.combine_env ctx' r fe f a (Option.map obj fc) (obj fd) f_ask
+    in
+    let d, q = map_deadcode f @@ List.rev @@ spec_list3_rev_acc [] ctx.local fc fd in
+    do_sideg ctx !sides;
+    do_spawns ctx !spawns;
+    let d = do_emits ctx !emits d q in
+    if q then raise Deadcode else d
+
+  let combine_assign (ctx:(D.t, G.t, C.t, V.t) ctx) r fe f a fc fd f_ask =
+    let spawns = ref [] in
+    let sides  = ref [] in
+    let emits = ref [] in
+    let ctx'' = outer_ctx "combine_assign" ~spawns ~sides ~emits ctx in
+    (* Like spec_list2 but for three lists. Tail recursion like map3_rev would have.
+       Due to context-insensitivity, second list is optional and may only contain a subset of analyses
+       in the same order, so some skipping needs to happen to align the three lists.
+       See https://github.com/goblint/analyzer/pull/578/files#r794376508. *)
+    let rec spec_list3_rev_acc acc l1 l2_opt l3 = match l1, l2_opt, l3 with
+      | [], _, [] -> acc
+      | (n, x) :: l1, Some ((n', y) :: l2), (n'', z) :: l3 when n = n' -> (* context-sensitive *)
+        assert (n = n'');
+        spec_list3_rev_acc ((n, spec n, (x, Some y, z)) :: acc) l1 (Some l2) l3
+      | (n, x) :: l1, l2_opt, (n'', z) :: l3 -> (* context-insensitive *)
+        assert (n = n'');
+        spec_list3_rev_acc ((n, spec n, (x, None, z)) :: acc) l1 l2_opt l3
+      | _, _, _ -> invalid_arg "MCP.spec_list3_rev_acc"
+    in
+    let f post_all (n,(module S:MCPSpec),(d,fc,fd)) =
+      let ctx' : (S.D.t, S.G.t, S.C.t, S.V.t) ctx = inner_ctx "combine_assign" ~post_all ctx'' n d in
+      n, repr @@ S.combine_assign ctx' r fe f a (Option.map obj fc) (obj fd) f_ask
     in
     let d, q = map_deadcode f @@ List.rev @@ spec_list3_rev_acc [] ctx.local fc fd in
     do_sideg ctx !sides;

--- a/src/analyses/mallocFresh.ml
+++ b/src/analyses/mallocFresh.ml
@@ -27,7 +27,10 @@ struct
   let assign ctx lval rval =
     assign_lval (Analyses.ask_of_ctx ctx) lval ctx.local
 
-  let combine ctx lval f fd args context f_local (f_ask: Queries.ask) =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx lval f fd args context f_local (f_ask: Queries.ask) =
     match lval with
     | None -> f_local
     | Some lval -> assign_lval (Analyses.ask_of_ctx ctx) lval f_local

--- a/src/analyses/mallocFresh.ml
+++ b/src/analyses/mallocFresh.ml
@@ -28,7 +28,7 @@ struct
     assign_lval (Analyses.ask_of_ctx ctx) lval ctx.local
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    ctx.local (* keep local as opposed to IdentitySpec *)
 
   let combine_assign ctx lval f fd args context f_local (f_ask: Queries.ask) =
     match lval with

--- a/src/analyses/mallocWrapperAnalysis.ml
+++ b/src/analyses/mallocWrapperAnalysis.ml
@@ -87,13 +87,13 @@ struct
     let callee = (counter, new_wrapper_node) in
     [(ctx.local, callee)]
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc ((counter, _):D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc (counter, _) f_ask =
     (* Keep (potentially higher) counter from callee and keep wrapper node from caller *)
     let _, lnode = ctx.local in
     (counter, lnode)
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc ((counter, _):D.t) (f_ask: Queries.ask) : D.t =
+    ctx.local
 
   let special (ctx: (D.t, G.t, C.t, V.t) ctx) (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     let desc = LibraryFunctions.find f in

--- a/src/analyses/mallocWrapperAnalysis.ml
+++ b/src/analyses/mallocWrapperAnalysis.ml
@@ -87,7 +87,10 @@ struct
     let callee = (counter, new_wrapper_node) in
     [(ctx.local, callee)]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc ((counter, _):D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc ((counter, _):D.t) (f_ask: Queries.ask) : D.t =
     (* Keep (potentially higher) counter from callee and keep wrapper node from caller *)
     let _, lnode = ctx.local in
     (counter, lnode)

--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -200,7 +200,10 @@ struct
     List.iter (warn_deref_exp (Analyses.ask_of_ctx ctx) ctx.local) args;
     [ctx.local,nst]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     let cal_st = remove_unreachable (Analyses.ask_of_ctx ctx) args ctx.local in
     let ret_st = D.union au (D.diff ctx.local cal_st) in
     let new_u =

--- a/src/analyses/modifiedSinceLongjmp.ml
+++ b/src/analyses/modifiedSinceLongjmp.ml
@@ -31,12 +31,12 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, D.bot ()] (* enter with bot as opposed to IdentitySpec *)
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask:Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au (f_ask: Queries.ask) =
     let taintedcallee = relevants_from_ls (f_ask.f Queries.MayBeTainted) in
     add_to_all_defined taintedcallee ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask:Queries.ask) : D.t =
+    ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     let desc = LibraryFunctions.find f in

--- a/src/analyses/modifiedSinceLongjmp.ml
+++ b/src/analyses/modifiedSinceLongjmp.ml
@@ -31,7 +31,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, D.bot ()] (* enter with bot as opposed to IdentitySpec *)
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask:Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask:Queries.ask) : D.t =
     let taintedcallee = relevants_from_ls (f_ask.f Queries.MayBeTainted) in
     add_to_all_defined taintedcallee ctx.local
 

--- a/src/analyses/poisonVariables.ml
+++ b/src/analyses/poisonVariables.ml
@@ -54,9 +54,6 @@ struct
   let combine_env ctx lval fexp f args fc au f_ask =
     VS.join au ctx.local
 
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    ctx.local
-
   let startstate v = D.bot ()
   let threadenter ctx lval f args = [D.bot ()]
   let exitstate  v = D.top ()

--- a/src/analyses/poisonVariables.ml
+++ b/src/analyses/poisonVariables.ml
@@ -52,10 +52,10 @@ struct
     )
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    VS.join au ctx.local
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    VS.join au ctx.local
+    ctx.local
 
   let startstate v = D.bot ()
   let threadenter ctx lval f args = [D.bot ()]

--- a/src/analyses/poisonVariables.ml
+++ b/src/analyses/poisonVariables.ml
@@ -51,7 +51,10 @@ struct
         [VS.diff ctx.local reachable_vars, VS.inter reachable_vars ctx.local]
     )
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     VS.join au ctx.local
 
   let startstate v = D.bot ()

--- a/src/analyses/pthreadSignals.ml
+++ b/src/analyses/pthreadSignals.ml
@@ -50,7 +50,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     au
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/pthreadSignals.ml
+++ b/src/analyses/pthreadSignals.ml
@@ -9,7 +9,7 @@ struct
   module Signals = SetDomain.ToppedSet (ValueDomain.Addr) (struct let topname = "All signals" end)
   module MustSignals = Lattice.Reverse (Signals)
 
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
   module V = VarinfoV
 
   let name () = "pthreadSignals"
@@ -51,10 +51,10 @@ struct
     [ctx.local, ctx.local]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    au
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    au
+    ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     let desc = LF.find f in

--- a/src/analyses/pthreadSignals.ml
+++ b/src/analyses/pthreadSignals.ml
@@ -9,7 +9,7 @@ struct
   module Signals = SetDomain.ToppedSet (ValueDomain.Addr) (struct let topname = "All signals" end)
   module MustSignals = Lattice.Reverse (Signals)
 
-  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
+  include Analyses.IdentitySpec
   module V = VarinfoV
 
   let name () = "pthreadSignals"
@@ -35,26 +35,6 @@ struct
     List.filter_map ValueDomain.Addr.to_var_may (eval_exp_addr a cv_arg)
 
   (* transfer functions *)
-  let assign ctx (lval:lval) (rval:exp) : D.t =
-    ctx.local
-
-  let branch ctx (exp:exp) (tv:bool) : D.t =
-    ctx.local
-
-  let body ctx (f:fundec) : D.t =
-    ctx.local
-
-  let return ctx (exp:exp option) (f:fundec) : D.t =
-    ctx.local
-
-  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
-    [ctx.local, ctx.local]
-
-  let combine_env ctx lval fexp f args fc au f_ask =
-    au
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     let desc = LF.find f in
@@ -108,7 +88,6 @@ struct
 
   let startstate v = Signals.empty ()
   let threadenter ctx lval f args = [ctx.local]
-  let threadspawn ctx lval f args fctx = ctx.local
   let exitstate  v = Signals.empty ()
 end
 

--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -137,7 +137,10 @@ struct
       [ctx.local, `Lifted reg]
     | x -> [x,x]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     match au with
     | `Lifted reg -> begin
       let old_regpart = ctx.global () in

--- a/src/analyses/spec.ml
+++ b/src/analyses/spec.ml
@@ -414,7 +414,10 @@ struct
         D.edit_callstack (BatList.cons (Option.get !Node.current_node)) ctx.local
       else ctx.local in [m, m]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     (* M.debug ~category:Analyzer @@ "leaving function "^f.vname^D.string_of_callstack au; *)
     let au = D.edit_callstack List.tl au in
     let return_val = D.find_option return_var au in

--- a/src/analyses/spec.ml
+++ b/src/analyses/spec.ml
@@ -415,31 +415,32 @@ struct
       else ctx.local in [m, m]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     (* M.debug ~category:Analyzer @@ "leaving function "^f.vname^D.string_of_callstack au; *)
     let au = D.edit_callstack List.tl au in
+    (* remove special return var *)
+    D.remove' return_var au
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     let return_val = D.find_option return_var au in
     match lval, return_val with
     | Some lval, Some v ->
       let k = D.key_from_lval lval in
-      (* remove special return var and handle potential overwrites *)
-      let au = D.remove' return_var au (* |> check_overwrite_open k *) in
+      (* handle potential overwrites *)
+      (* |> check_overwrite_open k *)
       (* if v.key is still in D, then it must be a global and we need to alias instead of rebind *)
       (* TODO what if there is a local with the same name as the global? *)
       if D.V.is_top v then (* returned a local that was top -> just add k as top *)
-        D.add' k v au
+        D.add' k v ctx.local
       else (* v is now a local which is not top or a global which is aliased *)
         let vvar = D.V.get_alias v in (* this is also ok if v is not an alias since it chooses an element from the May-Set which is never empty (global top gets aliased) *)
         if D.mem vvar au then (* returned variable was a global TODO what if local had the same name? -> seems to work *)
           (* let _ = M.debug ~category:Analyzer @@ vvar.vname^" was a global -> alias" in *)
-          D.alias k vvar au
+          D.alias k vvar ctx.local
         else (* returned variable was a local *)
           let v = D.V.set_key k v in (* adjust var-field to lval *)
           (* M.debug ~category:Analyzer @@ vvar.vname^" was a local -> rebind"; *)
-          D.add' k v au
-    | _ -> au
+          D.add' k v ctx.local
+    | _ -> ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     (* let _ = GobConfig.set_bool "dbg.debug" false in *)

--- a/src/analyses/stackTrace.ml
+++ b/src/analyses/stackTrace.ml
@@ -6,7 +6,7 @@ module LF = LibraryFunctions
 
 module Spec (D: StackDomain.S) (P: sig val name : string end)=
 struct
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
 
   let name () = P.name
   module D = D
@@ -45,7 +45,7 @@ end
 
 module SpecLoc =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
 
   let name () = "stack_loc"
   module D = StackDomain.Dom3

--- a/src/analyses/stackTrace.ml
+++ b/src/analyses/stackTrace.ml
@@ -6,75 +6,40 @@ module LF = LibraryFunctions
 
 module Spec (D: StackDomain.S) (P: sig val name : string end)=
 struct
-  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
+  include Analyses.IdentitySpec
 
   let name () = P.name
   module D = D
   module C = D
 
   (* transfer functions *)
-  let assign ctx (lval:lval) (rval:exp) : D.t =
-    ctx.local
-
-  let branch ctx (exp:exp) (tv:bool) : D.t =
-    ctx.local
 
   let body ctx (f:fundec) : D.t =
     if f.svar.vname = "__goblint_dummy_init" then ctx.local else D.push f.svar ctx.local
 
-  let return ctx (exp:exp option) (f:fundec) : D.t =
-    ctx.local
-
-  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
-    [ctx.local,ctx.local]
-
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    ctx.local
-
-  let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
-    ctx.local
+    ctx.local (* keep local as opposed to IdentitySpec *)
 
   let startstate v = D.bot ()
   let threadenter ctx lval f args = [D.bot ()]
-  let threadspawn ctx lval f args fctx = ctx.local
   let exitstate  v = D.top ()
 end
 
 module SpecLoc =
 struct
-  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
+  include Analyses.IdentitySpec
 
   let name () = "stack_loc"
   module D = StackDomain.Dom3
   module C = StackDomain.Dom3
 
   (* transfer functions *)
-  let assign ctx (lval:lval) (rval:exp) : D.t =
-    ctx.local
-
-  let branch ctx (exp:exp) (tv:bool) : D.t =
-    ctx.local
-
-  let body ctx (f:fundec) : D.t =
-    ctx.local
-
-  let return ctx (exp:exp option) (f:fundec) : D.t =
-    ctx.local
 
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, D.push !Tracing.current_loc ctx.local]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    ctx.local
-
-  let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
-    ctx.local
+    ctx.local (* keep local as opposed to IdentitySpec *)
 
 
   let startstate v = D.bot ()
@@ -82,8 +47,6 @@ struct
 
   let threadenter ctx lval f args =
     [D.push !Tracing.current_loc ctx.local]
-
-  let threadspawn ctx lval f args fctx = ctx.local
 end
 
 

--- a/src/analyses/stackTrace.ml
+++ b/src/analyses/stackTrace.ml
@@ -28,7 +28,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local,ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
@@ -64,7 +67,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, D.push !Tracing.current_loc ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -46,7 +46,9 @@ struct
     List.fold_right D.remove_var (fundec.sformals@fundec.slocals) ctx.local
 
   let enter ctx lval f args = [(ctx.local,ctx.local)]
-  let combine ctx lval fexp f args fc st2 f_ask = st2
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+  let combine_assign ctx lval fexp f args fc st2 f_ask = st2
 
   let get_locks e st =
     let add_perel x xs =

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -46,9 +46,8 @@ struct
     List.fold_right D.remove_var (fundec.sformals@fundec.slocals) ctx.local
 
   let enter ctx lval f args = [(ctx.local,ctx.local)]
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-  let combine_assign ctx lval fexp f args fc st2 f_ask = st2
+  let combine_env ctx lval fexp f args fc au f_ask = au
+  let combine_assign ctx lval fexp f args fc st2 f_ask = ctx.local
 
   let get_locks e st =
     let add_perel x xs =

--- a/src/analyses/taintPartialContexts.ml
+++ b/src/analyses/taintPartialContexts.ml
@@ -56,7 +56,10 @@ struct
     (* Entering a function, all globals count as untainted *)
     [ctx.local, (D.bot ())]
 
-  let combine ctx (lvalOpt:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lvalOpt:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     if M.tracing then M.trace "taintPC" "combine for %s in TaintPC: tainted: in function: %a before call: %a\n" f.svar.vname D.pretty au D.pretty ctx.local;
     let d =
       match lvalOpt with

--- a/src/analyses/taintPartialContexts.ml
+++ b/src/analyses/taintPartialContexts.ml
@@ -57,16 +57,13 @@ struct
     [ctx.local, (D.bot ())]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    if M.tracing then M.trace "taintPC" "combine for %s in TaintPC: tainted: in function: %a before call: %a\n" f.svar.vname D.pretty au D.pretty ctx.local;
+    D.union ctx.local au
 
   let combine_assign ctx (lvalOpt:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    if M.tracing then M.trace "taintPC" "combine for %s in TaintPC: tainted: in function: %a before call: %a\n" f.svar.vname D.pretty au D.pretty ctx.local;
-    let d =
-      match lvalOpt with
-      | Some lv -> taint_lval ctx lv
-      | None -> ctx.local
-    in
-    D.union d au
+    match lvalOpt with
+    | Some lv -> taint_lval ctx lv
+    | None -> ctx.local
 
   let special ctx (lvalOpt: lval option) (f:varinfo) (arglist:exp list) : D.t =
     (* perform shallow and deep invalidate according to Library descriptors *)

--- a/src/analyses/termination.ml
+++ b/src/analyses/termination.ml
@@ -184,7 +184,7 @@ end
 
 module Spec =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
 
   let name () = "term"
   module D = TermDomain
@@ -227,10 +227,10 @@ struct
     [ctx.local,ctx.local]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    au
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    au
+    ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     ctx.local

--- a/src/analyses/termination.ml
+++ b/src/analyses/termination.ml
@@ -226,7 +226,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local,ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     au
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/termination.ml
+++ b/src/analyses/termination.ml
@@ -184,7 +184,7 @@ end
 
 module Spec =
 struct
-  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
+  include Analyses.IdentitySpec
 
   let name () = "term"
   module D = TermDomain
@@ -197,8 +197,6 @@ struct
   (*| _ -> Queries.Result.top ()*)
 
   (* transfer functions *)
-  let assign ctx (lval:lval) (rval:exp) : D.t =
-    ctx.local
 
   let branch ctx (exp:exp) (tv:bool) : D.t =
     ctx.local
@@ -217,27 +215,8 @@ struct
   (*       ctx.local *)
   (* | _ -> ctx.local *)
 
-  let body ctx (f:fundec) : D.t =
-    ctx.local
-
-  let return ctx (exp:exp option) (f:fundec) : D.t =
-    ctx.local
-
-  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
-    [ctx.local,ctx.local]
-
-  let combine_env ctx lval fexp f args fc au f_ask =
-    au
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    ctx.local
-
-  let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
-    ctx.local
-
   let startstate v = D.bot ()
   let threadenter ctx lval f args = [D.bot ()]
-  let threadspawn ctx lval f args fctx = ctx.local
   let exitstate  v = D.bot ()
 end
 

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -8,7 +8,7 @@ module TS = ConcDomain.ThreadSet
 
 module Spec =
 struct
-  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
+  include Analyses.IdentitySpec
 
   let name () = "thread"
   module D = ConcDomain.CreatedThreadSet
@@ -23,9 +23,7 @@ struct
   let should_join = D.equal
 
   (* transfer functions *)
-  let assign ctx (lval:lval) (rval:exp) : D.t = ctx.local
-  let branch ctx (exp:exp) (tv:bool) : D.t =  ctx.local
-  let body ctx (f:fundec) : D.t =  ctx.local
+
   let return ctx (exp:exp option) (f:fundec) : D.t =
     let tid = ThreadId.get_current (Analyses.ask_of_ctx ctx) in
     begin match tid with
@@ -33,9 +31,6 @@ struct
       | _ -> ()
     end;
     ctx.local
-  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list = [ctx.local,ctx.local]
-  let combine_env ctx lval fexp f args fc au f_ask = au
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t = ctx.local
 
   let rec is_not_unique ctx tid =
     let (rep, parents, _) = ctx.global tid in

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -8,7 +8,7 @@ module TS = ConcDomain.ThreadSet
 
 module Spec =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
 
   let name () = "thread"
   module D = ConcDomain.CreatedThreadSet
@@ -34,9 +34,8 @@ struct
     end;
     ctx.local
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list = [ctx.local,ctx.local]
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t = au
+  let combine_env ctx lval fexp f args fc au f_ask = au
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t = ctx.local
 
   let rec is_not_unique ctx tid =
     let (rep, parents, _) = ctx.global tid in

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -34,7 +34,9 @@ struct
     end;
     ctx.local
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list = [ctx.local,ctx.local]
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t = au
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t = au
 
   let rec is_not_unique ctx tid =
     let (rep, parents, _) = ctx.global tid in

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -87,7 +87,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local,ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     au
 
   let special ctx (lval: lval option) (f:varinfo) (args:exp list) : D.t =

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -14,7 +14,7 @@ let has_escaped (ask: Queries.ask) (v: varinfo): bool =
 
 module Spec =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
 
   let name () = "escape"
   module D = EscapeDomain.EscapedVars
@@ -88,10 +88,10 @@ struct
     [ctx.local,ctx.local]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    au
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    au
+    ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (args:exp list) : D.t =
     let desc = LibraryFunctions.find f in

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -14,7 +14,7 @@ let has_escaped (ask: Queries.ask) (v: varinfo): bool =
 
 module Spec =
 struct
-  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
+  include Analyses.IdentitySpec
 
   let name () = "escape"
   module D = EscapeDomain.EscapedVars
@@ -74,24 +74,6 @@ struct
     )
     else
       ctx.local
-
-  let branch ctx (exp:exp) (tv:bool) : D.t =
-    ctx.local
-
-  let body ctx (f:fundec) : D.t =
-    ctx.local
-
-  let return ctx (exp:exp option) (f:fundec) : D.t =
-    ctx.local
-
-  let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
-    [ctx.local,ctx.local]
-
-  let combine_env ctx lval fexp f args fc au f_ask =
-    au
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (args:exp list) : D.t =
     let desc = LibraryFunctions.find f in

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -13,7 +13,7 @@ let is_multi (ask: Queries.ask): bool =
 
 module Spec =
 struct
-  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
+  include Analyses.IdentitySpec
 
   module Flag = ThreadFlagDomain.Simple
   module D = Flag
@@ -31,10 +31,6 @@ struct
 
   let should_join = D.equal
 
-  let body ctx f = ctx.local
-
-  let branch ctx exp tv = ctx.local
-
   let return ctx exp fundec  =
     match fundec.svar.vname with
     | "__goblint_dummy_init" ->
@@ -42,19 +38,6 @@ struct
       Flag.join ctx.local (Flag.get_main ())
     | _ ->
       ctx.local
-
-  let assign ctx (lval:lval) (rval:exp) : D.t  =
-    ctx.local
-
-  let enter ctx lval f args =
-    [ctx.local,ctx.local]
-
-  let combine_env ctx lval fexp f args fc au f_ask = au
-
-  let combine_assign ctx lval fexp f args fc st2 f_ask = ctx.local
-
-  let special ctx lval f args =
-    ctx.local
 
   let query ctx (type a) (x: a Queries.t): a Queries.result =
     match x with

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -13,7 +13,7 @@ let is_multi (ask: Queries.ask): bool =
 
 module Spec =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
 
   module Flag = ThreadFlagDomain.Simple
   module D = Flag
@@ -49,10 +49,9 @@ struct
   let enter ctx lval f args =
     [ctx.local,ctx.local]
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+  let combine_env ctx lval fexp f args fc au f_ask = au
 
-  let combine_assign ctx lval fexp f args fc st2 f_ask = st2
+  let combine_assign ctx lval fexp f args fc st2 f_ask = ctx.local
 
   let special ctx lval f args =
     ctx.local

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -49,7 +49,10 @@ struct
   let enter ctx lval f args =
     [ctx.local,ctx.local]
 
-  let combine ctx lval fexp f args fc st2 f_ask = st2
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx lval fexp f args fc st2 f_ask = st2
 
   let special ctx lval f args =
     ctx.local

--- a/src/analyses/threadId.ml
+++ b/src/analyses/threadId.ml
@@ -63,7 +63,10 @@ struct
   let enter ctx lval f args =
     [ctx.local,ctx.local]
 
-  let combine ctx lval fexp f args fc st2 f_ask = st2
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx lval fexp f args fc st2 f_ask = st2
 
   let special ctx lval f args =
     ctx.local

--- a/src/analyses/threadId.ml
+++ b/src/analyses/threadId.ml
@@ -21,7 +21,7 @@ let get_current_unlift ask: Thread.t =
 
 module Spec =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
 
   module TD = Thread.D
 
@@ -63,10 +63,9 @@ struct
   let enter ctx lval f args =
     [ctx.local,ctx.local]
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+  let combine_env ctx lval fexp f args fc au f_ask = au
 
-  let combine_assign ctx lval fexp f args fc st2 f_ask = st2
+  let combine_assign ctx lval fexp f args fc st2 f_ask = ctx.local
 
   let special ctx lval f args =
     ctx.local

--- a/src/analyses/threadId.ml
+++ b/src/analyses/threadId.ml
@@ -21,7 +21,7 @@ let get_current_unlift ask: Thread.t =
 
 module Spec =
 struct
-  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
+  include Analyses.IdentitySpec
 
   module TD = Thread.D
 
@@ -50,25 +50,6 @@ struct
       `Lifted tid
     | _ ->
       [`Lifted (Thread.threadinit v ~multiple:true)]
-
-  let body ctx f = ctx.local
-
-  let branch ctx exp tv = ctx.local
-
-  let return ctx exp fundec = ctx.local
-
-  let assign ctx (lval:lval) (rval:exp) : D.t  =
-    ctx.local
-
-  let enter ctx lval f args =
-    [ctx.local,ctx.local]
-
-  let combine_env ctx lval fexp f args fc au f_ask = au
-
-  let combine_assign ctx lval fexp f args fc st2 f_ask = ctx.local
-
-  let special ctx lval f args =
-    ctx.local
 
   let is_unique ctx =
     ctx.ask Queries.MustBeUniqueThread

--- a/src/analyses/threadJoins.ml
+++ b/src/analyses/threadJoins.ml
@@ -87,7 +87,10 @@ struct
     | Queries.MustJoinedThreads -> (ctx.local:ConcDomain.MustThreadSet.t) (* type annotation needed to avoid "would escape the scope of its equation" *)
     | _ ->  Queries.Result.top q
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
     D.union ctx.local au
 
   let startstate v = D.top ()

--- a/src/analyses/threadJoins.ml
+++ b/src/analyses/threadJoins.ml
@@ -90,9 +90,6 @@ struct
   let combine_env ctx lval fexp f args fc au f_ask =
     D.union ctx.local au
 
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
-    ctx.local
-
   let startstate v = D.top ()
   let exitstate  v = D.top ()
 end

--- a/src/analyses/threadJoins.ml
+++ b/src/analyses/threadJoins.ml
@@ -88,10 +88,10 @@ struct
     | _ ->  Queries.Result.top q
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    D.union ctx.local au
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
-    D.union ctx.local au
+    ctx.local
 
   let startstate v = D.top ()
   let exitstate  v = D.top ()

--- a/src/analyses/threadReturn.ml
+++ b/src/analyses/threadReturn.ml
@@ -35,7 +35,10 @@ struct
     else
       [ctx.local, false]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/threadReturn.ml
+++ b/src/analyses/threadReturn.ml
@@ -9,7 +9,7 @@ let is_current (ask: Queries.ask): bool =
 
 module Spec : Analyses.MCPSpec =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
 
   let name () = "threadreturn"
   module D = IntDomain.Booleans
@@ -36,7 +36,7 @@ struct
       [ctx.local, false]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    ctx.local (* keep local as opposed to IdentitySpec *)
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     ctx.local

--- a/src/analyses/threadReturn.ml
+++ b/src/analyses/threadReturn.ml
@@ -9,24 +9,13 @@ let is_current (ask: Queries.ask): bool =
 
 module Spec : Analyses.MCPSpec =
 struct
-  include Analyses.DefaultSpec (* TODO: IdentitySpec *)
+  include Analyses.IdentitySpec
 
   let name () = "threadreturn"
   module D = IntDomain.Booleans
   module C = D
 
   (* transfer functions *)
-  let assign ctx (lval:lval) (rval:exp) : D.t =
-    ctx.local
-
-  let branch ctx (exp:exp) (tv:bool) : D.t =
-    ctx.local
-
-  let body ctx (f:fundec) : D.t =
-    ctx.local
-
-  let return ctx (exp:exp option) (f:fundec) : D.t =
-    ctx.local
 
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     if !Goblintutil.global_initialization then
@@ -38,15 +27,8 @@ struct
   let combine_env ctx lval fexp f args fc au f_ask =
     ctx.local (* keep local as opposed to IdentitySpec *)
 
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    ctx.local
-
-  let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
-    ctx.local
-
   let startstate v = true
   let threadenter ctx lval f args = [true]
-  let threadspawn ctx lval f args fctx = ctx.local
   let exitstate  v = D.top ()
 
   let query (ctx: (D.t, _, _, _) ctx) (type a) (x: a Queries.t): a Queries.result =

--- a/src/analyses/tutorials/constants.ml
+++ b/src/analyses/tutorials/constants.ml
@@ -83,7 +83,10 @@ struct
         )
       |_ -> state
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask): D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask): D.t =
     (* If we have a function call with assignment
         x = f (e1, ... , ek)
       with a local int variable x on the left, we set it to top *)

--- a/src/analyses/tutorials/constants.ml
+++ b/src/analyses/tutorials/constants.ml
@@ -84,7 +84,7 @@ struct
       |_ -> state
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    ctx.local (* keep local as opposed to IdentitySpec *)
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask): D.t =
     (* If we have a function call with assignment

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -101,10 +101,13 @@ struct
     (* first component is state of caller, second component is state of callee *)
     [caller_state, callee_state]
 
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
   (** For a function call "lval = f(args)" or "f(args)",
       computes the state of the caller after the call.
       Argument [callee_local] is the state of [f] at its return node. *)
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (callee_local:D.t) (f_ask: Queries.ask): D.t =
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (callee_local:D.t) (f_ask: Queries.ask): D.t =
     let caller_state = ctx.local in
     (* TODO: Record whether lval was tainted. *)
     caller_state

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -85,7 +85,7 @@ struct
 
   (** For a function call "lval = f(args)" or "f(args)",
       [enter] returns a caller state, and the initial state of the callee.
-      In [enter], the caller state can usually be returned unchanged, as [combine] (below)
+      In [enter], the caller state can usually be returned unchanged, as [combine_env] and [combine_assign] (below)
       will compute the caller state after the function call, given the return state of the callee. *)
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     let caller_state = ctx.local in
@@ -101,11 +101,15 @@ struct
     (* first component is state of caller, second component is state of callee *)
     [caller_state, callee_state]
 
-  let combine_env ctx lval fexp f args fc au f_ask =
+  (** For a function call "lval = f(args)" or "f(args)",
+      computes the global environment state of the caller after the call.
+      Argument [callee_local] is the state of [f] at its return node. *)
+  let combine_env ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (callee_local:D.t) (f_ask: Queries.ask): D.t =
+    (* Nothing needs to be done *)
     ctx.local
 
   (** For a function call "lval = f(args)" or "f(args)",
-      computes the state of the caller after the call.
+      computes the state of the caller after assigning the return value from the call.
       Argument [callee_local] is the state of [f] at its return node. *)
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (callee_local:D.t) (f_ask: Queries.ask): D.t =
     let caller_state = ctx.local in

--- a/src/analyses/tutorials/unitAnalysis.ml
+++ b/src/analyses/tutorials/unitAnalysis.ml
@@ -30,10 +30,10 @@ struct
     [ctx.local, ctx.local]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    au
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    au
+    ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     ctx.local

--- a/src/analyses/tutorials/unitAnalysis.ml
+++ b/src/analyses/tutorials/unitAnalysis.ml
@@ -29,7 +29,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     au
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/unassumeAnalysis.ml
+++ b/src/analyses/unassumeAnalysis.ml
@@ -274,7 +274,10 @@ struct
   let enter ctx lv f args =
     [(ctx.local, D.empty ())]
 
-  let combine ctx lv fe f args fc fd f_ask =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx lv fe f args fc fd f_ask =
     emit_unassume ctx
 
   (* not in sync, query, entry, threadenter because they aren't final transfer function on edge *)

--- a/src/analyses/unassumeAnalysis.ml
+++ b/src/analyses/unassumeAnalysis.ml
@@ -275,7 +275,7 @@ struct
     [(ctx.local, D.empty ())]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    ctx.local (* not here because isn't final transfer function on edge *)
 
   let combine_assign ctx lv fe f args fc fd f_ask =
     emit_unassume ctx

--- a/src/analyses/uninit.ml
+++ b/src/analyses/uninit.ml
@@ -261,7 +261,10 @@ struct
     let nst = remove_unreachable (Analyses.ask_of_ctx ctx) args ctx.local in
     [ctx.local, nst]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : trans_out =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : trans_out =
     ignore (List.map (fun x -> is_expr_initd (Analyses.ask_of_ctx ctx) x ctx.local) args);
     let cal_st = remove_unreachable (Analyses.ask_of_ctx ctx) args ctx.local in
     let ret_st = D.union au (D.diff ctx.local cal_st) in

--- a/src/analyses/uninit.ml
+++ b/src/analyses/uninit.ml
@@ -262,15 +262,14 @@ struct
     [ctx.local, nst]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : trans_out =
     ignore (List.map (fun x -> is_expr_initd (Analyses.ask_of_ctx ctx) x ctx.local) args);
     let cal_st = remove_unreachable (Analyses.ask_of_ctx ctx) args ctx.local in
-    let ret_st = D.union au (D.diff ctx.local cal_st) in
+    D.union au (D.diff ctx.local cal_st)
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : trans_out =
     match lval with
-    | None -> ret_st
-    | Some lv -> init_lval (Analyses.ask_of_ctx ctx) lv ret_st
+    | None -> ctx.local
+    | Some lv -> init_lval (Analyses.ask_of_ctx ctx) lv ctx.local
 
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -429,10 +429,7 @@ struct
     | true -> raise Analyses.Deadcode
     | false -> [ctx.local,nst]
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx lval fexp f args fc st2 (f_ask : Queries.ask) =
+  let combine_env ctx lval fexp f args fc au (f_ask: Queries.ask) =
     let tainted = f_ask.f Queries.MayBeTainted in
     let d_local =
       (* if we are multithreaded, we run the risk, that some mutex protected variables got unlocked, so in this case caller state goes to top
@@ -443,13 +440,15 @@ struct
         let taint_exp = Queries.ES.of_list (List.map (fun lv -> Lval (Lval.CilLval.to_lval lv)) (Queries.LS.elements tainted)) in
         D.filter (fun exp -> not (Queries.ES.mem exp taint_exp)) ctx.local
     in
-    let d = D.meet st2 d_local in
+    let d = D.meet au d_local in
     match D.is_bot ctx.local with
     | true -> raise Analyses.Deadcode
-    | false ->
-      match lval with
-      | Some lval -> remove (Analyses.ask_of_ctx ctx) lval d
-      | None -> d
+    | false -> d
+
+  let combine_assign ctx lval fexp f args fc st2 (f_ask : Queries.ask) =
+    match lval with
+    | Some lval -> remove (Analyses.ask_of_ctx ctx) lval ctx.local
+    | None -> ctx.local
 
   let remove_reachable ~deep ask es st =
     match reachables ~deep ask es with

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -429,7 +429,10 @@ struct
     | true -> raise Analyses.Deadcode
     | false -> [ctx.local,nst]
 
-  let combine ctx lval fexp f args fc st2 (f_ask : Queries.ask) =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx lval fexp f args fc st2 (f_ask : Queries.ask) =
     let tainted = f_ask.f Queries.MayBeTainted in
     let d_local =
       (* if we are multithreaded, we run the risk, that some mutex protected variables got unlocked, so in this case caller state goes to top

--- a/src/analyses/vla.ml
+++ b/src/analyses/vla.ml
@@ -16,7 +16,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     [ctx.local, false]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/analyses/vla.ml
+++ b/src/analyses/vla.ml
@@ -17,10 +17,7 @@ struct
     [ctx.local, false]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
-
-  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    ctx.local
+    ctx.local (* keep local as opposed to IdentitySpec *)
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     match (LibraryFunctions.find f).special arglist with

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -638,11 +638,11 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) =
     [ctx.local, ctx.local]
 
-  let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+  let combine_env ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
+    au
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
-    au
+    ctx.local
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) =
     ctx.local

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -395,7 +395,8 @@ sig
 
   val special : (D.t, G.t, C.t, V.t) ctx -> lval option -> varinfo -> exp list -> D.t
   val enter   : (D.t, G.t, C.t, V.t) ctx -> lval option -> fundec -> exp list -> (D.t * D.t) list
-  val combine : (D.t, G.t, C.t, V.t) ctx -> lval option -> exp -> fundec -> exp list -> C.t option -> D.t -> Queries.ask -> D.t
+  val combine_env : (D.t, G.t, C.t, V.t) ctx -> lval option -> exp -> fundec -> exp list -> C.t option -> D.t -> Queries.ask -> D.t
+  val combine_assign : (D.t, G.t, C.t, V.t) ctx -> lval option -> exp -> fundec -> exp list -> C.t option -> D.t -> Queries.ask -> D.t
 
   (* Paths as sets: I know this is ugly! *)
   val paths_as_set : (D.t, G.t, C.t, V.t) ctx -> D.t list
@@ -637,7 +638,10 @@ struct
   let enter ctx (lval: lval option) (f:fundec) (args:exp list) =
     [ctx.local, ctx.local]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc au (f_ask: Queries.ask) =
     au
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) =

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -395,7 +395,19 @@ sig
 
   val special : (D.t, G.t, C.t, V.t) ctx -> lval option -> varinfo -> exp list -> D.t
   val enter   : (D.t, G.t, C.t, V.t) ctx -> lval option -> fundec -> exp list -> (D.t * D.t) list
+
+  (* Combine is split into two steps: *)
+
+  (** Combine environment (global variables, mutexes, etc)
+      between local state (first component from enter) and function return.
+
+      This shouldn't yet assign to the lval. *)
   val combine_env : (D.t, G.t, C.t, V.t) ctx -> lval option -> exp -> fundec -> exp list -> C.t option -> D.t -> Queries.ask -> D.t
+
+  (** Combine return value assignment
+      to local state (result from combine_env) and function return.
+
+      This should only assign to the lval. *)
   val combine_assign : (D.t, G.t, C.t, V.t) ctx -> lval option -> exp -> fundec -> exp list -> C.t option -> D.t -> Queries.ask -> D.t
 
   (* Paths as sets: I know this is ugly! *)

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -458,7 +458,7 @@ struct
 
   let paths_as_set ctx =
     let liftmap = List.map (fun x -> D.lift x) in
-    lift_fun ctx liftmap S.paths_as_set (Fun.id) [D.bot ()]
+    lift_fun ctx liftmap S.paths_as_set (Fun.id) [D.bot ()] (* One dead path instead of none, such that combine_env gets called for functions with dead normal return (and thus longjmpy returns can be correctly handled by lifter). *)
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     lift_fun ctx identity S.query (fun (x) -> x q) (Queries.Result.bot q)

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -274,7 +274,6 @@ struct
       enter' {ctx with local=(d, sub1 l)} r f args
 
   let combine_env ctx r fe f args fc es f_ask =
-    (* TODO: should do nothing? *)
     let (d,l) = ctx.local in
     let l = add1 l in
     if leq0 l then
@@ -285,7 +284,7 @@ struct
 
   let combine_assign ctx r fe f args fc es f_ask =
     let (d,l) = ctx.local in
-    let l = add1 l in
+    (* No need to add1 here, already done in combine_env. *)
     if leq0 l then
       (d, l)
     else

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1597,7 +1597,6 @@ struct
     S.combine_env (conv_ctx) lv e f args fc fd f_ask
 
   let combine_assign ctx lv e f args fc fd f_ask =
-    (* TODO *)
     S.combine_assign (conv ctx) lv e f args fc fd f_ask
 
   let special ctx lv f args =

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -459,7 +459,7 @@ struct
 
   let paths_as_set ctx =
     let liftmap = List.map (fun x -> D.lift x) in
-    lift_fun ctx liftmap S.paths_as_set (Fun.id) []
+    lift_fun ctx liftmap S.paths_as_set (Fun.id) [D.bot ()]
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     lift_fun ctx identity S.query (fun (x) -> x q) (Queries.Result.bot q)

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1555,7 +1555,7 @@ struct
         (* Globals are non-problematic here, as they are always carried around without any issues! *)
         (* A combine call is mostly needed to ensure locals have appropriate values. *)
         (* Using f from called function on purpose here! Needed? *)
-        S.combine_assign cd_ctx None e f args fc longfd_ctx.local (Analyses.ask_of_ctx longfd_ctx) (* no lval because longjmp return skips return value assignment *)
+        S.combine_env cd_ctx None e f args fc longfd_ctx.local (Analyses.ask_of_ctx longfd_ctx) (* no lval because longjmp return skips return value assignment *)
       )
       in
       let returned = lazy ( (* does not depend on target, do at most once *)

--- a/src/util/wideningTokens.ml
+++ b/src/util/wideningTokens.ml
@@ -172,7 +172,8 @@ struct
   let asm ctx         = lift_fun ctx lift'   S.asm    identity
   let skip ctx        = lift_fun ctx lift'   S.skip   identity
   let special ctx r f args       = lift_fun ctx lift' S.special ((|>) args % (|>) f % (|>) r)
-  let combine ctx r fe f args fc es f_ask = lift_fun ctx lift' S.combine (fun p -> p r fe f args fc (D.unlift es) f_ask) (* TODO: use tokens from es *)
+  let combine_env ctx r fe f args fc es f_ask = lift_fun ctx lift' S.combine_env (fun p -> p r fe f args fc (D.unlift es) f_ask) (* TODO: use tokens from es *)
+  let combine_assign ctx r fe f args fc es f_ask = lift_fun ctx lift' S.combine_assign (fun p -> p r fe f args fc (D.unlift es) f_ask) (* TODO: use tokens from es *)
 
   let threadenter ctx lval f args = lift_fun ctx (fun l ts -> List.map (Fun.flip lift' ts) l) S.threadenter ((|>) args % (|>) f % (|>) lval)
   let threadspawn ctx lval f args fctx = lift_fun ctx lift' S.threadspawn ((|>) (conv fctx) % (|>) args % (|>) f % (|>) lval)

--- a/src/witness/observerAnalysis.ml
+++ b/src/witness/observerAnalysis.ml
@@ -65,7 +65,10 @@ struct
     (* ctx.local doesn't matter here? *)
     [ctx.local, step ctx.local ctx.prev_node (FunctionEntry f)]
 
-  let combine ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
+  let combine_env ctx lval fexp f args fc au f_ask =
+    ctx.local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     step au (Function f) ctx.node
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =

--- a/src/witness/observerAnalysis.ml
+++ b/src/witness/observerAnalysis.ml
@@ -66,10 +66,10 @@ struct
     [ctx.local, step ctx.local ctx.prev_node (FunctionEntry f)]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    ctx.local
+    ctx.local (* Don't yet consider call edge done before assign. *)
 
   let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    step au (Function f) ctx.node
+    step au (Function f) ctx.node (* Consider call edge done after entire call-assign. *)
 
   let special ctx (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     step_ctx ctx

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -279,6 +279,7 @@ struct
     fold' ctx Spec.enter (fun h -> h l f a) g []
 
   let combine_env ctx l fe f a fc d  f_ask =
+    (* Don't yet consider call edge done before assign. *)
     assert (Dom.cardinal (fst ctx.local) = 1);
     let (cd, cdr) = Dom.choose (fst ctx.local) in
     let k x y =
@@ -292,6 +293,7 @@ struct
     if Dom.is_bot (fst d) then raise Deadcode else d
 
   let combine_assign ctx l fe f a fc d  f_ask =
+    (* Consider call edge done after entire call-assign. *)
     assert (Dom.cardinal (fst ctx.local) = 1);
     let cd = Dom.choose_key (fst ctx.local) in
     let k x (y, sync) =

--- a/tests/regression/04-mutex/74-combine-env-assign-imprecise.c
+++ b/tests/regression/04-mutex/74-combine-env-assign-imprecise.c
@@ -1,0 +1,25 @@
+#include <pthread.h>
+
+int myglobal;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+
+int foo() {
+  pthread_mutex_lock(&mutex1);
+  return myglobal+1; // NORACE
+}
+
+void *t_fun(void *arg) {
+  myglobal = foo(); // NORACE
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex1);
+  myglobal=myglobal+1; // NORACE
+  pthread_mutex_unlock(&mutex1);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/04-mutex/75-combine-env-assign-unsound.c
+++ b/tests/regression/04-mutex/75-combine-env-assign-unsound.c
@@ -1,0 +1,26 @@
+#include <pthread.h>
+
+int myglobal;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+
+int foo() {
+  int x = myglobal + 1; // NORACE
+  pthread_mutex_unlock(&mutex1);
+  return x;
+}
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  myglobal=foo(); // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex1);
+  myglobal=myglobal+1; // RACE!
+  pthread_mutex_unlock(&mutex1);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/46-apron2/56-combine-env-assign.c
+++ b/tests/regression/46-apron2/56-combine-env-assign.c
@@ -1,0 +1,21 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.base.privatization none --set ana.relation.privatization top
+#include <goblint.h>
+
+int g = 0;
+int h = 0;
+int *ptr = &g;
+
+int change_ptr_and_return_5() {
+    ptr = &h;
+    return 5;
+}
+
+int main() {
+    // ptr points to h here, but apron evaluates on pre-state of function call, updating g instead
+    *ptr = change_ptr_and_return_5();
+
+    int x = g + 1; // Currently this fails because of operation on bot
+    assert(g == h); //FAIL
+    assert(h == 5);
+    assert(g == 0);
+}

--- a/tests/regression/46-apron2/56-combine-env-assign.c
+++ b/tests/regression/46-apron2/56-combine-env-assign.c
@@ -15,7 +15,7 @@ int main() {
     *ptr = change_ptr_and_return_5();
 
     int x = g + 1; // Currently this fails because of operation on bot
-    assert(g == h); //FAIL
-    assert(h == 5);
-    assert(g == 0);
+    __goblint_check(g == h); //FAIL
+    __goblint_check(h == 5);
+    __goblint_check(g == 0);
 }

--- a/tests/regression/62-abortUnless/04-lval.c
+++ b/tests/regression/62-abortUnless/04-lval.c
@@ -1,0 +1,18 @@
+// PARAM: --set ana.activated[+] abortUnless
+#include <goblint.h>
+
+int assume_abort_if_not(int cond) {
+  if(!cond)
+  {
+    abort();
+  }
+  return 42;
+}
+
+int main(void)
+{
+    int x, y;
+    y = assume_abort_if_not(x == 8);
+    __goblint_check(x==8);
+    __goblint_check(y==42);
+}


### PR DESCRIPTION
Closes #1009.

### TODO
- [x] Check (and fix) witness lifter.
- [x] Rethink `IdentitySpec` defaults.
- [x] Document `combine_env` and `combine_assign`.