### PR TITLE
Fix 00-sanity/35-join-contexts by syncing at function entry

### DIFF
--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -523,9 +523,11 @@ struct
      2. fundec -> set of S.C  --  used for IterSysVars Node *)
 
   let sync ctx =
-    match Cfg.prev ctx.prev_node with
-    | _ :: _ :: _ -> S.sync ctx `Join
-    | _ -> S.sync ctx `Normal
+    match ctx.prev_node, Cfg.prev ctx.prev_node with
+    | _, _ :: _ :: _ (* Join in CFG. *)
+    | FunctionEntry _, _ -> (* Function entry, also needs sync because partial contexts joined by solver, see 00-sanity/35-join-contexts. *)
+      S.sync ctx `Join
+    | _, _ -> S.sync ctx `Normal
 
   let side_context sideg f c =
     if !GU.postsolving then

--- a/tests/regression/00-sanity/35-join-contexts.c
+++ b/tests/regression/00-sanity/35-join-contexts.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.ctx_insens[+] threadflag --set ana.ctx_insens[+] threadid --set ana.ctx_insens[+] base
+// PARAM: --set ana.ctx_insens[+] threadflag --set ana.ctx_insens[+] threadid --set ana.ctx_insens[+] base
 // Fully context-insensitive
 #include <goblint.h>
 #include <pthread.h>
@@ -9,9 +9,9 @@ void foo() {
   // Single-threaded: g = 1 in local state
   // Multi-threaded: g = 2 in global unprotected invariant
   // Joined contexts: g is unprotected, so read g = 2 from global unprotected invariant (only)
-  // Currently unsoundly claim that check will succeed!
+  // Was soundly claiming that check will succeed!
   int x = g;
-  __goblint_check(x == 2); // TODO UNKNOWN!
+  __goblint_check(x == 2); // UNKNOWN!
 }
 
 void *t_fun(void *arg) {


### PR DESCRIPTION
This is code-wise a tiny fix, but relatively important, so it's good to have a PR rather than quietly committing to master.

Side effects to function entry nodes are joined by the solver, but simply using joined values is unsound as the example also demonstrated. This inserts a `sync Join` also at the entry node, to be performed before the `body` transfer function is called. This way, whatever is joined is "made sound" for subsequent use.

This happens during solving in the `body` transfer function evaluation, so all new side effects from the sync are correctly handled for. A similar fix wouldn't work for join-over-all-contexts after the analysis, since new side effects may (and do) arise.