### PR TITLE
Replace `should_join` with path representative

### DIFF
--- a/src/analyses/activeSetjmp.ml
+++ b/src/analyses/activeSetjmp.ml
@@ -11,8 +11,7 @@ struct
 
   module D = JmpBufDomain.JmpBufSet
   module C = JmpBufDomain.JmpBufSet
-
-  let should_join a b = D.equal a b
+  module P = IdentityP (D)
 
   let combine_env ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask:Queries.ask): D.t =
     ctx.local (* keep local as opposed to IdentitySpec *)

--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -21,6 +21,12 @@ struct
     include Priv.V
     include StdV
   end
+  module P =
+  struct
+    include Priv.P
+
+    let of_elt {priv; _} = of_elt priv
+  end
 
   module RV = RD.V
 
@@ -28,8 +34,6 @@ struct
 
   (* Result map used for comparison of results for relational traces paper. *)
   let results = PCU.RH.create 103
-
-  let should_join = Priv.should_join
 
   let context fd x =
     if ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.relation.context" ~removeAttr:"relation.no-context" ~keepAttr:"relation.context" fd then

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -19,10 +19,11 @@ module type S =
     module D: Lattice.S
     module G: Lattice.S
     module V: Printable.S
+    module P: DisjointDomain.Representative with type elt := D.t (** Path-representative. *)
+
     type relation_components_t := RelationDomain.RelComponents (RD) (D).t
     val name: unit -> string
     val startstate: unit -> D.t
-    val should_join: relation_components_t -> relation_components_t -> bool
 
     val read_global: Q.ask -> (V.t -> G.t) -> relation_components_t -> varinfo -> varinfo -> RD.t
 
@@ -58,12 +59,12 @@ struct
   module G = Lattice.Unit
   module V = EmptyV
   module AV = RD.V
+  module P = UnitP
 
   type relation_components_t = RelComponents (RD) (D).t
 
   let name () = "top"
   let startstate () = ()
-  let should_join _ _ = true
 
   let read_global ask getg (st: relation_components_t) g x =
     let rel = st.rel in
@@ -146,10 +147,12 @@ struct
   open Protection
 
   (** Locally must-written protected globals that have been continuously protected since writing. *)
-  module P =
-  struct
-    include MustVars
-    let name () = "P"
+  open struct
+    module P =
+    struct
+      include MustVars
+      let name () = "P"
+    end
   end
 
   (** Locally may-written protected globals that have been continuously protected since writing. *)
@@ -163,6 +166,16 @@ struct
   module D = Lattice.Prod (P) (W)
   module G = RD
   module V = Printable.UnitConf (struct let name = "global" end)
+  module PS =
+  struct
+    include Printable.Option (P) (struct let name = "None" end)
+
+    let of_elt (p, _) =
+      if Param.path_sensitive then
+        Some p
+      else
+        None
+  end
 
   type relation_components_t = RelationComponents (RD) (D).t
 
@@ -210,15 +223,6 @@ struct
       )
 
   let startstate () = (P.empty (), W.empty ())
-
-  let should_join (st1: relation_components_t) (st2: relation_components_t) =
-    if Param.path_sensitive then (
-      let (p1, _) = st1.priv in
-      let (p2, _) = st2.priv in
-      P.equal p1 p2
-    )
-    else
-      true
 
   let read_global ask getg (st: relation_components_t) g x =
     let rel = st.rel in
@@ -408,6 +412,8 @@ struct
   let invariant_vars ask getg st = protected_vars ask (* TODO: is this right? *)
 
   let finalize () = ()
+
+  module P = PS
 end
 
 module CommonPerMutex = functor(RD: RelationDomain.RD) ->
@@ -452,6 +458,7 @@ struct
 
   module D = Lattice.Unit
   module G = RD
+  module P = UnitP
 
   type relation_components_t = RelationDomain.RelComponents (RD) (D).t
 
@@ -460,8 +467,6 @@ struct
   let name () = "PerMutexMeetPriv"
 
   let startstate () = ()
-
-  let should_join _ _ = true
 
   let get_m_with_mutex_inits ask getg m =
     let get_m = getg (V.mutex m) in
