### PR TITLE
Multi-threaded UAF Analysis

### DIFF
--- a/src/analyses/useAfterFree.ml
+++ b/src/analyses/useAfterFree.ml
@@ -27,10 +27,6 @@ struct
   let get_current_threadid ctx =
     ctx.ask Queries.CurrentThreadId
 
-  let warn_for_multi_threaded ctx behavior cwe_number =
-    if not (ctx.ask (Queries.MustBeSingleThreaded { since_start = true })) then
-      M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Program isn't running in single-threaded mode. Use-After-Free might occur due to multi-threading"
-
   let warn_for_multi_threaded_access ctx (heap_var:varinfo) behavior cwe_number =
     let freeing_threads = ctx.global heap_var in
     (* If we're single-threaded or there are no threads freeing the memory, we have nothing to WARN about *)
@@ -74,7 +70,6 @@ struct
     let state = ctx.local in
     let undefined_behavior = if is_double_free then Undefined DoubleFree else Undefined UseAfterFree in
     let cwe_number = if is_double_free then 415 else 416 in
-    warn_for_multi_threaded ctx undefined_behavior cwe_number; (* Simple solution to warn when multi-threaded *)
     let rec offset_might_contain_freed offset =
       match offset with
       | NoOffset -> ()

--- a/src/analyses/useAfterFree.ml
+++ b/src/analyses/useAfterFree.ml
@@ -1,4 +1,4 @@
-(** An analysis for the detection of use-after-free vulnerabilities. *)
+(** An analysis for the detection of use-after-free vulnerabilities ([useAfterFree]). *)
 
 open GoblintCil
 open Analyses


### PR DESCRIPTION
This PR:
* Extends the already existing Use-After-Free (UAF) analysis by extending with proper checks and warnings for UAF bugs in multi-threaded programs
* Removes the previously added simple heuristic for UAF warning in multi-threaded programs.

For reference, see also the idea outlined here: https://github.com/goblint/analyzer/pull/1050#issuecomment-1601670330

The multi-threaded UAF regression test case now passes successfully after the changes from this PR.