### PR TITLE
Fix longjmp marshaling tests, clean up relifting

### DIFF
--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -184,9 +184,7 @@ struct
     let arbs = map (fun (n, (module D: Printable.S)) -> QCheck.map ~rev:(fun (_, o) -> obj o) (fun x -> (n, repr x)) @@ D.arbitrary ()) @@ domain_list () in
     MyCheck.Arbitrary.sequence arbs
 
-  let relift = unop_map (fun (module S: Printable.S) x ->
-    ignore (Pretty.eprintf "MCP relifting: %s\n" (S.name ()));
-    repr (S.relift (obj x)))
+  let relift = unop_map (fun (module S: Printable.S) x -> Obj.repr (S.relift (Obj.obj x)))
 end
 
 module DomVariantPrintable (DLSpec : DomainListPrintableSpec)
@@ -257,9 +255,7 @@ struct
     let arbs = map (fun (n, (module S: Printable.S)) -> QCheck.map ~rev:(fun (_, o) -> obj o) (fun x -> (n, repr x)) @@ S.arbitrary ()) @@ domain_list () in
     QCheck.oneof arbs
 
-  let relift = unop_map (fun n (module S: Printable.S) x ->
-      ignore (Pretty.eprintf "MCP relifting: %s\n" (S.name ()));
-      (n, repr (S.relift (obj x))))
+  let relift = unop_map (fun n (module S: Printable.S) x -> (n, Obj.repr (S.relift (Obj.obj x))))
 end
 
 module DomVariantSysVar (DLSpec : DomainListSysVarSpec)

--- a/src/analyses/mCPRegistry.ml
+++ b/src/analyses/mCPRegistry.ml
@@ -114,6 +114,9 @@ struct
   let unop_fold f a (x:t) =
     fold_left2 (fun a (n,d) (n',s) -> assert (n = n'); f a n s d) a x (domain_list ())
 
+  let unop_map f x =
+    List.rev @@ unop_fold (fun a n s d -> (n, f s d) :: a) [] x
+
   let pretty () x =
     let f a n (module S : Printable.S) x = Pretty.dprintf "%s:%a" (S.name ()) S.pretty (obj x) :: a in
     let xs = unop_fold f [] x in
@@ -180,6 +183,10 @@ struct
   let arbitrary () =
     let arbs = map (fun (n, (module D: Printable.S)) -> QCheck.map ~rev:(fun (_, o) -> obj o) (fun x -> (n, repr x)) @@ D.arbitrary ()) @@ domain_list () in
     MyCheck.Arbitrary.sequence arbs
+
+  let relift = unop_map (fun (module S: Printable.S) x ->
+    ignore (Pretty.eprintf "MCP relifting: %s\n" (S.name ()));
+    repr (S.relift (obj x)))
 end
 
 module DomVariantPrintable (DLSpec : DomainListPrintableSpec)
@@ -249,6 +256,10 @@ struct
   let arbitrary () =
     let arbs = map (fun (n, (module S: Printable.S)) -> QCheck.map ~rev:(fun (_, o) -> obj o) (fun x -> (n, repr x)) @@ S.arbitrary ()) @@ domain_list () in
     QCheck.oneof arbs
+
+  let relift = unop_map (fun n (module S: Printable.S) x ->
+      ignore (Pretty.eprintf "MCP relifting: %s\n" (S.name ()));
+      (n, repr (S.relift (obj x))))
 end
 
 module DomVariantSysVar (DLSpec : DomainListSysVarSpec)

--- a/src/analyses/tutorials/signs.ml
+++ b/src/analyses/tutorials/signs.ml
@@ -5,7 +5,7 @@ open Analyses
 
 module Signs =
 struct
-  include Printable.Std
+  include Printable.StdLeaf
 
   type t = Neg | Zero | Pos [@@deriving eq, ord, hash, to_yojson]
   let name () = "signs"
@@ -28,8 +28,6 @@ struct
   let lt x y = match x, y with
     | Neg, Pos | Neg, Zero -> true (* TODO: Maybe something missing? *)
     | _ -> false
