### PR TITLE
Ignore accesses to variables with `__thread` keyword

### DIFF
--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -20,6 +20,7 @@ let is_ignorable_type (t: typ): bool =
 
 let is_ignorable = function
   | None -> false
+  | Some (v,os) when hasAttribute "thread" v.vattr -> true (* Thread-Local Storage *)
   | Some (v,os) ->
     try isFunctionType v.vtype || is_ignorable_type v.vtype
     with Not_found -> false

--- a/tests/regression/04-mutex/82-thread-local-storage.c
+++ b/tests/regression/04-mutex/82-thread-local-storage.c
@@ -1,0 +1,23 @@
+#include <pthread.h>
+#include <stdio.h>
+
+__thread int myglobal;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  myglobal=myglobal+1; // NORACE
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex2);
+  myglobal=myglobal+1; // NORACE
+  pthread_mutex_unlock(&mutex2);
+  pthread_join (id, NULL);
+  return 0;
+}


### PR DESCRIPTION
Relates to #876.