### PR TITLE
Remove unnecessary lval domain special cases

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -808,7 +808,12 @@ struct
       | BinOp ((Eq | Ne) as op, (CastE (t1, e1) as c1), (CastE (t2, e2) as c2), typ) when typeSig t1 = typeSig t2 ->
         let a1 = eval_rv a gs st e1 in
         let a2 = eval_rv a gs st e2 in
-        let (e1, e2) = binop_remove_same_casts ~extra_is_safe:(VD.equal a1 a2) ~e1 ~e2 ~t1 ~t2 ~c1 ~c2 in
+        let extra_is_safe =
+          match evalbinop_base a st op t1 a1 t2 a2 typ with
+          | `Int i -> ID.to_bool i = Some true
+          | _ -> false
+        in
+        let (e1, e2) = binop_remove_same_casts ~extra_is_safe ~e1 ~e2 ~t1 ~t2 ~c1 ~c2 in
         (* re-evaluate e1 and e2 in evalbinop because might be with cast *)
         evalbinop a gs st op ~e1 ~t1 ~e2 ~t2 typ
       | BinOp (LOr, e1, e2, typ) as exp ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -811,7 +811,8 @@ struct
         let extra_is_safe =
           match evalbinop_base a st op t1 a1 t2 a2 typ with
           | `Int i -> ID.to_bool i = Some true
-          | _ -> false
+          | _
+          | exception IntDomain.IncompatibleIKinds _ -> false
         in
         let (e1, e2) = binop_remove_same_casts ~extra_is_safe ~e1 ~e2 ~t1 ~t2 ~c1 ~c2 in
         (* re-evaluate e1 and e2 in evalbinop because might be with cast *)

--- a/unittest/cdomains/lvalTest.ml
+++ b/unittest/cdomains/lvalTest.ml
@@ -27,24 +27,8 @@ let assert_not_leq x y =
 let assert_equal x y =
   assert_equal ~cmp:LV.equal ~printer:LV.show x y
 
-
-let test_equal_0 _ =
-  assert_equal a_lv a_lv_0
-
-let test_compare_0 _ =
-  assert_bool "test_compare_0" @@ (LV.compare a_lv a_lv_0 = 0)
-
-let test_hash_0 _ =
-  assert_bool "test_hash_0" @@ (LV.hash a_lv = LV.hash a_lv_0)
-
-let test_leq_0 _ =
-  assert_leq a_lv a_lv_0;
-  assert_leq a_lv_0 a_lv
-
 let test_join_0 _ =
-  assert_equal a_lv_top (LV.join a_lv_0 a_lv_1);
-  skip_if true "TODO";
-  assert_equal a_lv_top (LV.join a_lv a_lv_1) (* TODO *)
+  assert_equal a_lv_top (LV.join a_lv_0 a_lv_1)
 
 let test_leq_not_0 _ =
   assert_leq a_lv_1 a_lv_not_0;
@@ -55,10 +39,6 @@ let test_leq_not_0 _ =
 
 let test () =
   "lvalTest" >::: [
-    "test_equal_0" >:: test_equal_0;
-    "test_compare_0" >:: test_compare_0;
-    "test_hash_0" >:: test_hash_0;
     "test_join_0" >:: test_join_0;
-    "test_leq_0" >:: test_leq_0;
     "test_leq_not_0" >:: test_leq_not_0;
   ]


### PR DESCRIPTION
Closes #998. This fixes the crash on Concrat's brubeck benchmark.

Since address domain keeps them in different buckets anyway, these special cases are no longer needed. By removing them, the the issue of bucket keys conflicting due to these overrides is fixed. The identity of offsets is thus completely standard and can be derived.

This requires a small fix in the evaluation of pointer equalities, which previously used `VD.equal`. `VD.equal` is not appropriate for semantic equality and is replaced with actual evaluation. A check in 21-casts/01-via_ptr, which checked `VD.equal {f[def_exc:0]} {f[def_exc:0].x}`, broke because the elements are no longer equal due to the offset equality handling such special case.

**EDIT:** sv-benchmarks runs show no difference in results or performance.
