### PR TITLE
Memory Leak Analysis

### DIFF
--- a/src/analyses/memLeak.ml
+++ b/src/analyses/memLeak.ml
@@ -36,7 +36,7 @@ struct
     let state = ctx.local in
     (* TODO: Is this too hacky of a solution? *)
     if f.svar.vname = "main" && not @@ D.is_empty state then
-      M.warn ~category:(Behavior (Undefined MemoryLeak)) ~tags:[CWE 401] "Memory leak from function \"%s\": %a\n" f.svar.vname D.pretty state;
+      M.warn ~category:(Behavior (Undefined MemoryLeak)) ~tags:[CWE 401] "Memory leak from function \"%s\": %a" f.svar.vname D.pretty state;
     state
 
   let enter ctx (lval:lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =

--- a/src/analyses/memLeak.ml
+++ b/src/analyses/memLeak.ml
@@ -25,10 +25,9 @@ struct
   let check_for_mem_leak ?(assert_exp_imprecise = false) ?(exp = None) ctx =
     let state = ctx.local in
     if not @@ D.is_empty state then
-      if assert_exp_imprecise && Option.is_some exp then
-        M.warn ~category:(Behavior (Undefined MemoryLeak)) ~tags:[CWE 401] "assert expression %a is unknown. Memory leak might possibly occur for heap variables: %a" d_exp (Option.get exp) D.pretty state
-      else
-        M.warn ~category:(Behavior (Undefined MemoryLeak)) ~tags:[CWE 401] "Memory leak detected for heap variables: %a" D.pretty state
+      match assert_exp_imprecise, exp with
+      | true, Some exp -> M.warn ~category:(Behavior (Undefined MemoryLeak)) ~tags:[CWE 401] "assert expression %a is unknown. Memory leak might possibly occur for heap variables: %a" d_exp exp D.pretty state
+      | _ -> M.warn ~category:(Behavior (Undefined MemoryLeak)) ~tags:[CWE 401] "Memory leak detected for heap variables: %a" D.pretty state
 
   (* TRANSFER FUNCTIONS *)
   let assign ctx (lval:lval) (rval:exp) : D.t =

--- a/src/analyses/memLeak.ml
+++ b/src/analyses/memLeak.ml
@@ -1,0 +1,87 @@
+(** An analysis for the detection of memory leaks ([memLeak]). *)
+
+open GoblintCil
+open Analyses
+open MessageCategory
+
+module ToppedVarInfoSet = SetDomain.ToppedSet(CilType.Varinfo)(struct let topname = "All Heap Variables" end)
+
+module Spec : Analyses.MCPSpec =
+struct
+  include Analyses.DefaultSpec
+
+  let name () = "memLeak"
+
+  module D = ToppedVarInfoSet
+  module C = Lattice.Unit
+
+  let context _ _ = ()
+
+  (* HELPER FUNCTIONS *)
+  let warn_for_multi_threaded ctx =
+    if not (ctx.ask (Queries.MustBeSingleThreaded { since_start = true })) then
+      M.warn ~category:(Behavior (Undefined MemoryLeak)) ~tags:[CWE 401] "Program isn't running in single-threaded mode. A memory leak might occur due to multi-threading"
+
+  (* TRANSFER FUNCTIONS *)
+  let assign ctx (lval:lval) (rval:exp) : D.t =
+    ctx.local
+
+  let branch ctx (exp:exp) (tv:bool) : D.t =
+    ctx.local
+
+  let body ctx (f:fundec) : D.t =
+    ctx.local
+
+  let return ctx (exp:exp option) (f:fundec) : D.t =
+    let state = ctx.local in
+    (* TODO: Is this too hacky of a solution? *)
+    if f.svar.vname = "main" && not @@ D.is_empty state then
+      M.warn ~category:(Behavior (Undefined MemoryLeak)) ~tags:[CWE 401] "Memory leak from function \"%s\": %a\n" f.svar.vname D.pretty state;
+    state
+
+  let enter ctx (lval:lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
+    [ctx.local, ctx.local]
+
+  let combine_env ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (callee_local:D.t) (f_ask:Queries.ask) : D.t =
+    callee_local
+
+  let combine_assign ctx (lval:lval option) fexp (f:fundec) (args:exp list) fc (callee_local:D.t) (f_ask: Queries.ask): D.t =
+    ctx.local
+
+  let special ctx (lval:lval option) (f:varinfo) (arglist:exp list) : D.t =
+    let state = ctx.local in
+    let desc = LibraryFunctions.find f in
+    match desc.special arglist with
+    | Malloc _
+    | Calloc _
+    | Realloc _ ->
+      (* Warn about multi-threaded programs as soon as we encounter a dynamic memory allocation function *)
+      warn_for_multi_threaded ctx;
+      begin match ctx.ask Queries.HeapVar with
+        | `Lifted var -> D.add var state
+        | _ -> state
+      end
+    | Free ptr ->
+      begin match ctx.ask (Queries.MayPointTo ptr) with
+        | a when not (Queries.LS.is_top a) && not (Queries.LS.mem (dummyFunDec.svar, `NoOffset) a) ->
+          (* TODO: Need to always set "ana.malloc.unique_address_count" to smth > 0 *)
+          let unique_pointed_to_heap_vars =
+            Queries.LS.filter (fun (v, _) -> ctx.ask (Queries.IsHeapVar v) && not @@ ctx.ask (Queries.IsMultiple v)) a
+            |> Queries.LS.elements
+            |> List.map fst
+            |> D.of_list
+          in
+          D.diff state unique_pointed_to_heap_vars
+        | _ -> state
+      end
+    | _ -> state
+
+  let threadenter ctx lval f args = [ctx.local]
+  let threadspawn ctx lval f args fctx = ctx.local
+
+  let startstate v = D.bot ()
+  let exitstate v = D.top ()
+end
+
+let _ =
+  MCP.register_analysis (module Spec : MCPSpec)

