### PR TITLE
Remove most `MapDomain.Groupable`

### DIFF
--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -713,11 +713,7 @@ module DownwardClosedCluster (ClusteringArg: ClusteringArg) =  functor (RD: Rela
 struct
   open CommonPerMutex(RD)
 
-  module VS =
-  struct
-    include Printable.Std
-    include SetDomain.Make (CilType.Varinfo)
-  end
+  module VS = SetDomain.Make (CilType.Varinfo)
   module LRD = MapDomain.MapBot (VS) (RD)
 
   let keep_only_protected_globals ask m octs =

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -117,11 +117,7 @@ module Locksets =
 struct
   module Lock = LockDomain.Addr
 
-  module Lockset =
-  struct
-    include Printable.Std (* To make it Groupable *)
-    include SetDomain.ToppedSet (Lock) (struct let topname = "All locks" end)
-  end
+  module Lockset = SetDomain.ToppedSet (Lock) (struct let topname = "All locks" end)
 
   module MustLockset = SetDomain.Reverse (Lockset)
 

--- a/src/analyses/spec.ml
+++ b/src/analyses/spec.ml
@@ -253,7 +253,7 @@ struct
     | Some k1, Some k2 when D.mem k2 m -> (* only k2 in D *)
       M.debug ~category:Analyzer "assign (only k2 in D): %s = %s" (D.string_of_key k1) (D.string_of_key k2);
       let m = D.alias k1 k2 m in (* point k1 to k2 *)
-      if Basetype.Variables.to_group (fst k2) = Some Temp (* check if k2 is a temporary Lval introduced by CIL *)
+      if Basetype.Variables.to_group (fst k2) = Temp (* check if k2 is a temporary Lval introduced by CIL *)
       then D.remove' k2 m (* if yes we need to remove it from our map *)
       else m (* otherwise no change *)
     | Some k1, _ when D.mem k1 m -> (* k1 in D and assign something unknown *)

--- a/src/cdomains/addressDomain.ml
+++ b/src/cdomains/addressDomain.ml
@@ -76,13 +76,6 @@ module AddressPrintable (Mval: Mval.Printable) =
 struct
   include AddressBase (Mval)
 
-  let trace_enabled = true (* TODO: remove *)
-  type group = Basetype.Variables.group
-  let show_group = Basetype.Variables.show_group
-  let to_group = function
-    | Addr (x,_) -> Basetype.Variables.to_group x
-    | _ -> Some Basetype.Variables.Local
-
   let of_var x = Addr (x, `NoOffset)
   let of_mval (x, o) = Addr (x, o)
 

--- a/src/cdomains/addressDomain.ml
+++ b/src/cdomains/addressDomain.ml
@@ -76,6 +76,7 @@ module AddressPrintable (Mval: Mval.Printable) =
 struct
   include AddressBase (Mval)
 
+  let trace_enabled = true (* TODO: remove *)
   type group = Basetype.Variables.group
   let show_group = Basetype.Variables.show_group
   let to_group = function

--- a/src/cdomains/addressDomain_intf.ml
+++ b/src/cdomains/addressDomain_intf.ml
@@ -31,7 +31,6 @@ sig
   module AddressPrintable (Mval: Mval.Printable):
   sig
     include module type of AddressBase (Mval)
-    include MapDomain.Groupable with type t := t and type group = Basetype.Variables.group (** @closed *)
 
     val is_definite: t -> bool
     (** Whether address is a [NULL] pointer or an mvalue that has only definite integer indexing (and fields). *)

--- a/src/cdomains/addressDomain_intf.ml
+++ b/src/cdomains/addressDomain_intf.ml
@@ -9,7 +9,6 @@ sig
       | UnknownPtr (** Unknown pointer. Could point to globals, heap and escaped variables. *)
       | StrPtr of string option (** String literal pointer. [StrPtr None] abstracts any string pointer *)
     include Printable.S with type t := t (** @closed *)
-    include MapDomain.Groupable with type t := t (** @closed *)
 
     val of_string: string -> t
     (** Convert string to {!StrPtr}. *)

--- a/src/cdomains/baseDomain.ml
+++ b/src/cdomains/baseDomain.ml
@@ -15,13 +15,6 @@ struct
   include M
 end
 
-
-module Glob =
-struct
-  module Var = Basetype.Variables
-  module Val = VD
-end
-
 (* Keeps track of which arrays are potentially partitioned according to an expression containing a specific variable *)
 (* Map from variables to sets of arrays: var -> {array} *)
 module PartDeps =

--- a/src/cdomains/baseDomain.ml
+++ b/src/cdomains/baseDomain.ml
@@ -6,13 +6,14 @@ module BI = IntOps.BigIntOps
 
 module CPA =
 struct
+  module M0 = MapDomain.MapBot (Basetype.Variables) (VD)
   module M =
   struct
-    include MapDomain.LiftTop (VD) (MapDomain.HashCached (MapDomain.MapBot (Basetype.Variables) (VD)))
-    let name () = "value domain"
+    include M0
+    include MapDomain.PrintGroupable (Basetype.Variables) (VD) (M0)
   end
-
-  include M
+  include MapDomain.LiftTop (VD) (MapDomain.HashCached (M))
+  let name () = "value domain"
 end
 
 (* Keeps track of which arrays are potentially partitioned according to an expression containing a specific variable *)

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -12,7 +12,7 @@ struct
       "(" ^ x.vname ^ ", " ^ description ^ ")"
     else x.vname
   let pretty () x = Pretty.text (show x)
-  type group = Global | Local | Parameter | Temp [@@deriving show { with_path = false }]
+  type group = Global | Local | Parameter | Temp [@@deriving ord, show { with_path = false }]
   let to_group = function
     | x when x.vglob -> Global
     | x when x.vdecl.line = -1 -> Temp

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -14,8 +14,7 @@ struct
     else x.vname
   let pretty () x = Pretty.text (show x)
   type group = Global | Local | Parameter | Temp [@@deriving show { with_path = false }]
-  let (%) = Batteries.(%)
-  let to_group = Option.some % function
+  let to_group = function
     | x when x.vglob -> Global
     | x when x.vdecl.line = -1 -> Temp
     | x when Cilfacade.is_varinfo_formal x -> Parameter

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -6,7 +6,6 @@ open GoblintCil
 module Variables =
 struct
   include CilType.Varinfo
-  let trace_enabled = true
   let show x =
     if RichVarinfo.BiVarinfoMap.Collection.mem_varinfo x then
       let description = RichVarinfo.BiVarinfoMap.Collection.describe_varinfo x in

--- a/src/cdomains/basetype.ml
+++ b/src/cdomains/basetype.ml
@@ -61,7 +61,6 @@ module Bools: Lattice.S with type t = [`Bot | `Lifted of bool | `Top] =
 
 module CilExp =
 struct
-  include Printable.Std (* for Groupable *)
   include CilType.Exp
 
   let name () = "expressions"
@@ -158,8 +157,4 @@ struct
   let printXml f x = BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (XmlUtil.escape (show x))
 end
 
-module CilField =
-struct
-  include Printable.Std (* for default MapDomain.Groupable *)
-  include CilType.Fieldinfo
-end
+module CilField = CilType.Fieldinfo

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -11,12 +11,6 @@ module Mutexes = SetDomain.ToppedSet (Addr) (struct let topname = "All mutexes" 
 module Simple = Lattice.Reverse (Mutexes)
 module Priorities = IntDomain.Lifted
 
-module Glob =
-struct
-  module Var = Basetype.Variables
-  module Val = Simple
-end
-
 module Lockset =
 struct
 

--- a/src/cdomains/mval_intf.ml
+++ b/src/cdomains/mval_intf.ml
@@ -5,7 +5,6 @@ sig
 
   type t = GoblintCil.varinfo * idx Offset.t
   include Printable.S with type t := t (** @closed *)
-  include MapDomain.Groupable with type t := t (** @closed *)
 
   val is_definite: t -> bool
   (** Whether offset of mvalue has only definite integer indexing (and fields). *)

--- a/src/cdomains/threadIdDomain.ml
+++ b/src/cdomains/threadIdDomain.ml
@@ -7,7 +7,6 @@ open BatPervasives
 module type S =
 sig
   include Printable.S
-  include MapDomain.Groupable with type t := t
 
   val threadinit: varinfo -> multiple:bool -> t
   val is_main: t -> bool
@@ -212,7 +211,7 @@ struct
   (* Plain thread IDs *)
   module P = Unit(FunNode)
 
-  include GroupableFlagHelper(H)(P)(struct
+  include FlagHelper(H)(P)(struct
       let msg = "FlagConfiguredTID received a value where not exactly one component is set"
       let name = "FlagConfiguredTID"
     end)

--- a/src/domains/disjointDomain.ml
+++ b/src/domains/disjointDomain.ml
@@ -615,7 +615,7 @@ struct
     include Printable.Std (* for Groupable *)
     include E
   end
-  include MapDomain.Print (GroupableE) (V) (
+  include MapDomain.PrintGroupable (GroupableE) (V) (
     struct
       type nonrec t = t
       type nonrec key = key
@@ -878,7 +878,7 @@ struct
     include Printable.Std (* for Groupable *)
     include E
   end
-  include MapDomain.Print (GroupableE) (R) (
+  include MapDomain.PrintGroupable (GroupableE) (R) (
     struct
       type nonrec t = t
       type nonrec key = key

--- a/src/domains/disjointDomain.ml
+++ b/src/domains/disjointDomain.ml
@@ -610,12 +610,7 @@ struct
         | _, _ -> None
       ) m1 m2
 
-  module GroupableE =
-  struct
-    include Printable.Std (* for Groupable *)
-    include E
-  end
-  include MapDomain.PrintGroupable (GroupableE) (V) (
+  include MapDomain.Print (E) (V) (
     struct
       type nonrec t = t
       type nonrec key = key
@@ -873,12 +868,7 @@ struct
     in
     snd (S.fold f s2 (s1, S.empty ()))
 
-  module GroupableE =
-  struct
-    include Printable.Std (* for Groupable *)
-    include E
-  end
-  include MapDomain.PrintGroupable (GroupableE) (R) (
+  include MapDomain.Print (E) (R) (
     struct
       type nonrec t = t
       type nonrec key = key

--- a/src/domains/disjointDomain.ml
+++ b/src/domains/disjointDomain.ml
@@ -36,11 +36,6 @@ end
 struct
   type elt = E.t
 
-  module R =
-  struct
-    include Printable.Std (* for Groupable *)
-    include R
-  end
   module M = MapDomain.MapBot (R) (B)
 
   (** Invariant: no explicit bot buckets.
@@ -475,11 +470,6 @@ struct
   type key = E.t
   type value = B.value
 
-  module R =
-  struct
-    include Printable.Std (* for Groupable *)
-    include R
-  end
   module M = MapDomain.MapBot (R) (B)
 
   (** Invariant: no explicit bot buckets.

--- a/src/domains/disjointDomain.ml
+++ b/src/domains/disjointDomain.ml
@@ -605,7 +605,7 @@ struct
       type nonrec t = t
       type nonrec key = key
       type nonrec value = value
-      let bindings = bindings
+      let fold = fold
       let iter = iter
     end
     )
@@ -863,7 +863,7 @@ struct
       type nonrec t = t
       type nonrec key = key
       type nonrec value = value
-      let bindings = bindings
+      let fold = fold
       let iter = iter
     end
     )

--- a/src/domains/flagHelper.ml
+++ b/src/domains/flagHelper.ml
@@ -40,28 +40,6 @@ struct
   let arbitrary () = failwith (Msg.name ^ ": no arbitrary")
 end
 
-module GroupableFlagHelper (L:MapDomain.Groupable) (R:MapDomain.Groupable) (Msg: FlagError) =
-struct
-  include FlagHelper (L) (R) (Msg)
-  type group = L.group option * R.group option
-
-  let trace_enabled = false
-
-  let show_group = unop L.show_group R.show_group
-  let to_group (h,p) = match (h, p) with
-    | (Some h, None) ->
-      (let r = L.to_group h in
-       match r with
-       | Some r -> Some (Some r, None)
-       | _ -> None)
-    | (None, Some p) ->
-      (let r = R.to_group p in
-       match r with
-       | Some r -> Some (None, Some r)
-       | _ -> None)
-    | _ -> failwith Msg.msg
-end
-
 module type LatticeFlagHelperArg = sig
   include Lattice.PO
   val is_top: t -> bool

--- a/src/domains/hoareDomain.ml
+++ b/src/domains/hoareDomain.ml
@@ -255,12 +255,7 @@ end
 (* TODO: weaken R to Lattice.S ? *)
 module MapBot (SpecD:Lattice.S) (R:SetDomain.S) =
 struct
-  module SpecDGroupable =
-  struct
-    include Printable.Std
-    include SpecD
-  end
-  include MapDomain.MapBot (SpecDGroupable) (R)
+  include MapDomain.MapBot (SpecD) (R)
 
   (* TODO: get rid of these value-ignoring set-mimicing hacks *)
   let choose' = choose

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -131,7 +131,7 @@ struct
     dprintf "@[%s {\n  @[%t@]}@]" (show mapping) content
 end
 
-module PMap (Domain: Groupable) (Range: Lattice.S) : PS with
+module PMap (Domain: Printable.S) (Range: Lattice.S) : PS with
   type key = Domain.t and
   type value = Range.t =
 struct
@@ -183,7 +183,7 @@ struct
     in
     M.merge f
 
-  include PrintGroupable (Domain) (Range) (
+  include Print (Domain) (Range) (
     struct
       type nonrec t = t
       type nonrec key = key
@@ -377,7 +377,7 @@ struct
   let relift x = M.relift x
 end
 
-module MapBot (Domain: Groupable) (Range: Lattice.S) : S with
+module MapBot (Domain: Printable.S) (Range: Lattice.S) : S with
   type key = Domain.t and
   type value = Range.t =
 struct
@@ -426,7 +426,7 @@ struct
   let narrow = map2 Range.narrow
 end
 
-module MapTop (Domain: Groupable) (Range: Lattice.S) : S with
+module MapTop (Domain: Printable.S) (Range: Lattice.S) : S with
   type key = Domain.t and
   type value = Range.t =
 struct
@@ -597,7 +597,7 @@ struct
     | `Lifted x -> `Lifted (M.mapi f x)
 end
 
-module MapBot_LiftTop (Domain: Groupable) (Range: Lattice.S) : S with
+module MapBot_LiftTop (Domain: Printable.S) (Range: Lattice.S) : S with
   type key = Domain.t and
   type value = Range.t =
 struct
@@ -725,7 +725,7 @@ struct
     | `Lifted x -> `Lifted (M.mapi f x)
 end
 
-module MapTop_LiftBot (Domain: Groupable) (Range: Lattice.S): S with
+module MapTop_LiftBot (Domain: Printable.S) (Range: Lattice.S): S with
   type key = Domain.t and
   type value = Range.t =
 struct

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -60,7 +60,7 @@ sig
   include Printable.S
   type group (* use [@@deriving show { with_path = false }] *)
   val show_group: group -> string
-  val to_group: t -> group option
+  val to_group: t -> group
   val trace_enabled: bool (* Just a global hack for tracing individual variables. *)
 end
 
@@ -123,10 +123,8 @@ struct
     in
     let group_name a () = text (D.show_group a) in
     let pretty_group map () = MM.fold f map nil in
-    let pretty_groups rest (group, map) =
-      match group with
-      | None ->  rest ++ pretty_group map ()
-      | Some g -> rest ++ dprintf "@[%t {\n  @[%t@]}@]\n" (group_name g) (pretty_group map) in
+    let pretty_groups rest (g, map) =
+      rest ++ dprintf "@[%t {\n  @[%t@]}@]\n" (group_name g) (pretty_group map) in
     let content () = List.fold_left pretty_groups nil groups in
     dprintf "@[%s {\n  @[%t@]}@]" (show mapping) content
 end

--- a/src/domains/mapDomain.ml
+++ b/src/domains/mapDomain.ml
@@ -61,7 +61,6 @@ sig
   type group (* use [@@deriving show { with_path = false }] *)
   val show_group: group -> string
   val to_group: t -> group
-  val trace_enabled: bool (* Just a global hack for tracing individual variables. *)
 end
 
 (** Subsignature of {!S}, which is sufficient for {!Print}. *)
@@ -115,11 +114,7 @@ struct
       BatHashtbl.to_list h |> List.sort (cmpBy fst)
     in
     let f key st dok =
-      if ME.tracing && D.trace_enabled && !ME.tracevars <> [] &&
-         not (List.mem (D.show key) !ME.tracevars) then
-        dok
-      else
-        dok ++ dprintf "%a ->@?  @[%a@]\n" D.pretty key R.pretty st
+      dok ++ dprintf "%a ->@?  @[%a@]\n" D.pretty key R.pretty st
     in
     let group_name a () = text (D.show_group a) in
     let pretty_group map () = MM.fold f map nil in

--- a/src/domains/printable.ml
+++ b/src/domains/printable.ml
@@ -48,13 +48,6 @@ end
     Include as the first thing to avoid these overriding actual definitions. *)
 module Std =
 struct
-  (* start MapDomain.Groupable *)
-  type group = |
-  let show_group (x: group) = match x with _ -> .
-  let to_group _ = None
-  let trace_enabled = false
-  (* end MapDomain.Groupable *)
-
   let tag _ = failwith "Std: no tag"
   let arbitrary () = failwith "no arbitrary"
 end

--- a/src/domains/trieDomain.ml
+++ b/src/domains/trieDomain.ml
@@ -1,6 +1,6 @@
 (** Trie domains. *)
 
-module Make (Key: MapDomain.Groupable) (Value: Lattice.S) =
+module Make (Key: Printable.S) (Value: Lattice.S) =
 struct
   module rec Trie:
   sig

--- a/src/util/cilType.ml
+++ b/src/util/cilType.ml
@@ -6,7 +6,6 @@ open Pretty
 module type S =
 sig
   include Printable.S
-  (* include MapDomain.Groupable *) (* FIXME: dependency cycle *)
 end
 
 module Std =

--- a/unittest/domains/mapDomainTest.ml
+++ b/unittest/domains/mapDomainTest.ml
@@ -3,12 +3,12 @@ open OUnit2
 
 module Pretty = GoblintCil.Pretty
 
-module GroupableDriver : MapDomain.Groupable with type t = string  =
+module PrintableDriver : Printable.S with type t = string  =
 struct
   include Printable.Strings
 end
 
-module LatticeDriver = Lattice.Fake (GroupableDriver)
+module LatticeDriver = Lattice.Fake (PrintableDriver)
 
 
 module TestMap (M:MapDomain.S with type key = string and type value = string) =
@@ -162,8 +162,8 @@ struct
 end
 
 
-module Mbot = MapDomain.MapBot (GroupableDriver) (LatticeDriver)
-module Mtop = MapDomain.MapTop (GroupableDriver) (LatticeDriver)
+module Mbot = MapDomain.MapBot (PrintableDriver) (LatticeDriver)
+module Mtop = MapDomain.MapTop (PrintableDriver) (LatticeDriver)
 
 module Tbot = TestMap (Mbot)
 module Ttop = TestMap (Mtop)


### PR DESCRIPTION
Closes #1097. The interface is kept such that base's `CPA` could still explicitly use grouped pretty-printing.