### PR TITLE
Witness invariants for arrays and principled handling of unknown indices

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1637,7 +1637,7 @@ struct
 
     let get_var = get_var
     let get a gs st addrs exp = get a gs st addrs exp
-    let set a ~ctx gs st lval lval_type value = set a ~ctx ~invariant:true gs st lval lval_type value
+    let set a ~ctx gs st lval lval_type ?lval_raw value = set a ~ctx ~invariant:true gs st lval lval_type ?lval_raw value
 
     let refine_entire_var = true
     let map_oldval oldval _ = oldval
@@ -2522,7 +2522,7 @@ struct
           (* all updates happen in ctx with top values *)
           let get_var = get_var
           let get a gs st addrs exp = get a gs st addrs exp
-          let set a ~ctx gs st lval lval_type value = set a ~ctx ~invariant:false gs st lval lval_type value (* TODO: should have invariant false? doesn't work with empty cpa then, because meets *)
+          let set a ~ctx gs st lval lval_type ?lval_raw value = set a ~ctx ~invariant:false gs st lval lval_type ?lval_raw value (* TODO: should have invariant false? doesn't work with empty cpa then, because meets *)
 
           let refine_entire_var = false
           let map_oldval oldval t_lval =

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -625,8 +625,7 @@ struct
       let toInt i =
         match IdxDom.to_int @@ ID.cast_to ik i with
         | Some x -> Const (CInt (x,ik, None))
-        | _ -> Cilfacade.mkCast ~e:(Const (CStr ("unknown",No_encoding))) ~newt:intType (* TODO: fix "unknown" offsets in accessed witness invariants *)
-
+        | _ -> Lval.any_index_exp
       in
       match o with
       | `NoOffset -> `NoOffset
@@ -1059,7 +1058,7 @@ struct
     match ofs with
     | NoOffset -> `NoOffset
     | Field (fld, ofs) -> `Field (fld, convert_offset a gs st ofs)
-    | Index (CastE (TInt(IInt,[]), Const (CStr ("unknown",No_encoding))), ofs) -> (* special offset added by convertToQueryLval *)
+    | Index (exp, ofs) when CilType.Exp.equal exp Lval.any_index_exp -> (* special offset added by convertToQueryLval *)
       `Index (IdxDom.top (), convert_offset a gs st ofs)
     | Index (exp, ofs) ->
       match eval_rv a gs st exp with

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -625,7 +625,7 @@ struct
       let toInt i =
         match IdxDom.to_int @@ ID.cast_to ik i with
         | Some x -> Const (CInt (x,ik, None))
-        | _ -> Cilfacade.mkCast ~e:(Const (CStr ("unknown",No_encoding))) ~newt:intType
+        | _ -> Cilfacade.mkCast ~e:(Const (CStr ("unknown",No_encoding))) ~newt:intType (* TODO: fix "unknown" offsets in accessed witness invariants *)
 
       in
       match o with

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -20,7 +20,7 @@ sig
 
   val get_var: Queries.ask -> (V.t -> G.t) -> D.t -> varinfo -> VD.t
   val get: Queries.ask -> (V.t -> G.t) -> D.t -> AD.t -> exp option -> VD.t
-  val set: Queries.ask -> ctx:(D.t, G.t, _, V.t) Analyses.ctx -> (V.t -> G.t) -> D.t -> AD.t -> typ -> VD.t -> D.t
+  val set: Queries.ask -> ctx:(D.t, G.t, _, V.t) Analyses.ctx -> (V.t -> G.t) -> D.t -> AD.t -> typ -> ?lval_raw:lval -> VD.t -> D.t
 
   val refine_entire_var: bool
   val map_oldval: VD.t -> typ -> VD.t
@@ -93,7 +93,7 @@ struct
       else set a gs st addr t_lval new_val ~ctx (* no *_raw because this is not a real assignment *)
 
   let refine_lv ctx a gs st c x c' pretty exp =
-    let set' lval v st = set a gs st (eval_lv a gs st lval) (Cilfacade.typeOfLval lval) v ~ctx in
+    let set' lval v st = set a gs st (eval_lv a gs st lval) (Cilfacade.typeOfLval lval) ~lval_raw:lval v ~ctx in
     match x with
     | Var var, o when refine_entire_var ->
       (* For variables, this is done at to the level of entire variables to benefit e.g. from disjunctive struct domains *)

--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -18,7 +18,7 @@ struct
   let should_join x y = D.equal x y
 
   (* NB! Currently we care only about concrete indexes. Base (seeing only a int domain
-     element) answers with the string "unknown" on all non-concrete cases. *)
+     element) answers with Lval.any_index_exp on all non-concrete cases. *)
   let rec conv_offset x =
     match x with
     | `NoOffset    -> `NoOffset

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -109,7 +109,7 @@ struct
       let i_exp =
         match ValueDomain.IndexDomain.to_int i with
         | Some i -> Const (CInt (i, Cilfacade.ptrdiff_ikind (), Some (Z.to_string i)))
-        | None -> MyCFG.unknown_exp
+        | None -> Lval.any_index_exp
       in
       `Index (i_exp, conv_offset_inv o)
 

--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -83,7 +83,7 @@ struct
       let rec unknown_index = function
         | `NoOffset -> `NoOffset
         | `Field (f, os) -> `Field (f, unknown_index os)
-        | `Index (i, os) -> `Index (MyCFG.unknown_exp, unknown_index os) (* forget specific indices *)
+        | `Index (i, os) -> `Index (Lval.any_index_exp, unknown_index os) (* forget specific indices *)
       in
       Option.map (Lvals.of_list % List.map (Tuple2.map2 unknown_index)) (get_region ctx e)
 

--- a/src/analyses/uninit.ml
+++ b/src/analyses/uninit.ml
@@ -31,7 +31,7 @@ struct
   let exitstate  v : D.t = D.empty ()
 
   (* NB! Currently we care only about concrete indexes. Base (seeing only a int domain
-     element) answers with the string "unknown" on all non-concrete cases. *)
+     element) answers with Lval.any_index_exp on all non-concrete cases. *)
   let rec conv_offset x =
     match x with
     | `NoOffset    -> `NoOffset

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -114,9 +114,11 @@ struct
   let invariant ~value_invariant ~offset ~lval x =
     match offset with
     (* invariants for all indices *)
