### PR TITLE
Fix missing dead code warning from strictly dead loop body

### DIFF
--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -857,15 +857,17 @@ struct
           (* TODO: Is it possible to do soundly for multi-entry loops? *)
           let stricts = NodeH.find_default scc.prev v [] in
           let xs_stricts = List.map tf' stricts in
+          (* Evaluate non-strict for dead code warnings. See 00-sanity/36-strict-loop-dead. *)
+          let equal = [%eq: (CilType.Location.t * Edge.t) list * Node.t] in
+          let is_strict eu = List.exists (equal eu) stricts in
+          let non_stricts = List.filter (neg is_strict) (Cfg.prev v) in
+          let xs_non_stricts = List.map tf' non_stricts in
           if List.for_all S.D.is_bot xs_stricts then
             S.D.bot ()
-          else
+          else (
             let xs_strict = List.fold_left S.D.join (S.D.bot ()) xs_stricts in
-            let equal = [%eq: (CilType.Location.t * Edge.t) list * Node.t] in
-            let is_strict eu = List.exists (equal eu) stricts in
-            let non_stricts = List.filter (neg is_strict) (Cfg.prev v) in
-            let xs_non_stricts = List.map tf' non_stricts in
             List.fold_left S.D.join xs_strict xs_non_stricts
+          )
         | _ ->
           let xs = List.map tf' (Cfg.prev v) in
           List.fold_left S.D.join (S.D.bot ()) xs

--- a/tests/regression/00-sanity/36-strict-loop-dead.c
+++ b/tests/regression/00-sanity/36-strict-loop-dead.c
@@ -6,8 +6,8 @@ int basic2(int n) {
     return 0;
 
   for (int i = 0; i < n; i++) // NOWARN
-    // Bug in dead code warnings: no dead code warning is emitted, because body is not included
-    // in the result. Transformation checks all CFG nodes, and therefore works.
+    // Was bug in dead code warnings: no dead code warning was emitted, because body was not included
+    // in the result. Transformation checks all CFG nodes, and therefore worked.
     a += i + n; // NOWARN
 
   return a; // NOWARN

--- a/tests/regression/00-sanity/36-strict-loop-dead.c
+++ b/tests/regression/00-sanity/36-strict-loop-dead.c
@@ -1,0 +1,19 @@
+// only called with negative n
+int basic2(int n) {
+  int a = 0;
+
+  if (n < 0)
+    return 0;
+
+  for (int i = 0; i < n; i++) // NOWARN
+    // Bug in dead code warnings: no dead code warning is emitted, because body is not included
+    // in the result. Transformation checks all CFG nodes, and therefore works.
+    a += i + n; // NOWARN
+
+  return a; // NOWARN
+}
+
+
+int main() {
+  basic2(-3);
+}

--- a/tests/regression/00-sanity/36-strict-loop-dead.t
+++ b/tests/regression/00-sanity/36-strict-loop-dead.t
@@ -1,9 +1,10 @@
   $ goblint 36-strict-loop-dead.c
   [Warning][Deadcode] Function 'basic2' has dead code:
     on line 8 (36-strict-loop-dead.c:8-8)
+    on line 11 (36-strict-loop-dead.c:11-11)
     on line 13 (36-strict-loop-dead.c:13-13)
   [Warning][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
-    dead: 2
-    total lines: 9
+    dead: 3
+    total lines: 10
   [Warning][Deadcode][CWE-571] condition 'n < 0' is always true (36-strict-loop-dead.c:5:7-5:12)

--- a/tests/regression/00-sanity/36-strict-loop-dead.t
+++ b/tests/regression/00-sanity/36-strict-loop-dead.t
@@ -1,0 +1,9 @@
+  $ goblint 36-strict-loop-dead.c
+  [Warning][Deadcode] Function 'basic2' has dead code:
+    on line 8 (36-strict-loop-dead.c:8-8)
+    on line 13 (36-strict-loop-dead.c:13-13)
+  [Warning][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 2
+    total lines: 9
+  [Warning][Deadcode][CWE-571] condition 'n < 0' is always true (36-strict-loop-dead.c:5:7-5:12)


### PR DESCRIPTION
Fixes the case identified in https://github.com/goblint/analyzer/pull/979#discussion_r1171079392.

If the loop entry edge is already dead, the loop's back edge was never even queried from the solver. Thus it was completely missing from the solver solution (not with dead code lifter's bottom) and no dead code warning was emitted.

This makes the constraint system query all of them, but still ignore the non-strict ones if the entry edge is dead. This way dead code lifter's bottom is propagated through the loop.

Using a cram test because the presence of dead code warnings cannot be checked with update_suite.rb.