### PR TITLE
Make privatizations sound in presence of analyses that can recover from multi-threaded mode

### DIFF
--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -43,7 +43,7 @@ struct
       + [deref=true], [reach=true] - Access [exp] by dereferencing transitively (reachable), used for deep special accesses. *)
   let access_one_top ?(force=false) ?(deref=false) ctx (kind: AccessKind.t) reach exp =
     if M.tracing then M.traceli "access" "access_one_top %a %b %a:\n" AccessKind.pretty kind reach d_exp exp;
-    if force || !collect_local || !emit_single_threaded || ThreadFlag.is_currently_multi (Analyses.ask_of_ctx ctx) then (
+    if force || !collect_local || !emit_single_threaded || ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx) then (
       if deref then
         do_access ctx kind reach exp;
       Access.distribute_access_exp (do_access ctx Read false) exp

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -43,7 +43,7 @@ struct
       + [deref=true], [reach=true] - Access [exp] by dereferencing transitively (reachable), used for deep special accesses. *)
   let access_one_top ?(force=false) ?(deref=false) ctx (kind: AccessKind.t) reach exp =
     if M.tracing then M.traceli "access" "access_one_top %a %b %a:\n" AccessKind.pretty kind reach d_exp exp;
-    if force || !collect_local || !emit_single_threaded || ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) then (
+    if force || !collect_local || !emit_single_threaded || ThreadFlag.is_currently_multi (Analyses.ask_of_ctx ctx) then (
       if deref then
         do_access ctx kind reach exp;
       Access.distribute_access_exp (do_access ctx Read false) exp

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -95,7 +95,7 @@ struct
   let sync (ask: Q.ask) getg sideg (st: relation_components_t) reason =
     match reason with
     | `Join ->
-      if (ask.f Q.MustBeSingleThreadedUptoCurrent) then
+      if ask.f (Q.MustBeSingleThreaded {since_start = true}) then
         st
       else
         (* must be like enter_multithreaded *)
@@ -342,7 +342,7 @@ struct
           st
       end
     | `Join ->
-      if (ask.f Q.MustBeSingleThreadedUptoCurrent) then
+      if (ask.f (Q.MustBeSingleThreaded { since_start= true })) then
         st
       else
         (* must be like enter_multithreaded *)
@@ -548,7 +548,7 @@ struct
           st
       end
     | `Join ->
-      if (ask.f Q.MustBeSingleThreadedUptoCurrent) then
+      if (ask.f (Q.MustBeSingleThreaded {since_start = true})) then
         st
       else
         let rel = st.rel in
@@ -1031,7 +1031,7 @@ struct
     match reason with
     | `Return -> st (* TODO: implement? *)
     | `Join ->
-      if (ask.f Q.MustBeSingleThreadedUptoCurrent) then
+      if (ask.f (Q.MustBeSingleThreaded {since_start = true})) then
         st
       else
         let rel = st.rel in

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -95,7 +95,7 @@ struct
   let sync (ask: Q.ask) getg sideg (st: relation_components_t) reason =
     match reason with
     | `Join ->
-      if (ask.f Q.MustBeSingleThreaded) then
+      if (ask.f Q.MustBeSingleThreadedUptoCurrent) then
         st
       else
         (* must be like enter_multithreaded *)
@@ -342,7 +342,7 @@ struct
           st
       end
     | `Join ->
-      if (ask.f Q.MustBeSingleThreaded) then
+      if (ask.f Q.MustBeSingleThreadedUptoCurrent) then
         st
       else
         (* must be like enter_multithreaded *)
@@ -548,7 +548,7 @@ struct
           st
       end
     | `Join ->
-      if (ask.f Q.MustBeSingleThreaded) then
+      if (ask.f Q.MustBeSingleThreadedUptoCurrent) then
         st
       else
         let rel = st.rel in
@@ -1031,7 +1031,7 @@ struct
     match reason with
     | `Return -> st (* TODO: implement? *)
     | `Join ->
-      if (ask.f Q.MustBeSingleThreaded) then
+      if (ask.f Q.MustBeSingleThreadedUptoCurrent) then
         st
       else
         let rel = st.rel in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2463,14 +2463,14 @@ struct
               let asked' = Queries.Set.add anyq asked in
               let r: a Queries.result =
                 match q with
-                | MustBeSingleThreaded when single -> true
+                | MustBeSingleThreadedUptoCurrent when single -> true
                 | MayEscape _
                 | MayBePublic _
                 | MayBePublicWithout _
                 | MustBeProtectedBy _
                 | MustLockset
                 | MustBeAtomic
-                | MustBeSingleThreaded
+                | MustBeSingleThreadedUptoCurrent
                 | MustBeUniqueThread
                 | CurrentThreadId
                 | MayBeThreadReturn

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -433,7 +433,7 @@ struct
       | `Thread ->
         true
       | _ ->
-        ThreadFlag.is_multi (Analyses.ask_of_ctx ctx)
+        ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx)
     in
     if M.tracing then M.tracel "sync" "sync multi=%B earlyglobs=%B\n" multi !GU.earlyglobs;
     if !GU.earlyglobs || multi then
@@ -449,7 +449,7 @@ struct
     ignore (sync' reason ctx)
 
   let get_var (a: Q.ask) (gs: glob_fun) (st: store) (x: varinfo): value =
-    if (!GU.earlyglobs || ThreadFlag.is_multi a) && is_global a x then
+    if (!GU.earlyglobs || ThreadFlag.has_ever_been_multi a) && is_global a x then
       Priv.read_global a (priv_getg gs) st x
     else begin
       if M.tracing then M.tracec "get" "Singlethreaded mode.\n";
@@ -1203,7 +1203,7 @@ struct
     in
 
     if CilLval.Set.is_top context.Invariant.lvals then (
-      if !GU.earlyglobs || ThreadFlag.is_multi ask then (
+      if !GU.earlyglobs || ThreadFlag.has_ever_been_multi ask then (
         let cpa_invariant =
           CPA.fold (fun k v a ->
               if not (is_global ask k) then
@@ -1471,7 +1471,7 @@ struct
       end else
         (* Check if we need to side-effect this one. We no longer generate
          * side-effects here, but the code still distinguishes these cases. *)
-      if (!GU.earlyglobs || ThreadFlag.is_multi a) && is_global a x then begin
+      if (!GU.earlyglobs || ThreadFlag.has_ever_been_multi a) && is_global a x then begin
         if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: update a global var '%s' ...\n" x.vname;
         let priv_getg = priv_getg gs in
         (* Optimization to avoid evaluating integer values when setting them.
@@ -1916,7 +1916,7 @@ struct
            Otherwise thread is analyzed with no global inits, reading globals gives bot, which turns into top, which might get published...
            sync `Thread doesn't help us here, it's not specific to entering multithreaded mode.
            EnterMultithreaded events only execute after threadenter and threadspawn. *)
-        if not (ThreadFlag.is_multi (Analyses.ask_of_ctx ctx)) then
+        if not (ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx)) then
           ignore (Priv.enter_multithreaded (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st);
         Priv.threadenter (Analyses.ask_of_ctx ctx) st
       ) else
