### PR TITLE
Make `join` and related operations for Unions preserve equal arguments

### DIFF
--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -545,9 +545,7 @@ struct
         | None -> AD.join y AD.top_ptr)
     | (Address x, Address y) -> Address (AD.join x y)
     | (Struct x, Struct y) -> Struct (Structs.join x y)
-    | (Union (f,x), Union (g,y)) -> Union (match UnionDomain.Field.join f g with
-        | `Lifted f -> (`Lifted f, join x y) (* f = g *)
-        | x -> (x, Top)) (* f <> g *)
+    | (Union x, Union y) -> Union (Unions.join x y)
     | (Array x, Array y) -> Array (CArrays.join x y)
     | (Blob x, Blob y) -> Blob (Blobs.join x y)
     | Blob (x,s,o), y
@@ -582,9 +580,7 @@ struct
         | None -> AD.widen y (AD.join y AD.top_ptr))
     | (Address x, Address y) -> Address (AD.widen x y)
     | (Struct x, Struct y) -> Struct (Structs.widen x y)
-    | (Union (f,x), Union (g,y)) -> Union (match UnionDomain.Field.widen f g with
-        | `Lifted f -> (`Lifted f, widen x y) (* f = g *)
-        | x -> (x, Top))
+    | (Union x, Union y) -> Union (Unions.widen x y)
     | (Array x, Array y) -> Array (CArrays.widen x y)
     | (Blob x, Blob y) -> Blob (Blobs.widen x y)
     | (Thread x, Thread y) -> Thread (Threads.widen x y)
@@ -605,9 +601,10 @@ struct
     let join_elem: (t -> t -> t) = smart_join x_eval_int y_eval_int in  (* does not compile without type annotation *)
     match (x,y) with
     | (Struct x, Struct y) -> Struct (Structs.join_with_fct join_elem x y)
-    | (Union (f,x), Union (g,y)) -> Union (match UnionDomain.Field.join f g with
-        | `Lifted f -> (`Lifted f, join_elem x y) (* f = g *)
-        | x -> (x, Top)) (* f <> g *)
+    | (Union (f,x), Union (g,y)) ->
+      let field = UnionDomain.Field.join f g in
+      let value = join_elem x y in
+      Union (field, value)
     | (Array x, Array y) -> Array (CArrays.smart_join x_eval_int y_eval_int x y)
     | _ -> join x y  (* Others can not contain array -> normal join  *)
 
@@ -615,9 +612,10 @@ struct
     let widen_elem: (t -> t -> t) = smart_widen x_eval_int y_eval_int in (* does not compile without type annotation *)
     match (x,y) with
     | (Struct x, Struct y) -> Struct (Structs.widen_with_fct widen_elem x y)
-    | (Union (f,x), Union (g,y)) -> Union (match UnionDomain.Field.widen f g with
-        | `Lifted f -> `Lifted f, widen_elem x y  (* f = g *)
-        | x -> x, Top) (* f <> g *)
+    | (Union (f,x), Union (g,y)) ->
+      let field = UnionDomain.Field.widen f g in
+      let value = widen_elem x y in
+      Union (field, value)
     | (Array x, Array y) -> Array (CArrays.smart_widen x_eval_int y_eval_int x y)
     | _ -> widen x y  (* Others can not contain array -> normal widen  *)
 


### PR DESCRIPTION
The implementation of `MapTop.join` uses a short-circuit optimization that relies on the fact that `join x x = x`

https://github.com/goblint/analyzer/blob/3af00a86da65ab5caac033b0ecff02dc69c3bfbf/src/domains/mapDomain.ml#L439-L442

Issue #1091 was caused by the `join` operation for unions in `ValueDomain` not satisfying the `join x x = x` property.
In the from-scratch run, when physical equality was given, the `join` of two abstract unions of the form $(field: \bot, value: \bot)$ yielded $(field: \bot, value: \bot)$. In the incremental run, the physical equality of the maps containing the Union abstraction was no longer given, and the result of the join is $(field: \bot, value: \top)$.

Therefore, this PR changes the behavior of the `join` and `widen` operations for the `UnionDomain`, such that `join x x = x` and `widen x x = x` is ensured.
 
 Fixes #1091.