### PR TITLE
Make address semantic equality more precise for 0-index

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -346,6 +346,7 @@ struct
             let ay = AD.choose y in
             let handle_address_is_multiple addr = begin match AD.Addr.to_var addr with
               | Some v when a.f (Q.IsMultiple v) ->
+                if M.tracing then M.tracel "addr" "IsMultiple %a\n" d_varinfo v;
                 None
               | _ ->
                 Some true
@@ -353,6 +354,7 @@ struct
             in
             match AD.Addr.semantic_equal ax ay with
             | Some true ->
+              if M.tracing then M.tracel "addr" "semantic_equal %a %a\n" AD.pretty x AD.pretty y;
               handle_address_is_multiple ax
             | Some false -> Some false
             | None -> None

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -164,14 +164,17 @@ struct
         let remaining_offset = offset_to_index_offset ~typ:field.ftype o in
         Idx.add bits_offset remaining_offset
       | `Index (x, o) ->
-        match Option.map unrollType typ with
-        | Some TArray(item_typ, _, _) ->
-          let item_size_in_bits = bitsSizeOf item_typ in
-          let item_size_in_bits = idx_of_int item_size_in_bits in
-          let bits_offset = Idx.mul item_size_in_bits x in
-          let remaining_offset = offset_to_index_offset ~typ:item_typ o in
-          Idx.add bits_offset remaining_offset
-        | _ -> Idx.top ()
+        let (item_typ, item_size_in_bits) =
+          match Option.map unrollType typ with
+          | Some TArray(item_typ, _, _) ->
+            let item_size_in_bits = bitsSizeOf item_typ in
+            (Some item_typ, idx_of_int item_size_in_bits)
+          | _ ->
+            (None, Idx.top ())
+        in
+        let bits_offset = Idx.mul item_size_in_bits x in
+        let remaining_offset = offset_to_index_offset ?typ:item_typ o in
+        Idx.add bits_offset remaining_offset
     in
     offset_to_index_offset ~typ offs
 

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -2,6 +2,7 @@ open GoblintCil
 open Pretty
 
 module GU = Goblintutil
+module M = Messages
 
 type ('a, 'b) offs = [
   | `NoOffset
@@ -177,6 +178,7 @@ struct
   let semantic_equal ~xtyp ~xoffs ~ytyp ~yoffs =
     let x_index = offset_to_index_offset xtyp xoffs in
     let y_index = offset_to_index_offset ytyp yoffs in
+    if M.tracing then M.tracel "addr" "xoffs=%a xtyp=%a xindex=%a yoffs=%a ytyp=%a yindex=%a\n" pretty xoffs d_plaintype xtyp Idx.pretty x_index pretty yoffs d_plaintype ytyp Idx.pretty y_index;
     Idx.to_bool (Idx.eq x_index y_index)
 
 end

--- a/tests/regression/02-base/91-ad-meet.c
+++ b/tests/regression/02-base/91-ad-meet.c
@@ -50,7 +50,7 @@ int main() {
   void *p = &a.fst;
   void *q = ((int(*)[1]) (&a))[0];
   // as an __goblint_check, this passes when compiled
-  __goblint_check(p == q); //UNKNOWN
+  __goblint_check(p == q);
 
   blob_offsets();
   array_offsets();

--- a/tests/regression/69-addresses/03-issue-564.c
+++ b/tests/regression/69-addresses/03-issue-564.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+typedef struct {
+  int x;
+} a;
+
+int main() {
+  a z;
+  a *y = &z;
+
+  int *m = &y->x; // {&z.x}
+  a *n = &y[0]; // {&z[def_exc:0]}
+
+  int b = m == n;
+  assert(b); // UNKNOWN
+  return 0;
+}

--- a/tests/regression/69-addresses/03-issue-564.c
+++ b/tests/regression/69-addresses/03-issue-564.c
@@ -12,6 +12,6 @@ int main() {
   a *n = &y[0]; // {&z[def_exc:0]}
 
   int b = m == n;
-  assert(b); // UNKNOWN
+  assert(b);
   return 0;
 }


### PR DESCRIPTION
Closes #564.

The test case from #564 was already made sound by #967, but it wasn't precise enough to make the assertion pass.
This slightly refactors the offset calculation in address semantic equality such that multiplication by 0 gives a precise result even when the size of the array item is unknown (due to indexing on a struct).