@@ -857,6 +862,7 @@ struct
     end)(LRD)
 
   module AV = RD.V
+  module P = UnitP
 
   let name () = "PerMutexMeetPrivTID(" ^ (Cluster.name ()) ^ (if GobConfig.get_bool "ana.relation.priv.must-joined" then  ",join"  else "") ^ ")"
 
@@ -871,8 +877,6 @@ struct
       ) v (LRD.bot ())
 
   type relation_components_t =  RelationDomain.RelComponents (RD) (D).t
-
-  let should_join _ _ = true
 
   let get_m_with_mutex_inits inits ask getg m =
     let get_m = get_relevant_writes ask m (G.mutex @@ getg (V.mutex m)) in

--- a/src/analyses/expsplit.ml
+++ b/src/analyses/expsplit.ml
@@ -17,8 +17,7 @@ struct
   let exitstate = startstate
 
   include Analyses.DefaultSpec
-
-  let should_join = D.equal
+  module P = IdentityP (D)
 
   let emit_splits ctx d =
     D.iter (fun e _ ->

--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -14,8 +14,7 @@ struct
   module Addr = ValueDomain.Addr
   module D = ValueDomain.AddrSetDomain
   module C = ValueDomain.AddrSetDomain
-
-  let should_join x y = D.equal x y
+  module P = IdentityP (D)
 
   (* NB! Currently we care only about concrete indexes. Base (seeing only a int domain
      element) answers with the string "unknown" on all non-concrete cases. *)

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -84,7 +84,7 @@ struct
   let name () = "mutex"
 
   module D = Arg.D (* help type checker using explicit constraint *)
-  let should_join x y = D.equal x y
+  module P = IdentityP (D)
 
   module V = Arg.V
   module GProtecting = Arg.GProtecting

--- a/src/analyses/stackTrace.ml
+++ b/src/analyses/stackTrace.ml
@@ -4,12 +4,11 @@ open GoblintCil
 open Analyses
 module LF = LibraryFunctions
 
-module Spec (D: StackDomain.S) (P: sig val name : string end)=
+module Spec (D: StackDomain.S) (N: sig val name : string end)=
 struct
-  module ArgP = P
   include Analyses.IdentitySpec
 
-  let name () = ArgP.name
+  let name () = N.name
   module D = D
   module C = D
 

--- a/src/analyses/stackTrace.ml
+++ b/src/analyses/stackTrace.ml
@@ -6,9 +6,10 @@ module LF = LibraryFunctions
 
 module Spec (D: StackDomain.S) (P: sig val name : string end)=
 struct
+  module ArgP = P
   include Analyses.IdentitySpec
 
-  let name () = P.name
+  let name () = ArgP.name
   module D = D
   module C = D
 

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -19,8 +19,7 @@ struct
     include T
     include StdV
   end
-
-  let should_join = D.equal
+  module P = IdentityP (D)
 
   (* transfer functions *)
 

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -18,6 +18,7 @@ struct
   module Flag = ThreadFlagDomain.Simple
   module D = Flag
   module C = Flag
+  module P = IdentityP (D)
 
   let name () = "threadflag"
 
@@ -28,8 +29,6 @@ struct
 
   let create_tid v =
     Flag.get_multi ()
-
-  let should_join = D.equal
 
   let return ctx exp fundec  =
     match fundec.svar.vname with

--- a/src/analyses/unassumeAnalysis.ml
+++ b/src/analyses/unassumeAnalysis.ml
@@ -23,7 +23,6 @@ struct
   let exitstate _ = D.empty ()
 
   let context _ _ = ()
-  let should_join _ _ = false
 
   module Locator = WitnessUtil.Locator (Node)
 

--- a/src/analyses/uninit.ml
+++ b/src/analyses/uninit.ml
@@ -16,14 +16,13 @@ struct
 
   module D = ValueDomain.AddrSetDomain
   module C = ValueDomain.AddrSetDomain
+  module P = IdentityP (D)
 
   type trans_in  = D.t
   type trans_out = D.t
   type transfer  = trans_in -> trans_out
 
   let name () = "uninit"
-
-  let should_join x y = D.equal x y
 
   let startstate v : D.t = D.empty ()
   let threadenter ctx lval f args = [D.empty ()]

--- a/src/util/wideningTokens.ml
+++ b/src/util/wideningTokens.ml
@@ -109,14 +109,17 @@ struct
   end
   module C = S.C
   module V = S.V
+  module P =
+  struct
+    include S.P
+    let of_elt (x, _) = of_elt x
+  end
 
   let name () = S.name ()^" with widening tokens"
 
   type marshal = S.marshal
   let init = S.init
   let finalize = S.finalize
-
-  let should_join (x, _) (y, _) = S.should_join x y
 
   let startstate v = (S.startstate v, TS.bot ())
   let exitstate  v = (S.exitstate  v, TS.bot ())

--- a/src/witness/observerAnalysis.ml
+++ b/src/witness/observerAnalysis.ml
@@ -29,8 +29,7 @@ struct
   end
   module D = Lattice.Flat (Printable.Chain (ChainParams)) (Printable.DefaultNames)
   module C = D
-
-  let should_join x y = D.equal x y (* fully path-sensitive *)
+  module P = IdentityP (D) (* fully path-sensitive *)
 
   let step d prev_node node =
     match d with

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -45,7 +45,7 @@ struct
     module C =
     struct
       type elt = Spec.D.t
-      let cong = Spec.should_join
+      let cong x y = Spec.P.equal (Spec.P.of_elt x) (Spec.P.of_elt y) (* TODO: ProjectiveMap *)
     end
     module J = MapDomain.Joined (Spec.D) (R)
     include DisjointDomain.PairwiseMap (Spec.D) (R) (J) (C)
@@ -94,14 +94,13 @@ struct
   module G = Spec.G
   module C = Spec.C
   module V = Spec.V
+  module P = UnitP
 
   let name () = "PathSensitive3("^Spec.name ()^")"
 
   type marshal = Spec.marshal
   let init = Spec.init
   let finalize = Spec.finalize
-
-  let should_join x y = true
 
   let exitstate  v = (Dom.singleton (Spec.exitstate  v) (R.bot ()), Sync.bot ())
   let startstate v = (Dom.singleton (Spec.startstate v) (R.bot ()), Sync.bot ())

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -40,19 +40,20 @@ struct
     let narrow x y = y
   end
 
-  module SpecDMap (R: Lattice.S) =
+  module SpecDMap (V: Lattice.S) =
   struct
-    module C =
+    module R =
     struct
+      include Spec.P
       type elt = Spec.D.t
-      let cong x y = Spec.P.equal (Spec.P.of_elt x) (Spec.P.of_elt y) (* TODO: ProjectiveMap *)
     end
-    module J = MapDomain.Joined (Spec.D) (R)
-    include DisjointDomain.PairwiseMap (Spec.D) (R) (J) (C)
+    module J = MapDomain.Joined (Spec.D) (V)
+    include DisjointDomain.ProjectiveMap (Spec.D) (V) (J) (R)
   end
 
   module Dom =
   struct
+    module V = R
     include SpecDMap (R)
 
     let name () = "PathSensitive (" ^ name () ^ ")"
@@ -60,7 +61,7 @@ struct
     let printXml f x =
       let print_one x r =
         (* BatPrintf.fprintf f "\n<path>%a</path>" Spec.D.printXml x *)
-        BatPrintf.fprintf f "\n<path>%a<analysis name=\"witness\">%a</analysis></path>" Spec.D.printXml x R.printXml r
+        BatPrintf.fprintf f "\n<path>%a<analysis name=\"witness\">%a</analysis></path>" Spec.D.printXml x V.printXml r
       in
       iter print_one x
 


### PR DESCRIPTION
Closes #1039.

On 08/02 with 7 malloced variables, this reduces analysis time 4.8s → 1.5s.

### TODO
- [x] Implement `DisjointDomain.ProjectiveMap`.
- [x] Use path representatives in `PathSensitive3` for witness generation.
- [x] Compare on sv-benchmarks.
- [x] Check if witness automata are constructed correctly.