--- a/src/analyses/memLeak.ml
+++ b/src/analyses/memLeak.ml
@@ -63,7 +63,7 @@ struct
       end
     | Free ptr ->
       begin match ctx.ask (Queries.MayPointTo ptr) with
-        | a when not (Queries.LS.is_top a) && not (Queries.LS.mem (dummyFunDec.svar, `NoOffset) a) ->
+        | a when not (Queries.LS.is_top a) && not (Queries.LS.mem (dummyFunDec.svar, `NoOffset) a) && Queries.LS.cardinal a = 1 ->
           (* TODO: Need to always set "ana.malloc.unique_address_count" to smth > 0 *)
           let unique_pointed_to_heap_vars =
             Queries.LS.filter (fun (v, _) -> ctx.ask (Queries.IsHeapVar v) && not @@ ctx.ask (Queries.IsMultiple v)) a

--- a/src/util/messageCategory.ml
+++ b/src/util/messageCategory.ml
@@ -13,6 +13,7 @@ type undefined_behavior =
   | UseAfterFree
   | DoubleFree
   | InvalidMemoryDeallocation
+  | MemoryLeak
   | Uninitialized
   | DoubleLocking
   | Other
@@ -67,6 +68,7 @@ struct
     let use_after_free: category = create @@ UseAfterFree
     let double_free: category = create @@ DoubleFree
     let invalid_memory_deallocation: category = create @@ InvalidMemoryDeallocation
+    let memory_leak: category = create @@ MemoryLeak
     let uninitialized: category = create @@ Uninitialized
     let double_locking: category = create @@ DoubleLocking
     let other: category = create @@ Other
@@ -117,6 +119,7 @@ struct
       | UseAfterFree -> ["UseAfterFree"]
       | DoubleFree -> ["DoubleFree"]
       | InvalidMemoryDeallocation -> ["InvalidMemoryDeallocation"]
+      | MemoryLeak -> ["MemoryLeak"]
       | Uninitialized -> ["Uninitialized"]
       | DoubleLocking -> ["DoubleLocking"]
       | Other -> ["Other"]
@@ -228,6 +231,7 @@ let behaviorName = function
     |UseAfterFree -> "UseAfterFree"
     |DoubleFree -> "DoubleFree"
     |InvalidMemoryDeallocation -> "InvalidMemoryDeallocation"
+    |MemoryLeak -> "MemoryLeak"
     |Uninitialized -> "Uninitialized"
     |DoubleLocking -> "DoubleLocking"
     |Other -> "Other"

--- a/tests/regression/76-memleak/01-simple-no-mem-leak.c
+++ b/tests/regression/76-memleak/01-simple-no-mem-leak.c
@@ -1,0 +1,9 @@
+//PARAM: --set ana.malloc.unique_address_count 1 --set ana.activated[+] memLeak
+#include <stdlib.h>
+
+int main(int argc, char const *argv[]) {
+    int *p = malloc(sizeof(int));
+    free(p);
+
+    return 0; //NOWARN
+}

