### PR TITLE
Warn for {d,r}eallocation of non-dynamically allocated memory

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2003,7 +2003,7 @@ struct
       let points_to_set = addrToLvalSet a in
       if Q.LS.is_top points_to_set then
         M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Points-to set for pointer %a in function %s is top. Potential free of non-dynamically allocated memory may occur" d_exp ptr special_fn.vname
-      else if Q.LS.exists (fun (v, _) -> not (ctx.ask (Q.IsHeapVar v))) points_to_set then
+      else if (Q.LS.exists (fun (v, _) -> not (ctx.ask (Q.IsHeapVar v))) points_to_set) || (AD.mem Addr.UnknownPtr a) then
         M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Free of non-dynamically allocated memory in function %s for pointer %a" special_fn.vname d_exp ptr
     | _ -> M.warn ~category:MessageCategory.Analyzer "Pointer %a in function %s doesn't evaluate to a valid address." d_exp ptr special_fn.vname
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1998,18 +1998,14 @@ struct
     invalidate ~deep:true ~ctx (Analyses.ask_of_ctx ctx) gs st' deep_addrs
 
   let check_free_of_non_heap_mem ctx special_fn ptr =
-    match ctx.ask (Queries.MayPointTo ptr) with
-    | a when not (Queries.LS.is_top a) ->
-      let warn_if_not_heap_var special_fn var =
-        if not (ctx.ask (Queries.IsHeapVar var)) then
-          M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Free of non-dynamically allocated memory in function %s for pointer %a" special_fn.vname d_exp ptr
-      in
-      let pointed_to_vars =
-        Queries.LS.elements a
-        |> List.map fst
-      in
-      List.iter (warn_if_not_heap_var special_fn) pointed_to_vars
-    | _ -> ()
+    let points_to_set = ctx.ask (Queries.MayPointTo ptr) in
+    let exists_non_heap_var =
+      Queries.LS.elements points_to_set
+      |> List.map fst
+      |> List.exists (fun var -> not (ctx.ask (Queries.IsHeapVar var)))
+    in
+    if exists_non_heap_var then
+      M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Free of non-dynamically allocated memory in function %s for pointer %a" special_fn.vname d_exp ptr
 
   let special ctx (lv:lval option) (f: varinfo) (args: exp list) =
     let invalidate_ret_lv st = match lv with

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1998,18 +1998,14 @@ struct
     invalidate ~deep:true ~ctx (Analyses.ask_of_ctx ctx) gs st' deep_addrs
 
   let check_free_of_non_heap_mem ctx special_fn ptr =
-    let points_to_set = ctx.ask (Queries.MayPointTo ptr) in
-    begin try
-        let exists_non_heap_var =
-          (* elements throws Unsupported if the points-to set is top *)
-          Queries.LS.elements points_to_set
-          |> List.map fst
-          |> List.exists (fun var -> not (ctx.ask (Queries.IsHeapVar var)))
-        in
-        if exists_non_heap_var then
-          M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Free of non-dynamically allocated memory in function %s for pointer %a" special_fn.vname d_exp ptr
-      with _ -> M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Points-to set for pointer %a in function %s is top. Potential free of non-dynamically allocated memory may occur" d_exp ptr special_fn.vname
-    end
+    match eval_rv_address (Analyses.ask_of_ctx ctx) ctx.global ctx.local ptr with
+    | Address a ->
+      let points_to_set = addrToLvalSet a in
+      if Q.LS.is_top points_to_set then
+        M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Points-to set for pointer %a in function %s is top. Potential free of non-dynamically allocated memory may occur" d_exp ptr special_fn.vname
+      else if Q.LS.exists (fun (v, _) -> not (ctx.ask (Q.IsHeapVar v))) points_to_set then
+        M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Free of non-dynamically allocated memory in function %s for pointer %a" special_fn.vname d_exp ptr
+    | _ -> M.warn ~category:MessageCategory.Analyzer "Pointer %a in function %s doesn't evaluate to a valid address." d_exp ptr special_fn.vname
 
   let special ctx (lv:lval option) (f: varinfo) (args: exp list) =
     let invalidate_ret_lv st = match lv with

--- a/src/util/messageCategory.ml
+++ b/src/util/messageCategory.ml
@@ -12,6 +12,7 @@ type undefined_behavior =
   | NullPointerDereference
   | UseAfterFree
   | DoubleFree
+  | InvalidMemoryDeallocation
   | Uninitialized
   | DoubleLocking
   | Other