@@ -2463,14 +2463,14 @@ struct
               let asked' = Queries.Set.add anyq asked in
               let r: a Queries.result =
                 match q with
-                | MustBeSingleThreadedUptoCurrent when single -> true
+                | MustBeSingleThreaded _ when single -> true
                 | MayEscape _
                 | MayBePublic _
                 | MayBePublicWithout _
                 | MustBeProtectedBy _
                 | MustLockset
                 | MustBeAtomic
-                | MustBeSingleThreadedUptoCurrent
+                | MustBeSingleThreaded _
                 | MustBeUniqueThread
                 | CurrentThreadId
                 | MayBeThreadReturn
@@ -2576,10 +2576,10 @@ struct
   let event ctx e octx =
     let st: store = ctx.local in
     match e with
-    | Events.Lock (addr, _) when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+    | Events.Lock (addr, _) when ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       if M.tracing then M.tracel "priv" "LOCK EVENT %a\n" LockDomain.Addr.pretty addr;
       Priv.lock (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) st addr
-    | Events.Unlock addr when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
+    | Events.Unlock addr when ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
       if addr = UnknownPtr then
         M.info ~category:Unsound "Unknown mutex unlocked, base privatization unsound"; (* TODO: something more sound *)
       WideningTokens.with_local_side_tokens (fun () ->

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -40,7 +40,7 @@ end
 module Protection =
 struct
   let is_unprotected ask x: bool =
-    let multi = ThreadFlag.is_multi ask in
+    let multi = ThreadFlag.has_ever_been_multi ask in
     (!GU.earlyglobs && not multi && not (is_excluded_from_earlyglobs x)) ||
     (
       multi &&
@@ -48,7 +48,7 @@ struct
     )
 
   let is_unprotected_without ask ?(write=true) x m: bool =
-    ThreadFlag.is_multi ask &&
+    ThreadFlag.has_ever_been_multi ask &&
     ask.f (Q.MayBePublicWithout {global=x; write; without_mutex=m})
 
   let is_protected_by ask m x: bool =

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -209,7 +209,7 @@ struct
 
   let event ctx e octx =
     match e with
-    | Events.Access {exp; lvals; kind; _} when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* threadflag query in post-threadspawn ctx *)
+    | Events.Access {exp; lvals; kind; _} when ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx) -> (* threadflag query in post-threadspawn ctx *)
       (* must use original (pre-assign, etc) ctx queries *)
       let old_access var_opt offs_opt =
         (* TODO: this used to use ctx instead of octx, why? *)

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -92,7 +92,7 @@ struct
 
   let event ctx e octx =
     match e with