-    | NoOffset ->
+    | NoOffset when get_bool "witness.invariant.goblint" ->
       let i_lval = Cil.addOffsetLval (Index (all_index_exp, NoOffset)) lval in
       value_invariant ~offset ~lval:i_lval x
+    | NoOffset ->
+      Invariant.none
     (* invariant for one index *)
     | Index (i, offset) ->
       value_invariant ~offset ~lval x
@@ -226,10 +228,12 @@ struct
       let i_all =
         if Val.is_bot xr then
           Invariant.top ()
-        else (
+        else if get_bool "witness.invariant.goblint" then (
           let i_lval = Cil.addOffsetLval (Index (all_index_exp, NoOffset)) lval in
           value_invariant ~offset ~lval:i_lval (join_of_all_parts x)
         )
+        else
+          Invariant.top ()
       in
       BatList.fold_lefti (fun acc i x ->
           let i_lval = Cil.addOffsetLval (Index (Cil.integer i, NoOffset)) lval in
@@ -762,9 +766,11 @@ struct
   let invariant ~value_invariant ~offset ~lval x =
     match offset with
     (* invariants for all indices *)
-    | NoOffset ->
+    | NoOffset when get_bool "witness.invariant.goblint" ->
       let i_lval = Cil.addOffsetLval (Index (all_index_exp, NoOffset)) lval in
       value_invariant ~offset ~lval:i_lval (join_of_all_parts x)
+    | NoOffset ->
+      Invariant.none
     (* invariant for one index *)
     | Index (i, offset) ->
       Invariant.none (* TODO: look up *)

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -106,7 +106,7 @@ struct
     match offset with
     (* invariants for all indices *)
     | NoOffset ->
-      let i_lval = Cil.addOffsetLval (Index (MyCFG.all_array_index_exp, NoOffset)) lval in
+      let i_lval = Cil.addOffsetLval (Index (MyCFG.strong_all_array_index_exp, NoOffset)) lval in
       value_invariant ~offset ~lval:i_lval x
     (* invariant for one index *)
     | Index (i, offset) ->
@@ -211,7 +211,7 @@ struct
         if Val.is_bot xr then
           Invariant.top ()
         else (
-          let i_lval = Cil.addOffsetLval (Index (MyCFG.all_array_index_exp, NoOffset)) lval in
+          let i_lval = Cil.addOffsetLval (Index (MyCFG.strong_all_array_index_exp, NoOffset)) lval in
           value_invariant ~offset ~lval:i_lval (join_of_all_parts x)
         )
       in
@@ -744,7 +744,7 @@ struct
     match offset with
     (* invariants for all indices *)
     | NoOffset ->
-      let i_lval = Cil.addOffsetLval (Index (MyCFG.all_array_index_exp, NoOffset)) lval in
+      let i_lval = Cil.addOffsetLval (Index (MyCFG.strong_all_array_index_exp, NoOffset)) lval in
       value_invariant ~offset ~lval:i_lval (join_of_all_parts x)
     (* invariant for one index *)
     | Index (i, offset) ->

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -86,7 +86,12 @@ struct
   let pretty () x = text "Array: " ++ pretty () x
   let pretty_diff () (x,y) = dprintf "%s: %a not leq %a" (name ()) pretty x pretty y
   let get ?(checkBounds=true) (ask: VDQ.t) a i = a
-  let set (ask: VDQ.t) a i v = join a v
+  let set (ask: VDQ.t) a (ie, i) v =
+    match ie with
+    | Some ie when CilType.Exp.equal ie MyCFG.strong_all_array_index_exp ->
+      v
+    | _ ->
+      join a v
   let make ?(varAttr=[]) ?(typAttr=[])  i v = v
   let length _ = None
 

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -103,7 +103,17 @@ struct
   let project ?(varAttr=[]) ?(typAttr=[]) _ t = t
 
   let invariant ~value_invariant ~offset ~lval x =
-    Invariant.none (* TODO *)
+    match offset with
+    (* invariants for all indices *)
+    | NoOffset ->
+      let i_lval = Cil.addOffsetLval (Index (MyCFG.all_array_index_exp, NoOffset)) lval in
+      value_invariant ~offset ~lval:i_lval x
+    (* invariant for one index *)
+    | Index (i, offset) ->
+      value_invariant ~offset ~lval x
+    (* invariant for one field *)
+    | Field (f, offset) ->
+      Invariant.none
 end
 
 let factor () =

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -741,7 +741,17 @@ struct
   let project ?(varAttr=[]) ?(typAttr=[]) _ t = t
 
   let invariant ~value_invariant ~offset ~lval x =
-    Invariant.none (* TODO *)
+    match offset with
+    (* invariants for all indices *)
+    | NoOffset ->
+      let i_lval = Cil.addOffsetLval (Index (MyCFG.all_array_index_exp, NoOffset)) lval in
+      value_invariant ~offset ~lval:i_lval (join_of_all_parts x)
+    (* invariant for one index *)
+    | Index (i, offset) ->
+      Invariant.none (* TODO: look up *)
+    (* invariant for one field *)
+    | Field (f, offset) ->
+      Invariant.none
 end
 
 (* This is the main array out of bounds check *)

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -194,6 +194,7 @@ struct
   let set ask (xl, xr) (ie, i) v =
     match ie with
     | Some ie when CilType.Exp.equal ie Lval.all_index_exp ->
+      (* TODO: Doesn't seem to work for unassume because unrolled elements are top-initialized, not bot-initialized. *)
       (BatList.make (factor ()) v, v)
     | _ ->
       set ask (xl, xr) (ie, i) v
@@ -481,6 +482,7 @@ struct
     if M.tracing then M.trace "update_offset" "part array set_with_length %a %s %a\n" pretty x (BatOption.map_default Basetype.CilExp.show "None" i) Val.pretty a;
     match i with
     | Some ie when CilType.Exp.equal ie Lval.all_index_exp ->
+      (* TODO: Doesn't seem to work for unassume. *)
       Joint a
     | Some i when CilType.Exp.equal i Lval.any_index_exp ->
       (assert !Goblintutil.global_initialization; (* just joining with xm here assumes that all values will be set, which is guaranteed during inits *)

--- a/src/cdomains/arrayDomain.ml
+++ b/src/cdomains/arrayDomain.ml
@@ -8,10 +8,6 @@ module A = Array
 module BI = IntOps.BigIntOps
 module VDQ = ValueDomainQueries
 
-let any_index_exp = CastE (TInt (Cilfacade.ptrdiff_ikind (), []), mkString "any_index")
-let all_index_exp = CastE (TInt (Cilfacade.ptrdiff_ikind (), []), mkString "all_index")
-
-
 type domain = TrivialDomain | PartitionedDomain | UnrolledDomain
 
 (* determines the domain based on variable, type and flag *)
@@ -92,7 +88,7 @@ struct
   let get ?(checkBounds=true) (ask: VDQ.t) a i = a
   let set (ask: VDQ.t) a (ie, i) v =
     match ie with
-    | Some ie when CilType.Exp.equal ie all_index_exp ->
+    | Some ie when CilType.Exp.equal ie Lval.all_index_exp ->
       v
     | _ ->
       join a v
@@ -115,7 +111,7 @@ struct
     match offset with
     (* invariants for all indices *)
     | NoOffset when get_bool "witness.invariant.goblint" ->
-      let i_lval = Cil.addOffsetLval (Index (all_index_exp, NoOffset)) lval in
+      let i_lval = Cil.addOffsetLval (Index (Lval.all_index_exp, NoOffset)) lval in
       value_invariant ~offset ~lval:i_lval x
     | NoOffset ->
       Invariant.none
@@ -197,7 +193,7 @@ struct
     else ((update_unrolled_values min_i (Z.of_int ((factor ())-1))), (Val.join xr v))
   let set ask (xl, xr) (ie, i) v =
     match ie with
-    | Some ie when CilType.Exp.equal ie all_index_exp ->
+    | Some ie when CilType.Exp.equal ie Lval.all_index_exp ->
       (BatList.make (factor ()) v, v)
     | _ ->
       set ask (xl, xr) (ie, i) v
@@ -229,7 +225,7 @@ struct
         if Val.is_bot xr then
           Invariant.top ()
         else if get_bool "witness.invariant.goblint" then (
-          let i_lval = Cil.addOffsetLval (Index (all_index_exp, NoOffset)) lval in
+          let i_lval = Cil.addOffsetLval (Index (Lval.all_index_exp, NoOffset)) lval in
           value_invariant ~offset ~lval:i_lval (join_of_all_parts x)
         )
         else
@@ -484,9 +480,9 @@ struct
   let set_with_length length (ask:VDQ.t) x (i,_) a =
     if M.tracing then M.trace "update_offset" "part array set_with_length %a %s %a\n" pretty x (BatOption.map_default Basetype.CilExp.show "None" i) Val.pretty a;
     match i with
-    | Some ie when CilType.Exp.equal ie all_index_exp ->
+    | Some ie when CilType.Exp.equal ie Lval.all_index_exp ->
       Joint a
-    | Some i when CilType.Exp.equal i any_index_exp ->
+    | Some i when CilType.Exp.equal i Lval.any_index_exp ->
       (assert !Goblintutil.global_initialization; (* just joining with xm here assumes that all values will be set, which is guaranteed during inits *)
        (* the join is needed here! see e.g 30/04 *)
        let o = match x with Partitioned (_, (_, xm, _)) -> xm | Joint v -> v in
@@ -767,7 +763,7 @@ struct
     match offset with
     (* invariants for all indices *)
     | NoOffset when get_bool "witness.invariant.goblint" ->
-      let i_lval = Cil.addOffsetLval (Index (all_index_exp, NoOffset)) lval in
+      let i_lval = Cil.addOffsetLval (Index (Lval.all_index_exp, NoOffset)) lval in
       value_invariant ~offset ~lval:i_lval (join_of_all_parts x)
     | NoOffset ->
       Invariant.none

--- a/src/cdomains/arrayDomain.mli
+++ b/src/cdomains/arrayDomain.mli
@@ -57,6 +57,7 @@ sig
   val update_length: idx -> t -> t
 
   val project: ?varAttr:Cil.attributes -> ?typAttr:Cil.attributes -> VDQ.t -> t -> t
+  val invariant: value_invariant:(offset:Cil.offset -> lval:Cil.lval -> value -> Invariant.t) -> offset:Cil.offset -> lval:Cil.lval -> t -> Invariant.t
 end
 
 module type LatticeWithSmartOps =

--- a/src/cdomains/arrayDomain.mli
+++ b/src/cdomains/arrayDomain.mli
@@ -90,14 +90,3 @@ module PartitionedWithLength (Val: LatticeWithSmartOps) (Idx:IntDomain.Z): S wit
 
 module AttributeConfiguredArrayDomain(Val: LatticeWithSmartOps) (Idx:IntDomain.Z):S with type value = Val.t and type idx = Idx.t
 (** Switches between PartitionedWithLength, TrivialWithLength and Unroll based on variable, type, and flag. *)
-
-
-val any_index_exp: exp
-(** Special index expression for some unknown index.
-    Weakly updates array in assignment.
-    Used for exp.fast_global_inits. *)
-
-val all_index_exp: exp
-(** Special index expression for all indices.
-    Strongly updates array in assignment.
-    Used for Goblint-specific witness invariants. *)

--- a/src/cdomains/arrayDomain.mli
+++ b/src/cdomains/arrayDomain.mli
@@ -90,3 +90,14 @@ module PartitionedWithLength (Val: LatticeWithSmartOps) (Idx:IntDomain.Z): S wit
 
 module AttributeConfiguredArrayDomain(Val: LatticeWithSmartOps) (Idx:IntDomain.Z):S with type value = Val.t and type idx = Idx.t
 (** Switches between PartitionedWithLength, TrivialWithLength and Unroll based on variable, type, and flag. *)
+
+
+val any_index_exp: exp
+(** Special index expression for some unknown index.
+    Weakly updates array in assignment.
+    Used for exp.fast_global_inits. *)
+
+val all_index_exp: exp
+(** Special index expression for all indices.
+    Strongly updates array in assignment.
+    Used for Goblint-specific witness invariants. *)

--- a/src/cdomains/lval.ml
+++ b/src/cdomains/lval.ml
@@ -4,6 +4,17 @@ open Pretty
 module GU = Goblintutil
 module M = Messages
 
+(** Special index expression for some unknown index.
+    Weakly updates array in assignment.
+    Used for exp.fast_global_inits. *)
+let any_index_exp = CastE (TInt (Cilfacade.ptrdiff_ikind (), []), mkString "any_index")
+
+(** Special index expression for all indices.
+    Strongly updates array in assignment.
+    Used for Goblint-specific witness invariants. *)
+let all_index_exp = CastE (TInt (Cilfacade.ptrdiff_ikind (), []), mkString "all_index")
+
+
 type ('a, 'b) offs = [
   | `NoOffset
   | `Field of 'a * ('a,'b) offs
@@ -583,7 +594,7 @@ struct
     match o with
     | `NoOffset -> a
     | `Field (f,o) -> short_offs o (a^"."^f.fname)
-    | `Index (e,o) when CilType.Exp.equal e MyCFG.unknown_exp -> short_offs o (a^"[?]")
+    | `Index (e,o) when CilType.Exp.equal e any_index_exp -> short_offs o (a^"[?]")
     | `Index (e,o) -> short_offs o (a^"["^CilType.Exp.show e^"]")
 
   let rec of_ciloffs x =

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -873,7 +873,7 @@ struct
 
   let update_offset (ask: VDQ.t) (x:t) (offs:offs) (value:t) (exp:exp option) (v:lval) (t:typ): t =
     let rec do_update_offset (ask:VDQ.t) (x:t) (offs:offs) (value:t) (exp:exp option) (l:lval option) (o:offset option) (v:lval) (t:typ):t =
-      if M.tracing then M.traceli "update_offset" "do_update_offset %a %a %a\n" pretty x Offs.pretty offs pretty value;
+      if M.tracing then M.traceli "update_offset" "do_update_offset %a %a (%a) %a\n" pretty x Offs.pretty offs (Pretty.docOpt (CilType.Exp.pretty ())) exp pretty value;
       let mu = function `Blob (`Blob (y, s', orig), s, orig2) -> `Blob (y, ID.join s s',orig) | x -> x in
       let r =
       match x, offs with

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -1317,6 +1317,7 @@ struct
     | `Address n -> ad_invariant ~vs ~offset ~lval n
     | `Struct n -> Structs.invariant ~value_invariant:(vd_invariant ~vs) ~offset ~lval n
     | `Union n -> Unions.invariant ~value_invariant:(vd_invariant ~vs) ~offset ~lval n
+    | `Array n -> CArrays.invariant ~value_invariant:(vd_invariant ~vs) ~offset ~lval n
     | `Blob n when GobConfig.get_bool "ana.base.invariant.blobs" -> blob_invariant ~vs ~offset ~lval n
     | _ -> Invariant.none (* TODO *)
 

--- a/src/domains/invariantCil.ml
+++ b/src/domains/invariantCil.ml
@@ -57,7 +57,8 @@ class exp_contains_tmp_visitor (acc: bool ref) = object
 
   method! vexpr (e: exp) =
     if e = MyCFG.unknown_exp then (
-      acc := true;
+      (* TODO: add config option *)
+      (* acc := true; *)
       SkipChildren
     )
     else

--- a/src/domains/invariantCil.ml
+++ b/src/domains/invariantCil.ml
@@ -57,8 +57,7 @@ class exp_contains_tmp_visitor (acc: bool ref) = object
 
   method! vexpr (e: exp) =
     if e = MyCFG.unknown_exp then (
-      (* TODO: add config option *)
-      (* acc := true; *)
+      acc := true;
       SkipChildren
     )
     else

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -683,7 +683,7 @@ let getGlobalInits (file: file) : edges  =
       lval
     in
     let rec any_index_offset = function
-      | Index (e,o) -> Index (ArrayDomain.any_index_exp, any_index_offset o)
+      | Index (e,o) -> Index (Lval.any_index_exp, any_index_offset o)
       | Field (f,o) -> Field (f, any_index_offset o)
       | NoOffset -> NoOffset
     in

--- a/src/framework/cfgTools.ml
+++ b/src/framework/cfgTools.ml
@@ -682,12 +682,12 @@ let getGlobalInits (file: file) : edges  =
       doInit (addOffsetLval offs lval) loc init is_zero;
       lval
     in
-    let rec all_index = function
-      | Index (e,o) -> Index (all_array_index_exp, all_index o)
-      | Field (f,o) -> Field (f, all_index o)
+    let rec any_index_offset = function
+      | Index (e,o) -> Index (ArrayDomain.any_index_exp, any_index_offset o)
+      | Field (f,o) -> Field (f, any_index_offset o)
       | NoOffset -> NoOffset
     in
-    let all_index (lh,offs) = lh, all_index offs in
+    let any_index (lh,offs) = lh, any_index_offset offs in
     match init with
     | SingleInit exp ->
       let assign lval = (loc, Assign (lval, exp)) in
@@ -695,8 +695,8 @@ let getGlobalInits (file: file) : edges  =
          Instead, we get one assign for each distinct value in the array *)
       if not fast_global_inits then
         Hashtbl.add inits (assign lval) ()
-      else if not (Hashtbl.mem inits (assign (all_index lval))) then
-        Hashtbl.add inits (assign (all_index lval)) ()
+      else if not (Hashtbl.mem inits (assign (any_index lval))) then
+        Hashtbl.add inits (assign (any_index lval)) ()
       else
         ()
     | CompoundInit (typ, lst) ->

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -58,11 +58,6 @@ let unknown_exp : exp = mkString "__unknown_value__"
 let dummy_func = emptyFunction "__goblint_dummy_init" (* TODO get rid of this? *)
 let dummy_node = FunctionEntry Cil.dummyFunDec
 
-(* TODO: actually some/exists, not all in fast_global_inits? *)
-let all_array_index_exp : exp = CastE(TInt(Cilfacade.ptrdiff_ikind (),[]), unknown_exp)
-
-let strong_all_array_index_exp : exp = CastE(TInt(Cilfacade.ptrdiff_ikind (),[]), mkString "strong_all_array_index_exp")
-
 
 module type FileCfg =
 sig

--- a/src/framework/myCFG.ml
+++ b/src/framework/myCFG.ml
@@ -58,7 +58,10 @@ let unknown_exp : exp = mkString "__unknown_value__"
 let dummy_func = emptyFunction "__goblint_dummy_init" (* TODO get rid of this? *)
 let dummy_node = FunctionEntry Cil.dummyFunDec
 
+(* TODO: actually some/exists, not all in fast_global_inits? *)
 let all_array_index_exp : exp = CastE(TInt(Cilfacade.ptrdiff_ikind (),[]), unknown_exp)
+
+let strong_all_array_index_exp : exp = CastE(TInt(Cilfacade.ptrdiff_ikind (),[]), mkString "strong_all_array_index_exp")
 
 
 module type FileCfg =

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1679,7 +1679,7 @@
         "fast_global_inits": {
           "title": "exp.fast_global_inits",
           "description":
-            "Only generate one 'a[MyCFG.all_array_index_exp] = x' for all assignments a[...] = x for a global array a[n].",
+            "Only generate one 'a[any_index] = x' for all assignments a[...] = x for a global array a[n].",
           "type": "boolean",
           "default": true
         },

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -2319,6 +2319,12 @@
                 "cond",
                 "RETURN"
               ]
+            },
+            "goblint": {
+              "title": "witness.invariant.goblint",
+              "description": "Emit non-standard Goblint-specific invariants. Currently array invariants with all_index offsets.",
+              "type": "boolean",
+              "default": false
             }
           },
           "additionalProperties": false

--- a/tests/regression/56-witness/44-base-unassume-array.c
+++ b/tests/regression/56-witness/44-base-unassume-array.c
@@ -1,0 +1,16 @@
+// PARAM: --set ana.activated[+] unassume --set witness.yaml.unassume 44-base-unassume-array.yml --enable ana.int.interval
+#include <goblint.h>
+
+int main() {
+  int a[10];
+
+  for (int i = 0; i < 3; i++) {
+    a[i] = i;
+  }
+
+  for (int i = 0; i < 10; i++) {
+    __goblint_check(a[i] >= 0);
+    __goblint_check(a[i] < 3);
+  }
+  return 0;
+}

--- a/tests/regression/56-witness/44-base-unassume-array.yml
+++ b/tests/regression/56-witness/44-base-unassume-array.yml
@@ -24,7 +24,7 @@
     column: 6
     function: main
   loop_invariant:
-    string: 0 <= a[(long )"__unknown_value__"]
+    string: 0 <= a[(long )"strong_all_array_index_exp"]
     type: assertion
     format: C
 - entry_type: loop_invariant
@@ -53,6 +53,6 @@
     column: 6
     function: main
   loop_invariant:
-    string: a[(long )"__unknown_value__"] < 3
+    string: a[(long )"strong_all_array_index_exp"] < 3
     type: assertion
     format: C

--- a/tests/regression/56-witness/44-base-unassume-array.yml
+++ b/tests/regression/56-witness/44-base-unassume-array.yml
@@ -1,0 +1,58 @@
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: c03a4c45-567e-4791-ac75-0675f782dc8c
+    creation_time: 2023-05-10T15:02:06Z
+    producer:
+      name: Goblint
+      version: heads/array-witness-invariant-0-gfb806119b-dirty
+      command_line: '''/home/simmo/dev/goblint/sv-comp/goblint/goblint'' ''44-base-unassume-array.c''
+        ''--enable'' ''ana.int.interval'' ''--enable'' ''witness.yaml.enabled'' ''--set''
+        ''dbg.debug'' ''true'' ''--enable'' ''dbg.timing.enabled'' ''--set'' ''goblint-dir''
+        ''.goblint-56-44'''
+    task:
+      input_files:
+      - 44-base-unassume-array.c
+      input_file_hashes:
+        44-base-unassume-array.c: 9d9dc013c8d8aee483852aa73d0b4ac48ee7ea0f5433dc86ee28c3fe54c49726
+      data_model: LP64
+      language: C
+  location:
+    file_name: 44-base-unassume-array.c
+    file_hash: 9d9dc013c8d8aee483852aa73d0b4ac48ee7ea0f5433dc86ee28c3fe54c49726
+    line: 7
+    column: 6
+    function: main
+  loop_invariant:
+    string: 0 <= a[(long )"__unknown_value__"]
+    type: assertion
+    format: C
+- entry_type: loop_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: c03a4c45-567e-4791-ac75-0675f782dc8c
+    creation_time: 2023-05-10T15:02:06Z
+    producer:
+      name: Goblint
+      version: heads/array-witness-invariant-0-gfb806119b-dirty
+      command_line: '''/home/simmo/dev/goblint/sv-comp/goblint/goblint'' ''44-base-unassume-array.c''
+        ''--enable'' ''ana.int.interval'' ''--enable'' ''witness.yaml.enabled'' ''--set''
+        ''dbg.debug'' ''true'' ''--enable'' ''dbg.timing.enabled'' ''--set'' ''goblint-dir''
+        ''.goblint-56-44'''
+    task:
+      input_files:
+      - 44-base-unassume-array.c
+      input_file_hashes:
+        44-base-unassume-array.c: 9d9dc013c8d8aee483852aa73d0b4ac48ee7ea0f5433dc86ee28c3fe54c49726
+      data_model: LP64
+      language: C
+  location:
+    file_name: 44-base-unassume-array.c
+    file_hash: 9d9dc013c8d8aee483852aa73d0b4ac48ee7ea0f5433dc86ee28c3fe54c49726
+    line: 7
+    column: 6
+    function: main
+  loop_invariant:
+    string: a[(long )"__unknown_value__"] < 3
+    type: assertion
+    format: C

--- a/tests/regression/56-witness/44-base-unassume-array.yml
+++ b/tests/regression/56-witness/44-base-unassume-array.yml
@@ -24,7 +24,7 @@
     column: 6
     function: main
   loop_invariant:
-    string: 0 <= a[(long )"strong_all_array_index_exp"]
+    string: 0 <= a[(long )"all_index"]
     type: assertion
     format: C
 - entry_type: loop_invariant
@@ -53,6 +53,6 @@
     column: 6
     function: main
   loop_invariant:
-    string: a[(long )"strong_all_array_index_exp"] < 3
+    string: a[(long )"all_index"] < 3
     type: assertion
     format: C


### PR DESCRIPTION
Closes #1044.

Turns out `all_array_index_exp` was a misnomer and that has bit us in the past:
https://github.com/goblint/analyzer/blob/997f9ae5bcb4729161019c719b068dc358ae6d86/src/cdomains/arrayDomain.ml#L428-L433
That is because `exp.fast_global_inits` converts
```c
int g[10] = {1, 2, 3};
```
into
```c
g[all_array_index_exp] = 1;
g[all_array_index_exp] = 2;
g[all_array_index_exp] = 3;
```
But it doesn't actually mean assigning to _all_ indices, but rather assigning to _some_ indices. Thus the weak update with `join`.

For the Goblint-specific array invariants, we actually want _all_ indices and thus a strong update. Soundness of unassume is still ensured by a final join of the environments, but when unassuming `g[all_index] >= 0 && g[all_index] <= 3` we don't want the two subinvariants to be joined, rather acting as refinements which allow complete overwriting.

Thus this introduces `any_index_exp`, which is used for `exp.fast_global_inits` and all kinds of `unknown_exp` or `"unknown"` indices, to make everything consistent. And `all_index_exp`, which is used for array invariants.