### PR TITLE
Fix `Queries.BlobSize`

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -462,7 +462,7 @@ struct
         let var = get_var a gs st x in
         let v = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get a gs st x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
         if M.tracing then M.tracec "get" "var = %a, %a = %a\n" VD.pretty var AD.pretty (AD.of_mval (x, offs)) VD.pretty v;
-        if full then v else match v with
+        if full then var else match v with
           | Blob (c,s,_) -> c
           | x -> x
       in


### PR DESCRIPTION
This PR is an attempt to fix the issue described in #1119:
* `make test` seems to pass just fine locally -> hence, hopefully nothing is broken
* With the test program from #1119 (cf. below), calling `Queries.BlobSize` for the pointer `ptr` in the line with the comment `//BlobSize` now seems to return the size `5`, respectively `[5, 5]` when using intervals.

Test program from #1119:
```c
#include <stdlib.h>

int main(int argc, char const *argv[]) {
    char *ptr = malloc(5 * sizeof(char));

    *ptr = 'a';

    free(ptr); //BlobSize

    return 0;
}
```