--- a/tests/regression/76-memleak/02-simple-mem-leak.c
+++ b/tests/regression/76-memleak/02-simple-mem-leak.c
@@ -1,0 +1,8 @@
+//PARAM: --set ana.malloc.unique_address_count 1 --set ana.activated[+] memLeak
+#include <stdlib.h>
+
+int main(int argc, char const *argv[]) {
+    int *p = malloc(sizeof(int));
+    // No free => memory is leaked
+    return 0; //TODO: `make test` detects OTHER and not WARN here
+}

--- a/tests/regression/76-memleak/02-simple-mem-leak.c
+++ b/tests/regression/76-memleak/02-simple-mem-leak.c
@@ -4,5 +4,5 @@
 int main(int argc, char const *argv[]) {
     int *p = malloc(sizeof(int));
     // No free => memory is leaked
-    return 0; //TODO: `make test` detects OTHER and not WARN here
+    return 0; //WARN
 }

--- a/tests/regression/76-memleak/03-simple-exit-mem-leak.c
+++ b/tests/regression/76-memleak/03-simple-exit-mem-leak.c
@@ -1,0 +1,7 @@
+//PARAM: --set ana.malloc.unique_address_count 1 --set ana.activated[+] memLeak
+#include <stdlib.h>
+
+int main(int argc, char const *argv[]) {
+    int *p = malloc(sizeof(int));
+    exit(0); //WARN
+}

--- a/tests/regression/76-memleak/04-simple-abort-mem-leak.c
+++ b/tests/regression/76-memleak/04-simple-abort-mem-leak.c
@@ -1,0 +1,7 @@
+//PARAM: --set ana.malloc.unique_address_count 1 --set ana.activated[+] memLeak
+#include <stdlib.h>
+
+int main(int argc, char const *argv[]) {
+    int *p = malloc(sizeof(int));
+    abort(); //WARN
+}

--- a/tests/regression/76-memleak/05-simple-assert-no-mem-leak.c
+++ b/tests/regression/76-memleak/05-simple-assert-no-mem-leak.c
@@ -1,0 +1,10 @@
+//PARAM: --set ana.malloc.unique_address_count 1 --set ana.activated[+] memLeak
+#include <stdlib.h>
+#include <assert.h>
+
+int main(int argc, char const *argv[]) {
+    int *p = malloc(sizeof(int));
+    assert(1); //NOWARN
+    free(p);
+    return 0; //NOWARN
+}

--- a/tests/regression/76-memleak/05-simple-assert-no-mem-leak.c
+++ b/tests/regression/76-memleak/05-simple-assert-no-mem-leak.c
@@ -4,7 +4,7 @@
 
 int main(int argc, char const *argv[]) {
     int *p = malloc(sizeof(int));
-    assert(1); //NOWARN
+    assert(1);
     free(p);
     return 0; //NOWARN
 }

--- a/tests/regression/76-memleak/06-simple-assert-mem-leak.c
+++ b/tests/regression/76-memleak/06-simple-assert-mem-leak.c
@@ -1,4 +1,4 @@
-//PARAM: --set ana.malloc.unique_address_count 1 --set ana.activated[+] memLeak
+//PARAM: --set warn.assert false --set ana.malloc.unique_address_count 1 --set ana.activated[+] memLeak
 #include <stdlib.h>
 #include <assert.h>
 

--- a/tests/regression/76-memleak/06-simple-assert-mem-leak.c
+++ b/tests/regression/76-memleak/06-simple-assert-mem-leak.c
@@ -1,0 +1,8 @@
+//PARAM: --set ana.malloc.unique_address_count 1 --set ana.activated[+] memLeak
+#include <stdlib.h>
+#include <assert.h>
+
+int main(int argc, char const *argv[]) {
+    int *p = malloc(sizeof(int));
+    assert(0); //WARN
+}

--- a/tests/regression/76-memleak/07-simple-quick-exit-mem-leak.c
+++ b/tests/regression/76-memleak/07-simple-quick-exit-mem-leak.c
@@ -1,0 +1,7 @@
+//PARAM: --set ana.malloc.unique_address_count 1 --set ana.activated[+] memLeak
+#include <stdlib.h>
+
+int main(int argc, char const *argv[]) {
+    int *p = malloc(sizeof(int));
+    quick_exit(0); //WARN
+}


### PR DESCRIPTION
This PR contains a first simple version of a memory leak analysis:
* Should work for single-threaded programs provided that `ana.malloc.unique_address_count` is set to a value > 0
* Currently uses a simple heuristic to warn for potential memory leaks whenever the program is multi-threaded

`make test` fails for test case `76/02` if one uses a comment `//WARN` on line 7 of this test case. The error message is:
`Expected warn, but registered other`
Because of this I've removed the `//WARN` from this test case for now