### PR TITLE
`ThreadEscape`: Collect flow-insensitive set of variables reachable from globals

### DIFF
--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -50,10 +50,15 @@ struct
       if M.tracing then M.tracel "escape" "mpt %a: %a\n" d_exp e Queries.LS.pretty a;
       D.empty ()
 
+  let emit_escaped ctx escaped =
+    if not (D.is_empty escaped) then (* avoid emitting unnecessary event *)
+      ctx.emit (Events.Escape escaped)
+
   (* queries *)
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     match q with
-    | Queries.MayEscape v -> D.mem v ctx.local
+    | Queries.MayEscape v ->
+      D.mem v ctx.local
     | _ -> Queries.Result.top q
 
   (* transfer functions *)
@@ -65,8 +70,8 @@ struct
       let escaped = reachable ask rval in
       let escaped = D.filter (fun v -> not v.vglob) escaped in
       if M.tracing then M.tracel "escape" "assign vs: %a | %a\n" D.pretty vs D.pretty escaped;
-      if not (D.is_empty escaped) && ThreadFlag.has_ever_been_multi ask then (* avoid emitting unnecessary event *)
-        ctx.emit (Events.Escape escaped);
+      if ThreadFlag.has_ever_been_multi ask then (* avoid emitting unnecessary event *)
+        emit_escaped ctx escaped;
       D.iter (fun v ->
           ctx.sideg v escaped;
         ) vs;
@@ -81,8 +86,7 @@ struct
     | _, "pthread_setspecific" , [key; pt_value] ->
       let escaped = reachable (Analyses.ask_of_ctx ctx) pt_value in
       let escaped = D.filter (fun v -> not v.vglob) escaped in
-      if not (D.is_empty escaped) then (* avoid emitting unnecessary event *)
-        ctx.emit (Events.Escape escaped);
+      emit_escaped ctx escaped;
       let extra = D.fold (fun v acc -> D.join acc (ctx.global v)) escaped (D.empty ()) in (* TODO: must transitively join escapes of every ctx.global v as well? *)
       D.join ctx.local (D.join escaped extra)
     | _ -> ctx.local
@@ -95,8 +99,7 @@ struct
     | [ptc_arg] ->
       let escaped = reachable (Analyses.ask_of_ctx ctx) ptc_arg in
       let escaped = D.filter (fun v -> not v.vglob) escaped in
-      if not (D.is_empty escaped) then (* avoid emitting unnecessary event *)
-        ctx.emit (Events.Escape escaped);
+      emit_escaped ctx escaped;
       let extra = D.fold (fun v acc -> D.join acc (ctx.global v)) escaped (D.empty ()) in (* TODO: must transitively join escapes of every ctx.global v as well? *)
       [D.join ctx.local (D.join escaped extra)]
     | _ -> [ctx.local]
@@ -109,8 +112,7 @@ struct
         let escaped = reachable (Analyses.ask_of_ctx ctx) ptc_arg in
         let escaped = D.filter (fun v -> not v.vglob) escaped in
         if M.tracing then M.tracel "escape" "%a: %a\n" d_exp ptc_arg D.pretty escaped;
-        if not (D.is_empty escaped) then (* avoid emitting unnecessary event *)
-          ctx.emit (Events.Escape escaped);
+        emit_escaped ctx escaped;
         escaped
       | _ -> D.bot ()
 
@@ -118,8 +120,7 @@ struct
     match e with
     | Events.EnterMultiThreaded ->
       let escaped = ctx.local in
-      if not (D.is_empty escaped) then (* avoid emitting unnecessary event *)
-        ctx.emit (Events.Escape escaped);
+      emit_escaped ctx escaped;
       ctx.local
     | _ -> ctx.local
 end

--- a/tests/regression/45-escape/06-local-escp.c
+++ b/tests/regression/45-escape/06-local-escp.c
@@ -1,4 +1,3 @@
-// SKIP
 #include<stdlib.h>
 #include<pthread.h>
 #include<goblint.h>
