### PR TITLE
Refactor to Remove Dependency of `ValueDomain` on `Queries`

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -465,7 +465,7 @@ struct
       let f_addr (x, offs) =
         (* get hold of the variable value, either from local or global state *)
         let var = get_var a gs st x in
-        let v = VD.eval_offset a (fun x -> get a gs st x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
+        let v = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get a gs st x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
         if M.tracing then M.tracec "get" "var = %a, %a = %a\n" VD.pretty var AD.pretty (AD.from_var_offset (x, offs)) VD.pretty v;
         if full then v else match v with
           | `Blob (c,s,_) -> c
@@ -528,7 +528,7 @@ struct
     | `Union (f,e) -> reachable_from_value ask gs st e t description
     (* For arrays, we ask to read from an unknown index, this will cause it
      * join all its values. *)
-    | `Array a -> reachable_from_value ask gs st (ValueDomain.CArrays.get ask a (None, ValueDomain.ArrIdxDomain.top ())) t description
+    | `Array a -> reachable_from_value ask gs st (ValueDomain.CArrays.get (Queries.to_value_domain_ask ask) a (None, ValueDomain.ArrIdxDomain.top ())) t description
     | `Blob (e,_,_) -> reachable_from_value ask gs st e t description
     | `Struct s -> ValueDomain.Structs.fold (fun k v acc -> AD.join (reachable_from_value ask gs st v t description) acc) s empty
     | `Int _ -> empty
@@ -665,7 +665,7 @@ struct
         | `Address adrs when AD.is_top adrs -> (empty,TS.bot (), true)
         | `Address adrs -> (adrs,TS.bot (), AD.has_unknown adrs)
         | `Union (t,e) -> with_field (reachable_from_value e) t
-        | `Array a -> reachable_from_value (ValueDomain.CArrays.get (Analyses.ask_of_ctx ctx) a (None, ValueDomain.ArrIdxDomain.top ()))
+        | `Array a -> reachable_from_value (ValueDomain.CArrays.get (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) a (None, ValueDomain.ArrIdxDomain.top ()))
         | `Blob (e,_,_) -> reachable_from_value e
         | `Struct s ->
           let join_tr (a1,t1,_) (a2,t2,_) = AD.join a1 a2, TS.join t1 t2, false in
@@ -977,7 +977,7 @@ struct
         in
         let v' = VD.cast t v in (* cast to the expected type (the abstract type might be something other than t since we don't change addresses upon casts!) *)
         if M.tracing then M.tracel "cast" "Ptr-Deref: cast %a to %a = %a!\n" VD.pretty v d_type t VD.pretty v';
-        let v' = VD.eval_offset a (fun x -> get a gs st x (Some exp)) v' (convert_offset a gs st ofs) (Some exp) None t in (* handle offset *)
+        let v' = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get a gs st x (Some exp)) v' (convert_offset a gs st ofs) (Some exp) None t in (* handle offset *)
         let v' = do_offs v' ofs in (* handle blessed fields? *)
         v'
       in
@@ -1441,8 +1441,8 @@ struct
       in
       let update_offset old_value =
         (* Projection globals to highest Precision *)
-        let projected_value = project_val a None None value (is_global a x) in
-        let new_value = VD.update_offset a old_value offs projected_value lval_raw ((Var x), cil_offset) t in
+        let projected_value = project_val (Queries.to_value_domain_ask a) None None value (is_global a x) in
+        let new_value = VD.update_offset (Queries.to_value_domain_ask a) old_value offs projected_value lval_raw ((Var x), cil_offset) t in
         if WeakUpdates.mem x st.weak then
           VD.join old_value new_value
         else if invariant then