@@ -65,6 +66,7 @@ struct
     let nullpointer_dereference: category = create @@ NullPointerDereference
     let use_after_free: category = create @@ UseAfterFree
     let double_free: category = create @@ DoubleFree
+    let invalid_memory_deallocation: category = create @@ InvalidMemoryDeallocation
     let uninitialized: category = create @@ Uninitialized
     let double_locking: category = create @@ DoubleLocking
     let other: category = create @@ Other
@@ -102,6 +104,7 @@ struct
         | "nullpointer_dereference" -> nullpointer_dereference
         | "use_after_free" -> use_after_free
         | "double_free" -> double_free
+        | "invalid_memory_deallocation" -> invalid_memory_deallocation
         | "uninitialized" -> uninitialized
         | "double_locking" -> double_locking
         | "other" -> other
@@ -113,6 +116,7 @@ struct
       | NullPointerDereference -> ["NullPointerDereference"]
       | UseAfterFree -> ["UseAfterFree"]
       | DoubleFree -> ["DoubleFree"]
+      | InvalidMemoryDeallocation -> ["InvalidMemoryDeallocation"]
       | Uninitialized -> ["Uninitialized"]
       | DoubleLocking -> ["DoubleLocking"]
       | Other -> ["Other"]
@@ -223,6 +227,7 @@ let behaviorName = function
     |NullPointerDereference -> "NullPointerDereference"
     |UseAfterFree -> "UseAfterFree"
     |DoubleFree -> "DoubleFree"
+    |InvalidMemoryDeallocation -> "InvalidMemoryDeallocation"
     |Uninitialized -> "Uninitialized"
     |DoubleLocking -> "DoubleLocking"
     |Other -> "Other"

--- a/tests/regression/75-invalid_dealloc/01-invalid-dealloc-simple.c
+++ b/tests/regression/75-invalid_dealloc/01-invalid-dealloc-simple.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+
+int main(int argc, char const *argv[])
+{
+    int a;
+    int *p = &a;
+    free(p); //WARN
+
+    char b = 'b';
+    char *p2 = &b;
+    free(p2); //WARN
+
+    return 0;
+}

--- a/tests/regression/75-invalid_dealloc/02-invalid-dealloc-struct.c
+++ b/tests/regression/75-invalid_dealloc/02-invalid-dealloc-struct.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+
+typedef struct custom_t {
+    int x;
+    int y;
+} custom_t;
+
+int main(int argc, char const *argv[])
+{
+    custom_t *var;
+    free(var); //WARN
+
+    return 0;
+}

--- a/tests/regression/75-invalid_dealloc/03-invalid-dealloc-array.c
+++ b/tests/regression/75-invalid_dealloc/03-invalid-dealloc-array.c
@@ -1,0 +1,25 @@
+#include <stdlib.h>
+
+typedef struct custom_t {
+    int x;
+    int y;
+} custom_t;
+
+#define MAX_SIZE 5000
+
+int main(int argc, char const *argv[])
+{
+    custom_t custom_arr[MAX_SIZE];
+    free(custom_arr); //WARN
+
+    int int_arr[MAX_SIZE];
+    free(int_arr); //WARN
+
+    char char_arr[MAX_SIZE];
+    free(char_arr); //WARN
+
+    char char_arr2[1];
+    free(char_arr2); //WARN
+
+    return 0;
+}

--- a/tests/regression/75-invalid_dealloc/04-invalid-realloc.c
+++ b/tests/regression/75-invalid_dealloc/04-invalid-realloc.c
@@ -1,0 +1,25 @@
+#include <stdlib.h>
+
+typedef struct custom_t {
+    int x;
+    int y;
+} custom_t;
+
+#define MAX_SIZE 5000
+
+int main(int argc, char const *argv[])
+{
+    custom_t custom_arr[10];
+    realloc(custom_arr, MAX_SIZE); //WARN
+
+    int int_arr[100];
+    realloc(int_arr, MAX_SIZE); //WARN
+
+    char char_arr[1000];
+    realloc(char_arr, MAX_SIZE); //WARN
+
+    char char_arr2[1];
+    realloc(char_arr2, MAX_SIZE); //WARN
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds checks in the `base.ml` analysis for calls to the special functions `realloc` and `free`:
* Whenever the pointer argument to either of these functions does not point to dynamically allocated memory, we need to WARN appropriately
* Cf. https://wiki.sei.cmu.edu/confluence/display/c/MEM34-C.+Only+free+memory+allocated+dynamically
* Cf. [CWE 590](https://cwe.mitre.org/data/definitions/590.html)

Also added a few regression test cases that should cover these newly introduced checks.
`make test` runs through successfully (including the new regression tests)