@@ -10,7 +9,7 @@ int *p = &g;
 
 void *thread1(void *pp){
 	int x = 23;
-	__goblint_check(x == 23);
+	__goblint_check(x == 23); //TODO
 	p = &x;
 	sleep(2);
 	__goblint_check(x == 23); //UNKNOWN!

--- a/tests/regression/45-escape/06-local-escp.c
+++ b/tests/regression/45-escape/06-local-escp.c
@@ -1,3 +1,4 @@
+// SKIP
 #include<stdlib.h>
 #include<pthread.h>
 #include<goblint.h>
@@ -6,28 +7,20 @@
 int g = 0;
 int *p = &g;
 
-int let_escape(){
-	int x = 23;
-	g = 23;
-
-	__goblint_check(x == 23);
-	p = &x;
-	sleep(5);
-	__goblint_check(x == 23); //UNKNOWN!
-}
 
 void *thread1(void *pp){
-	let_escape();
+	int x = 23;
+	__goblint_check(x == 23);
+	p = &x;
+	sleep(2);
+	__goblint_check(x == 23); //UNKNOWN!
 	return NULL;
 }
 
-void write_through_pointer(){
-	sleep(2);
+void *thread2(void *ignored){
+	sleep(1);
+	int *i = p;
 	*p = 1;
-}
-
-void *thread2(void *p){
-	write_through_pointer();
 	return NULL;
 }
 

--- a/tests/regression/45-escape/07-local-in-global-after-create.c
+++ b/tests/regression/45-escape/07-local-in-global-after-create.c
@@ -1,4 +1,3 @@
-// SKIP
 #include <pthread.h>
 #include <goblint.h>
 

--- a/tests/regression/45-escape/07-local-in-global-after-create.c
+++ b/tests/regression/45-escape/07-local-in-global-after-create.c
@@ -1,0 +1,22 @@
+// SKIP
+#include <pthread.h>
+#include <goblint.h>
+
+int* gptr;
+
+void *foo(void* p){
+    *gptr = 17;
+    return NULL;
+}
+
+int main(){
+    int x = 0;
+    __goblint_check(x==0);
+    pthread_t thread;
+    pthread_create(&thread, NULL, foo, NULL);
+    gptr = &x;
+    sleep(3);
+    __goblint_check(x == 0); // UNKNOWN!
+    pthread_join(thread, NULL);
+    return 0;
+}

--- a/tests/regression/74-escape/01-local-esacpe.c
+++ b/tests/regression/74-escape/01-local-esacpe.c
@@ -17,13 +17,13 @@ int let_escape(){
 }
 
 void *thread1(void *pp){
-	let_escape(); //RACE
+	let_escape();
 	return NULL;
 }
 
 void write_through_pointer(){
 	sleep(2);
-	*p = 1; //RACE
+	*p = 1;
 }
 
 void *thread2(void *p){

--- a/tests/regression/74-escape/01-local-esacpe.c
+++ b/tests/regression/74-escape/01-local-esacpe.c
@@ -1,0 +1,42 @@
+#include<stdlib.h>
+#include<pthread.h>
+#include<goblint.h>
+#include<unistd.h>
+
+int g = 0;
+int *p = &g;
+
+int let_escape(){
+	int x = 23;
+	g = 23;
+
+	__goblint_check(x == 23);
+	p = &x;
+	sleep(5);
+	__goblint_check(x == 23); //UNKNOWN!
+}
+
+void *thread1(void *pp){
+	let_escape(); //RACE
+	return NULL;
+}
+
+void write_through_pointer(){
+	sleep(2);
+	*p = 1; //RACE
+}
+
+void *thread2(void *p){
+	write_through_pointer();
+	return NULL;
+}
+
+int main(){
+	pthread_t t1;
+	pthread_t t2;
+	pthread_create(&t1, NULL, thread1, NULL);
+	pthread_create(&t2, NULL, thread2, NULL);
+	pthread_join(t1, NULL);
+	pthread_join(t2, NULL);
+}
+


### PR DESCRIPTION
In #1074 it was discovered that in the analysis it is not communicated to a thread that variable may escape (via a global), after the thread has been created.
Previously, the analysis was adding variables that may become reachable via the argument passed to `pthreadcreate`. This does not take into account that the escaping after the thread creation may also happen via global variables.
This PR collects variables that are assigned to global variables separately under a flow-insensitive variable `global_var`.
In the `threadenter`, the set of variables escaped to globals, that was collected flow-insensitively, is then joined into the local state.

This increases the imprecision of the escape analysis, due to the flow-insensitive nature of the handling of variables escaped via globals. Such variables will be considered escaped even in unique threads before they have actually escaped. 
   
Fixes #1074. 
