### PR TITLE
Improve mallocFresh analysis

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -648,7 +648,7 @@ struct
         )
     | Events.EnterMultiThreaded ->
       Priv.enter_multithreaded (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st
-    | Events.Escape escaped ->
+    | Events.Escape {escaped; _} ->
       Priv.escape ctx.node (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st escaped
     | Assert exp ->
       assert_fn ctx exp true

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2584,7 +2584,7 @@ struct
       WideningTokens.with_local_side_tokens (fun () ->
           Priv.unlock (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st addr
         )
-    | Events.Escape escaped ->
+    | Events.Escape {escaped; _} ->
       Priv.escape (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st escaped
     | Events.EnterMultiThreaded ->
       Priv.enter_multithreaded (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st

--- a/src/analyses/mallocFresh.ml
+++ b/src/analyses/mallocFresh.ml
@@ -7,7 +7,7 @@ struct
   include Analyses.IdentitySpec
 
   (* must fresh (or may not fresh) variables *)
-  module DF = SetDomain.ToppedSet (Basetype.Variables) (struct let topname = "All variables" end)
+  module DF = SetDomain.ToppedSet (CilType.Varinfo) (struct let topname = "All variables" end)
   module D =
   struct 
     include Lattice.Prod (DF) (DF)

--- a/src/analyses/mallocFresh.ml
+++ b/src/analyses/mallocFresh.ml
@@ -7,7 +7,7 @@ struct
   include Analyses.IdentitySpec
 
   (* must fresh (or may not fresh) variables *)
-  module DF = SetDomain.ToppedSet (CilType.Varinfo) (struct let topname = "All variables" end) (* need bot (top) for hoare widen *)
+  module DF = SetDomain.ToppedSet (Basetype.Variables) (struct let topname = "All variables" end)
   module D =
   struct 
     include Lattice.Prod (DF) (DF)
@@ -30,25 +30,14 @@ struct
   let startstate _ = (DF.empty (), DF.empty ())
   let exitstate _ = (DF.empty (), DF.empty ())
 
-  let assign_lval (ask: Queries.ask) lval local =
-    match ask.f (MayPointTo (AddrOf lval)), local with
-    | ls, (df, dnf) when Queries.LS.is_top ls || Queries.LS.mem (dummyFunDec.svar, `NoOffset) ls ->
-      (DF.empty (), DF.union df dnf)
-    | ls, (df, dnf) when Queries.LS.exists (fun (v, _) -> not (DF.mem v (fst local)) && (v.vglob || ThreadEscape.has_escaped ask v)) ls ->
-      (DF.empty (), DF.union df dnf)
-    | _ ->
-      local
-
   let assign ctx lval rval =
-    assign_lval (Analyses.ask_of_ctx ctx) lval ctx.local
+    ctx.local
 
   let combine_env ctx lval fexp f args fc au f_ask =
     ctx.local (* keep local as opposed to IdentitySpec *)
 
   let combine_assign ctx lval f fd args context f_local (f_ask: Queries.ask) =
-    match lval with
-    | None -> f_local
-    | Some lval -> assign_lval (Analyses.ask_of_ctx ctx) lval f_local
+    f_local (* TODO: no combine_assign in threadEscape *)
 
   let special ctx lval f args =
     let desc = LibraryFunctions.find f in
@@ -57,19 +46,26 @@ struct
     | Calloc _
     | Realloc _ ->
       begin match ctx.ask HeapVar with
-        | `Lifted var -> (DF.add var (fst ctx.local), (snd ctx.local)) 
+        | `Lifted var -> (DF.add var (fst ctx.local), (snd ctx.local))
         | _ -> ctx.local
       end
-    | _ ->
-      match lval with
-      | None -> ctx.local
-      | Some lval -> assign_lval (Analyses.ask_of_ctx ctx) lval ctx.local
+    | _ -> ctx.local
 
   let threadenter ctx lval f args =
     [(DF.empty (), DF.empty ())]
 
   let threadspawn ctx lval f args fctx =
-    (DF.empty (), DF.union (fst ctx.local) (snd ctx.local))
+    ctx.local
+
+  let event ctx e octx =
+    let local = ctx.local in
+    match e, local with
+    | Events.Escape {escaped; escaped_to}, (df, dnf) when DF.is_top escaped ->
+      (DF.empty (), DF.union df dnf)
+    | Events.Escape {escaped; escaped_to}, (df, dnf) when not (DF.subset escaped_to df) ->
+      (DF.diff df escaped, DF.union dnf escaped)
+    | _ ->
+      local
 
   module A =
   struct

--- a/src/analyses/mallocFresh.ml
+++ b/src/analyses/mallocFresh.ml
@@ -13,9 +13,10 @@ struct
     include Lattice.Prod (DF) (DF)
 
     let join (df1, dnf1) (df2, dnf2) =
-      let dnf = DF.union dnf1 dnf2 in
-      let df = DF.diff (DF.union df1 df2) dnf in
-      (df, dnf)
+      let df_both = DF.meet df1 df2 in
+      let dnf_any = DF.union dnf1 dnf2 in
+      let df_one = DF.diff (DF.union df1 df2) dnf_any in
+      (DF.union df_both df_one, dnf_any)
 
     let leq x y = equal (join x y) y
 

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -571,15 +571,15 @@ struct
       |> List.fold_left (fun st lv ->
           remove (Analyses.ask_of_ctx ctx) lv st
         ) ctx.local
-    | Events.Escape vars ->
-      if EscapeDomain.EscapedVars.is_top vars then
+    | Events.Escape {escaped; _} ->
+      if EscapeDomain.EscapedVars.is_top escaped then
         D.top ()
       else
         let ask = Analyses.ask_of_ctx ctx in
         let remove_var st v =
           remove ask (Cil.var v) st
         in
-        List.fold_left remove_var ctx.local (EscapeDomain.EscapedVars.elements vars)
+        List.fold_left remove_var ctx.local (EscapeDomain.EscapedVars.elements escaped)
     | _ ->
       ctx.local
 end

--- a/src/cdomains/escapeDomain.ml
+++ b/src/cdomains/escapeDomain.ml
@@ -1,4 +1,4 @@
 module EscapedVars  =
 struct
-  include SetDomain.ToppedSet (Basetype.Variables) (struct let topname = "All Variables" end)
+  include SetDomain.ToppedSet (CilType.Varinfo) (struct let topname = "All Variables" end)
 end

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -4,7 +4,7 @@ open Pretty
 type t =
   | Lock of LockDomain.Lockset.Lock.t
   | Unlock of LockDomain.Addr.t
-  | Escape of EscapeDomain.EscapedVars.t
+  | Escape of {escaped_to: EscapeDomain.EscapedVars.t; escaped: EscapeDomain.EscapedVars.t}
   | EnterMultiThreaded
   | SplitBranch of exp * bool (** Used to simulate old branch-based split. *)
   | AssignSpawnedThread of lval * ThreadIdDomain.Thread.t (** Assign spawned thread's ID to lval. *)
@@ -35,7 +35,7 @@ let emit_on_deadcode = function
 let pretty () = function
   | Lock m -> dprintf "Lock %a" LockDomain.Lockset.Lock.pretty m
   | Unlock m -> dprintf "Unlock %a" LockDomain.Addr.pretty m
-  | Escape escaped -> dprintf "Escape %a" EscapeDomain.EscapedVars.pretty escaped
+  | Escape {escaped_to; escaped} -> dprintf "Escaped {escaped_to=%a; escaped=%a}" EscapeDomain.EscapedVars.pretty escaped_to EscapeDomain.EscapedVars.pretty escaped
   | EnterMultiThreaded -> text "EnterMultiThreaded"
   | SplitBranch (exp, tv) -> dprintf "SplitBranch (%a, %B)" d_exp exp tv
   | AssignSpawnedThread (lval, tid) -> dprintf "AssignSpawnedThread (%a, %a)" d_lval lval ThreadIdDomain.Thread.pretty tid

--- a/tests/regression/45-escape/53-fresh-malloc-unassigned.c
+++ b/tests/regression/45-escape/53-fresh-malloc-unassigned.c
@@ -1,0 +1,34 @@
+// PARAM: --set ana.activated[+] mallocFresh --set ana.activated[-] mhp --set ana.thread.domain plain
+#include <pthread.h>
+#include <stdlib.h>
+
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun2(void *arg) {
+  int *i = arg;
+  pthread_mutex_lock(&A);
+  *i = 10; // NORACE
+  pthread_mutex_unlock(&A);
+  return NULL;
+}
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+int main() {
+  int r, *i;
+  pthread_t id, id2;
+  pthread_create(&id, NULL, t_fun, NULL); // enter multithreaded
+
+  if (r) {
+    i = malloc(sizeof(int));
+  } else {
+    i = NULL;
+  }
+
+  i = i == NULL ? malloc(sizeof(int)) : i;
+  *i = 5; // NORACE (fresh)
+  pthread_create(&id2, NULL, t_fun2, i);
+  return 0;
+}

--- a/tests/regression/45-escape/54-fresh-global-branch.c
+++ b/tests/regression/45-escape/54-fresh-global-branch.c
@@ -1,0 +1,35 @@
+// PARAM: --set ana.activated[+] mallocFresh --set ana.activated[-] mhp --set ana.thread.domain plain
+#include <pthread.h>
+#include <stdlib.h>
+
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun2(void *arg) {
+  int *i = arg;
+  pthread_mutex_lock(&A);
+  *i = 10; // RACE!
+  pthread_mutex_unlock(&A);
+  return NULL;
+}
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+int *g;
+
+int main() {
+  int r, *i;
+  pthread_t id, id2;
+  pthread_create(&id, NULL, t_fun, NULL); // enter multithreaded
+
+  i = malloc(sizeof(int));
+
+  if (r) {
+    g = i;
+  }
+
+  *i = 5; // RACE! (not fresh)
+  pthread_create(&id2, NULL, t_fun2, i);
+  return 0;
+}


### PR DESCRIPTION
Some false positive warnings from [the-silver-searcher](https://github.com/goblint/bench/tree/master/gobpie-demos/silver-searcher) could be removed with a more precise `mallocFresh` analysis. The changes I have done are:

1. Instead of a set of only fresh variables, also track the set of not fresh variables in the domain. That is because previously the domain was a reversed set domain of fresh variables, in which case if the variable was fresh in one branch, but unassigned in another, it was considered not fresh. Also added two test cases for that scenario.
2. Using `Escape` events. Previously all fresh variables became not fresh once anything escaped. The analysis now tracks whether the escaped variables are the same as the fresh variables.
3. Made the `Escape` events return the `escaped_to` variables in addition to `escaped` variables, to track whether a variable escaped into itself and thus remained fresh.

Note: I noticed that there is no `combine_assign` in `threadEscape`. Why is that? Should there be one?