### PR TITLE
Use TrieDomain to distribute accesses to contained fields

### DIFF
--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -102,9 +102,11 @@ struct
             OffsetTrieMap.iter (fun child_key child_trie ->
                 traverse_offset_trie (GroupableOffset.add_offset key child_key) child_trie (Access.AS.union accs parent_accs)
               ) children;
-            let memo = (g', key) in
-            let mem_loc_str = GobPretty.sprint Access.Memo.pretty memo in
-            Timing.wrap ~args:[("memory location", `String mem_loc_str)] "race" (Access.warn_global safe vulnerable unsafe memo) accs parent_accs
+            if not (Access.AS.is_empty accs) then (
+              let memo = (g', key) in
+              let mem_loc_str = GobPretty.sprint Access.Memo.pretty memo in
+              Timing.wrap ~args:[("memory location", `String mem_loc_str)] "race" (Access.warn_global safe vulnerable unsafe memo) accs parent_accs
+            )
           in
           traverse_offset_trie `NoOffset (accs, children) (Access.AS.empty ())
         | `Right _ -> (* vars *)

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -127,7 +127,7 @@ struct
       in
       let add_access_struct conf ci =
         let a = part_access None in
-        Access.add_distribute_inner (side_access octx (conf, kind, loc, e, a)) (`Type (TComp (ci, [])), `NoOffset)
+        Access.add_one (side_access octx (conf, kind, loc, e, a)) (`Type (TComp (ci, [])), `NoOffset)
       in
       let has_escaped g = octx.ask (Queries.MayEscape g) in
       (* The following function adds accesses to the lval-set ls

--- a/src/domains/trieDomain.ml
+++ b/src/domains/trieDomain.ml
@@ -1,0 +1,19 @@
+(** Trie domains. *)
+
+module Make (Key: MapDomain.Groupable) (Value: Lattice.S) =
+struct
+  module rec Trie:
+  sig
+    type key = Key.t
+    type value = Value.t
+    include Lattice.S with type t = value * ChildMap.t
+  end =
+  struct
+    type key = Key.t
+    type value = Value.t
+    include Lattice.Prod (Value) (ChildMap)
+  end
+  and ChildMap: MapDomain.S with type key = Key.t and type value = Trie.t = MapDomain.MapBot (Key) (Trie)
+
+  include Trie
+end

--- a/src/goblint_lib.ml
+++ b/src/goblint_lib.ml
@@ -177,6 +177,7 @@ module Lattice = Lattice
 module BoolDomain = BoolDomain
 module SetDomain = SetDomain
 module MapDomain = MapDomain
+module TrieDomain = TrieDomain
 module DisjointDomain = DisjointDomain
 module HoareDomain = HoareDomain
 module PartitionDomain = PartitionDomain

--- a/tests/regression/04-mutex/49-type-invariants.t
+++ b/tests/regression/04-mutex/49-type-invariants.t
@@ -11,11 +11,11 @@
     live: 7
     dead: 0
     total lines: 7
-  [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:21:3-21:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:22:3-22:21)
   [Warning][Race] Memory location s.field@49-type-invariants.c:9:10-9:11 (race with conf. 110):
     write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:21:3-21:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:22:3-22:21)
     read with [mhp:{tid=[main, t_fun@49-type-invariants.c:21:3-21:40#top]}, thread:[main, t_fun@49-type-invariants.c:21:3-21:40#top]] (conf. 110)  (exp: & s.field) (49-type-invariants.c:12:3-12:23)
+  [Success][Race] Memory location (struct S).field (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:21:3-21:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:22:3-22:21)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0
@@ -35,11 +35,11 @@
     live: 7
     dead: 0
     total lines: 7
-  [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:21:3-21:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:22:3-22:21)
   [Warning][Race] Memory location s.field@49-type-invariants.c:9:10-9:11 (race with conf. 110):
     write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:21:3-21:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:22:3-22:21)
     read with [mhp:{tid=[main, t_fun@49-type-invariants.c:21:3-21:40#top]}, thread:[main, t_fun@49-type-invariants.c:21:3-21:40#top]] (conf. 110)  (exp: & s.field) (49-type-invariants.c:12:3-12:23)
+  [Success][Race] Memory location (struct S).field (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:21:3-21:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:22:3-22:21)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0

--- a/tests/regression/04-mutex/84-distribute-fields-1.c
+++ b/tests/regression/04-mutex/84-distribute-fields-1.c
@@ -1,0 +1,23 @@
+#include <pthread.h>
+#include <stdlib.h>
+
+struct S {
+  int data;
+  int data2;
+};
+
+struct S s;
+
+void *t_fun(void *arg) {
+  s.data = 1; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  struct S s2;
+  s = s2; // RACE!
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/04-mutex/84-distribute-fields-1.t
+++ b/tests/regression/04-mutex/84-distribute-fields-1.t
@@ -13,5 +13,3 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
-
-TODO: fix memory location counts

--- a/tests/regression/04-mutex/84-distribute-fields-1.t
+++ b/tests/regression/04-mutex/84-distribute-fields-1.t
@@ -1,0 +1,17 @@
+  $ goblint --enable allglobs 84-distribute-fields-1.c
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8
+  [Warning][Race] Memory location s.data@84-distribute-fields-1.c:9:10-9:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}, thread:[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]] (conf. 110)  (exp: & s.data) (84-distribute-fields-1.c:12:3-12:13)
+    write with [mhp:{tid=[main]; created={[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (84-distribute-fields-1.c:20:3-20:9)
+  [Success][Race] Memory location s.data2@84-distribute-fields-1.c:9:10-9:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (84-distribute-fields-1.c:20:3-20:9)
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 3
+
+TODO: fix memory location counts

--- a/tests/regression/04-mutex/84-distribute-fields-1.t
+++ b/tests/regression/04-mutex/84-distribute-fields-1.t
@@ -1,15 +1,15 @@
-  $ goblint --enable allglobs 84-distribute-fields-1.c
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 8
-    dead: 0
-    total lines: 8
+  $ goblint --enable warn.deterministic --enable allglobs 84-distribute-fields-1.c
   [Warning][Race] Memory location s.data@84-distribute-fields-1.c:9:10-9:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}, thread:[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]] (conf. 110)  (exp: & s.data) (84-distribute-fields-1.c:12:3-12:13)
-    write with [mhp:{tid=[main]; created={[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (84-distribute-fields-1.c:20:3-20:9)
-  [Success][Race] Memory location s@84-distribute-fields-1.c:9:10-9:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (84-distribute-fields-1.c:20:3-20:9)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
+  [Success][Race] Memory location s@84-distribute-fields-1.c:9:10-9:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (84-distribute-fields-1.c:20:3-20:9)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8

--- a/tests/regression/04-mutex/84-distribute-fields-1.t
+++ b/tests/regression/04-mutex/84-distribute-fields-1.t
@@ -6,12 +6,12 @@
   [Warning][Race] Memory location s.data@84-distribute-fields-1.c:9:10-9:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}, thread:[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]] (conf. 110)  (exp: & s.data) (84-distribute-fields-1.c:12:3-12:13)
     write with [mhp:{tid=[main]; created={[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (84-distribute-fields-1.c:20:3-20:9)
-  [Success][Race] Memory location s.data2@84-distribute-fields-1.c:9:10-9:11 (safe):
+  [Success][Race] Memory location s@84-distribute-fields-1.c:9:10-9:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (84-distribute-fields-1.c:20:3-20:9)
   [Info][Race] Memory locations race summary:
-    safe: 2
+    safe: 1
     vulnerable: 0
     unsafe: 1
-    total memory locations: 3
+    total memory locations: 2
 
 TODO: fix memory location counts

--- a/tests/regression/04-mutex/85-distribute-fields-2.c
+++ b/tests/regression/04-mutex/85-distribute-fields-2.c
@@ -1,0 +1,29 @@
+#include <pthread.h>
+#include <stdlib.h>
+
+struct S {
+  int data;
+  int data2;
+};
+
+struct T {
+  struct S s;
+  struct S s2;
+  int data3;
+};
+
+struct T t;
+
+void *t_fun(void *arg) {
+  t.s.data = 1; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  struct S s2;
+  t.s = s2; // RACE!
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/04-mutex/85-distribute-fields-2.t
+++ b/tests/regression/04-mutex/85-distribute-fields-2.t
@@ -6,12 +6,12 @@
   [Warning][Race] Memory location t.s.data@85-distribute-fields-2.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}, thread:[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (85-distribute-fields-2.c:18:3-18:15)
     write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
-  [Success][Race] Memory location t.s.data2@85-distribute-fields-2.c:15:10-15:11 (safe):
+  [Success][Race] Memory location t.s@85-distribute-fields-2.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
   [Info][Race] Memory locations race summary:
-    safe: 3
+    safe: 2
     vulnerable: 0
     unsafe: 1
-    total memory locations: 4
+    total memory locations: 3
 
 TODO: fix memory location counts

--- a/tests/regression/04-mutex/85-distribute-fields-2.t
+++ b/tests/regression/04-mutex/85-distribute-fields-2.t
@@ -9,9 +9,7 @@
   [Success][Race] Memory location t.s@85-distribute-fields-2.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
   [Info][Race] Memory locations race summary:
-    safe: 2
+    safe: 1
     vulnerable: 0
     unsafe: 1
-    total memory locations: 3
-
-TODO: fix memory location counts
+    total memory locations: 2

--- a/tests/regression/04-mutex/85-distribute-fields-2.t
+++ b/tests/regression/04-mutex/85-distribute-fields-2.t
@@ -1,15 +1,15 @@
-  $ goblint --enable allglobs 85-distribute-fields-2.c
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 8
-    dead: 0
-    total lines: 8
+  $ goblint --enable warn.deterministic --enable allglobs 85-distribute-fields-2.c
   [Warning][Race] Memory location t.s.data@85-distribute-fields-2.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}, thread:[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (85-distribute-fields-2.c:18:3-18:15)
-    write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
-  [Success][Race] Memory location t.s@85-distribute-fields-2.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
+  [Success][Race] Memory location t.s@85-distribute-fields-2.c:15:10-15:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8

--- a/tests/regression/04-mutex/85-distribute-fields-2.t
+++ b/tests/regression/04-mutex/85-distribute-fields-2.t
@@ -1,0 +1,17 @@
+  $ goblint --enable allglobs 85-distribute-fields-2.c
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8
+  [Warning][Race] Memory location t.s.data@85-distribute-fields-2.c:15:10-15:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}, thread:[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (85-distribute-fields-2.c:18:3-18:15)
+    write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
+  [Success][Race] Memory location t.s.data2@85-distribute-fields-2.c:15:10-15:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
+  [Info][Race] Memory locations race summary:
+    safe: 3
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 4
+
+TODO: fix memory location counts

--- a/tests/regression/04-mutex/86-distribute-fields-3.c
+++ b/tests/regression/04-mutex/86-distribute-fields-3.c
@@ -1,0 +1,29 @@
+#include <pthread.h>
+#include <stdlib.h>
+
+struct S {
+  int data;
+  int data2;
+};
+
+struct T {
+  struct S s;
+  struct S s2;
+  int data3;
+};
+
+struct T t;
+
+void *t_fun(void *arg) {
+  t.s.data = 1; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  struct T t2;
+  t = t2; // RACE!
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/04-mutex/86-distribute-fields-3.t
+++ b/tests/regression/04-mutex/86-distribute-fields-3.t
@@ -3,21 +3,17 @@
     live: 8
     dead: 0
     total lines: 8
-  [Success][Race] Memory location t.data3@86-distribute-fields-3.c:15:10-15:11 (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Warning][Race] Memory location t.s.data@86-distribute-fields-3.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}, thread:[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (86-distribute-fields-3.c:18:3-18:15)
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
-  [Success][Race] Memory location t.s.data2@86-distribute-fields-3.c:15:10-15:11 (safe):
+  [Success][Race] Memory location t.s@86-distribute-fields-3.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
-  [Success][Race] Memory location t.s2.data@86-distribute-fields-3.c:15:10-15:11 (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
-  [Success][Race] Memory location t.s2.data2@86-distribute-fields-3.c:15:10-15:11 (safe):
+  [Success][Race] Memory location t@86-distribute-fields-3.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Info][Race] Memory locations race summary:
-    safe: 7
+    safe: 2
     vulnerable: 0
     unsafe: 1
-    total memory locations: 8
+    total memory locations: 3
 
 TODO: fix memory location counts

--- a/tests/regression/04-mutex/86-distribute-fields-3.t
+++ b/tests/regression/04-mutex/86-distribute-fields-3.t
@@ -9,9 +9,7 @@
   [Success][Race] Memory location t@86-distribute-fields-3.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Info][Race] Memory locations race summary:
-    safe: 2
+    safe: 1
     vulnerable: 0
     unsafe: 1
-    total memory locations: 3
-
-TODO: fix memory location counts
+    total memory locations: 2

--- a/tests/regression/04-mutex/86-distribute-fields-3.t
+++ b/tests/regression/04-mutex/86-distribute-fields-3.t
@@ -1,15 +1,15 @@
-  $ goblint --enable allglobs 86-distribute-fields-3.c
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 8
-    dead: 0
-    total lines: 8
+  $ goblint --enable warn.deterministic --enable allglobs 86-distribute-fields-3.c
   [Warning][Race] Memory location t.s.data@86-distribute-fields-3.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}, thread:[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (86-distribute-fields-3.c:18:3-18:15)
-    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
-  [Success][Race] Memory location t@86-distribute-fields-3.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
+  [Success][Race] Memory location t@86-distribute-fields-3.c:15:10-15:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8

--- a/tests/regression/04-mutex/86-distribute-fields-3.t
+++ b/tests/regression/04-mutex/86-distribute-fields-3.t
@@ -6,8 +6,6 @@
   [Warning][Race] Memory location t.s.data@86-distribute-fields-3.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}, thread:[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (86-distribute-fields-3.c:18:3-18:15)
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
-  [Success][Race] Memory location t.s@86-distribute-fields-3.c:15:10-15:11 (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Success][Race] Memory location t@86-distribute-fields-3.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Info][Race] Memory locations race summary:

--- a/tests/regression/04-mutex/86-distribute-fields-3.t
+++ b/tests/regression/04-mutex/86-distribute-fields-3.t
@@ -1,0 +1,23 @@
+  $ goblint --enable allglobs 86-distribute-fields-3.c
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8
+  [Success][Race] Memory location t.data3@86-distribute-fields-3.c:15:10-15:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
+  [Warning][Race] Memory location t.s.data@86-distribute-fields-3.c:15:10-15:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}, thread:[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (86-distribute-fields-3.c:18:3-18:15)
+    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
+  [Success][Race] Memory location t.s.data2@86-distribute-fields-3.c:15:10-15:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
+  [Success][Race] Memory location t.s2.data@86-distribute-fields-3.c:15:10-15:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
+  [Success][Race] Memory location t.s2.data2@86-distribute-fields-3.c:15:10-15:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
+  [Info][Race] Memory locations race summary:
+    safe: 7
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 8
+
+TODO: fix memory location counts

--- a/tests/regression/04-mutex/87-distribute-fields-4.c
+++ b/tests/regression/04-mutex/87-distribute-fields-4.c
@@ -1,0 +1,24 @@
+#include <pthread.h>
+#include <stdlib.h>
+
+struct S {
+  int data;
+  int data2;
+};
+
+struct S s;
+
+void *t_fun(void *arg) {
+  struct S s3;
+  s = s3; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  struct S s2;
+  s = s2; // RACE!
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/04-mutex/87-distribute-fields-4.t
+++ b/tests/regression/04-mutex/87-distribute-fields-4.t
@@ -1,0 +1,18 @@
+  $ goblint --enable allglobs 87-distribute-fields-4.c
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8
+  [Warning][Race] Memory location s.data@87-distribute-fields-4.c:9:10-9:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]}, thread:[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]] (conf. 110)  (exp: & s) (87-distribute-fields-4.c:13:3-13:9)
+    write with [mhp:{tid=[main]; created={[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (87-distribute-fields-4.c:21:3-21:9)
+  [Warning][Race] Memory location s.data2@87-distribute-fields-4.c:9:10-9:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]}, thread:[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]] (conf. 110)  (exp: & s) (87-distribute-fields-4.c:13:3-13:9)
+    write with [mhp:{tid=[main]; created={[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (87-distribute-fields-4.c:21:3-21:9)
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 2
+    total memory locations: 3
+
+TODO: fix memory location counts

--- a/tests/regression/04-mutex/87-distribute-fields-4.t
+++ b/tests/regression/04-mutex/87-distribute-fields-4.t
@@ -1,8 +1,4 @@
-  $ goblint --enable allglobs 87-distribute-fields-4.c
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 8
-    dead: 0
-    total lines: 8
+  $ goblint --enable warn.deterministic --enable allglobs 87-distribute-fields-4.c
   [Warning][Race] Memory location s@87-distribute-fields-4.c:9:10-9:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]}, thread:[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]] (conf. 110)  (exp: & s) (87-distribute-fields-4.c:13:3-13:9)
     write with [mhp:{tid=[main]; created={[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (87-distribute-fields-4.c:21:3-21:9)
@@ -11,3 +7,7 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 1
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8

--- a/tests/regression/04-mutex/87-distribute-fields-4.t
+++ b/tests/regression/04-mutex/87-distribute-fields-4.t
@@ -11,5 +11,3 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 1
-
-TODO: fix memory location counts

--- a/tests/regression/04-mutex/87-distribute-fields-4.t
+++ b/tests/regression/04-mutex/87-distribute-fields-4.t
@@ -3,16 +3,13 @@
     live: 8
     dead: 0
     total lines: 8
-  [Warning][Race] Memory location s.data@87-distribute-fields-4.c:9:10-9:11 (race with conf. 110):
-    write with [mhp:{tid=[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]}, thread:[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]] (conf. 110)  (exp: & s) (87-distribute-fields-4.c:13:3-13:9)
-    write with [mhp:{tid=[main]; created={[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (87-distribute-fields-4.c:21:3-21:9)
-  [Warning][Race] Memory location s.data2@87-distribute-fields-4.c:9:10-9:11 (race with conf. 110):
+  [Warning][Race] Memory location s@87-distribute-fields-4.c:9:10-9:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]}, thread:[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]] (conf. 110)  (exp: & s) (87-distribute-fields-4.c:13:3-13:9)
     write with [mhp:{tid=[main]; created={[main, t_fun@87-distribute-fields-4.c:19:3-19:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (87-distribute-fields-4.c:21:3-21:9)
   [Info][Race] Memory locations race summary:
-    safe: 1
+    safe: 0
     vulnerable: 0
-    unsafe: 2
-    total memory locations: 3
+    unsafe: 1
+    total memory locations: 1
 
 TODO: fix memory location counts

--- a/tests/regression/04-mutex/88-distribute-fields-5.c
+++ b/tests/regression/04-mutex/88-distribute-fields-5.c
@@ -1,0 +1,30 @@
+#include <pthread.h>
+#include <stdlib.h>
+
+struct S {
+  int data;
+  int data2;
+};
+
+struct T {
+  struct S s;
+  struct S s2;
+  int data3;
+};
+
+struct T t;
+
+void *t_fun(void *arg) {
+  struct S s3;
+  t.s = s3; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  struct S s2;
+  t.s = s2; // RACE!
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/04-mutex/88-distribute-fields-5.t
+++ b/tests/regression/04-mutex/88-distribute-fields-5.t
@@ -1,0 +1,18 @@
+  $ goblint --enable allglobs 88-distribute-fields-5.c
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8
+  [Warning][Race] Memory location t.s.data@88-distribute-fields-5.c:15:10-15:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}, thread:[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:19:3-19:11)
+    write with [mhp:{tid=[main]; created={[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:27:3-27:11)
+  [Warning][Race] Memory location t.s.data2@88-distribute-fields-5.c:15:10-15:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}, thread:[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:19:3-19:11)
+    write with [mhp:{tid=[main]; created={[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:27:3-27:11)
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 2
+    total memory locations: 4
+
+TODO: fix memory location counts

--- a/tests/regression/04-mutex/88-distribute-fields-5.t
+++ b/tests/regression/04-mutex/88-distribute-fields-5.t
@@ -1,8 +1,4 @@
-  $ goblint --enable allglobs 88-distribute-fields-5.c
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 8
-    dead: 0
-    total lines: 8
+  $ goblint --enable warn.deterministic --enable allglobs 88-distribute-fields-5.c
   [Warning][Race] Memory location t.s@88-distribute-fields-5.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}, thread:[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:19:3-19:11)
     write with [mhp:{tid=[main]; created={[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:27:3-27:11)
@@ -11,3 +7,7 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 1
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8

--- a/tests/regression/04-mutex/88-distribute-fields-5.t
+++ b/tests/regression/04-mutex/88-distribute-fields-5.t
@@ -3,16 +3,13 @@
     live: 8
     dead: 0
     total lines: 8
-  [Warning][Race] Memory location t.s.data@88-distribute-fields-5.c:15:10-15:11 (race with conf. 110):
-    write with [mhp:{tid=[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}, thread:[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:19:3-19:11)
-    write with [mhp:{tid=[main]; created={[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:27:3-27:11)
-  [Warning][Race] Memory location t.s.data2@88-distribute-fields-5.c:15:10-15:11 (race with conf. 110):
+  [Warning][Race] Memory location t.s@88-distribute-fields-5.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}, thread:[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:19:3-19:11)
     write with [mhp:{tid=[main]; created={[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:27:3-27:11)
   [Info][Race] Memory locations race summary:
-    safe: 2
+    safe: 1
     vulnerable: 0
-    unsafe: 2
-    total memory locations: 4
+    unsafe: 1
+    total memory locations: 2
 
 TODO: fix memory location counts

--- a/tests/regression/04-mutex/88-distribute-fields-5.t
+++ b/tests/regression/04-mutex/88-distribute-fields-5.t
@@ -7,9 +7,7 @@
     write with [mhp:{tid=[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}, thread:[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:19:3-19:11)
     write with [mhp:{tid=[main]; created={[main, t_fun@88-distribute-fields-5.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (88-distribute-fields-5.c:27:3-27:11)
   [Info][Race] Memory locations race summary:
-    safe: 1
+    safe: 0
     vulnerable: 0
     unsafe: 1
-    total memory locations: 2
-
-TODO: fix memory location counts
+    total memory locations: 1

--- a/tests/regression/04-mutex/89-distribute-fields-6.c
+++ b/tests/regression/04-mutex/89-distribute-fields-6.c
@@ -1,0 +1,30 @@
+#include <pthread.h>
+#include <stdlib.h>
+
+struct S {
+  int data;
+  int data2;
+};
+
+struct T {
+  struct S s;
+  struct S s2;
+  int data3;
+};
+
+struct T t;
+
+void *t_fun(void *arg) {
+  struct T t3;
+  t = t3; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  struct T t2;
+  t = t2; // RACE!
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/04-mutex/89-distribute-fields-6.t
+++ b/tests/regression/04-mutex/89-distribute-fields-6.t
@@ -1,8 +1,4 @@
-  $ goblint --enable allglobs 89-distribute-fields-6.c
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 8
-    dead: 0
-    total lines: 8
+  $ goblint --enable warn.deterministic --enable allglobs 89-distribute-fields-6.c
   [Warning][Race] Memory location t@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
     write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
@@ -11,3 +7,7 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 1
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8

--- a/tests/regression/04-mutex/89-distribute-fields-6.t
+++ b/tests/regression/04-mutex/89-distribute-fields-6.t
@@ -1,0 +1,27 @@
+  $ goblint --enable allglobs 89-distribute-fields-6.c
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 8
+    dead: 0
+    total lines: 8
+  [Warning][Race] Memory location t.data3@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
+    write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
+  [Warning][Race] Memory location t.s.data@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
+    write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
+  [Warning][Race] Memory location t.s.data2@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
+    write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
+  [Warning][Race] Memory location t.s2.data@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
+    write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
+  [Warning][Race] Memory location t.s2.data2@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
+    write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
+    write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
+  [Info][Race] Memory locations race summary:
+    safe: 3
+    vulnerable: 0
+    unsafe: 5
+    total memory locations: 8
+
+TODO: fix memory location counts

--- a/tests/regression/04-mutex/89-distribute-fields-6.t
+++ b/tests/regression/04-mutex/89-distribute-fields-6.t
@@ -11,5 +11,3 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 1
-
-TODO: fix memory location counts

--- a/tests/regression/04-mutex/89-distribute-fields-6.t
+++ b/tests/regression/04-mutex/89-distribute-fields-6.t
@@ -3,25 +3,13 @@
     live: 8
     dead: 0
     total lines: 8
-  [Warning][Race] Memory location t.data3@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
-    write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
-    write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
-  [Warning][Race] Memory location t.s.data@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
-    write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
-    write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
-  [Warning][Race] Memory location t.s.data2@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
-    write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
-    write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
-  [Warning][Race] Memory location t.s2.data@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
-    write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
-    write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
-  [Warning][Race] Memory location t.s2.data2@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
+  [Warning][Race] Memory location t@89-distribute-fields-6.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}, thread:[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:19:3-19:9)
     write with [mhp:{tid=[main]; created={[main, t_fun@89-distribute-fields-6.c:25:3-25:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (89-distribute-fields-6.c:27:3-27:9)
   [Info][Race] Memory locations race summary:
-    safe: 3
+    safe: 0
     vulnerable: 0
-    unsafe: 5
-    total memory locations: 8
+    unsafe: 1
+    total memory locations: 1
 
 TODO: fix memory location counts

--- a/tests/regression/06-symbeq/31-zstd-thread-pool.c
+++ b/tests/regression/06-symbeq/31-zstd-thread-pool.c
@@ -1,4 +1,5 @@
-// PARAM: --set ana.activated[+] symb_locks --set lib.activated[+] zstd
+// PARAM: --set ana.activated[+] symb_locks --set lib.activated[+] zstd --disable ana.race.free
+// disabled free races because unsound: https://github.com/goblint/analyzer/pull/978
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) Facebook, Inc.

--- a/tests/regression/06-symbeq/35-zstd-thread-pool-multi.c
+++ b/tests/regression/06-symbeq/35-zstd-thread-pool-multi.c
@@ -1,4 +1,5 @@
-// PARAM: --set ana.activated[+] symb_locks --set ana.activated[+] mallocFresh --set lib.activated[+] zstd
+// PARAM: --set ana.activated[+] symb_locks --set ana.activated[+] mallocFresh --set lib.activated[+] zstd --disable ana.race.free
+// disabled free races because unsound: https://github.com/goblint/analyzer/pull/978
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) Facebook, Inc.

--- a/tests/regression/06-symbeq/36-zstd-thread-pool-add.c
+++ b/tests/regression/06-symbeq/36-zstd-thread-pool-add.c
@@ -1,4 +1,5 @@
-// PARAM: --set ana.activated[+] symb_locks --set ana.activated[+] var_eq --set lib.activated[+] zstd --set exp.extraspecials[+] ZSTD_customMalloc --set exp.extraspecials[+] ZSTD_customCalloc
+// PARAM: --set ana.activated[+] symb_locks --set ana.activated[+] var_eq --set lib.activated[+] zstd --set exp.extraspecials[+] ZSTD_customMalloc --set exp.extraspecials[+] ZSTD_customCalloc --disable ana.race.free
+// disabled free races because unsound: https://github.com/goblint/analyzer/pull/978
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) Facebook, Inc.

--- a/tests/regression/06-symbeq/45-zstd-thread-pool-free.c
+++ b/tests/regression/06-symbeq/45-zstd-thread-pool-free.c
@@ -1,0 +1,264 @@
+// PARAM: --set ana.activated[+] symb_locks
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) Facebook, Inc.
+ * All rights reserved.
+ *
+ * This code is a challenging example for race detection extracted from zstd.
+ * Copyright (c) The Goblint Contributors
+ */
+
+#include<stdlib.h>
+#include<pthread.h>
+#include<goblint.h>
+#define ZSTD_pthread_mutex_t            pthread_mutex_t
+#define ZSTD_pthread_mutex_init(a, b)   pthread_mutex_init((a), (b))
+#define ZSTD_pthread_mutex_destroy(a)   pthread_mutex_destroy((a))
+#define ZSTD_pthread_mutex_lock(a)      pthread_mutex_lock((a))
+#define ZSTD_pthread_mutex_unlock(a)    pthread_mutex_unlock((a))
+
+#define ZSTD_pthread_cond_t             pthread_cond_t
+#define ZSTD_pthread_cond_init(a, b)    pthread_cond_init((a), (b))
+#define ZSTD_pthread_cond_destroy(a)    pthread_cond_destroy((a))
+#define ZSTD_pthread_cond_wait(a, b)    pthread_cond_wait((a), (b))
+#define ZSTD_pthread_cond_signal(a)     pthread_cond_signal((a))
+#define ZSTD_pthread_cond_broadcast(a)  pthread_cond_broadcast((a))
+
+#define ZSTD_pthread_t                  pthread_t
+#define ZSTD_pthread_create(a, b, c, d) pthread_create((a), (b), (c), (d))
+#define ZSTD_pthread_join(a, b)         pthread_join((a),(b))
+
+#define ZSTD_malloc(s) malloc(s)
+#define ZSTD_calloc(n,s) calloc((n), (s))
+#define ZSTD_free(p) free((p))
+#define ZSTD_memset(d,s,n) __builtin_memset((d),(s),(n))
+
+typedef struct POOL_ctx_s POOL_ctx;
+
+typedef void* (*ZSTD_allocFunction) (void* opaque, size_t size);
+typedef void  (*ZSTD_freeFunction) (void* opaque, void* address);
+typedef struct { ZSTD_allocFunction customAlloc; ZSTD_freeFunction customFree; void* opaque; } ZSTD_customMem;
+typedef struct POOL_ctx_s ZSTD_threadPool;
+
+
+void* ZSTD_customMalloc(size_t size, ZSTD_customMem customMem)
+{
+    if (customMem.customAlloc)
+        return customMem.customAlloc(customMem.opaque, size);
+    return ZSTD_malloc(size);
+}
+
+void* ZSTD_customCalloc(size_t size, ZSTD_customMem customMem)
+{
+    if (customMem.customAlloc) {
+        /* calloc implemented as malloc+memset;
+         * not as efficient as calloc, but next best guess for custom malloc */
+        void* const ptr = customMem.customAlloc(customMem.opaque, size);
+        ZSTD_memset(ptr, 0, size);
+        return ptr;
+    }
+    return ZSTD_calloc(1, size);
+}
+
+void ZSTD_customFree(void* ptr, ZSTD_customMem customMem)
+{
+    if (ptr!=NULL) {
+        if (customMem.customFree)
+            customMem.customFree(customMem.opaque, ptr);
+        else
+            ZSTD_free(ptr); // RACE
+    }
+}
+
+
+
+/*! POOL_create() :
+ *  Create a thread pool with at most `numThreads` threads.
+ * `numThreads` must be at least 1.
+ *  The maximum number of queued jobs before blocking is `queueSize`.
+ * @return : POOL_ctx pointer on success, else NULL.
+*/
+POOL_ctx* POOL_create(size_t numThreads, size_t queueSize);
+
+POOL_ctx* POOL_create_advanced(size_t numThreads, size_t queueSize, ZSTD_customMem customMem);
+
+/*! POOL_free() :
+ *  Free a thread pool returned by POOL_create().
+ */
+void POOL_free(POOL_ctx* ctx);
+
+
+/*! POOL_function :
+ *  The function type that can be added to a thread pool.
+ */
+typedef void (*POOL_function)(void*);
+
+
+static
+#ifdef __GNUC__
+__attribute__((__unused__))
+#endif
+ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  /**< this constant defers to stdlib's functions */
+
+
+/* A job is a function and an opaque argument */
+typedef struct POOL_job_s {
+    POOL_function function;
+    void *opaque;
+} POOL_job;
+
+struct POOL_ctx_s {
+    ZSTD_customMem customMem;
+    /* Keep track of the threads */
+    ZSTD_pthread_t* threads;
+    size_t threadCapacity;
+    size_t threadLimit;
+
+    /* The queue is a circular buffer */
+    POOL_job *queue;
+    size_t queueHead;
+    size_t queueTail;
+    size_t queueSize;
+
+    /* The number of threads working on jobs */
+    size_t numThreadsBusy;
+    /* Indicates if the queue is empty */
+    int queueEmpty;
+
+    /* The mutex protects the queue */
+    ZSTD_pthread_mutex_t queueMutex;
+    /* Condition variable for pushers to wait on when the queue is full */
+    ZSTD_pthread_cond_t queuePushCond;
+    /* Condition variables for poppers to wait on when the queue is empty */
+    ZSTD_pthread_cond_t queuePopCond;
+    /* Indicates if the queue is shutting down */
+    int shutdown;
+};
+
+/* POOL_thread() :
+ * Work thread for the thread pool.
+ * Waits for jobs and executes them.
+ * @returns : NULL on failure else non-null.
+ */
+static void* POOL_thread(void* opaque) {
+    POOL_ctx* const ctx = (POOL_ctx*)opaque;
+    if (!ctx) { return NULL; }
+    for (;;) {
+        /* Lock the mutex and wait for a non-empty queue or until shutdown */
+        ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+
+        while ( ctx->queueEmpty // RACE! (threadLimit)
+            || (ctx->numThreadsBusy >= ctx->threadLimit) ) {
+            if (ctx->shutdown) {
+                /* even if !queueEmpty, (possible if numThreadsBusy >= threadLimit),
+                 * a few threads will be shutdown while !queueEmpty,
+                 * but enough threads will remain active to finish the queue */
+                ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+                return opaque;
+            }
+            ZSTD_pthread_cond_wait(&ctx->queuePopCond, &ctx->queueMutex);
+        }
+        /* Pop a job off the queue */
+        {   POOL_job const job = ctx->queue[ctx->queueHead]; // TODO NORACE
+            ctx->queueHead = (ctx->queueHead + 1) % ctx->queueSize; // RACE
+            ctx->numThreadsBusy++; // RACE
+            ctx->queueEmpty = (ctx->queueHead == ctx->queueTail); // RACE
+            /* Unlock the mutex, signal a pusher, and run the job */
+            ZSTD_pthread_cond_signal(&ctx->queuePushCond);
+            ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+
+            job.function(job.opaque);
+
+            /* If the intended queue size was 0, signal after finishing job */
+            ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+            ctx->numThreadsBusy--; // RACE
+            ZSTD_pthread_cond_signal(&ctx->queuePushCond);
+            ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+        }
+    }  /* for (;;) */
+    __goblint_check(0);  //NOWARN (unreachable)
+}
+
+POOL_ctx* POOL_create(size_t numThreads, size_t queueSize) {
+    return POOL_create_advanced(numThreads, queueSize, ZSTD_defaultCMem);
+}
+
+POOL_ctx* POOL_create_advanced(size_t numThreads, size_t queueSize,
+                               ZSTD_customMem customMem)
+{
+    POOL_ctx* ctx;
+    /* Check parameters */
+    if (!numThreads) { return NULL; }
+    /* Allocate the context and zero initialize */
+    ctx = (POOL_ctx*)ZSTD_customCalloc(sizeof(POOL_ctx), customMem);
+    if (!ctx) { return NULL; }
+    /* Initialize the job queue.
+     * It needs one extra space since one space is wasted to differentiate
+     * empty and full queues.
+     */
+    ctx->queueSize = queueSize + 1;
+    ctx->queue = (POOL_job*)ZSTD_customMalloc(ctx->queueSize * sizeof(POOL_job), customMem);
+    ctx->queueHead = 0;
+    ctx->queueTail = 0;
+    ctx->numThreadsBusy = 0;
+    ctx->queueEmpty = 1;
+    {
+        int error = 0;
+        error |= ZSTD_pthread_mutex_init(&ctx->queueMutex, NULL);
+        error |= ZSTD_pthread_cond_init(&ctx->queuePushCond, NULL);
+        error |= ZSTD_pthread_cond_init(&ctx->queuePopCond, NULL);
+        if (error) { POOL_free(ctx); return NULL; }
+    }
+    ctx->shutdown = 0;
+    /* Allocate space for the thread handles */
+    ctx->threads = (ZSTD_pthread_t*)ZSTD_customMalloc(numThreads * sizeof(ZSTD_pthread_t), customMem);
+    ctx->threadCapacity = 0;
+    ctx->customMem = customMem;
+    /* Check for errors */
+    if (!ctx->threads || !ctx->queue) { POOL_free(ctx); return NULL; }
+    /* Initialize the threads */
+    {   size_t i;
+        for (i = 0; i < numThreads; ++i) {
+            if (ZSTD_pthread_create(&ctx->threads[i], NULL, &POOL_thread, ctx)) {
+                ctx->threadCapacity = i;
+                POOL_free(ctx);
+                return NULL;
+        }   }
+        ctx->threadCapacity = numThreads;
+        ctx->threadLimit = numThreads; // RACE!
+    }
+    return ctx;
+}
+
+/*! POOL_join() :
+    Shutdown the queue, wake any sleeping threads, and join all of the threads.
+*/
+static void POOL_join(POOL_ctx* ctx) {
+    /* Shut down the queue */
+    ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+    ctx->shutdown = 1; //NORACE
+    ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+    /* Wake up sleeping threads */
+    ZSTD_pthread_cond_broadcast(&ctx->queuePushCond);
+    ZSTD_pthread_cond_broadcast(&ctx->queuePopCond);
+    /* Join all of the threads */
+    {   size_t i;
+        for (i = 0; i < ctx->threadCapacity; ++i) {
+            ZSTD_pthread_join(ctx->threads[i], NULL);  /* note : could fail */
+    }   }
+}
+
+void POOL_free(POOL_ctx *ctx) {
+    if (!ctx) { return; }
+    POOL_join(ctx);
+    ZSTD_pthread_mutex_destroy(&ctx->queueMutex);
+    ZSTD_pthread_cond_destroy(&ctx->queuePushCond);
+    ZSTD_pthread_cond_destroy(&ctx->queuePopCond);
+    ZSTD_customFree(ctx->queue, ctx->customMem);
+    ZSTD_customFree(ctx->threads, ctx->customMem);
+    ZSTD_customFree(ctx, ctx->customMem);
+}
+
+int main() {
+    POOL_ctx* const ctx = POOL_create(20, 10);
+}

--- a/tests/regression/06-symbeq/46-calloc-free.c
+++ b/tests/regression/06-symbeq/46-calloc-free.c
@@ -1,0 +1,63 @@
+// PARAM: --set ana.activated[+] symb_locks
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) Facebook, Inc.
+ * All rights reserved.
+ *
+ * This code is a challenging example for race detection extracted from zstd.
+ * Copyright (c) The Goblint Contributors
+ */
+
+#include<stdlib.h>
+#include<pthread.h>
+
+typedef struct POOL_ctx_s POOL_ctx;
+
+struct POOL_ctx_s {
+    pthread_t* threads;
+    size_t numThreadsBusy;
+    pthread_mutex_t queueMutex;
+};
+
+static void* POOL_thread(void* opaque) {
+    POOL_ctx* const ctx = (POOL_ctx*)opaque;
+    for (;;) {
+        /* Lock the mutex and wait for a non-empty queue or until shutdown */
+        pthread_mutex_lock(&ctx->queueMutex);
+        ctx->numThreadsBusy++; // RACE!
+        pthread_mutex_unlock(&ctx->queueMutex);
+    }
+}
+
+void POOL_free(POOL_ctx *ctx) {
+    pthread_mutex_destroy(&ctx->queueMutex);
+    free(ctx->threads);
+    free(ctx); // RACE!
+}
+
+POOL_ctx* POOL_create(size_t numThreads) {
+    POOL_ctx* ctx;
+    ctx = (POOL_ctx*)calloc(1, sizeof(POOL_ctx));
+    if (!ctx) { return NULL; }
+    ctx->numThreadsBusy = 0;
+    {
+        int error = 0;
+        error |= pthread_mutex_init(&ctx->queueMutex, NULL);
+        if (error) { POOL_free(ctx); return NULL; }
+    }
+    ctx->threads = (pthread_t*)malloc(numThreads * sizeof(pthread_t));
+    if (!ctx->threads) { POOL_free(ctx); return NULL; }
+    {   size_t i;
+        for (i = 0; i < numThreads; ++i) {
+            if (pthread_create(&ctx->threads[i], NULL, &POOL_thread, ctx)) {
+                POOL_free(ctx);
+                return NULL;
+        }   }
+    }
+    return ctx;
+}
+
+
+int main() {
+    POOL_ctx* const ctx = POOL_create(20);
+}


### PR DESCRIPTION
Builds on #1084.

Instead of distributing an access-to-a-struct to all of the fields in that struct, the implementation distributes to those fields only that had direct access(es) themselves. Meaning that if there is access to a struct only, there will be one warning for that struct instead of a separate warning for each of the struct fields. And if there was access to a field of a struct, a race between the access to that struct's field and the access to the whole struct is not lost.

For that, the accesses are collected in a `trie` structure representing a struct. In the `trie` node, there is a set of accesses to that offset and a map of that offset's children with the child offset as a key and a sub-`trie` as a value. Later, the accesses of each node's ancestors are also checked for races with the node accesses, doing the distribution.

Also fixes soundness issue described in #978.
Previously `Access.add_distribute_inner` was based on the type. Since alloc variables have `void` type, contained fields for a blob could not be iterated and distributed to. Since this delays the inner distribution and flips the direction, the issue is automatically avoided: an access to `(alloc).foo` will be checked against an access to just `(alloc)` simply due to the trie structure.