-    | Events.Access {exp=e; lvals; kind; reach} when ThreadFlag.is_multi (Analyses.ask_of_ctx ctx) -> (* threadflag query in post-threadspawn ctx *)
+    | Events.Access {exp=e; lvals; kind; reach} when ThreadFlag.is_currently_multi (Analyses.ask_of_ctx ctx) -> (* threadflag query in post-threadspawn ctx *)
       (* must use original (pre-assign, etc) ctx queries *)
       let conf = 110 in
       let module LS = Queries.LS in

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -67,7 +67,7 @@ struct
         | `Lifted tid -> not (is_not_unique ctx tid)
         | _ -> false
       end
-    | Queries.MustBeSingleThreaded -> begin
+    | Queries.MustBeSingleThreadedUptoCurrent -> begin
         let tid = ThreadId.get_current (Analyses.ask_of_ctx ctx) in
         match tid with
         | `Lifted tid when T.is_main tid -> D.is_empty ctx.local

--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -67,10 +67,12 @@ struct
         | `Lifted tid -> not (is_not_unique ctx tid)
         | _ -> false
       end
-    | Queries.MustBeSingleThreadedUptoCurrent -> begin
+    | Queries.MustBeSingleThreaded {since_start = false} -> begin
         let tid = ThreadId.get_current (Analyses.ask_of_ctx ctx) in
         match tid with
-        | `Lifted tid when T.is_main tid -> D.is_empty ctx.local
+        | `Lifted tid when T.is_main tid ->
+          (* This analysis cannot tell if we are back in single-threaded mode or never left it. *)
+          D.is_empty ctx.local
         | _ -> false
       end
     | _ -> Queries.Result.top q

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -65,7 +65,7 @@ struct
       let escaped = reachable ask rval in
       let escaped = D.filter (fun v -> not v.vglob) escaped in
       if M.tracing then M.tracel "escape" "assign vs: %a | %a\n" D.pretty vs D.pretty escaped;
-      if not (D.is_empty escaped) && ThreadFlag.is_multi ask then (* avoid emitting unnecessary event *)
+      if not (D.is_empty escaped) && ThreadFlag.has_ever_been_multi ask then (* avoid emitting unnecessary event *)
         ctx.emit (Events.Escape escaped);
       D.iter (fun v ->
           ctx.sideg v escaped;

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -8,7 +8,7 @@ open Analyses
 
 let is_multi (ask: Queries.ask): bool =
   if !GU.global_initialization then false else
-  not (ask.f Queries.MustBeSingleThreaded)
+    not (ask.f Queries.MustBeSingleThreadedUptoCurrent)
 
 
 module Spec =
@@ -41,7 +41,7 @@ struct
 
   let query ctx (type a) (x: a Queries.t): a Queries.result =
     match x with
-    | Queries.MustBeSingleThreaded -> not (Flag.is_multi ctx.local)
+    | Queries.MustBeSingleThreadedUptoCurrent -> not (Flag.is_multi ctx.local)
     | Queries.MustBeUniqueThread -> not (Flag.is_not_main ctx.local)
     (* This used to be in base but also commented out. *)
     (* | Queries.MayBePublic _ -> Flag.is_multi ctx.local *)

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -434,7 +434,7 @@ struct
     let d_local =
       (* if we are multithreaded, we run the risk, that some mutex protected variables got unlocked, so in this case caller state goes to top
          TODO: !!Unsound, this analysis does not handle this case -> regtest 63 08!! *)
-      if Queries.LS.is_top tainted || not (ctx.ask Queries.MustBeSingleThreaded) then
+      if Queries.LS.is_top tainted || not (ctx.ask Queries.MustBeSingleThreadedUptoCurrent) then
         D.top ()
       else
         let taint_exp = Queries.ES.of_list (List.map (fun lv -> Lval (Lval.CilLval.to_lval lv)) (Queries.LS.elements tainted)) in

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -434,7 +434,7 @@ struct
     let d_local =
       (* if we are multithreaded, we run the risk, that some mutex protected variables got unlocked, so in this case caller state goes to top
          TODO: !!Unsound, this analysis does not handle this case -> regtest 63 08!! *)
-      if Queries.LS.is_top tainted || not (ctx.ask Queries.MustBeSingleThreadedUptoCurrent) then
+      if Queries.LS.is_top tainted || not (ctx.ask (Queries.MustBeSingleThreaded {since_start = true})) then
         D.top ()
       else
         let taint_exp = Queries.ES.of_list (List.map (fun lv -> Lval (Lval.CilLval.to_lval lv)) (Queries.LS.elements tainted)) in

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -66,7 +66,7 @@ type _ t =
   | MustBeProtectedBy: mustbeprotectedby -> MustBool.t t
   | MustLockset: LS.t t
   | MustBeAtomic: MustBool.t t
-  | MustBeSingleThreaded: MustBool.t t
+  | MustBeSingleThreadedUptoCurrent: MustBool.t t
   | MustBeUniqueThread: MustBool.t t
   | CurrentThreadId: ThreadIdDomain.ThreadLifted.t t
   | MayBeThreadReturn: MayBool.t t
@@ -130,7 +130,7 @@ struct
     | IsHeapVar _ -> (module MayBool)
     | MustBeProtectedBy _ -> (module MustBool)
     | MustBeAtomic -> (module MustBool)
-    | MustBeSingleThreaded -> (module MustBool)
+    | MustBeSingleThreadedUptoCurrent -> (module MustBool)
     | MustBeUniqueThread -> (module MustBool)
     | EvalInt _ -> (module ID)
     | EvalLength _ -> (module ID)
@@ -189,7 +189,7 @@ struct
     | IsHeapVar _ -> MayBool.top ()
     | MustBeProtectedBy _ -> MustBool.top ()
     | MustBeAtomic -> MustBool.top ()
-    | MustBeSingleThreaded -> MustBool.top ()
+    | MustBeSingleThreadedUptoCurrent -> MustBool.top ()
     | MustBeUniqueThread -> MustBool.top ()
     | EvalInt _ -> ID.top ()
     | EvalLength _ -> ID.top ()
@@ -241,7 +241,7 @@ struct
     | Any (MustBeProtectedBy _) -> 9
     | Any MustLockset -> 10
     | Any MustBeAtomic -> 11
-    | Any MustBeSingleThreaded -> 12
+    | Any MustBeSingleThreadedUptoCurrent -> 12
     | Any MustBeUniqueThread -> 13
     | Any CurrentThreadId -> 14
     | Any MayBeThreadReturn -> 15
@@ -371,7 +371,7 @@ struct
     | Any (MustBeProtectedBy x) -> Pretty.dprintf "MustBeProtectedBy _"
     | Any MustLockset -> Pretty.dprintf "MustLockset"
     | Any MustBeAtomic -> Pretty.dprintf "MustBeAtomic"
-    | Any MustBeSingleThreaded -> Pretty.dprintf "MustBeSingleThreaded"
+    | Any MustBeSingleThreadedUptoCurrent -> Pretty.dprintf "MustBeSingleThreaded"
     | Any MustBeUniqueThread -> Pretty.dprintf "MustBeUniqueThread"
     | Any CurrentThreadId -> Pretty.dprintf "CurrentThreadId"
     | Any MayBeThreadReturn -> Pretty.dprintf "MayBeThreadReturn"

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -66,7 +66,7 @@ type _ t =
   | MustBeProtectedBy: mustbeprotectedby -> MustBool.t t
   | MustLockset: LS.t t
   | MustBeAtomic: MustBool.t t
-  | MustBeSingleThreadedUptoCurrent: MustBool.t t
+  | MustBeSingleThreaded: {since_start: bool} -> MustBool.t t
   | MustBeUniqueThread: MustBool.t t
   | CurrentThreadId: ThreadIdDomain.ThreadLifted.t t
   | MayBeThreadReturn: MayBool.t t
@@ -130,7 +130,7 @@ struct
     | IsHeapVar _ -> (module MayBool)
     | MustBeProtectedBy _ -> (module MustBool)
     | MustBeAtomic -> (module MustBool)
-    | MustBeSingleThreadedUptoCurrent -> (module MustBool)
+    | MustBeSingleThreaded _ -> (module MustBool)
     | MustBeUniqueThread -> (module MustBool)
     | EvalInt _ -> (module ID)
     | EvalLength _ -> (module ID)
@@ -189,7 +189,7 @@ struct
     | IsHeapVar _ -> MayBool.top ()
     | MustBeProtectedBy _ -> MustBool.top ()
     | MustBeAtomic -> MustBool.top ()
-    | MustBeSingleThreadedUptoCurrent -> MustBool.top ()
+    | MustBeSingleThreaded _ -> MustBool.top ()
     | MustBeUniqueThread -> MustBool.top ()
     | EvalInt _ -> ID.top ()
     | EvalLength _ -> ID.top ()
@@ -241,7 +241,7 @@ struct
     | Any (MustBeProtectedBy _) -> 9
     | Any MustLockset -> 10
     | Any MustBeAtomic -> 11
-    | Any MustBeSingleThreadedUptoCurrent -> 12
+    | Any (MustBeSingleThreaded _)-> 12
     | Any MustBeUniqueThread -> 13
     | Any CurrentThreadId -> 14
     | Any MayBeThreadReturn -> 15
@@ -316,6 +316,7 @@ struct
       | Any (IterSysVars (vq1, vf1)), Any (IterSysVars (vq2, vf2)) -> VarQuery.compare vq1 vq2 (* not comparing fs *)
       | Any (MustProtectedVars m1), Any (MustProtectedVars m2) -> compare_mustprotectedvars m1 m2
       | Any (MayBeModifiedSinceSetjmp e1), Any (MayBeModifiedSinceSetjmp e2) -> JmpBufDomain.BufferEntry.compare e1 e2
+      | Any (MustBeSingleThreaded {since_start=s1;}),  Any (MustBeSingleThreaded {since_start=s2;}) -> Stdlib.compare s1 s2
       (* only argumentless queries should remain *)
       | _, _ -> Stdlib.compare (order a) (order b)
 
@@ -351,6 +352,7 @@ struct
     | Any (InvariantGlobal vi) -> Hashtbl.hash vi
     | Any (MustProtectedVars m) -> hash_mustprotectedvars m
     | Any (MayBeModifiedSinceSetjmp e) -> JmpBufDomain.BufferEntry.hash e
+    | Any (MustBeSingleThreaded {since_start}) -> Hashtbl.hash since_start
     (* IterSysVars:                                                                    *)
     (*   - argument is a function and functions cannot be compared in any meaningful way. *)
     (*   - doesn't matter because IterSysVars is always queried from outside of the analysis, so MCP's query caching is not done for it. *)
@@ -371,7 +373,7 @@ struct
     | Any (MustBeProtectedBy x) -> Pretty.dprintf "MustBeProtectedBy _"
     | Any MustLockset -> Pretty.dprintf "MustLockset"
     | Any MustBeAtomic -> Pretty.dprintf "MustBeAtomic"
-    | Any MustBeSingleThreadedUptoCurrent -> Pretty.dprintf "MustBeSingleThreaded"
+    | Any (MustBeSingleThreaded {since_start}) -> Pretty.dprintf "MustBeSingleThreaded since_start=%b" since_start
     | Any MustBeUniqueThread -> Pretty.dprintf "MustBeUniqueThread"
     | Any CurrentThreadId -> Pretty.dprintf "CurrentThreadId"
     | Any MayBeThreadReturn -> Pretty.dprintf "MayBeThreadReturn"

--- a/tests/regression/58-base-mm-tid/24-phases-sound.c
+++ b/tests/regression/58-base-mm-tid/24-phases-sound.c
@@ -1,4 +1,5 @@
 // PARAM: --set ana.path_sens[+] threadflag --set ana.base.privatization mutex-meet-tid --enable ana.int.interval --set ana.activated[+] threadJoins --set ana.activated[+] thread
+// Tests soundness when additionally thread analysis is enabled, that is able to go back to single-threaded mode after all created joins have been joined.
 #include <pthread.h>
 #include <goblint.h>
 
@@ -9,7 +10,7 @@ pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
 void *t_benign(void *arg) {
   pthread_mutex_lock(&A);
   g = 10;
-  __goblint_check(g == 10);
+  __goblint_check(g == 10); //TODO
   pthread_mutex_unlock(&A);
   return NULL;
 }
@@ -18,7 +19,7 @@ void *t_benign2(void *arg) {
   pthread_mutex_lock(&A);
   __goblint_check(g == 20);
   g = 10;
-  __goblint_check(g == 10);
+  __goblint_check(g == 10); //TODO
   pthread_mutex_unlock(&A);
   return NULL;
 }

--- a/tests/regression/58-base-mm-tid/24-phases.c
+++ b/tests/regression/58-base-mm-tid/24-phases.c
@@ -1,0 +1,45 @@
+// PARAM: --set ana.path_sens[+] threadflag --set ana.base.privatization mutex-meet-tid --enable ana.int.interval --set ana.activated[+] threadJoins
+#include <pthread.h>
+#include <goblint.h>
+
+int g = 10;
+
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_benign(void *arg) {
+  pthread_mutex_lock(&A);
+  g = 10;
+  __goblint_check(g == 10);
+  pthread_mutex_unlock(&A);
+  return NULL;
+}
+
+void *t_benign2(void *arg) {
+  pthread_mutex_lock(&A);
+  __goblint_check(g == 20);
+  g = 10;
+  __goblint_check(g == 10);
+  pthread_mutex_unlock(&A);
+  return NULL;
+}
+
+int main(void) {
+
+  pthread_t id2;
+  pthread_create(&id2, NULL, t_benign, NULL);
+  pthread_join(id2, NULL);
+
+
+  g = 20;
+  __goblint_check(g == 20);
+
+
+  pthread_create(&id2, NULL, t_benign2, NULL);
+
+
+  pthread_mutex_lock(&A);
+  __goblint_check(g == 20); //UNKNOWN!
+  pthread_mutex_unlock(&A);
+
+  return 0;
+}

--- a/tests/regression/58-base-mm-tid/24-phases.c
+++ b/tests/regression/58-base-mm-tid/24-phases.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.path_sens[+] threadflag --set ana.base.privatization mutex-meet-tid --enable ana.int.interval --set ana.activated[+] threadJoins
+// PARAM: --set ana.path_sens[+] threadflag --set ana.base.privatization mutex-meet-tid --enable ana.int.interval --set ana.activated[+] threadJoins --set ana.activated[+] thread
 #include <pthread.h>
 #include <goblint.h>
 


### PR DESCRIPTION
This is the immediate soundness fix needed for #1043.

The idea here is to distinguish the situation where the program is currently single-threaded but has been multi-threaded before from the situation where no threads have been started yet at all.

The privatizations all assume that no recovery from multi-threaded mode is possible, so if an analysis such as `thread` is activated, they misbehave and become unsound.

I will also attempt to make some of the privatizations support phases, but this requires fundamental changes, e.g., to how protecting locksets are computed, so I will do that in a separate PR.

Closes #1043