@@ -1513,10 +1513,10 @@ struct
                 | Some (Lval(Var l',NoOffset)), Some r' ->
                   begin
                     let moved_by = movement_for_expr l' r' in
-                    VD.affect_move a v x moved_by
+                    VD.affect_move (Queries.to_value_domain_ask a) v x moved_by
                   end
                 | _  ->
-                  VD.affect_move a v x (fun x -> None)
+                  VD.affect_move (Queries.to_value_domain_ask a) v x (fun x -> None)
               else
                 let patched_ask =
                   (* The usual recursion trick for ctx. *)
@@ -1540,7 +1540,7 @@ struct
                 in
                 let moved_by = fun x -> Some 0 in (* this is ok, the information is not provided if it *)
                 (* TODO: why does affect_move need general ask (of any query) instead of eval_exp? *)
-                VD.affect_move patched_ask v x moved_by     (* was a set call caused e.g. by a guard *)
+                VD.affect_move (Queries.to_value_domain_ask patched_ask) v x moved_by     (* was a set call caused e.g. by a guard *)
             in
             { st with cpa = update_variable arr arr.vtype nval st.cpa }
           in
@@ -1735,7 +1735,7 @@ struct
               let t = v.vtype in
               let iv = VD.bot_value ~varAttr:v.vattr t in (* correct bottom value for top level variable *)
               if M.tracing then M.tracel "set" "init bot value: %a\n" VD.pretty iv;
-              let nv = VD.update_offset (Analyses.ask_of_ctx ctx) iv offs rval_val (Some  (Lval lval)) lval t in (* do desired update to value *)
+              let nv = VD.update_offset (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) iv offs rval_val (Some  (Lval lval)) lval t in (* do desired update to value *)
               set_savetop ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local (AD.from_var v) lval_t nv ~lval_raw:lval ~rval_raw:rval (* set top-level variable to updated value *)
             | None ->
               set_savetop ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local lval_val lval_t rval_val ~lval_raw:lval ~rval_raw:rval
@@ -1812,7 +1812,7 @@ struct
       Priv.enter_multithreaded (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st
     | _ ->
       let locals = List.filter (fun v -> not (WeakUpdates.mem v st.weak)) (fundec.sformals @ fundec.slocals) in
-      let nst_part = rem_many_partitioning (Analyses.ask_of_ctx ctx) ctx.local locals in
+      let nst_part = rem_many_partitioning (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) ctx.local locals in
       let nst: store = rem_many (Analyses.ask_of_ctx ctx) nst_part locals in
       match exp with
       | None -> nst
@@ -1872,7 +1872,7 @@ struct
     let invalidate_address st a =
       let t = AD.get_type a in
       let v = get ask gs st a None in (* None here is ok, just causes us to be a bit less precise *)
-      let nv =  VD.invalidate_value ask t v in
+      let nv =  VD.invalidate_value (Queries.to_value_domain_ask ask) t v in
       (a, t, nv)
     in
     (* We define the function that invalidates all the values that an address
@@ -1928,7 +1928,7 @@ struct
 
     (* Projection to Precision of the Callee *)
     let p = PU.int_precision_from_fundec fundec in
-    let new_cpa = project (Analyses.ask_of_ctx ctx) (Some p) new_cpa fundec in
+    let new_cpa = project (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) (Some p) new_cpa fundec in
 
     (* Identify locals of this fundec for which an outer copy (from a call down the callstack) is reachable *)
     let reachable_other_copies = List.filter (fun v -> match Cilfacade.find_scope_fundec v with Some scope -> CilType.Fundec.equal scope fundec | None -> false) reachable in
@@ -2376,7 +2376,7 @@ struct
         | Some n -> Node.find_fundec n
         | None -> failwith "callerfundec not found"
       in
-      let cpa' = project (Analyses.ask_of_ctx ctx) (Some p) nst.cpa callerFundec in
+      let cpa' = project (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) (Some p) nst.cpa callerFundec in
 
       if get_bool "sem.noreturn.dead_code" && Cil.hasAttribute "noreturn" f.svar.vattr then raise Deadcode;
 
@@ -2399,7 +2399,7 @@ struct
         | Some n -> Node.find_fundec n
         | None -> failwith "callerfundec not found"
       in
-      let return_val = project_val (Analyses.ask_of_ctx ctx) (attributes_varinfo (return_varinfo ()) callerFundec) (Some p) return_val (is_privglob (return_varinfo ())) in
+      let return_val = project_val (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) (attributes_varinfo (return_varinfo ()) callerFundec) (Some p) return_val (is_privglob (return_varinfo ())) in
 
       match lval with
       | None      -> st

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -101,7 +101,7 @@ struct
       let oldv = get_var a gs st var in
       let oldv = map_oldval oldv var.vtype in
       let offs = convert_offset a gs st o in
-      let newv = VD.update_offset a oldv offs c' (Some exp) x (var.vtype) in
+      let newv = VD.update_offset (Queries.to_value_domain_ask a) oldv offs c' (Some exp) x (var.vtype) in
       let v = VD.meet oldv newv in
       if is_some_bot v then contra st
       else (

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -6,6 +6,7 @@ open FlagHelper
 module M = Messages
 module A = Array
 module BI = IntOps.BigIntOps
+module VDQ = ValueDomainQueries
 
 type domain = TrivialDomain | PartitionedDomain | UnrolledDomain
 
@@ -46,12 +47,12 @@ sig
 
   val domain_of_t: t -> domain
 
-  val get: ?checkBounds:bool -> ValueDomainQueries.t -> t -> Basetype.CilExp.t option * idx -> value
-  val set: ValueDomainQueries.t -> t -> Basetype.CilExp.t option * idx -> value -> t
+  val get: ?checkBounds:bool -> VDQ.t -> t -> Basetype.CilExp.t option * idx -> value
+  val set: VDQ.t -> t -> Basetype.CilExp.t option * idx -> value -> t
   val make: ?varAttr:attributes -> ?typAttr:attributes -> idx -> value -> t
   val length: t -> idx option
 
-  val move_if_affected: ?replace_with_const:bool -> ValueDomainQueries.t -> t -> Cil.varinfo -> (Cil.exp -> int option) -> t
+  val move_if_affected: ?replace_with_const:bool -> VDQ.t -> t -> Cil.varinfo -> (Cil.exp -> int option) -> t
   val get_vars_in_e: t -> Cil.varinfo list
   val map: (value -> value) -> t -> t
   val fold_left: ('a -> value -> 'a) -> 'a -> t -> 'a
@@ -59,7 +60,7 @@ sig
   val smart_widen: (exp -> BI.t option) -> (exp -> BI.t option) -> t -> t -> t
   val smart_leq: (exp -> BI.t option) -> (exp -> BI.t option) -> t -> t -> bool
   val update_length: idx -> t -> t
-  val project: ?varAttr:attributes -> ?typAttr:attributes -> ValueDomainQueries.t -> t -> t
+  val project: ?varAttr:attributes -> ?typAttr:attributes -> VDQ.t -> t -> t
 end
 
 module type LatticeWithSmartOps =
@@ -83,8 +84,8 @@ struct
   let show x = "Array: " ^ Val.show x
   let pretty () x = text "Array: " ++ pretty () x
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
-  let get ?(checkBounds=true) (ask: ValueDomainQueries.t) a i = a
-  let set (ask: ValueDomainQueries.t) a i v = join a v
+  let get ?(checkBounds=true) (ask: VDQ.t) a i = a
+  let set (ask: VDQ.t) a i v = join a v
   let make ?(varAttr=[]) ?(typAttr=[])  i v = v
   let length _ = None
 
@@ -130,7 +131,7 @@ struct
   let extract x default = match x with
     | Some c -> c
     | None -> default
-  let get ?(checkBounds=true)  (ask: ValueDomainQueries.t) (xl, xr) (_,i) =
+  let get ?(checkBounds=true)  (ask: VDQ.t) (xl, xr) (_,i) =
     let search_unrolled_values min_i max_i =
       let rec subjoin l i = match l with
         | [] -> Val.bot ()
@@ -148,7 +149,7 @@ struct
     if Z.geq min_i f then xr
     else if Z.lt max_i f then search_unrolled_values min_i max_i
     else Val.join xr (search_unrolled_values min_i (Z.of_int ((factor ())-1)))
-  let set (ask: ValueDomainQueries.t) (xl,xr) (_,i) v =
+  let set (ask: VDQ.t) (xl,xr) (_,i) v =
     let update_unrolled_values min_i max_i =
       let rec weak_update l i = match l with
         | [] -> []
@@ -194,11 +195,11 @@ end
 module type SPartitioned =
 sig
   include S
-  val set_with_length: idx option -> ValueDomainQueries.t -> t -> Basetype.CilExp.t option * idx -> value -> t
+  val set_with_length: idx option -> VDQ.t -> t -> Basetype.CilExp.t option * idx -> value -> t
   val smart_join_with_length: idx option -> (exp -> BI.t option) -> (exp -> BI.t option) -> t -> t -> t
   val smart_widen_with_length: idx option -> (exp -> BI.t option) -> (exp -> BI.t option)  -> t -> t-> t
   val smart_leq_with_length: idx option -> (exp -> BI.t option) -> (exp -> BI.t option) -> t -> t -> bool
-  val move_if_affected_with_length: ?replace_with_const:bool -> idx option -> ValueDomainQueries.t -> t -> Cil.varinfo -> (Cil.exp -> int option) -> t
+  val move_if_affected_with_length: ?replace_with_const:bool -> idx option -> VDQ.t -> t -> Cil.varinfo -> (Cil.exp -> int option) -> t
 end
 
 module Partitioned (Val: LatticeWithSmartOps) (Idx:IntDomain.Z): SPartitioned with type value = Val.t and type idx = Idx.t =
@@ -290,21 +291,21 @@ struct
                ("m", Val.to_yojson xm);
                ("r", Val.to_yojson xr) ]
 
-  let get ?(checkBounds=true) (ask:ValueDomainQueries.t) (x:t) (i,_) =
+  let get ?(checkBounds=true) (ask:VDQ.t) (x:t) (i,_) =
     match x, i with
     | Joint v, _ -> v
     | Partitioned (e, (xl, xm, xr)), Some i' ->
       begin
-        if ValueDomainQueries.must_be_equal ask.eval_int e i' then xm
+        if VDQ.must_be_equal ask.eval_int e i' then xm
         else
           begin
-            let contributionLess = match ValueDomainQueries.may_be_less ask.eval_int i' e with        (* (may i < e) ? xl : bot *)
+            let contributionLess = match VDQ.may_be_less ask.eval_int i' e with        (* (may i < e) ? xl : bot *)
               | false -> Val.bot ()
               | _ -> xl in
-            let contributionEqual = match ValueDomainQueries.may_be_equal ask.eval_int i' e with      (* (may i = e) ? xm : bot *)
+            let contributionEqual = match VDQ.may_be_equal ask.eval_int i' e with      (* (may i = e) ? xm : bot *)
               | false -> Val.bot ()
               | _ -> xm in
-            let contributionGreater =  match ValueDomainQueries.may_be_less ask.eval_int e i' with    (* (may i > e) ? xr : bot *)
+            let contributionGreater =  match VDQ.may_be_less ask.eval_int e i' with    (* (may i > e) ? xr : bot *)
               | false -> Val.bot ()
               | _ -> xr in
             Val.join (Val.join contributionLess contributionEqual) contributionGreater
@@ -357,7 +358,7 @@ struct
     | Joint x -> f a x
     | Partitioned (_, (xl,xm,xr)) -> f (f (f a xl) xm) xr
 
-  let move_if_affected_with_length ?(replace_with_const=false) length (ask:ValueDomainQueries.t) x (v:varinfo) (movement_for_exp: exp -> int option) =
+  let move_if_affected_with_length ?(replace_with_const=false) length (ask:VDQ.t) x (v:varinfo) (movement_for_exp: exp -> int option) =
     normalize @@
     let move (i:int option) (e, (xl,xm, xr)) =
       match i with
@@ -377,7 +378,7 @@ struct
           let default = Joint nval in
           if replace_with_const then
             let n = ask.eval_int e in
-            match ValueDomainQueries.ID.to_int n with
+            match VDQ.ID.to_int n with
             | Some i ->
               Partitioned ((Cil.kintegerCilint (Cilfacade.ptrdiff_ikind ()) i), (xl, xm, xr))
             | _ -> default
@@ -399,14 +400,14 @@ struct
               begin
                 match Idx.to_int l with
                 | Some i ->
-                  let b = ValueDomainQueries.may_be_less ask.eval_int e (Cil.kintegerCilint (Cilfacade.ptrdiff_ikind ()) i) in
+                  let b = VDQ.may_be_less ask.eval_int e (Cil.kintegerCilint (Cilfacade.ptrdiff_ikind ()) i) in
                   not b (* !(e <_{may} length) => e >=_{must} length *)
                 | None -> false
               end
             | _ -> false
           in
           let e_must_less_zero =
-            ValueDomainQueries.eval_int_binop (module BoolDomain.MustBool) Lt ask.eval_int e Cil.zero (* TODO: untested *)
+            VDQ.eval_int_binop (module BoolDomain.MustBool) Lt ask.eval_int e Cil.zero (* TODO: untested *)
           in
           if e_must_bigger_max_index then
             (* Entire array is covered by left part, dropping partitioning. *)
@@ -422,7 +423,7 @@ struct
 
   let move_if_affected ?replace_with_const = move_if_affected_with_length ?replace_with_const None
 
-  let set_with_length length (ask:ValueDomainQueries.t) x (i,_) a =
+  let set_with_length length (ask:VDQ.t) x (i,_) a =
     if M.tracing then M.trace "update_offset" "part array set_with_length %a %s %a\n" pretty x (BatOption.map_default Basetype.CilExp.show "None" i) Val.pretty a;
     if i = Some MyCFG.all_array_index_exp then
       (assert !Goblintutil.global_initialization; (* just joining with xm here assumes that all values will be set, which is guaranteed during inits *)
@@ -435,7 +436,7 @@ struct
       let use_last = get_string "ana.base.partition-arrays.keep-expr" = "last" in
       let exp_value e =
         let n = ask.eval_int e in
-        Option.map BI.of_bigint (ValueDomainQueries.ID.to_int n)
+        Option.map BI.of_bigint (VDQ.ID.to_int n)
       in
       let equals_zero e = BatOption.map_default (BI.equal BI.zero) false (exp_value e) in
       let equals_maxIndex e =
@@ -459,20 +460,20 @@ struct
          | _ -> Joint (Val.join v a)
         )
       | Partitioned (e, (xl, xm, xr)) ->
-        let isEqual = ValueDomainQueries.must_be_equal ask.eval_int in
+        let isEqual = VDQ.must_be_equal ask.eval_int in
         match i with
         | Some i' when not use_last || not_allowed_for_part i' -> begin
             let default =
               let left =
-                match ValueDomainQueries.may_be_less ask.eval_int i' e with     (* (may i < e) ? xl : bot *) (* TODO: untested *)
+                match VDQ.may_be_less ask.eval_int i' e with     (* (may i < e) ? xl : bot *) (* TODO: untested *)
                 | false -> xl
                 | _ -> lubIfNotBot xl in
               let middle =
-                match ValueDomainQueries.may_be_equal ask.eval_int i' e with    (* (may i = e) ? xm : bot *)
+                match VDQ.may_be_equal ask.eval_int i' e with    (* (may i = e) ? xm : bot *)
                 | false -> xm
                 | _ -> Val.join xm a in
               let right =
-                match ValueDomainQueries.may_be_less ask.eval_int e i' with     (* (may i > e) ? xr : bot *) (* TODO: untested *)
+                match VDQ.may_be_less ask.eval_int e i' with     (* (may i > e) ? xr : bot *) (* TODO: untested *)
                 | false -> xr
                 | _ -> lubIfNotBot xr in
               Partitioned (e, (left, middle, right))
@@ -500,35 +501,35 @@ struct
             Partitioned (e, (xl, a, xr))
           else
             let left = if equals_zero i' then Val.bot () else Val.join xl @@ Val.join
-                  (match ValueDomainQueries.may_be_equal ask.eval_int e i' with (* TODO: untested *)
+                  (match VDQ.may_be_equal ask.eval_int e i' with (* TODO: untested *)
                    | false -> Val.bot()
                    | _ -> xm) (* if e' may be equal to i', but e' may not be smaller than i' then we only need xm *)
                   (
                     let t = Cilfacade.typeOf e in
                     let ik = Cilfacade.get_ikind t in
-                    match ValueDomainQueries.must_be_equal ask.eval_int (BinOp(PlusA, e, Cil.kinteger ik 1, t)) i' with
+                    match VDQ.must_be_equal ask.eval_int (BinOp(PlusA, e, Cil.kinteger ik 1, t)) i' with
                     | true -> xm
                     | _ ->
                       begin
-                        match ValueDomainQueries.may_be_less ask.eval_int e i' with (* TODO: untested *)
+                        match VDQ.may_be_less ask.eval_int e i' with (* TODO: untested *)
                         | false-> Val.bot()
                         | _ -> Val.join xm xr (* if e' may be less than i' then we also need xm for sure *)
                       end
                   )
             in
             let right = if equals_maxIndex i' then Val.bot () else  Val.join xr @@  Val.join
-                  (match ValueDomainQueries.may_be_equal ask.eval_int e i' with (* TODO: untested *)
+                  (match VDQ.may_be_equal ask.eval_int e i' with (* TODO: untested *)
                    | false -> Val.bot()
                    | _ -> xm)
 
                   (
                     let t = Cilfacade.typeOf e in
                     let ik = Cilfacade.get_ikind t in
-                    match ValueDomainQueries.must_be_equal ask.eval_int (BinOp(PlusA, e, Cil.kinteger ik (-1), t)) i' with (* TODO: untested *)
+                    match VDQ.must_be_equal ask.eval_int (BinOp(PlusA, e, Cil.kinteger ik (-1), t)) i' with (* TODO: untested *)
                     | true -> xm
                     | _ ->
                       begin
-                        match ValueDomainQueries.may_be_less ask.eval_int i' e with (* TODO: untested *)
+                        match VDQ.may_be_less ask.eval_int i' e with (* TODO: untested *)
                         | false -> Val.bot()
                         | _ -> Val.join xl xm (* if e' may be less than i' then we also need xm for sure *)
                       end
@@ -733,10 +734,10 @@ struct
 
   let domain_of_t _ = TrivialDomain
 
-  let get ?(checkBounds=true) (ask : ValueDomainQueries.t) (x, (l : idx)) (e, v) =
+  let get ?(checkBounds=true) (ask : VDQ.t) (x, (l : idx)) (e, v) =
     if checkBounds then (array_oob_check (module Idx) (x, l) (e, v));
     Base.get ask x (e, v)
-  let set (ask: ValueDomainQueries.t) (x,l) i v = Base.set ask x i v, l
+  let set (ask: VDQ.t) (x,l) i v = Base.set ask x i v, l
   let make ?(varAttr=[]) ?(typAttr=[])  l x = Base.make l x, l
   let length (_,l) = Some l
   let move_if_affected ?(replace_with_const=false) _ x _ _ = x
@@ -774,7 +775,7 @@ struct
 
   let domain_of_t _ = PartitionedDomain
 
-  let get ?(checkBounds=true) (ask : ValueDomainQueries.t) (x, (l : idx)) (e, v) =
+  let get ?(checkBounds=true) (ask : VDQ.t) (x, (l : idx)) (e, v) =
     if checkBounds then (array_oob_check (module Idx) (x, l) (e, v));
     Base.get ask x (e, v)
   let set ask (x,l) i v = Base.set_with_length (Some l) ask x i v, l
@@ -825,10 +826,10 @@ struct
 
   let domain_of_t _ = UnrolledDomain
 
-  let get ?(checkBounds=true) (ask : ValueDomainQueries.t) (x, (l : idx)) (e, v) =
+  let get ?(checkBounds=true) (ask : VDQ.t) (x, (l : idx)) (e, v) =
     if checkBounds then (array_oob_check (module Idx) (x, l) (e, v));
     Base.get ask x (e, v)
-  let set (ask: ValueDomainQueries.t) (x,l) i v = Base.set ask x i v, l
+  let set (ask: VDQ.t) (x,l) i v = Base.set ask x i v, l
   let make ?(varAttr=[]) ?(typAttr=[]) l x = Base.make l x, l
   let length (_,l) = Some l
 
@@ -899,12 +900,12 @@ struct
       else
         P.get ~checkBounds a x (e, i)
     ) (fun x -> T.get ~checkBounds a x (e,i)) (fun x -> U.get ~checkBounds a x (e,i)) x
-  let set (ask:ValueDomainQueries.t) x i a = unop_to_t' (fun x -> P.set ask x i a) (fun x -> T.set ask x i a) (fun x -> U.set ask x i a) x
+  let set (ask:VDQ.t) x i a = unop_to_t' (fun x -> P.set ask x i a) (fun x -> T.set ask x i a) (fun x -> U.set ask x i a) x
   let length = unop' P.length T.length U.length
   let map f = unop_to_t' (P.map f) (T.map f) (U.map f)
   let fold_left f s = unop' (P.fold_left f s) (T.fold_left f s) (U.fold_left f s)
 
-  let move_if_affected ?(replace_with_const=false) (ask:ValueDomainQueries.t) x v f = unop_to_t' (fun x -> P.move_if_affected ~replace_with_const:replace_with_const ask x v f) (fun x -> T.move_if_affected ~replace_with_const:replace_with_const ask x v f) (fun x -> U.move_if_affected ~replace_with_const:replace_with_const ask x v f) x
+  let move_if_affected ?(replace_with_const=false) (ask:VDQ.t) x v f = unop_to_t' (fun x -> P.move_if_affected ~replace_with_const:replace_with_const ask x v f) (fun x -> T.move_if_affected ~replace_with_const:replace_with_const ask x v f) (fun x -> U.move_if_affected ~replace_with_const:replace_with_const ask x v f) x
   let get_vars_in_e = unop' P.get_vars_in_e T.get_vars_in_e U.get_vars_in_e
   let smart_join f g = binop_to_t' (P.smart_join f g) (T.smart_join f g) (U.smart_join f g)
   let smart_widen f g =  binop_to_t' (P.smart_widen f g) (T.smart_widen f g) (U.smart_widen f g)

--- a/src/cdomains/arrayDomain.mli
+++ b/src/cdomains/arrayDomain.mli
@@ -1,5 +1,6 @@
 open IntOps
 open GoblintCil
+module VDQ = ValueDomainQueries
 
 type domain = TrivialDomain | PartitionedDomain | UnrolledDomain
 
@@ -22,10 +23,10 @@ sig
   val domain_of_t: t -> domain
   (* Returns the domain used for the array*)
 
-  val get: ?checkBounds:bool -> ValueDomainQueries.t -> t -> Basetype.CilExp.t option * idx -> value
+  val get: ?checkBounds:bool -> VDQ.t -> t -> Basetype.CilExp.t option * idx -> value
   (** Returns the element residing at the given index. *)
 
-  val set: ValueDomainQueries.t -> t -> Basetype.CilExp.t option * idx -> value -> t
+  val set: VDQ.t -> t -> Basetype.CilExp.t option * idx -> value -> t
   (** Returns a new abstract value, where the given index is replaced with the
     * given element. *)
 
@@ -36,7 +37,7 @@ sig
   val length: t -> idx option
   (** returns length of array if known *)
 
-  val move_if_affected: ?replace_with_const:bool -> ValueDomainQueries.t -> t -> Cil.varinfo -> (Cil.exp -> int option) -> t
+  val move_if_affected: ?replace_with_const:bool -> VDQ.t -> t -> Cil.varinfo -> (Cil.exp -> int option) -> t
   (** changes the way in which the array is partitioned if this is necessitated by a change
     * to the variable **)
 
@@ -55,7 +56,7 @@ sig
   val smart_leq: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t  -> bool
   val update_length: idx -> t -> t
 
-  val project: ?varAttr:Cil.attributes -> ?typAttr:Cil.attributes -> ValueDomainQueries.t -> t -> t
+  val project: ?varAttr:Cil.attributes -> ?typAttr:Cil.attributes -> VDQ.t -> t -> t
 end
 
 module type LatticeWithSmartOps =

--- a/src/cdomains/arrayDomain.mli
+++ b/src/cdomains/arrayDomain.mli
@@ -22,10 +22,10 @@ sig
   val domain_of_t: t -> domain
   (* Returns the domain used for the array*)
 
-  val get: ?checkBounds:bool -> Queries.ask -> t -> Basetype.CilExp.t option * idx -> value
+  val get: ?checkBounds:bool -> ValueDomainQueries.t -> t -> Basetype.CilExp.t option * idx -> value
   (** Returns the element residing at the given index. *)
 
-  val set: Queries.ask -> t -> Basetype.CilExp.t option * idx -> value -> t
+  val set: ValueDomainQueries.t -> t -> Basetype.CilExp.t option * idx -> value -> t
   (** Returns a new abstract value, where the given index is replaced with the
     * given element. *)
 
@@ -36,7 +36,7 @@ sig
   val length: t -> idx option
   (** returns length of array if known *)
 
-  val move_if_affected: ?replace_with_const:bool -> Queries.ask -> t -> Cil.varinfo -> (Cil.exp -> int option) -> t
+  val move_if_affected: ?replace_with_const:bool -> ValueDomainQueries.t -> t -> Cil.varinfo -> (Cil.exp -> int option) -> t
   (** changes the way in which the array is partitioned if this is necessitated by a change
     * to the variable **)
 
@@ -55,7 +55,7 @@ sig
   val smart_leq: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t  -> bool
   val update_length: idx -> t -> t
 
-  val project: ?varAttr:Cil.attributes -> ?typAttr:Cil.attributes -> Queries.ask -> t -> t
+  val project: ?varAttr:Cil.attributes -> ?typAttr:Cil.attributes -> ValueDomainQueries.t -> t -> t
 end
 
 module type LatticeWithSmartOps =

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -6,8 +6,8 @@ include PreValueDomain
 module Offs = Lval.OffsetLat (IndexDomain)
 module M = Messages
 module GU = Goblintutil
-module Q = Queries
 module BI = IntOps.BigIntOps
+module LS = ValueDomainQueries.LS
 module AddrSetDomain = SetDomain.ToppedSet(Addr)(struct let topname = "All" end)
 module ArrIdxDomain = IndexDomain
 
@@ -15,12 +15,12 @@ module type S =
 sig
   include Lattice.S
   type offs
-  val eval_offset: Q.ask -> (AD.t -> t) -> t-> offs -> exp option -> lval option -> typ -> t
-  val update_offset: Q.ask -> t -> offs -> t -> exp option -> lval -> typ -> t
+  val eval_offset: ValueDomainQueries.t -> (AD.t -> t) -> t-> offs -> exp option -> lval option -> typ -> t
+  val update_offset: ValueDomainQueries.t -> t -> offs -> t -> exp option -> lval -> typ -> t
   val update_array_lengths: (exp -> t) -> t -> Cil.typ -> t
-  val affect_move: ?replace_with_const:bool -> Q.ask -> t -> varinfo -> (exp -> int option) -> t
+  val affect_move: ?replace_with_const:bool -> ValueDomainQueries.t -> t -> varinfo -> (exp -> int option) -> t
   val affecting_vars: t -> varinfo list
-  val invalidate_value: Q.ask -> typ -> t -> t
+  val invalidate_value: ValueDomainQueries.t -> typ -> t -> t
   val is_safe_cast: typ -> typ -> bool
   val cast: ?torg:typ -> typ -> t -> t
   val smart_join: (exp -> BI.t option) -> (exp -> BI.t option) -> t -> t ->  t
@@ -34,7 +34,7 @@ sig
   val is_top_value: t -> typ -> bool
   val zero_init_value: ?varAttr:attributes -> typ -> t
 
-  val project: Q.ask -> int_precision option-> ( attributes * attributes ) option -> t -> t
+  val project: ValueDomainQueries.t -> int_precision option-> ( attributes * attributes ) option -> t -> t
   val mark_jmpbufs_as_copied: t -> t
 end
 
@@ -46,7 +46,7 @@ sig
   include Lattice.S with type t = value * size * origin
 
   val value: t -> value
-  val invalidate_value: Q.ask -> typ -> t -> t
+  val invalidate_value: ValueDomainQueries.t -> typ -> t -> t
 end
 
 (* ZeroInit is true if malloc was used to allocate memory and it's false if calloc was used *)
@@ -670,7 +670,7 @@ struct
       warn_type "narrow" x y;
       x
 
-  let rec invalidate_value (ask:Q.ask) typ (state:t) : t =
+  let rec invalidate_value (ask:ValueDomainQueries.t) typ (state:t) : t =
     let typ = unrollType typ in
     let invalid_struct compinfo old =
       let nstruct = Structs.create (fun fd -> invalidate_value ask fd.ftype (Structs.get old fd)) compinfo in
@@ -714,7 +714,7 @@ struct
       end
     | _ -> None, None
 
-  let determine_offset (ask: Q.ask) left offset exp v =
+  let determine_offset (ask: ValueDomainQueries.t) left offset exp v =
     let rec contains_pointer exp = (* CIL offsets containing pointers is no issue here, as pointers can only occur in `Index and the domain *)
       match exp with               (* does not partition according to expressions having `Index in them *)
       |	Const _
@@ -739,9 +739,9 @@ struct
     let equiv_expr exp start_of_array_lval =
       match exp, start_of_array_lval with
       | BinOp(IndexPI, Lval lval, add, _), (Var arr_start_var, NoOffset) when not (contains_pointer add) ->
-        begin match ask.f (Q.MayPointTo (Lval lval)) with
-          | v when Q.LS.cardinal v = 1 && not (Q.LS.is_top v) ->
-            begin match Q.LS.choose v with
+        begin match ask.may_point_to (Lval lval) with
+          | v when LS.cardinal v = 1 && not (LS.is_top v) ->
+            begin match LS.choose v with
               | (var,`Index (i,`NoOffset)) when Cil.isZero (Cil.constFold true i) && CilType.Varinfo.equal var arr_start_var ->
                 (* The idea here is that if a must(!) point to arr and we do sth like a[i] we don't want arr to be partitioned according to (arr+i)-&a but according to i instead  *)
                 add
@@ -806,8 +806,8 @@ struct
       x (* This already contains some value *)
 
   (* Funny, this does not compile without the final type annotation! *)
-  let rec eval_offset (ask: Q.ask) f (x: t) (offs:offs) (exp:exp option) (v:lval option) (t:typ): t =
-    let rec do_eval_offset (ask:Q.ask) f (x:t) (offs:offs) (exp:exp option) (l:lval option) (o:offset option) (v:lval option) (t:typ): t =
+  let rec eval_offset (ask: ValueDomainQueries.t) f (x: t) (offs:offs) (exp:exp option) (v:lval option) (t:typ): t =
+    let rec do_eval_offset (ask:ValueDomainQueries.t) f (x:t) (offs:offs) (exp:exp option) (l:lval option) (o:offset option) (v:lval option) (t:typ): t =
       match x, offs with
       | `Blob((va, _, orig) as c), `Index (_, ox) ->
         begin
@@ -877,8 +877,8 @@ struct
     in
     do_eval_offset ask f x offs exp l o v t
 
-  let update_offset (ask: Q.ask) (x:t) (offs:offs) (value:t) (exp:exp option) (v:lval) (t:typ): t =
-    let rec do_update_offset (ask:Q.ask) (x:t) (offs:offs) (value:t) (exp:exp option) (l:lval option) (o:offset option) (v:lval) (t:typ):t =
+  let update_offset (ask: ValueDomainQueries.t) (x:t) (offs:offs) (value:t) (exp:exp option) (v:lval) (t:typ): t =
+    let rec do_update_offset (ask:ValueDomainQueries.t) (x:t) (offs:offs) (value:t) (exp:exp option) (l:lval option) (o:offset option) (v:lval) (t:typ):t =
       if M.tracing then M.traceli "update_offset" "do_update_offset %a %a %a\n" pretty x Offs.pretty offs pretty value;
       let mu = function `Blob (`Blob (y, s', orig), s, orig2) -> `Blob (y, ID.join s s',orig) | x -> x in
       let r =
@@ -904,7 +904,7 @@ struct
             | (Var var, Field (fld,_)) ->
               let toptype = fld.fcomp in
               let blob_size_opt = ID.to_int s in
-              not @@ ask.f (Q.IsMultiple var)
+              not @@ ask.is_multiple var
               && not @@ Cil.isVoidType t      (* Size of value is known *)
               && Option.is_some blob_size_opt (* Size of blob is known *)
               && BI.equal (Option.get blob_size_opt) (BI.of_int @@ Cil.bitsSizeOf (TComp (toptype, []))/8)
@@ -924,7 +924,7 @@ struct
             begin match v with
               | (Var var, _) ->
                 let blob_size_opt = ID.to_int s in
-                not @@ ask.f (Q.IsMultiple var)
+                not @@ ask.is_multiple var
                 && not @@ Cil.isVoidType t      (* Size of value is known *)
                 && Option.is_some blob_size_opt (* Size of blob is known *)
                 && BI.equal (Option.get blob_size_opt) (BI.of_int @@ Cil.alignOf_int t)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -4,9 +4,11 @@ open GoblintCil
 
 module GU = Goblintutil
 
-module ID = ValueDomainQueries.ID
+module VDQ = ValueDomainQueries
 
-module LS = ValueDomainQueries.LS
+module ID = VDQ.ID
+
+module LS = VDQ.LS
 module TS = SetDomain.ToppedSet (CilType.Typ) (struct let topname = "All" end)
 module ES = SetDomain.Reverse (SetDomain.ToppedSet (CilType.Exp) (struct let topname = "All" end))
 module VS = SetDomain.ToppedSet (CilType.Varinfo) (struct let topname = "All" end)
@@ -407,11 +409,11 @@ let to_value_domain_ask (ask: ask) =
   let eval_int e = ask.f (EvalInt e) in
   let may_point_to e = ask.f (MayPointTo e) in
   let is_multiple v = ask.f (IsMultiple v) in
-  { ValueDomainQueries.eval_int; may_point_to; is_multiple }
+  { VDQ.eval_int; may_point_to; is_multiple }
 
 let eval_int_binop (module Bool: Lattice.S with type t = bool) binop (ask: ask) e1 e2: Bool.t =
   let eval_int e = ask.f (EvalInt e) in
-  ValueDomainQueries.eval_int_binop (module Bool) binop eval_int e1 e2
+  VDQ.eval_int_binop (module Bool) binop eval_int e1 e2
 
 (** Backwards-compatibility for former [MustBeEqual] query. *)
 let must_be_equal = eval_int_binop (module MustBool) Eq

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -403,16 +403,9 @@ struct
     | Any MayBeModifiedSinceSetjmp buf -> Pretty.dprintf "MayBeModifiedSinceSetjmp %a" JmpBufDomain.BufferEntry.pretty buf
 end
 
-
 let eval_int_binop (module Bool: Lattice.S with type t = bool) binop (ask: ask) e1 e2: Bool.t =
-  let e = Cilfacade.makeBinOp binop e1 e2 in
-  let i = ask.f (EvalInt e) in
-  if ID.is_bot i || ID.is_bot_ikind i then
-    Bool.top () (* base returns bot for non-int results, consider unknown *)
-  else
-    match ID.to_bool i with
-    | Some b -> b
-    | None -> Bool.top ()
+  let eval_int e = ask.f (EvalInt e) in
+  ValueDomainQueries.eval_int_binop (module Bool) binop eval_int e1 e2
 
 (** Backwards-compatibility for former [MustBeEqual] query. *)
 let must_be_equal = eval_int_binop (module MustBool) Eq

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -3,44 +3,10 @@
 open GoblintCil
 
 module GU = Goblintutil
-module ID =
-struct
-  module I = IntDomain.IntDomTuple
-  include Lattice.Lift (I) (Printable.DefaultNames)
 
-  let lift op x = `Lifted (op x)
-  let unlift op x = match x with
-    | `Lifted x -> op x
-    | _ -> failwith "Queries.ID.unlift"
-  let unlift_opt op x = match x with
-    | `Lifted x -> op x
-    | _ -> None
-  let unlift_is op x = match x with
-    | `Lifted x -> op x
-    | _ -> false
+module ID = ValueDomainQueries.ID
 
-  let bot_of = lift I.bot_of
-  let top_of = lift I.top_of
-
-  let of_int ik = lift (I.of_int ik)
-  let of_bool ik = lift (I.of_bool ik)
-  let of_interval ?(suppress_ovwarn=false) ik = lift (I.of_interval ~suppress_ovwarn ik)
-  let of_excl_list ik = lift (I.of_excl_list ik)
-  let of_congruence ik = lift (I.of_congruence ik)
-  let starting ?(suppress_ovwarn=false) ik = lift (I.starting ~suppress_ovwarn ik)
-  let ending ?(suppress_ovwarn=false) ik = lift (I.ending ~suppress_ovwarn ik)
-
-  let to_int x = unlift_opt I.to_int x
-  let to_bool x = unlift_opt I.to_bool x
-
-  let is_top_of ik = unlift_is (I.is_top_of ik)
-
-  let is_bot_ikind = function
-    | `Bot -> false
-    | `Lifted x -> I.is_bot x
-    | `Top -> false
-end
-module LS = SetDomain.ToppedSet (Lval.CilLval) (struct let topname = "All" end)
+module LS = ValueDomainQueries.LS
 module TS = SetDomain.ToppedSet (CilType.Typ) (struct let topname = "All" end)
 module ES = SetDomain.Reverse (SetDomain.ToppedSet (CilType.Exp) (struct let topname = "All" end))
 module VS = SetDomain.ToppedSet (CilType.Varinfo) (struct let topname = "All" end)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -403,6 +403,12 @@ struct
     | Any MayBeModifiedSinceSetjmp buf -> Pretty.dprintf "MayBeModifiedSinceSetjmp %a" JmpBufDomain.BufferEntry.pretty buf
 end
 
+let to_value_domain_ask (ask: ask) =
+  let eval_int e = ask.f (EvalInt e) in
+  let may_point_to e = ask.f (MayPointTo e) in
+  let is_multiple v = ask.f (IsMultiple v) in
+  { ValueDomainQueries.eval_int; may_point_to; is_multiple }
+
 let eval_int_binop (module Bool: Lattice.S with type t = bool) binop (ask: ask) e1 e2: Bool.t =
   let eval_int e = ask.f (EvalInt e) in
   ValueDomainQueries.eval_int_binop (module Bool) binop eval_int e1 e2

--- a/src/domains/valueDomainQueries.ml
+++ b/src/domains/valueDomainQueries.ml
@@ -1,4 +1,3 @@
-(** Subset of queries used by the valuedomain, using a simpler representation. *)
 open GoblintCil
 open BoolDomain
 
@@ -46,6 +45,7 @@ type eval_int = exp -> ID.t
 type may_point_to = exp -> LS.t
 type is_multiple = varinfo -> bool
 
+(** Subset of queries used by the valuedomain, using a simpler representation. *)
 type t = {
   eval_int: eval_int;
   may_point_to: may_point_to;

--- a/src/domains/valueDomainQueries.ml
+++ b/src/domains/valueDomainQueries.ml
@@ -1,5 +1,6 @@
 (** Subset of queries used by the valuedomain, using a simpler representation. *)
 open GoblintCil
+open BoolDomain
 
 module LS = SetDomain.ToppedSet (Lval.CilLval) (struct let topname = "All" end)
 
@@ -60,3 +61,12 @@ let eval_int_binop (module Bool: Lattice.S with type t = bool) binop (eval_int: 
     match ID.to_bool i with
     | Some b -> b
     | None -> Bool.top ()
+
+(** Backwards-compatibility for former [MustBeEqual] query. *)
+let must_be_equal = eval_int_binop (module MustBool) Eq
+
+(** Backwards-compatibility for former [MayBeEqual] query. *)
+let may_be_equal = eval_int_binop (module MayBool) Eq
+
+(** Backwards-compatibility for former [MayBeLess] query. *)
+let may_be_less = eval_int_binop (module MayBool) Lt

--- a/src/domains/valueDomainQueries.ml
+++ b/src/domains/valueDomainQueries.ml
@@ -1,0 +1,48 @@
+(** Subset of queries used by the valuedomain, using a simpler representation. *)
+open GoblintCil
+
+module LS = SetDomain.ToppedSet (Lval.CilLval) (struct let topname = "All" end)
+
+module ID =
+struct
+  module I = IntDomain.IntDomTuple
+  include Lattice.Lift (I) (Printable.DefaultNames)
+
+  let lift op x = `Lifted (op x)
+  let unlift op x = match x with
+    | `Lifted x -> op x
+    | _ -> failwith "Queries.ID.unlift"
+  let unlift_opt op x = match x with
+    | `Lifted x -> op x
+    | _ -> None
+  let unlift_is op x = match x with
+    | `Lifted x -> op x
+    | _ -> false
+
+  let bot_of = lift I.bot_of
+  let top_of = lift I.top_of
+
+  let of_int ik = lift (I.of_int ik)
+  let of_bool ik = lift (I.of_bool ik)
+  let of_interval ?(suppress_ovwarn=false) ik = lift (I.of_interval ~suppress_ovwarn ik)
+  let of_excl_list ik = lift (I.of_excl_list ik)
+  let of_congruence ik = lift (I.of_congruence ik)
+  let starting ?(suppress_ovwarn=false) ik = lift (I.starting ~suppress_ovwarn ik)
+  let ending ?(suppress_ovwarn=false) ik = lift (I.ending ~suppress_ovwarn ik)
+
+  let to_int x = unlift_opt I.to_int x
+  let to_bool x = unlift_opt I.to_bool x
+
+  let is_top_of ik = unlift_is (I.is_top_of ik)
+
+  let is_bot_ikind = function
+    | `Bot -> false
+    | `Lifted x -> I.is_bot x
+    | `Top -> false
+end
+
+type t = {
+  eval_int: exp -> ID.t;
+  may_point_to: exp -> LS.t;
+  is_multiple: varinfo -> bool;
+}

--- a/src/domains/valueDomainQueries.ml
+++ b/src/domains/valueDomainQueries.ml
@@ -41,8 +41,22 @@ struct
     | `Top -> false
 end
 
+type eval_int = exp -> ID.t
+type may_point_to = exp -> LS.t
+type is_multiple = varinfo -> bool
+
 type t = {
-  eval_int: exp -> ID.t;
-  may_point_to: exp -> LS.t;
-  is_multiple: varinfo -> bool;
+  eval_int: eval_int;
+  may_point_to: may_point_to;
+  is_multiple: is_multiple;
 }
+
+let eval_int_binop (module Bool: Lattice.S with type t = bool) binop (eval_int: eval_int) e1 e2: Bool.t =
+  let e = Cilfacade.makeBinOp binop e1 e2 in
+  let i = eval_int e in
+  if ID.is_bot i || ID.is_bot_ikind i then
+    Bool.top () (* base returns bot for non-int results, consider unknown *)
+  else
+    match ID.to_bool i with
+    | Some b -> b
+    | None -> Bool.top ()


### PR DESCRIPTION
#### Changes

This PR refactors the `ValueDomain` such that its compilation no longer depends on  `Queries`. To this goal, the subset of queries that were previously used by the `ValueDomain` (and by the `ArrayDomain` in particular), are now passed as a record to the `ValueDomain` functions. 

#### Benefit
Removing this dependency has the benefit of allowing use of the `ValueDomain` in `Queries`, which would otherwise not be possible as it would introduce a cyclic dependency. One instance where queries passing `ValueDomain.t` values are needed is the implementation of the modular analysis, where values written by functions should be communicated. 