### PR TITLE
Add Selenium test case for rerunning analysis feature in GobView

### DIFF
--- a/scripts/test-gobview.py
+++ b/scripts/test-gobview.py
@@ -80,6 +80,9 @@ try:
     inputBar.send_keys(parameter)
     inputBar.send_keys(Keys.ENTER)
     
+    # wait for ten seconds to let the analysis finish
+    browser.implicitly_wait(10)
+
     parameterChip = browser.find_element(By.X_PATH, '//span[@class="m-1 badge rounded-pill bg-secondary text"]')
     textFromParameterChip = parameterChip.text
     assert(parameterChip == parameter)

--- a/scripts/test-gobview.py
+++ b/scripts/test-gobview.py
@@ -85,7 +85,7 @@ try:
 
     parameterChip = browser.find_element(By.XPATH, '//span[@class="m-1 badge rounded-pill bg-secondary text"]')
     textFromParameterChip = parameterChip.text
-    assert(parameterChip == parameter)
+    assert(textFromParameterChip == parameter)
     print("found the parameter chip in history", textFromParameterChip)
 
     # search for first tick symbol in history

--- a/scripts/test-gobview.py
+++ b/scripts/test-gobview.py
@@ -5,6 +5,7 @@ from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.options import Options
 from threading import Thread
 import http.server
@@ -61,6 +62,32 @@ try:
     content = browser.find_element(By.CLASS_NAME, "content")
     panel = browser.find_element(By.CLASS_NAME, "panel")
     print("found DOM elements main, sidebar-left, sidebar-right, content and panel")
+
+    # simulate work flow for analysis rerun
+    parameterViewTab = browser.find_element(By.ID, "nav-item-2")
+    parameterViewTab.click()
+    parameterView = browser.find_element(By.ID, "parameterview")
+    print("found DOM element parameterview")
+    inputBar = browser.find_element(By.CLASS_NAME, "input")
+    inputBar.clear()
+    invalidFeedback = browser.find_element(By.X_PATH, '//div[@class="invalid-tooltip"]')
+    
+    feedback = invalidFeedback.text
+    assert(feedback == "At least one parameter has to be entered")
+    print("found the feedback", feedback)
+
+    parameter = '--incremental.force-reanalyze.funs ["main"]'
+    inputBar.send_keys(parameter)
+    inputBar.send_keys(Keys.ENTER)
+    
+    parameterChip = browser.find_element(By.X_PATH, '//span[@class="m-1 badge rounded-pill bg-secondary text"]')
+    textFromParameterChip = parameterChip.text
+    assert(parameterChip == parameter)
+    print("found the parameter chip in history", textFromParameterChip)
+
+    # search for first tick symbol in history
+    executedSvg = browser.find_element(By.X_PATH, '//svg[@class="bi bi-check2"]')
+    print("found tick symbol in history indicating successful reanalysis")
 
     cleanup(browser, httpd, thread)
 

--- a/scripts/test-gobview.py
+++ b/scripts/test-gobview.py
@@ -29,7 +29,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=DIRECTORY, **kwargs)
 class Server(socketserver.TCPServer):
-    allow_reuse_address = True # avoids that during a consecutive run the server cannot connect due to an 'Adress already in use' os error
+    allow_reuse_address = True # avoids that during a consecutive run the server cannot connect due to an 'Address already in use' os error
 
 httpd = Server((IP, PORT), Handler)
 print("serving at port", PORT)

--- a/scripts/test-gobview.py
+++ b/scripts/test-gobview.py
@@ -70,7 +70,7 @@ try:
     print("found DOM element parameterview")
     inputBar = browser.find_element(By.CLASS_NAME, "input")
     inputBar.clear()
-    invalidFeedback = browser.find_element(By.X_PATH, '//div[@class="invalid-tooltip"]')
+    invalidFeedback = browser.find_element(By.XPATH, '//div[@class="invalid-tooltip"]')
     
     feedback = invalidFeedback.text
     assert(feedback == "At least one parameter has to be entered")
@@ -83,13 +83,13 @@ try:
     # wait for ten seconds to let the analysis finish
     browser.implicitly_wait(10)
 
-    parameterChip = browser.find_element(By.X_PATH, '//span[@class="m-1 badge rounded-pill bg-secondary text"]')
+    parameterChip = browser.find_element(By.XPATH, '//span[@class="m-1 badge rounded-pill bg-secondary text"]')
     textFromParameterChip = parameterChip.text
     assert(parameterChip == parameter)
     print("found the parameter chip in history", textFromParameterChip)
 
     # search for first tick symbol in history
-    executedSvg = browser.find_element(By.X_PATH, '//svg[@class="bi bi-check2"]')
+    executedSvg = browser.find_element(By.XPATH, '//svg[@class="bi bi-check2"]')
     print("found tick symbol in history indicating successful reanalysis")
 
     cleanup(browser, httpd, thread)


### PR DESCRIPTION
This is part of a Bachelor's Thesis, see [this pull request](https://github.com/goblint/gobview/pull/21)
Since a new feature has been implemented in the above mentioned PR, it would be useful to extend the Selenium test file for GobView accordingly.

The Selenium test flow is the following:
1. It clicks on the "Parameters" tab in the Navbar (center, bottom)
2. It deletes the input string from the input bar
3. The test checks whether it receieved feedback about the invalid input
4. Now, it enters "--incremental.force-reanalyze.funs ["main"]" as parameter into the input bar
5. Enter is pressed
6. Analysis has to be awaited
7. 10 seconds later, the analysis should have succeeded, thus checking if the parameter occurs in the parameter history
8. It is also checking its status afterwards, whether it succeeded or not

**DO NOT MERGE THIS PR UNTIL THE ABOVE MENTIONED ONE HAS BEEN MERGED INTO GOBVIEW**.