### PR TITLE
Fix GobView Test

### DIFF
--- a/.github/workflows/locked.yml
+++ b/.github/workflows/locked.yml
@@ -174,5 +174,4 @@ jobs:
 
       - name: Test Gobview
         run: |
-          ./goblint --enable gobview tests/regression/00-sanity/01-assert.c
           python3 scripts/test-gobview.py

--- a/docs/user-guide/inspecting.md
+++ b/docs/user-guide/inspecting.md
@@ -22,4 +22,4 @@ To build GobView (also for development):
 2. The executable for the http-server can then be found in the directory `./_build/default/gobview/goblint-http-server`. It takes the analyzer directory and additional Goblint configurations such as the files to be analyzed as parameters. Run it e.g. with the following command:\
 `./_build/default/gobview/goblint-http-server/goblint_http.exe -with-goblint ../analyzer/goblint -goblint --set files[+] "../analyzer/tests/regression/00-sanity/01-assert.c"`
 
-4. Visit <http://localhost:8000>
+4. Visit <http://localhost:8080>

--- a/scripts/test-gobview.py
+++ b/scripts/test-gobview.py
@@ -40,6 +40,7 @@ options.add_argument('headless')
 browser = webdriver.Chrome(service=Service(ChromeDriverManager().install()),options=options)
 print("finished webdriver installation \n")
 browser.maximize_window()
+browser.implicitly_wait(10);
 
 try:
     # retrieve and wait until page is fully loaded and rendered

--- a/scripts/test-gobview.py
+++ b/scripts/test-gobview.py
@@ -7,32 +7,30 @@ from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
 from threading import Thread
-import http.server
-import socketserver
+import subprocess
 
-PORT = 9000
+PORT = 8080 # has to match port defined in goblint_http.ml
 DIRECTORY = "run"
 IP = "localhost"
 url = 'http://' + IP + ':' + str(PORT) + '/'
 
 # cleanup
-def cleanup(browser, httpd, thread):
+def cleanup(browser, thread):
   print("cleanup")
   browser.close()
-  httpd.shutdown()
-  httpd.server_close()
+  p.kill()
   thread.join()
 
 # serve GobView in different thread so it does not block the testing
-class Handler(http.server.SimpleHTTPRequestHandler):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, directory=DIRECTORY, **kwargs)
-class Server(socketserver.TCPServer):
-    allow_reuse_address = True # avoids that during a consecutive run the server cannot connect due to an 'Adress already in use' os error
+def serve():
+  global p
+  goblint_http_path = '_build/default/gobview/goblint-http-server/goblint_http.exe'
+  p = subprocess.Popen(['./' + goblint_http_path,
+                  '-with-goblint', '../analyzer/goblint',
+                  '-goblint', '--set', 'files[+]', '"../analyzer/tests/regression/00-sanity/01-assert.c"'])
 
-httpd = Server((IP, PORT), Handler)
 print("serving at port", PORT)
-thread = Thread(target=httpd.serve_forever, args=())
+thread = Thread(target=serve, args=())
 thread.start()
 
 # installation of browser
@@ -62,8 +60,8 @@ try:
     panel = browser.find_element(By.CLASS_NAME, "panel")
     print("found DOM elements main, sidebar-left, sidebar-right, content and panel")
 
-    cleanup(browser, httpd, thread)
+    cleanup(browser, thread)
 
 except Exception as e:
-    cleanup(browser, httpd, thread)
+    cleanup(browser, thread)
     raise e


### PR DESCRIPTION
The spuriously occuring crashes of the GobView tests automated with Selenium are due to a race. The race can be forced by letting the goblint-http server sleep for 10s before returning e.g. `stats.marshalled`.

When the GobView page is loaded, it first displays a spinner. After all files necessary for the initialization are marshalled  including `stats.marshalled`), the DOM element with the spinner is updated (through React) to display the actual web page. The call `browser.get(url)` in the python selenium test opens the web page of the url and waits for the page to be loaded. Waiting for it to be loaded here means, that the property `document.readyState` will be `complete` before the next statement in the test is executed. This does however not indicate whether the page is fully loaded, dynamic updates through React might still happen after `document.readyState == complete`. The condition can be fulfilled even though the spinner is still being displayed.

This PR
- sets an implicit wait of 10s for the selenium driver to make it less fragile towards races. An implicit wait will allow to repeatedly try to e.g. find a DOM element until it is either found or the time limit of the implicit wait is up. I also checked whether there could be more specific solutions. An implicit wait has the benefit that it does not slow down the test execution in general. Compared to an explicit wait it will help to make the test more robust in general. Actually checking whether the spinner was replaced would require to set some document property in GobView solely for testing (and I haven't tried if this approach would be feasible with js_of_ocaml).
- changes the test to use the goblint-http server to serve the files instead of the previously used python http server

Closes #1085