-
-  let relift x = x
 end
 
 (* Now we turn this into a lattice by adding Top and Bottom elements.

--- a/src/analyses/tutorials/signs.ml
+++ b/src/analyses/tutorials/signs.ml
@@ -29,6 +29,7 @@ struct
     | Neg, Pos | Neg, Zero -> true (* TODO: Maybe something missing? *)
     | _ -> false
 
+  let relift x = x
 end
 
 (* Now we turn this into a lattice by adding Top and Bottom elements.

--- a/src/cdomains/apron/affineEqualityDomain.apron.ml
+++ b/src/cdomains/apron/affineEqualityDomain.apron.ml
@@ -209,6 +209,7 @@ end
 
 module D(Vc: AbstractVector) (Mx: AbstractMatrix) =
 struct
+  include Printable.Std
   include ConvenienceOps (Mpqf)
   include VarManagement (Vc) (Mx)
 
@@ -217,8 +218,6 @@ struct
   module Convert = SharedFunctions.Convert (V) (Bounds) (struct let allow_global = true end) (SharedFunctions.Tracked)
 
   type var = V.t
-
-  let tag t = failwith "No tag"
 
   let show t =
     let conv_to_ints row =
@@ -267,8 +266,6 @@ struct
   let name () = "affeq"
 
   let to_yojson _ = failwith "ToDo Implement in future"
-
-  let arbitrary () = failwith "no arbitrary"
 
 
   let is_bot t = equal t (bot ())

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -463,6 +463,8 @@ end
 
 module DBase (Man: Manager): SPrintable with type t = Man.mt A.t =
 struct
+  include Printable.StdLeaf
+
   type t = Man.mt A.t
 
   let name () = "Apron " ^ Man.name ()
@@ -474,9 +476,6 @@ struct
   let is_bot_env = A.is_bottom Man.mgr
 
   let invariant _ = []
-  let tag _ = failwith "Std: no tag"
-  let arbitrary () = failwith "no arbitrary"
-  let relift x = x
 
   let show (x:t) =
     Format.asprintf "%a (env: %a)" A.print x (Environment.print: Format.formatter -> Environment.t -> unit) (A.env x)

--- a/src/cdomains/apron/relationDomain.apron.ml
+++ b/src/cdomains/apron/relationDomain.apron.ml
@@ -163,6 +163,8 @@ struct
   include Printable.Std
   open Pretty
 
+  let relift {rel; priv} = {rel = RD.relift rel; priv = PrivD.relift priv}
+
   let show r =
     let first  = RD.show r.rel in
     let third  = PrivD.show r.priv in

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -204,6 +204,8 @@ end
 
 module Partitioned (Val: LatticeWithSmartOps) (Idx:IntDomain.Z): SPartitioned with type value = Val.t and type idx = Idx.t =
 struct
+  include Printable.Std
+
   type t = Joint of Val.t | Partitioned of (CilType.Exp.t * (Val.t * Val.t * Val.t)) [@@deriving eq, ord, hash]
 
   type idx = Idx.t
@@ -212,8 +214,6 @@ struct
   let domain_of_t _ = PartitionedDomain
 
   let name () = "partitioned array"
-
-  let tag _ = failwith "Std: no tag"
 
   let relift = function
     | Joint v -> Joint (Val.relift v)
@@ -261,8 +261,6 @@ struct
     | Partitioned (e,(xl, xm, xr)), Partitioned (e',(yl, ym, yr)) ->
       if CilType.Exp.equal e e' then Partitioned (e,(Val.widen xl yl, Val.widen xm ym, Val.widen xr yr))
       else Joint (Val.widen (join_of_all_parts x) (join_of_all_parts y))
-
-  let arbitrary () = failwith "no arbitray"
 
   let show = function
     | Joint x ->  "Array (no part.): " ^ Val.show x

--- a/src/cdomains/baseDomain.ml
+++ b/src/cdomains/baseDomain.ml
@@ -121,6 +121,9 @@ struct
   let meet = op_scheme CPA.meet PartDeps.meet WeakUpdates.meet PrivD.meet
   let widen = op_scheme CPA.widen PartDeps.widen WeakUpdates.widen PrivD.widen
   let narrow = op_scheme CPA.narrow PartDeps.narrow WeakUpdates.narrow PrivD.narrow
+
+  let relift {cpa; deps; weak; priv} =
+    {cpa = CPA.relift cpa; deps = PartDeps.relift deps; weak = WeakUpdates.relift weak; priv = PrivD.relift priv}
 end
 
 module type ExpEvaluator =

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -50,6 +50,7 @@ struct
   let pretty () x = text (show x)
   let name () = "raw strings"
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
+  let relift x = x
 end
 
 module Strings: Lattice.S with type t = [`Bot | `Lifted of string | `Top] =

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -67,6 +67,7 @@ struct
   let pretty () x = text (show x)
   let name () = "raw bools"
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (show x)
+  let relift x = x
 end
 
 module Bools: Lattice.S with type t = [`Bot | `Lifted of bool | `Top] =

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -43,14 +43,13 @@ end
 
 module RawStrings: Printable.S with type t = string =
 struct
-  include Printable.Std
+  include Printable.StdLeaf
   open Pretty
   type t = string [@@deriving eq, ord, hash, to_yojson]
   let show x = "\"" ^ x ^ "\""
   let pretty () x = text (show x)
   let name () = "raw strings"
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
-  let relift x = x
 end
 
 module Strings: Lattice.S with type t = [`Bot | `Lifted of string | `Top] =
@@ -61,14 +60,13 @@ module Strings: Lattice.S with type t = [`Bot | `Lifted of string | `Top] =
 
 module RawBools: Printable.S with type t = bool =
 struct
-  include Printable.Std
+  include Printable.StdLeaf
   open Pretty
   type t = bool [@@deriving eq, ord, hash, to_yojson]
   let show (x:t) =  if x then "true" else "false"
   let pretty () x = text (show x)
   let name () = "raw bools"
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (show x)
-  let relift x = x
 end
 
 module Bools: Lattice.S with type t = [`Bot | `Lifted of bool | `Top] =

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -734,6 +734,7 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
   let sin = eval_unop (top ()) eval_sin
   let tan = eval_unop (top ()) eval_tan
 
+  let relift x = x
 end
 
 module F64Interval = FloatIntervalImpl(CDouble)

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -933,6 +933,8 @@ module FloatIntervalImplLifted = struct
       let i2 = Invariant.of_exp Cil.(BinOp (Le, e, Const (CReal (x2, fk, None)), intType)) in
       Invariant.(&&) i1 i2
     | _ -> Invariant.none
+
+  let relift x = x
 end
 
 module FloatDomTupleImpl = struct
@@ -1139,4 +1141,6 @@ module FloatDomTupleImpl = struct
       let show = show
     end
     )
+
+  let relift a = Option.map F1.relift a
 end

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -96,7 +96,7 @@ module type FloatDomainBase = sig
 end
 
 module FloatIntervalImpl(Float_t : CFloatType) = struct
-  include Printable.Std (* for default invariant, tag and relift *)
+  include Printable.StdLeaf (* for default invariant, tag and relift *)
   type t = Top | Bot | NaN | PlusInfinity | MinusInfinity | Interval of (Float_t.t * Float_t.t) [@@deriving eq, ord, to_yojson, hash]
 
   let show = function
@@ -733,8 +733,6 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
   let cos = eval_unop (top ()) eval_cos
   let sin = eval_unop (top ()) eval_sin
   let tan = eval_unop (top ()) eval_tan
-
-  let relift x = x
 end
 
 module F64Interval = FloatIntervalImpl(CDouble)
@@ -773,7 +771,7 @@ module type FloatDomain = sig
 end
 
 module FloatIntervalImplLifted = struct
-  include Printable.Std (* for default invariant, tag and relift *)
+  include Printable.StdLeaf (* for default invariant, tag and relift *)
 
   module F1 = F32Interval
   module F2 = F64Interval
@@ -934,8 +932,6 @@ module FloatIntervalImplLifted = struct
       let i2 = Invariant.of_exp Cil.(BinOp (Le, e, Const (CReal (x2, fk, None)), intType)) in
       Invariant.(&&) i1 i2
     | _ -> Invariant.none
-
-  let relift x = x
 end
 
 module FloatDomTupleImpl = struct

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -576,7 +576,7 @@ module Std (B: sig
     val show: t -> string
     val equal: t -> t -> bool
   end) = struct
-  include Printable.Std
+  include Printable.StdLeaf
   let name = B.name (* overwrite the one from Printable.Std *)
   open B
   let is_top x = failwith "is_top not implemented for IntDomain.Std"
@@ -973,7 +973,6 @@ struct
       | None -> empty
     in
     QCheck.(set_shrink shrink @@ set_print show @@ map (*~rev:BatOption.get*) (fun x -> of_interval ik x |> fst ) pair_arb)
-  let relift x = x
 
   let modulo n k =
     let result = Ints_t.rem n k in
@@ -1583,8 +1582,6 @@ struct
     let canonize_randomly_generated_list = (fun x -> norm_intvs ik  x |> fst) in
     let shrink xs = MyCheck.shrink list_pair_arb xs >|= canonize_randomly_generated_list
     in QCheck.(set_shrink shrink @@ set_print show @@ map (*~rev:BatOption.get*) canonize_randomly_generated_list list_pair_arb)
-
-  let relift x = x
 end
 
 module SOverflowUnlifter (D : SOverflow) : S with type int_t = D.int_t and type t = D.t = struct
@@ -1613,8 +1610,6 @@ module SOverflowUnlifter (D : SOverflow) : S with type int_t = D.int_t and type 
   let shift_left ik x y = fst @@ D.shift_left ik x y
 
   let shift_right ik x y = fst @@ D.shift_right ik x y
-
-  let relift x = x
 end
 
 module IntIkind = struct let ikind () = Cil.IInt end
@@ -1675,7 +1670,6 @@ struct
   let cast_to ?torg t x =  failwith @@ "Cast_to not implemented for " ^ (name ()) ^ "."
   let arbitrary ik = QCheck.map ~rev:Ints_t.to_int64 Ints_t.of_int64 MyCheck.Arbitrary.int64 (* TODO: use ikind *)
   let invariant _ _ = Invariant.none (* TODO *)
-  let relift x = x
 end
 
 module FlatPureIntegers: IkindUnawareS with type t = int64 and type int_t = int64 = (* Integers, but raises Unknown/Error on join/meet *)
@@ -1858,7 +1852,6 @@ module BigInt = struct
   let show x = BI.to_string x
   include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
   let arbitrary () = QCheck.map ~rev:to_int64 of_int64 QCheck.int64
-  let relift x = x
 end
 
 module BISet = struct
@@ -2377,8 +2370,6 @@ struct
   let refine_with_incl_list ik a b = a
 
   let project ik p t = t
-
-  let relift x = x
 end
 
 (* BOOLEAN DOMAINS *)
@@ -2439,7 +2430,6 @@ struct
   let logor  = (||)
   let arbitrary () = QCheck.bool
   let invariant _ _ = Invariant.none (* TODO *)
-  let relift x = x
 end
 
 module Booleans = MakeBooleans (
@@ -2797,8 +2787,6 @@ module Enums : S with type int_t = BigInt.t = struct
     | _ -> a
 
   let project ik p t = t
-
-  let relift x = x
 end
 
 module Congruence : S with type int_t = BI.t and type t = (BI.t * BI.t) option =
@@ -3254,8 +3242,6 @@ struct
     let of_pair ik p = normalize ik (Some p) in
     let to_pair = Option.get in
     set_print show (map ~rev:to_pair (of_pair ik) cong_arb)
-
-  let relift x = x
 
   let refine_with_interval ik (cong : t) (intv : (int_t * int_t ) option) : t =
     match intv, cong with

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -1584,6 +1584,7 @@ struct
     let shrink xs = MyCheck.shrink list_pair_arb xs >|= canonize_randomly_generated_list
     in QCheck.(set_shrink shrink @@ set_print show @@ map (*~rev:BatOption.get*) canonize_randomly_generated_list list_pair_arb)
 
+  let relift x = x
 end
 
 module SOverflowUnlifter (D : SOverflow) : S with type int_t = D.int_t and type t = D.t = struct
@@ -1613,6 +1614,7 @@ module SOverflowUnlifter (D : SOverflow) : S with type int_t = D.int_t and type 
 
   let shift_right ik x y = fst @@ D.shift_right ik x y
 
+  let relift x = x
 end
 
 module IntIkind = struct let ikind () = Cil.IInt end
@@ -1673,6 +1675,7 @@ struct
   let cast_to ?torg t x =  failwith @@ "Cast_to not implemented for " ^ (name ()) ^ "."
   let arbitrary ik = QCheck.map ~rev:Ints_t.to_int64 Ints_t.of_int64 MyCheck.Arbitrary.int64 (* TODO: use ikind *)
   let invariant _ _ = Invariant.none (* TODO *)
+  let relift x = x
 end
 
 module FlatPureIntegers: IkindUnawareS with type t = int64 and type int_t = int64 = (* Integers, but raises Unknown/Error on join/meet *)
@@ -1855,6 +1858,7 @@ module BigInt = struct
   let show x = BI.to_string x
   include Std (struct type nonrec t = t let name = name let top_of = top_of let bot_of = bot_of let show = show let equal = equal end)
   let arbitrary () = QCheck.map ~rev:to_int64 of_int64 QCheck.int64
+  let relift x = x
 end
 
 module BISet = struct
@@ -2373,6 +2377,8 @@ struct
   let refine_with_incl_list ik a b = a
 
   let project ik p t = t
+
+  let relift x = x
 end
 
 (* BOOLEAN DOMAINS *)
@@ -2433,6 +2439,7 @@ struct
   let logor  = (||)
   let arbitrary () = QCheck.bool
   let invariant _ _ = Invariant.none (* TODO *)
+  let relift x = x
 end
 
 module Booleans = MakeBooleans (
@@ -2790,6 +2797,8 @@ module Enums : S with type int_t = BigInt.t = struct
     | _ -> a
 
   let project ik p t = t
+
+  let relift x = x
 end
 
 module Congruence : S with type int_t = BI.t and type t = (BI.t * BI.t) option =
@@ -3759,6 +3768,9 @@ module IntDomTupleImpl = struct
         ) (Invariant.top ()) is
 
   let arbitrary ik = QCheck.(set_print show @@ tup5 (option (I1.arbitrary ik)) (option (I2.arbitrary ik)) (option (I3.arbitrary ik)) (option (I4.arbitrary ik)) (option (I5.arbitrary ik)))
+
+  let relift (a, b, c, d, e) =
+    (Option.map I1.relift a, Option.map I2.relift b, Option.map I3.relift c, Option.map I4.relift d, Option.map I5.relift e)
 end
 
 module IntDomTuple =

--- a/src/cdomains/jmpBufDomain.ml
+++ b/src/cdomains/jmpBufDomain.ml
@@ -3,6 +3,10 @@ module BufferEntry = Printable.ProdSimple(Node)(ControlSpecC)
 module BufferEntryOrTop = struct
   include Printable.Std
   type t = AllTargets | Target of BufferEntry.t [@@deriving eq, ord, hash, to_yojson]
+  let relift = function
+    | AllTargets -> AllTargets
+    | Target x -> Target (BufferEntry.relift x)
+
   let show = function AllTargets -> "All" | Target x -> BufferEntry.show x
 
   include Printable.SimpleShow (struct

--- a/src/cdomains/jmpBufDomain.ml
+++ b/src/cdomains/jmpBufDomain.ml
@@ -3,6 +3,9 @@ module BufferEntry = Printable.ProdSimple(Node)(ControlSpecC)
 module BufferEntryOrTop = struct
   include Printable.Std
   type t = AllTargets | Target of BufferEntry.t [@@deriving eq, ord, hash, to_yojson]
+
+  let name () = "jmpbuf entry"
+
   let relift = function
     | AllTargets -> AllTargets
     | Target x -> Target (BufferEntry.relift x)

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -202,7 +202,7 @@ struct
         hash x
     | _ -> hash x
 
-  include Printable.Std
+  include Printable.StdLeaf
   let name () = "Normal Lvals"
 
   type group = Basetype.Variables.group
@@ -315,8 +315,6 @@ struct
     | `Field (f,o) -> `Field (f, remove_offset o)
 
   let arbitrary () = QCheck.always UnknownPtr (* S TODO: non-unknown *)
-
-  let relift x = x
 end
 
 (** Lvalue lattice.
@@ -527,7 +525,7 @@ end
 
 module CilLval =
 struct
-  include Printable.Std
+  include Printable.StdLeaf
   type t = CilType.Varinfo.t * (CilType.Fieldinfo.t, Basetype.CilExp.t) offs [@@deriving eq, ord, hash]
 
   let name () = "simplified lval"
@@ -575,6 +573,4 @@ struct
       let show = show
     end
     )
-
-  let relift x = x
 end

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -29,6 +29,8 @@ struct
   type t = (fieldinfo, Idx.t) offs
   include Printable.Std
 
+  let name () = "offset"
+
   let is_first_field x = match x.fcomp.cfields with
     | [] -> false
     | f :: _ -> CilType.Fieldinfo.equal f x

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -313,6 +313,8 @@ struct
     | `Field (f,o) -> `Field (f, remove_offset o)
 
   let arbitrary () = QCheck.always UnknownPtr (* S TODO: non-unknown *)
+
+  let relift x = x
 end
 
 (** Lvalue lattice.
@@ -571,4 +573,6 @@ struct
       let show = show
     end
     )
+
+  let relift x = x
 end

--- a/src/cdomains/lvalMapDomain.ml
+++ b/src/cdomains/lvalMapDomain.ml
@@ -73,6 +73,7 @@ struct
     type t = { key: k; loc: Node.t list; state: s } [@@deriving eq, ord, hash]
     let to_yojson _ = failwith "TODO to_yojson"
     let name () = "LValMapDomainValue"
+    let relift x = x
   end
   type r = R.t
   open R

--- a/src/cdomains/lvalMapDomain.ml
+++ b/src/cdomains/lvalMapDomain.ml
@@ -69,11 +69,11 @@ struct
   type k = Lval.CilLval.t [@@deriving eq, ord, hash]
   type s = Impl.s [@@deriving eq, ord, hash]
   module R = struct
+    include Printable.StdLeaf
     include Printable.Blank
     type t = { key: k; loc: Node.t list; state: s } [@@deriving eq, ord, hash]
     let to_yojson _ = failwith "TODO to_yojson"
     let name () = "LValMapDomainValue"
-    let relift x = x
   end
   type r = R.t
   open R

--- a/src/cdomains/lvalMapDomain.ml
+++ b/src/cdomains/lvalMapDomain.ml
@@ -70,10 +70,18 @@ struct
   type s = Impl.s [@@deriving eq, ord, hash]
   module R = struct
     include Printable.StdLeaf
-    include Printable.Blank
     type t = { key: k; loc: Node.t list; state: s } [@@deriving eq, ord, hash]
-    let to_yojson _ = failwith "TODO to_yojson"
     let name () = "LValMapDomainValue"
+
+    let pretty () {key; loc; state} =
+      Pretty.dprintf "{key=%a; loc=%a; state=%s}" Lval.CilLval.pretty key (Pretty.d_list ", " Node.pretty) loc (Impl.string_of_state state)
+
+    include Printable.SimplePretty (
+      struct
+        type nonrec t = t
+        let pretty = pretty
+      end
+      )
   end
   type r = R.t
   open R

--- a/src/cdomains/mHP.ml
+++ b/src/cdomains/mHP.ml
@@ -9,6 +9,9 @@ type t = {
   must_joined: ConcDomain.ThreadSet.t;
 } [@@deriving eq, ord, hash]
 
+let relift {tid; created; must_joined} =
+  {tid = ThreadIdDomain.ThreadLifted.relift tid; created = ConcDomain.ThreadSet.relift created; must_joined = ConcDomain.ThreadSet.relift must_joined}
+
 let current (ask:Queries.ask) =
   {
     tid = ask.f Queries.CurrentThreadId;

--- a/src/cdomains/mHP.ml
+++ b/src/cdomains/mHP.ml
@@ -1,5 +1,7 @@
 include Printable.Std
 
+let name () = "mhp"
+
 module TID = ThreadIdDomain.FlagConfiguredTID
 module Pretty = GoblintCil.Pretty
 

--- a/src/cdomains/pthreadDomain.ml
+++ b/src/cdomains/pthreadDomain.ml
@@ -21,6 +21,8 @@ module Pred = struct
 end
 
 module D = struct
+  include Printable.StdLeaf
+
   type domain = { tid : Tid.t; pred : Pred.t; ctx : Ctx.t } [@@deriving to_yojson]
   type t = domain
 
@@ -70,10 +72,6 @@ module D = struct
   let widen = join
   let meet = op_scheme Tid.meet Pred.meet Ctx.meet
   let narrow = meet
-
-  let arbitrary () = failwith "no arbitrary"
-  let tag x = failwith "no tag"
-  let relift x = x
 
   let pretty_diff () (x,y) =
     if not (Tid.leq x.tid y.tid) then

--- a/src/cdomains/structDomain.ml
+++ b/src/cdomains/structDomain.ml
@@ -98,6 +98,8 @@ struct
     (* invariant for one index *)
     | Index (i, offset) ->
       Invariant.none
+
+  let relift = M.relift
 end
 
 module SetsCommon (Val:Arg) =
@@ -230,6 +232,8 @@ struct
 
   (* let invariant = HS.invariant *)
   let invariant ~value_invariant ~offset ~lval _ = Invariant.none (* TODO *)
+
+  let relift = HS.relift
 end
 
 module KeyedSets (Val: Arg) =
@@ -438,6 +442,8 @@ struct
 
   (* let invariant c (x,_) = HS.invariant c x *)
   let invariant ~value_invariant ~offset ~lval _ = Invariant.none (* TODO *)
+
+  let relift x = x
 end
 
 

--- a/src/cdomains/structDomain.ml
+++ b/src/cdomains/structDomain.ml
@@ -443,7 +443,7 @@ struct
   (* let invariant c (x,_) = HS.invariant c x *)
   let invariant ~value_invariant ~offset ~lval _ = Invariant.none (* TODO *)
 
-  let relift x = x
+  let relift (hs, f) = (HS.relift hs, f)
 end
 
 

--- a/src/cdomains/symbLocksDomain.ml
+++ b/src/cdomains/symbLocksDomain.ml
@@ -162,12 +162,8 @@ end
 
 module LockingPattern =
 struct
-  include Printable.Std
-  type t = Exp.t * Exp.t * Exp.t [@@deriving eq, ord, hash, to_yojson]
+  include Printable.Prod3 (Exp) (Exp) (Exp)
   let name () = "Per-Element locking triple"
-
-  let pretty () (x,y,z) = text "(" ++ d_exp () x ++ text ", "++ d_exp () y ++ text ", "++ d_exp () z ++ text ")"
-  let show (x,y,z) = sprint ~width:max_int (dprintf "(%a,%a,%a)" d_exp x d_exp y d_exp z)
 
   type ee = EVar of varinfo
           | EAddr
@@ -276,9 +272,6 @@ struct
         Some (elem, fromEl a dummy, fromEl l dummy)
       | _ -> None
     with Invalid_argument _ -> None
-  let printXml f (x,y,z) = BatPrintf.fprintf f "<value>\n<map>\n<key>1</key>\n%a<key>2</key>\n%a<key>3</key>\n%a</map>\n</value>\n" Exp.printXml x Exp.printXml y Exp.printXml z
-
-  let relift (x, y, z) = (Exp.relift x, Exp.relift y, Exp.relift z) (* TODO: Prod3? *)
 end
 
 (** Index-based symbolic lock *)

--- a/src/cdomains/symbLocksDomain.ml
+++ b/src/cdomains/symbLocksDomain.ml
@@ -288,7 +288,7 @@ struct
   (** Index in index-based symbolic lock *)
   module Idx =
   struct
-    include Printable.Std
+    include Printable.StdLeaf
     type t =
       | Unknown (** Unknown index. Mutex index not synchronized with access index. *)
       | Star (** Star index. Mutex index synchronized with access index. Corresponds to star_0 in ASE16 paper, multiple star indices not supported in this implementation. *)
@@ -308,7 +308,6 @@ struct
 
     let equal_to _ _ = `Top
     let to_int _ = None
-    let relift x = x
   end
 
   include Lval.Normal (Idx)

--- a/src/cdomains/symbLocksDomain.ml
+++ b/src/cdomains/symbLocksDomain.ml
@@ -277,6 +277,8 @@ struct
       | _ -> None
     with Invalid_argument _ -> None
   let printXml f (x,y,z) = BatPrintf.fprintf f "<value>\n<map>\n<key>1</key>\n%a<key>2</key>\n%a<key>3</key>\n%a</map>\n</value>\n" Exp.printXml x Exp.printXml y Exp.printXml z
+
+  let relift (x, y, z) = (Exp.relift x, Exp.relift y, Exp.relift z) (* TODO: Prod3? *)
 end
 
 (** Index-based symbolic lock *)
@@ -306,6 +308,7 @@ struct
 
     let equal_to _ _ = `Top
     let to_int _ = None
+    let relift x = x
   end
 
   include Lval.Normal (Idx)

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -1183,6 +1183,21 @@ struct
     | None, _
     | _, None -> n'
     | Some l, Some p -> CArrays.update_length (ID.project p l) n'
+
+  let relift state =
+    match state with
+    | `Int n -> `Int (ID.relift n)
+    | `Float n -> `Float (FD.relift n)
+    | `Address n -> `Address (AD.relift n)
+    | `Struct n -> `Struct (Structs.relift n)
+    | `Union n -> `Union (Unions.relift n)
+    | `Array n -> `Array (CArrays.relift n)
+    | `Blob n -> `Blob (Blobs.relift n)
+    | `Thread n -> `Thread (Threads.relift n)
+    | `JmpBuf n -> `JmpBuf (JmpBufs.relift n)
+    | `Mutex -> `Mutex
+    | `Bot -> `Bot
+    | `Top -> `Top
 end
 
 and Structs: StructDomain.S with type field = fieldinfo and type value = Compound.t =

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -342,7 +342,8 @@ struct
 
   let conf (conf, _, _, _, _) = conf
 
-  let relift x = x (* TODO: relift MCPAccess *)
+  let relift (conf, kind, node, e, a) =
+    (conf, kind, node, e, MCPAccess.A.relift a)
 end
 module AS =
 struct

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -339,6 +339,8 @@ struct
     )
 
   let conf (conf, _, _, _, _) = conf
+
+  let relift x = x (* TODO: relift MCPAccess *)
 end
 module AS =
 struct
@@ -359,6 +361,8 @@ struct
       let pretty = pretty
     end
     )
+
+  let relift x = x
 end
 module O =
 struct
@@ -372,6 +376,8 @@ struct
       let pretty = pretty
     end
     )
+
+  let relift x = x
 end
 module LV = Printable.Prod (CilType.Varinfo) (O)
 module LVOpt = Printable.Option (LV) (struct let name = "NONE" end)

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -353,7 +353,7 @@ struct
 end
 module T =
 struct
-  include Printable.Std
+  include Printable.StdLeaf
   type t = acc_typ [@@deriving eq, ord, hash]
 
   let name () = "acc_typ"
@@ -365,12 +365,10 @@ struct
       let pretty = pretty
     end
     )
-
-  let relift x = x
 end
 module O =
 struct
-  include Printable.Std
+  include Printable.StdLeaf
   type t = offs [@@deriving eq, ord, hash]
 
   let name () = "offs"
@@ -382,8 +380,6 @@ struct
       let pretty = pretty
     end
     )
-
-  let relift x = x
 end
 module LV = Printable.Prod (CilType.Varinfo) (O)
 module LVOpt = Printable.Option (LV) (struct let name = "NONE" end)

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -328,6 +328,8 @@ struct
   include Printable.Std
   type t = int * AccessKind.t * Node.t * CilType.Exp.t * MCPAccess.A.t [@@deriving eq, ord, hash]
 
+  let name () = "access"
+
   let pretty () (conf, kind, node, e, lp) =
     Pretty.dprintf "%d, %a, %a, %a, %a" conf AccessKind.pretty kind CilType.Location.pretty (Node.location node) CilType.Exp.pretty e MCPAccess.A.pretty lp
 
@@ -354,6 +356,8 @@ struct
   include Printable.Std
   type t = acc_typ [@@deriving eq, ord, hash]
 
+  let name () = "acc_typ"
+
   let pretty = d_acct
   include Printable.SimplePretty (
     struct
@@ -368,6 +372,8 @@ module O =
 struct
   include Printable.Std
   type t = offs [@@deriving eq, ord, hash]
+
+  let name () = "offs"
 
   let pretty = d_offs
   include Printable.SimplePretty (

--- a/src/domains/accessDomain.ml
+++ b/src/domains/accessDomain.ml
@@ -20,6 +20,8 @@ struct
       let pretty = pretty
     end
     )
+
+  let relift x = x
 end
 
 module EventSet = SetDomain.ToppedSet (Event) (struct let topname = "All accesses" end)

--- a/src/domains/accessDomain.ml
+++ b/src/domains/accessDomain.ml
@@ -2,7 +2,7 @@ open GoblintCil.Pretty
 
 module Event =
 struct
-  include Printable.Std
+  include Printable.StdLeaf
   type t = {
     var_opt: CilType.Varinfo.t option; (** Access varinfo (unknown if None). *)
     offs_opt: CilType.Offset.t option; (** Access offset (unknown if None). *)
@@ -20,8 +20,6 @@ struct
       let pretty = pretty
     end
     )
-
-  let relift x = x
 end
 
 module EventSet = SetDomain.ToppedSet (Event) (struct let topname = "All accesses" end)

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -130,6 +130,8 @@ struct
   type value = Range.t
   type t = Range.t M.t (* key -> value  mapping *)
 
+  let name () = "map"
+
   (* And one less brainy definition *)
   let for_all2 = M.equal
   let equal x y = x == y || for_all2 Range.equal x y

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -182,6 +182,15 @@ struct
   (* let add k v m = let _ = Pretty.printf "%a\n" pretty m in M.add k v m *)
 
   let arbitrary () = QCheck.always M.empty (* S TODO: non-empty map *)
+
+  let relift m =
+    M.fold (fun k v acc ->
+        ignore (Pretty.eprintf "map relift key: %s\n" (Domain.name ()));
+        let k' = Domain.relift k in
+        ignore (Pretty.eprintf "map relift value: %s\n" (Range.name ()));
+        let v' = Range.relift v in
+        M.add k' v' acc
+      ) m M.empty
 end
 
 (* TODO: why is HashCached.hash significantly slower as a functor compared to being inlined into PMap? *)
@@ -230,7 +239,7 @@ struct
   let join_with_fct f = lift_f2' (M.join_with_fct f)
   let widen_with_fct f = lift_f2' (M.widen_with_fct f)
 
-  let relift x = x
+  let relift = lift_f' M.relift
 end
 
 (* TODO: this is very slow because every add/remove in a fold-loop relifts *)

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -187,11 +187,7 @@ struct
 
   let relift m =
     M.fold (fun k v acc ->
-        ignore (Pretty.eprintf "map relift key: %s\n" (Domain.name ()));
-        let k' = Domain.relift k in
-        ignore (Pretty.eprintf "map relift value: %s\n" (Range.name ()));
-        let v' = Range.relift v in
-        M.add k' v' acc
+        M.add (Domain.relift k) (Range.relift v) acc
       ) m M.empty
 end
 

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -138,26 +138,20 @@ struct
   let unlift x = x.BatHashcons.obj
   let lift = HC.hashcons htable
   let lift_f f (x:Base.t BatHashcons.hobj) = f (x.BatHashcons.obj)
-  let pretty () x = Pretty.dprintf "%a[%d,%d]" Base.pretty x.BatHashcons.obj x.BatHashcons.tag x.BatHashcons.hcode
-  let show x = (Base.show x.BatHashcons.obj) ^ "[" ^ string_of_int x.BatHashcons.tag ^ "," ^ string_of_int x.BatHashcons.hcode ^ "]"
-  let indent = ref 0
-  let relift x =
-    ignore (Pretty.eprintf "%srelifting %a\n" (String.make !indent '.') pretty x);
-    incr indent;
-    let y = Base.relift x.BatHashcons.obj in
-    decr indent;
-    let x' = HC.hashcons htable y in
-    (* ignore (Pretty.eprintf "relift %a\nas %a\n" pretty x pretty x'); *)
-    ignore (Pretty.eprintf "%srelifted %a\n" (String.make !indent '.') pretty x');
-    x'
-  (* let relift x = relift (relift x) *)
+
+  let show = lift_f Base.show
+  let pretty () = lift_f (Base.pretty ())
+
+  (* Debug printing with tags *)
+  (* let pretty () x = Pretty.dprintf "%a[%d,%d]" Base.pretty x.BatHashcons.obj x.BatHashcons.tag x.BatHashcons.hcode
+     let show x = (Base.show x.BatHashcons.obj) ^ "[" ^ string_of_int x.BatHashcons.tag ^ "," ^ string_of_int x.BatHashcons.hcode ^ "]" *)
+
+  let relift x = let y = Base.relift x.BatHashcons.obj in HC.hashcons htable y
   let name () = "HConsed "^Base.name ()
   let hash x = x.BatHashcons.hcode
   let tag x = x.BatHashcons.tag
   let compare x y =  Stdlib.compare x.BatHashcons.tag y.BatHashcons.tag
-  (* let show = lift_f Base.show *)
   let to_yojson = lift_f (Base.to_yojson)
-  (* let pretty () = lift_f (Base.pretty ()) *)
   let printXml f x = Base.printXml f x.BatHashcons.obj
 
   let equal_debug x y = (* This debug version checks if we call hashcons enough to have up-to-date tags. Comment out the equal below to use this. This will be even slower than with hashcons disabled! *)
@@ -398,12 +392,7 @@ struct
 
   let arbitrary () = QCheck.pair (Base1.arbitrary ()) (Base2.arbitrary ())
 
-  let relift (x,y) =
-    ignore (Pretty.eprintf "prod relift fst: %s\n" (Base1.name ()));
-    let x' = Base1.relift x in
-    ignore (Pretty.eprintf "prod relift snd: %s\n" (Base2.name ()));
-    let y' = Base2.relift y in
-    (x', y')
+  let relift (x,y) = (Base1.relift x, Base2.relift y)
 end
 
 module Prod = ProdConf (struct let expand_fst = true let expand_snd = true end)

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -58,7 +58,7 @@ struct
 
   let tag _ = failwith "Std: no tag"
   let arbitrary () = failwith "no arbitrary"
-  let relift x = failwith "Std: no relift"
+  (* let relift x = failwith "Std: no relift" *)
 end
 
 module Blank =
@@ -582,6 +582,7 @@ struct
   let show n = n
   let name () = "String"
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" x
+  let relift x = x
 end
 
 
@@ -658,4 +659,5 @@ struct
     )
 
   let to_yojson x = x (* override SimplePretty *)
+  let relift x = x
 end

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -42,7 +42,9 @@ struct
   let relift (x: t) = match x with _ -> .
 end
 
+(** Default dummy definitions.
 
+    Include as the first thing to avoid these overriding actual definitions. *)
 module Std =
 struct
   (* start MapDomain.Groupable *)
@@ -56,6 +58,8 @@ struct
   let arbitrary () = failwith "no arbitrary"
 end
 
+(** Default dummy definitions for leaf types: primitive and CIL types,
+    which don't contain inner types that require relifting. *)
 module StdLeaf =
 struct
   include Std

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -47,7 +47,7 @@ module Std =
 struct
   (*  let equal = Util.equals
       let hash = Hashtbl.hash*)
-  let name () = "std"
+  (* let name () = "std" *)
 
   (* start MapDomain.Groupable *)
   type group = |
@@ -489,6 +489,7 @@ module Chain (P: ChainParams): S with type t = int =
 struct
   type t = int [@@deriving eq, ord, hash]
   include Std
+  let name () = "chain"
 
   let show x = P.names x
   let pretty () x = text (show x)

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -45,10 +45,6 @@ end
 
 module Std =
 struct
-  (*  let equal = Util.equals
-      let hash = Hashtbl.hash*)
-  (* let name () = "std" *)
-
   (* start MapDomain.Groupable *)
   type group = |
   let show_group (x: group) = match x with _ -> .
@@ -58,7 +54,13 @@ struct
 
   let tag _ = failwith "Std: no tag"
   let arbitrary () = failwith "no arbitrary"
-  (* let relift x = failwith "Std: no relift" *)
+end
+
+module StdLeaf =
+struct
+  include Std
+
+  let relift x = x
 end
 
 module Blank =
@@ -102,14 +104,13 @@ module type Name = sig val name: string end
 module UnitConf (N: Name) =
 struct
   type t = unit [@@deriving eq, ord, hash]
-  include Std
+  include StdLeaf
   let pretty () _ = text N.name
   let show _ = N.name
   let name () = "Unit"
   let printXml f () = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape N.name)
   let to_yojson () = `String N.name
   let arbitrary () = QCheck.unit
-  let relift x = x
 end
 module Unit = UnitConf (struct let name = "()" end)
 
@@ -488,7 +489,7 @@ end
 module Chain (P: ChainParams): S with type t = int =
 struct
   type t = int [@@deriving eq, ord, hash]
-  include Std
+  include StdLeaf
   let name () = "chain"
 
   let show x = P.names x
@@ -497,7 +498,6 @@ struct
   let to_yojson x = `String (P.names x)
 
   let arbitrary () = QCheck.int_range 0 (P.n () - 1)
-  let relift x = x
 end
 
 module LiftBot (Base : S) =
@@ -578,12 +578,11 @@ end
 module Strings =
 struct
   type t = string [@@deriving eq, ord, hash, to_yojson]
-  include Std
+  include StdLeaf
   let pretty () n = text n
   let show n = n
   let name () = "String"
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" x
-  let relift x = x
 end
 
 
@@ -643,7 +642,7 @@ let get_short_list begin_str end_str list =
 
 module Yojson =
 struct
-  include Std
+  include StdLeaf
   type t = Yojson.Safe.t [@@deriving eq]
   let name () = "yojson"
 
@@ -660,5 +659,4 @@ struct
     )
 
   let to_yojson x = x (* override SimplePretty *)
-  let relift x = x
 end

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -58,7 +58,7 @@ struct
 
   let tag _ = failwith "Std: no tag"
   let arbitrary () = failwith "no arbitrary"
-  let relift x = x
+  let relift x = failwith "Std: no relift"
 end
 
 module Blank =
@@ -137,14 +137,26 @@ struct
   let unlift x = x.BatHashcons.obj
   let lift = HC.hashcons htable
   let lift_f f (x:Base.t BatHashcons.hobj) = f (x.BatHashcons.obj)
-  let relift x = let y = Base.relift x.BatHashcons.obj in HC.hashcons htable y
+  let pretty () x = Pretty.dprintf "%a[%d,%d]" Base.pretty x.BatHashcons.obj x.BatHashcons.tag x.BatHashcons.hcode
+  let show x = (Base.show x.BatHashcons.obj) ^ "[" ^ string_of_int x.BatHashcons.tag ^ "," ^ string_of_int x.BatHashcons.hcode ^ "]"
+  let indent = ref 0
+  let relift x =
+    ignore (Pretty.eprintf "%srelifting %a\n" (String.make !indent '.') pretty x);
+    incr indent;
+    let y = Base.relift x.BatHashcons.obj in
+    decr indent;
+    let x' = HC.hashcons htable y in
+    (* ignore (Pretty.eprintf "relift %a\nas %a\n" pretty x pretty x'); *)
+    ignore (Pretty.eprintf "%srelifted %a\n" (String.make !indent '.') pretty x');
+    x'
+  (* let relift x = relift (relift x) *)
   let name () = "HConsed "^Base.name ()
   let hash x = x.BatHashcons.hcode
   let tag x = x.BatHashcons.tag
   let compare x y =  Stdlib.compare x.BatHashcons.tag y.BatHashcons.tag
-  let show = lift_f Base.show
+  (* let show = lift_f Base.show *)
   let to_yojson = lift_f (Base.to_yojson)
-  let pretty () = lift_f (Base.pretty ())
+  (* let pretty () = lift_f (Base.pretty ()) *)
   let printXml f x = Base.printXml f x.BatHashcons.obj
 
   let equal_debug x y = (* This debug version checks if we call hashcons enough to have up-to-date tags. Comment out the equal below to use this. This will be even slower than with hashcons disabled! *)
@@ -385,7 +397,12 @@ struct
 
   let arbitrary () = QCheck.pair (Base1.arbitrary ()) (Base2.arbitrary ())
 
-  let relift (x,y) = (Base1.relift x, Base2.relift y)
+  let relift (x,y) =
+    ignore (Pretty.eprintf "prod relift fst: %s\n" (Base1.name ()));
+    let x' = Base1.relift x in
+    ignore (Pretty.eprintf "prod relift snd: %s\n" (Base2.name ()));
+    let y' = Base2.relift y in
+    (x', y')
 end
 
 module Prod = ProdConf (struct let expand_fst = true let expand_snd = true end)

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -67,15 +67,6 @@ struct
   let relift x = x
 end
 
-module Blank =
-struct
-  include Std
-  let pretty () _ = text "Output not supported"
-  let show _ = "Output not supported"
-  let name () = "blank"
-  let printXml f _ = BatPrintf.fprintf f "<value>\n<data>\nOutput not supported!\n</data>\n</value>\n"
-end
-
 
 module type Showable =
 sig

--- a/src/domains/setDomain.ml
+++ b/src/domains/setDomain.ml
@@ -160,7 +160,7 @@ module Make (Base: Printable.S): S with
   type elt = Base.t and
   type t = BatSet.Make (Base).t = (* TODO: remove, only needed in VarEq for some reason... *)
 struct
-  include Printable.Blank
+  include Printable.Std
   include BatSet.Make(Base)
   let name () = "Set (" ^ Base.name () ^ ")"
   let empty _ = empty

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -34,7 +34,7 @@ end
 module Var =
 struct
   type t = Node.t [@@deriving eq, ord, hash]
-  let relift x = x
+  let relift = Node.relift
 
   let printXml f n =
     let l = Node.location n in

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1762,6 +1762,7 @@ struct
   struct
     include Printable.Std
     include Var
+    let name () = "var"
 
     let pretty = pretty_trace
     include Printable.SimplePretty (

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -70,3 +70,5 @@ let of_id s =
     | "ret" -> Function fundec
     | "fun" -> FunctionEntry fundec
     | _     -> raise Not_found
+
+let relift x = x

--- a/src/framework/node.ml
+++ b/src/framework/node.ml
@@ -1,7 +1,7 @@
 open GoblintCil
 open Pretty
 
-include Printable.Std
+include Printable.StdLeaf
 
 include Node0
 
@@ -70,5 +70,3 @@ let of_id s =
     | "ret" -> Function fundec
     | "fun" -> FunctionEntry fundec
     | _     -> raise Not_found
-
-let relift x = x

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -10,6 +10,7 @@ end
 module Std =
 struct
   include Printable.Std
+  let relift x = x
 end
 
 let hash_float = Hashtbl.hash (* TODO: float hash in ppx_deriving_hash *)

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -9,8 +9,7 @@ end
 
 module Std =
 struct
-  include Printable.Std
-  let relift x = x
+  include Printable.StdLeaf
 end
 
 let hash_float = Hashtbl.hash (* TODO: float hash in ppx_deriving_hash *)

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -96,6 +96,8 @@ struct
     end
     )
     (* TODO: deriving to_yojson gets overridden by SimplePretty *)
+
+  let relift x = x
 end
 
 module InlineEdge: Edge with type t = inline_edge =

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -83,7 +83,7 @@ let inline_edge_to_yojson = function
 
 module InlineEdgePrintable: Printable.S with type t = inline_edge =
 struct
-  include Printable.Std
+  include Printable.StdLeaf
   type t = inline_edge [@@deriving eq, ord, hash, to_yojson]
 
   let name () = "inline edge"
@@ -96,8 +96,6 @@ struct
     end
     )
     (* TODO: deriving to_yojson gets overridden by SimplePretty *)
-
-  let relift x = x
 end
 
 module InlineEdge: Edge with type t = inline_edge =

--- a/unittest/maindomaintest.ml
+++ b/unittest/maindomaintest.ml
@@ -15,6 +15,7 @@ struct
     let show = show
   end
   include Printable.SimpleShow (P)
+  let relift x = x
 end
 
 module ArbitraryLattice = SetDomain.FiniteSet (PrintableChar) (

--- a/unittest/maindomaintest.ml
+++ b/unittest/maindomaintest.ml
@@ -4,7 +4,7 @@ open GoblintCil
 
 module PrintableChar =
 struct
-  include Printable.Std
+  include Printable.StdLeaf
   type t = char [@@deriving eq, ord, hash, to_yojson]
   let name () = "char"
   let show x = String.make 1 x
@@ -15,7 +15,6 @@ struct
     let show = show
   end
   include Printable.SimpleShow (P)
-  let relift x = x
 end
 
 module ArbitraryLattice = SetDomain.FiniteSet (PrintableChar) (


### PR DESCRIPTION
Besides just fixing the necessary, this does broader cleanup with the hope to avoid similar issues again.

### Changes
1. Remove identity `Printable.Std.relift` which hides missing definitions.
2. Add all missing `relift` definitions. Some rather core types like `MapDomain` were not relifting their inner components.
3. Introduce `Printable.StdLeaf` as `Printable.Std` alternative with identity `relift`. This is only to be used with primitive and CIL types which don't contain inner types that could require relifting.
4. Remove default `Printable.Std.name`, which names everything "std". This makes debugging such issues a total pain, e.g. "lifted std and either std or std option" is completely ineligible. All printables must specify a name explicitly.
5. Add all missing `name` definitions. 

### TODO
- [x] Readd `relift`s for all other marshaling tests.