### PR TITLE
Ignore indentation for blank lines suggested by ocp-indent

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -28,3 +28,6 @@ ec8611a3a72ae0d95ec82ffee16c5c4785111aa1
 
 # Set up end-of-line normalization.
 78fd79e7f4d15c4412221b155971fac2e0616b90
+
+# fix indentation in baseInvariant
+f3ffd5e45c034574020f56519ccdb021da2a1479

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -71,7 +71,7 @@ for f in $(git diff --cached --name-only | grep -E ".*\.mli?$"); do
       lines="$a-$b"
     fi
     echo "ocp-indent file: $f, lines: $lines"
-    [[ $lines -eq "0" ]] || diff $f <(ocp-indent --lines=$lines $f) || fail="true"
+    [[ $lines -eq "0" ]] || diff $f <(ocp-indent --lines=$lines $f | sed 's/^[[:space:]]\+$//') || fail="true"
   done
 done
 if [ "$fail" == "true" ]; then


### PR DESCRIPTION
With our usual vscode settings trailing whitespaces at the end of a line are removed (whenever a file is saved). This is also the case for blank lines. Ocp-indent on the other hand complains if blank lines between two indented lines are not indented in the same way. I did not find a configuration option for ocp-indent that allows to have no indentation on blank lines.
To avoid spurious ocp-indent warnings that are created by this differing behaviour of the IDE and ocp-indent  I would suggest to ignore the indentation required by ocp-indent on blank lines in our pre-commit hook, because I think removing trailing whitespaces at the end of lines is desirable.