### PR TITLE
ThreadEscape: Collect set of escaping threads flow-insensitively

### DIFF
--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -61,7 +61,7 @@ struct
   let side_effect_escape ctx escaped threadid =
     let threadid = G.singleton threadid in
     D.iter (fun v ->
-      ctx.sideg v threadid) escaped
+        ctx.sideg v threadid) escaped
 
   (* queries *)
   let query ctx (type a) (q: a Queries.t): a Queries.result =
@@ -88,7 +88,7 @@ struct
         | `Bot ->
           M.warn ~category:MessageCategory.Analyzer "CurrentThreadId is bottom.";
           false
-        end
+      end
     | _ -> Queries.Result.top q
 
   let escape_rval ctx (rval:exp) =
@@ -132,17 +132,17 @@ struct
 
   let threadspawn ctx lval f args fctx =
     D.join ctx.local @@
-      match args with
-      | [ptc_arg] ->
-        (* not reusing fctx.local to avoid unnecessarily early join of extra *)
-        let escaped = reachable (Analyses.ask_of_ctx ctx) ptc_arg in
-        let escaped = D.filter (fun v -> not v.vglob) escaped in
-        if M.tracing then M.tracel "escape" "%a: %a\n" d_exp ptc_arg D.pretty escaped;
-        let thread_id = thread_id ctx in
-        emit_escape_event ctx escaped;
-        side_effect_escape ctx escaped thread_id;
-        escaped
-      | _ -> D.bot ()
+    match args with
+    | [ptc_arg] ->
+      (* not reusing fctx.local to avoid unnecessarily early join of extra *)
+      let escaped = reachable (Analyses.ask_of_ctx ctx) ptc_arg in
+      let escaped = D.filter (fun v -> not v.vglob) escaped in
+      if M.tracing then M.tracel "escape" "%a: %a\n" d_exp ptc_arg D.pretty escaped;
+      let thread_id = thread_id ctx in
+      emit_escape_event ctx escaped;
+      side_effect_escape ctx escaped thread_id;
+      escaped
+    | _ -> D.bot ()
 
   let event ctx e octx =
     match e with

--- a/tests/regression/45-escape/06-local-escp.c
+++ b/tests/regression/45-escape/06-local-escp.c
@@ -1,3 +1,4 @@
+// SKIP
 #include<stdlib.h>
 #include<pthread.h>
 #include<goblint.h>
@@ -6,28 +7,20 @@
 int g = 0;
 int *p = &g;
 
-int let_escape(){
-	int x = 23;
-	g = 23;
-
-	__goblint_check(x == 23);
-	p = &x;
-	sleep(5);
-	__goblint_check(x == 23); //UNKNOWN!
-}
 
 void *thread1(void *pp){
-	let_escape();
+	int x = 23;
+	__goblint_check(x == 23);
+	p = &x;
+	sleep(2);
+	__goblint_check(x == 23); //UNKNOWN!
 	return NULL;
 }
 
-void write_through_pointer(){
-	sleep(2);
+void *thread2(void *ignored){
+	sleep(1);
+	int *i = p;
 	*p = 1;
-}
-
-void *thread2(void *p){
-	write_through_pointer();
 	return NULL;
 }
 

--- a/tests/regression/45-escape/07-local-in-global-after-create.c
+++ b/tests/regression/45-escape/07-local-in-global-after-create.c
@@ -1,0 +1,22 @@
+// SKIP
+#include <pthread.h>
+#include <goblint.h>
+
+int* gptr;
+
+void *foo(void* p){
+    *gptr = 17;
+    return NULL;
+}
+
+int main(){
+    int x = 0;
+    __goblint_check(x==0);
+    pthread_t thread;
+    pthread_create(&thread, NULL, foo, NULL);
+    gptr = &x;
+    sleep(3);
+    __goblint_check(x == 0); // UNKNOWN!
+    pthread_join(thread, NULL);
+    return 0;
+}

--- a/tests/regression/45-escape/08-local-escp-main.c
+++ b/tests/regression/45-escape/08-local-escp-main.c
@@ -1,4 +1,4 @@
-// SKIP
+//PARAM: --enable ana.int.interval
 #include<stdlib.h>
 #include<pthread.h>
 #include<goblint.h>
@@ -17,13 +17,7 @@ void *thread1(void *pp){
 	__goblint_check(x <= 23);
 	__goblint_check(x >= 1);
 
-	return NULL;
-}
-
-void *thread2(void *ignored){
-	sleep(1);
-	int *i = p;
-	*p = 1;
+	int y = x;
 	return NULL;
 }
 
@@ -31,8 +25,7 @@ int main(){
 	pthread_t t1;
 	pthread_t t2;
 	pthread_create(&t1, NULL, thread1, NULL);
-	pthread_create(&t2, NULL, thread2, NULL);
-	pthread_join(t1, NULL);
-	pthread_join(t2, NULL);
+	sleep(1);
+	*p = 1;
 }
 

--- a/tests/regression/74-escape/01-local-esacpe.c
+++ b/tests/regression/74-escape/01-local-esacpe.c
@@ -17,13 +17,13 @@ int let_escape(){
 }
 
 void *thread1(void *pp){
-	let_escape(); //RACE
+	let_escape();
 	return NULL;
 }
 
 void write_through_pointer(){
 	sleep(2);
-	*p = 1; //RACE
+	*p = 1;
 }
 
 void *thread2(void *p){

--- a/tests/regression/74-escape/01-local-esacpe.c
+++ b/tests/regression/74-escape/01-local-esacpe.c
@@ -1,0 +1,42 @@
+#include<stdlib.h>
+#include<pthread.h>
+#include<goblint.h>
+#include<unistd.h>
+
+int g = 0;
+int *p = &g;
+
+int let_escape(){
+	int x = 23;
+	g = 23;
+
+	__goblint_check(x == 23);
+	p = &x;
+	sleep(5);
+	__goblint_check(x == 23); //UNKNOWN!
+}
+
+void *thread1(void *pp){
+	let_escape(); //RACE
+	return NULL;
+}
+
+void write_through_pointer(){
+	sleep(2);
+	*p = 1; //RACE
+}
+
+void *thread2(void *p){
+	write_through_pointer();
+	return NULL;
+}
+
+int main(){
+	pthread_t t1;
+	pthread_t t2;
+	pthread_create(&t1, NULL, thread1, NULL);
+	pthread_create(&t2, NULL, thread2, NULL);
+	pthread_join(t1, NULL);
+	pthread_join(t2, NULL);
+}
+


### PR DESCRIPTION
This PR changes the `ThreadEscape` analysis to track which threads escaped a variable in a flow-insensitive invariant. A thread escapes a variable if it assigns it to an lvalue that may already be escaped.

The escape information in the local state now collects only the escapes that happened in the threads own past. That means, there is no joining of escaped variables from the flow-insensitive invariant into the local state. 

When queried whether a variable is escaped, the analysis checks the flow-insensitive set of threads that escaped it. If the set is empty, it is not escaped. If the set is not empty, it is checked whether any of the other threads that escaped it may already be started. If so, the variable may be escaped. If none of the other threads escaped the variable, then it is checked whether the current thread may have escaped the variable. This is done by looking it up in the local state. 

This approach in particular handles the case when variables escape via globals after some threads have already started (see #1074), while not treating such variables as escaped at all program points (which was one issue with #1075, as well as the issue with the implementation in `threadenter` mentioned here: https://github.com/goblint/analyzer/pull/1075#issuecomment-1578756437).

Fixes #1074 