### PR TITLE
Add automated test for GobView beyond building

### DIFF
--- a/.github/workflows/locked.yml
+++ b/.github/workflows/locked.yml
@@ -165,3 +165,9 @@ jobs:
 
       - name: Build Gobview
         run: opam exec -- dune build gobview
+
+      - name: Test Gobview
+        run: |
+          ./goblint --enable gobview tests/regression/00-sanity/01-assert.c
+          pip3 install selenium webdriver-manager
+          python3 scripts/test-gobview.py

--- a/scripts/test-gobview.py
+++ b/scripts/test-gobview.py
@@ -1,0 +1,70 @@
+# needs preinstalled libraries:
+# pip3 install selenium webdriver-manager
+
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.options import Options
+from threading import Thread
+import http.server
+import socketserver
+
+PORT = 9000
+DIRECTORY = "run"
+IP = "localhost"
+url = 'http://' + IP + ':' + str(PORT) + '/'
+
+# cleanup
+def cleanup(browser, httpd, thread):
+  print("cleanup")
+  browser.close()
+  httpd.shutdown()
+  httpd.server_close()
+  thread.join()
+
+# serve GobView in different thread so it does not block the testing
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=DIRECTORY, **kwargs)
+class Server(socketserver.TCPServer):
+    allow_reuse_address = True # avoids that during a consecutive run the server cannot connect due to an 'Adress already in use' os error
+
+httpd = Server((IP, PORT), Handler)
+print("serving at port", PORT)
+thread = Thread(target=httpd.serve_forever, args=())
+thread.start()
+
+# installation of browser
+print("starting installation of browser\n")
+browser = webdriver.Chrome(service=Service(ChromeDriverManager().install()),options=Options())
+print("finished webdriver installation \n")
+browser.maximize_window()
+
+# register cleanup function
+# atexit.register(cleanup, browser, httpd, thread)
+
+try:
+    # retrieve and wait until page is fully loaded and rendered
+    browser.get(url)
+    print("open local GobView page\n")
+
+    # check for the right page title:
+    title = browser.title
+    assert(title == "GobView")
+    print("found the site's title", title)
+
+    # check the general structure of the page (whether main element, navbar, left and right sidebar, content view and panel exists)
+    # find_element throws an NoSuchElementException if this is not the case
+    main = browser.find_element(By.CLASS_NAME, "main")
+    leftS = browser.find_element(By.CLASS_NAME, "sidebar-left")
+    rightS = browser.find_element(By.CLASS_NAME, "sidebar-right")
+    content = browser.find_element(By.CLASS_NAME, "content")
+    panel = browser.find_element(By.CLASS_NAME, "panel")
+    print("found DOM elements main, sidebar-left, sidebar-right, content and panel")
+
+    cleanup(browser, httpd, thread)
+
+except Exception as e:
+    cleanup(browser, httpd, thread)
+    raise e


### PR DESCRIPTION
This PR adds an automated python test that serves the GobView page and checks that the overall structure of the page is correct, i.e., that the DOM elements for the navbar, sidebars, bottom panel and content view are displayed. Although this is not a very detailed check, it should be sufficient to detect errors during the initialization phase that can cause nothing to be displayed at all even though the build was successful. 
In the ubuntu-latest image for the Github actions, pip3 and chrome should already be preinstalled (https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md).