### PR TITLE
Fix `--html` when Goblint is run from elsewhere

### DIFF
--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -557,18 +557,24 @@ let do_analyze change_info merged_AST =
   )
 
 let do_html_output () =
-  (* TODO: Fpath *)
-  let jar = Filename.concat (get_string "exp.g2html_path") "g2html.jar" in
   if get_bool "g2html" then (
-    if Sys.file_exists jar then (
-      let command = "java -jar "^ jar ^" --num-threads " ^ (string_of_int (jobs ())) ^ " --dot-timeout 0 --result-dir "^ (get_string "outfile")^" "^ !Messages.xml_file_name in
-      try match Timing.wrap "g2html" Unix.system command with
-        | Unix.WEXITED 0 -> ()
-        | _ -> eprintf "HTML generation failed! Command: %s\n" command
-      with Unix.Unix_error (e, f, a) ->
+    let jar = Fpath.(v (get_string "exp.g2html_path") / "g2html.jar") in
+    if Sys.file_exists (Fpath.to_string jar) then (
+      let command = Filename.quote_command "java" [
+          "-jar"; Fpath.to_string jar;
+          "--num-threads"; string_of_int (jobs ());
+          "--dot-timeout"; "0";
+          "--result-dir"; get_string "outfile";
+          !Messages.xml_file_name
+        ]
+      in
+      match Timing.wrap "g2html" Unix.system command with
+      | Unix.WEXITED 0 -> ()
+      | _ -> eprintf "HTML generation failed! Command: %s\n" command
+      | exception Unix.Unix_error (e, f, a) ->
         eprintf "%s at syscall %s with argument \"%s\".\n" (Unix.error_message e) f a
     ) else
-      eprintf "Warning: jar file %s not found.\n" jar
+      Format.eprintf "Warning: jar file %a not found.\n" Fpath.pp jar
   )
 
 let do_gobview cilfile =

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1651,9 +1651,9 @@
         },
         "g2html_path": {
           "title": "exp.g2html_path",
-          "description": "Location of the g2html.jar file.",
+          "description": "Location of the g2html.jar file. If empty, then goblint executable directory is used.",
           "type": "string",
-          "default": "."
+          "default": ""
         },
         "extraspecials": {
           "title": "exp.extraspecials",


### PR DESCRIPTION
Using `--html` when running Goblint outside of this repository's root has always been annoying since `g2html.jar` is not found and `exp.g2html_path` needs to be set. Turns out some logic already exists to avoid this:
https://github.com/goblint/analyzer/blob/a94ac7fbc1f38c2718f5c28e115a168a41205318/src/maingoblint.ml#L63-L64

But the default value for `exp.g2html_path` hasn't been `""`, but rather `"."` which bypasses that logic. Thus this PR changes the default to use the more useful logic by default.

Also a bit of cleanup in the code that actually runs g2html.