### PR TITLE
Make access outer distribution lazy

### DIFF
--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -106,10 +106,11 @@ struct
     side_vars ctx memo
 
   let outer_memo ((root, offset) : Access.Memo.t) : Access.Memo.t option =
-    match offset with
-    | `NoOffset -> None
-    | `Field (f, offset') -> Some (`Type f.ftype, offset')
-    | `Index ((), offset') -> None (* TODO *)
+    match root, offset with
+    | `Var v, _ -> Some (`Type v.vtype, offset) (* TODO: Alloc variables void type *)
+    | _, `NoOffset -> None
+    | _, `Field (f, offset') -> Some (`Type f.ftype, offset')
+    | _, `Index ((), offset') -> None (* TODO *)
 
   let rec distribute_outer ctx ((root, offset) : Access.Memo.t) : Access.AS.t =
     let trie = G.access (ctx.global (V.access root)) in

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -70,28 +70,60 @@ open Analyses
     - prefix relations are indicated by [/], so access paths run diagonally from top-right to bottom-left;
     - type suffix relations are indicated by [\ ].
 
-    Prefix races:
+    All same-node races:
+    - Race between [t.s.f] and [t.s.f] is checked/reported at [t.s.f].
+    - Race between [t.s] and [t.s] is checked/reported at [t.s].
+    - Race between [t] and [t] is checked/reported at [t].
+    - Race between [(T).s.f] and [(T).s.f] is checked/reported at [(T).s.f].
+    - Race between [(T).s] and [(T).s] is checked/reported at [(T).s].
+    - Race between [(T)] and [(T)] is checked/reported at [(T)].
+    - Race between [(S).f] and [(S).f] is checked/reported at [(S).f].
+    - Race between [(S)] and [(S)] is checked/reported at [(S)].
+    - Race between [(int)] and [(int)] is checked/reported at [(int)].
+
+    All prefix races:
     - Race between [t.s.f] and [t.s] is checked/reported at [t.s.f].
     - Race between [t.s.f] and [t] is checked/reported at [t.s.f].
     - Race between [t.s] and [t] is checked/reported at [t.s].
-    - Race between [t] and [t] is checked/reported at [t].
+    - Race between [(T).s.f] and [(T).s] is checked/reported at [(T).s.f].
+    - Race between [(T).s.f] and [(T)] is checked/reported at [(T).s.f].
+    - Race between [(T).s] and [(T)] is checked/reported at [(T).s].
     - Race between [(S).f] and [(S)] is checked/reported at [(S).f].
 
-    Type suffix races:
+    All type suffix races:
     - Race between [t.s.f] and [(T).s.f] is checked/reported at [t.s.f].
     - Race between [t.s.f] and [(S).f] is checked/reported at [t.s.f].
     - Race between [t.s.f] and [(int)] is checked/reported at [t.s.f].
+    - Race between [(T).s.f] and [(S).f] is checked/reported at [(T).s.f].
+    - Race between [(T).s.f] and [(int)] is checked/reported at [(T).s.f].
     - Race between [(S).f] and [(int)] is checked/reported at [(S).f].
+    - Race between [t.s] and [(T).s] is checked/reported at [t.s].
+    - Race between [t.s] and [(S)] is checked/reported at [t.s].
+    - Race between [(T).s] and [(S)] is checked/reported at [(T).s].
+    - Race between [t] and [(T)] is checked/reported at [t].
 
-    Type suffix prefix races:
+    All type suffix prefix races:
     - Race between [t.s.f] and [(T).s] is checked/reported at [t.s.f].
     - Race between [t.s.f] and [(T)] is checked/reported at [t.s.f].
     - Race between [t.s.f] and [(S)] is checked/reported at [t.s.f].
     - Race between [(T).s.f] and [(S)] is checked/reported at [(T).s.f].
+    - Race between [t.s] and [(T)] is checked/reported at [t.s].
 
-    Prefix-type suffix races:
+    All prefix-type suffix races:
+    - Race between [t.s] and [(T).s.f] is checked/reported at [t.s.f].
+    - Race between [t.s] and [(S).f] is checked/reported at [t.s.f].
+    - Race between [t.s] and [(int)] is checked/reported at [t.s.f].
+    - Race between [t] and [(T).s.f] is checked/reported at [t.s.f].
+    - Race between [t] and [(S).f] is checked/reported at [t.s.f].
+    - Race between [t] and [(int)] is checked/reported at [t.s.f].
+    - Race between [t] and [(T).s] is checked/reported at [t.s].
+    - Race between [t] and [(S)] is checked/reported at [t.s].
     - Race between [(T).s] and [(S).f] is checked/reported at [(T).s.f].
-    - Race between [t] and [(S).f] is checked/reported at [t.s.f]. *)
+    - Race between [(T).s] and [(int)] is checked/reported at [(T).s.f].
+    - Race between [(T)] and [(S).f] is checked/reported at [(T).s.f].
+    - Race between [(T)] and [(int)] is checked/reported at [(T).s.f].
+    - Race between [(T)] and [(S)] is checked/reported at [(T).s].
+    - Race between [(S)] and [(int)] is checked/reported at [(S).f]. *)
 
 
 (** Data race analyzer without base --- this is the new standard *)

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -238,10 +238,11 @@ struct
 
   (** Get immediate type_suffix memo. *)
   let type_suffix_memo ((root, offset) : Access.Memo.t) : Access.Memo.t option =
+    (* No need to make ana.race.direct-arithmetic return None here,
+       because (int) is empty anyway since Access.add_distribute_outer isn't called. *)
     match root, offset with
     | `Var v, _ -> Some (`Type (Cil.typeSig v.vtype), offset) (* global.foo.bar -> (struct S).foo.bar *) (* TODO: Alloc variables void type *)
     | _, `NoOffset -> None (* primitive type *)
-    (* TODO: should handle ana.race.direct-arithmetic special case here? *)
     | _, `Field (f, offset') -> Some (`Type (Cil.typeSig f.ftype), offset') (* (struct S).foo.bar -> (struct T).bar *)
     | `Type (TSArray (ts, _, _)), `Index ((), offset') -> Some (`Type ts, offset') (* (int[])[*] -> int *)
     | _, `Index ((), offset') -> None (* TODO: why indexing on non-array? *)

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -241,6 +241,7 @@ struct
     match root, offset with
     | `Var v, _ -> Some (`Type (Cil.typeSig v.vtype), offset) (* global.foo.bar -> (struct S).foo.bar *) (* TODO: Alloc variables void type *)
     | _, `NoOffset -> None (* primitive type *)
+    (* TODO: should handle ana.race.direct-arithmetic special case here? *)
     | _, `Field (f, offset') -> Some (`Type (Cil.typeSig f.ftype), offset') (* (struct S).foo.bar -> (struct T).bar *)
     | `Type (TSArray (ts, _, _)), `Index ((), offset') -> Some (`Type ts, offset') (* (int[])[*] -> int *)
     | _, `Index ((), offset') -> None (* TODO: why indexing on non-array? *)

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -3,7 +3,7 @@
 open GoblintCil
 open Analyses
 
-(** Data race analysis with tries and hookers.
+(** Data race analysis with tries for offsets and type-based memory locations for open code.
 
     Accesses are to memory locations ({{!Access.Memo} memos}) which consist of a root and offset.
     {{!Access.MemoRoot} Root} can be:

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -152,7 +152,6 @@ struct
               | Some outer_memo -> distribute_outer ctx outer_memo
               | None -> Access.AS.empty ()
             in
-            M.trace "access" "outer accs = %a" Access.AS.pretty outer_accs;
             if not (Access.AS.is_empty accs) || (not (Access.AS.is_empty ancestor_accs) && not (Access.AS.is_empty outer_accs)) then (
               let memo = (g', offset) in
               let mem_loc_str = GobPretty.sprint Access.Memo.pretty memo in

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -153,10 +153,10 @@ struct
               | None -> Access.AS.empty ()
             in
             M.trace "access" "outer accs = %a" Access.AS.pretty outer_accs;
-            if not (Access.AS.is_empty accs && Access.AS.is_empty ancestor_accs && Access.AS.is_empty outer_accs) then (
+            if not (Access.AS.is_empty accs) || (not (Access.AS.is_empty ancestor_accs) && not (Access.AS.is_empty outer_accs)) then (
               let memo = (g', offset) in
               let mem_loc_str = GobPretty.sprint Access.Memo.pretty memo in
-              Timing.wrap ~args:[("memory location", `String mem_loc_str)] "race" (Access.warn_global ~safe ~vulnerable ~unsafe ~ancestor_accs ~ancestor_outer_accs ~outer_accs memo) accs 
+              Timing.wrap ~args:[("memory location", `String mem_loc_str)] "race" (Access.warn_global ~safe ~vulnerable ~unsafe ~ancestor_accs ~ancestor_outer_accs ~outer_accs memo) accs
             );
             let ancestor_outer_accs' = Access.AS.union ancestor_outer_accs outer_accs in
             let ancestor_accs' = Access.AS.union ancestor_accs accs in

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -113,9 +113,9 @@ struct
 
   let type_suffix_memo ((root, offset) : Access.Memo.t) : Access.Memo.t option =
     match root, offset with
-    | `Var v, _ -> Some (`Type v.vtype, offset) (* TODO: Alloc variables void type *)
+    | `Var v, _ -> Some (`Type (Cil.typeSig v.vtype), offset) (* TODO: Alloc variables void type *)
     | _, `NoOffset -> None
-    | _, `Field (f, offset') -> Some (`Type f.ftype, offset')
+    | _, `Field (f, offset') -> Some (`Type (Cil.typeSig f.ftype), offset')
     | _, `Index ((), offset') -> None (* TODO *)
 
   let rec distribute_outer ctx ((root, offset) : Access.Memo.t) : Access.AS.t =
@@ -190,7 +190,7 @@ struct
       in
       let add_access_struct conf ci =
         let a = part_access None in
-        Access.add_one (side_access octx (conf, kind, loc, e, a)) (`Type (TComp (ci, [])), `NoOffset)
+        Access.add_one (side_access octx (conf, kind, loc, e, a)) (`Type (TSComp (ci.cstruct, ci.cname, [])), `NoOffset)
       in
       let has_escaped g = octx.ask (Queries.MayEscape g) in
       (* The following function adds accesses to the lval-set ls

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -41,7 +41,20 @@ open Analyses
     This requires an implementation hack to still eagerly do outer distribution, but only of empty access sets.
     It ensures that corresponding trie nodes exist for traversal later. *)
 
-(** Example structure of related memos for race checking:
+(** Given C declarations:
+    {@c[
+    struct S {
+      int f;
+    };
+
+    struct T {
+      struct S s;
+    };
+
+    struct T t;
+    ]}
+
+    Example structure of related memos for race checking:
     {v
      (int)   (S)     (T)
         \   /   \   /   \
@@ -54,9 +67,7 @@ open Analyses
     where:
     - [(int)] is a type-based memo root for the primitive [int] type;
     - [(S)] and [(T)] are short for [(struct S)] and [(struct T)], which are type-based memo roots;
-    - [f] is a field of [S] and [s] is a field of [T];
-    - [t] is a global variable of type [T].
-    - prefix relations are indicated by [/];
+    - prefix relations are indicated by [/], so access paths run diagonally from top-right to bottom-left;
     - type suffix relations are indicated by [\ ].
 
     Prefix races:

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -116,7 +116,8 @@ struct
     | `Var v, _ -> Some (`Type (Cil.typeSig v.vtype), offset) (* TODO: Alloc variables void type *)
     | _, `NoOffset -> None
     | _, `Field (f, offset') -> Some (`Type (Cil.typeSig f.ftype), offset')
-    | _, `Index ((), offset') -> None (* TODO *)
+    | `Type (TSArray (ts, _, _)), `Index ((), offset') -> Some (`Type ts, offset')
+    | _, `Index ((), offset') -> None (* TODO: why indexing on non-array? *)
 
   let rec distribute_outer ctx ((root, offset) : Access.Memo.t) : Access.AS.t =
     let trie = G.access (ctx.global (V.access root)) in

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -155,7 +155,7 @@ struct
             if not (Access.AS.is_empty accs) || (not (Access.AS.is_empty ancestor_accs) && not (Access.AS.is_empty outer_accs)) then (
               let memo = (g', offset) in
               let mem_loc_str = GobPretty.sprint Access.Memo.pretty memo in
-              Timing.wrap ~args:[("memory location", `String mem_loc_str)] "race" (Access.warn_global ~safe ~vulnerable ~unsafe ~ancestor_accs ~ancestor_outer_accs ~outer_accs memo) accs
+              Timing.wrap ~args:[("memory location", `String mem_loc_str)] "race" (Access.warn_global ~safe ~vulnerable ~unsafe {prefix=ancestor_accs; type_suffix_prefix=ancestor_outer_accs; type_suffix=outer_accs; node=accs}) memo
             );
             let ancestor_outer_accs' = Access.AS.union ancestor_outer_accs outer_accs in
             let ancestor_accs' = Access.AS.union ancestor_accs accs in

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -211,27 +211,6 @@ let add_one side memo: unit =
   if not ignorable then
     side memo
 
-(** Distribute type-based access to variables and containing fields. *)
-let rec add_distribute_outer side (t: typ) (o: Offset.Unit.t) =
-  let memo = (`Type t, o) in
-  if M.tracing then M.tracei "access" "add_distribute_outer %a\n" Memo.pretty memo;
-  add_one side memo;
-
-  (* distribute to variables of the type *)
-  let ts = typeSig t in
-  let vars = TSH.find_all typeVar ts in
-  List.iter (fun v ->
-      add_one side (`Var v, o) (* same offset, but on variable *)
-    ) vars;
-
-  (* recursively distribute to fields containing the type *)
-  let fields = TSH.find_all typeIncl ts in
-  List.iter (fun f ->
-      (* prepend field and distribute to outer struct *)
-      add_distribute_outer side (TComp (f.fcomp, [])) (`Field (f, o))
-    ) fields;
-
-  if M.tracing then M.traceu "access" "add_distribute_outer\n"
 
 (** Add access to known variable with offsets or unknown variable from expression. *)
 let add side e voffs =
@@ -249,7 +228,7 @@ let add side e voffs =
       in
       match o with
       | `NoOffset when not !collect_direct_arithmetic && isArithmeticType t -> ()
-      | _ -> add_distribute_outer side t o (* distribute to variables and outer offsets *)
+      | _ -> add_one side (`Type t, o) (* add_distribute_outer side t o (* distribute to variables and outer offsets *)*)
   end;
   if M.tracing then M.traceu "access" "add\n"
 

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -93,7 +93,7 @@ struct
     match vt with
     | `Var v -> CilType.Varinfo.pretty () v
     | `Type (TSComp (_, name, _)) -> Pretty.dprintf "(struct %s)" name
-    | `Type t -> Pretty.dprintf "(%a)" CilType.Typsig.pretty t (* TODO: fix TSBase printing *)
+    | `Type t -> Pretty.dprintf "(%a)" Cilfacade.pretty_typsig_like_typ t
 
   include Printable.SimplePretty (
     struct
@@ -116,7 +116,7 @@ struct
     match vt with
     | `Var v -> Pretty.dprintf "%a%a" CilType.Varinfo.pretty v Offset.Unit.pretty o
     | `Type (TSComp (_, name, _)) -> Pretty.dprintf "(struct %s)%a" name Offset.Unit.pretty o
-    | `Type t -> Pretty.dprintf "(%a)%a" CilType.Typsig.pretty t Offset.Unit.pretty o (* TODO: fix TSBase printing *)
+    | `Type t -> Pretty.dprintf "(%a)%a" Cilfacade.pretty_typsig_like_typ t Offset.Unit.pretty o
 
   include Printable.SimplePretty (
     struct

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -432,7 +432,12 @@ let group_may_race ~ancestor_accs ~ancestor_outer_accs ~outer_accs accs =
       let ancestor_acc = AS.choose ancestor_accs in
       let (_, ancestor_accs', _, outer_accs', comp) = bfs ~ancestor_accs ~ancestor_outer_accs:(AS.empty ()) ~outer_accs ~accs:(AS.empty ()) ancestor_acc in
       (* ignore (Pretty.printf "ancestor: %a comp: %a\n" A.pretty ancestor_acc AS.pretty comp); *)
-      let comps' = comp :: comps in
+      let comps' =
+        if AS.cardinal comp > 1 then
+          comp :: comps
+        else
+          comps (* ignore self-race ancestor_acc component, self-race checked at ancestor's level *)
+      in
       components_cross comps' ~ancestor_accs:ancestor_accs' ~outer_accs:outer_accs'
     )
   in

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -359,6 +359,101 @@ let split_anoncomp_name name =
   else
     invalid_arg "Cilfacade.split_anoncomp_name"
 
+(** Pretty-print typsig like typ, because
+    {!d_typsig} prints with CIL constructors. *)
+let rec pretty_typsig_like_typ (nameOpt: Pretty.doc option) () ts =
+  (* Copied & modified from Cil.defaultCilPrinterClass#pType. *)
+  let open Pretty in
+  let name = match nameOpt with None -> nil | Some d -> d in
+  let printAttributes (a: attributes) =
+    let pa = d_attrlist () a in
+    match nameOpt with
+    | None when not !print_CIL_Input ->
+      (* Cannot print the attributes in this case because gcc does not
+          like them here, except if we are printing for CIL. *)
+      if pa = nil then nil else
+        text "/*" ++ pa ++ text "*/"
+    | _ -> pa
+  in
+  match ts with
+  | TSBase t -> dn_type () t
+  | TSComp (cstruct, cname, a) ->
+    let su = if cstruct then "struct" else "union" in
+    text (su ^ " " ^ cname ^ " ")
+    ++ d_attrlist () a
+    ++ name
+  | TSEnum (ename, a) ->
+    text ("enum " ^ ename ^ " ")
+    ++ d_attrlist () a
+    ++ name
+  | TSPtr (bt, a)  ->
+    (* Parenthesize the ( * attr name) if a pointer to a function or an
+        array. *)
+    let (paren: doc option), (bt': typsig) =
+      match bt with
+      | TSFun _ | TSArray _ -> Some (text "("), bt
+      | _ -> None, bt
+    in
+    let name' = text "*" ++ printAttributes a ++ name in
+    let name'' = (* Put the parenthesis *)
+      match paren with
+        Some p -> p ++ name' ++ text ")"
+      | _ -> name'
+    in
+    pretty_typsig_like_typ
+      (Some name'')
+      ()
+      bt'
+
+  | TSArray (elemt, lo, a) ->
+    (* ignore the const attribute for arrays *)
+    let a' = dropAttributes [ "pconst" ] a in
+    let name' =
+      if a' == [] then name else
+      if nameOpt == None then printAttributes a' else
+        text "(" ++ printAttributes a' ++ name ++ text ")"
+    in
+    pretty_typsig_like_typ
+      (Some (name'
+             ++ text "["
+             ++ (match lo with None -> nil | Some e -> text (Z.to_string e))
+             ++ text "]"))
+      ()
+      elemt
+
+  | TSFun (restyp, args, isvararg, a) ->
+    let name' =
+      if a == [] then name else
+      if nameOpt == None then printAttributes a else
+        text "(" ++ printAttributes a ++ name ++ text ")"
+    in
+    pretty_typsig_like_typ
+      (Some
+         (name'
+          ++ text "("
+          ++ (align
+              ++
+              (if args = Some [] && isvararg then
+                 text "..."
+               else
+                 (if args = None then nil
+                  else if args = Some [] then text "void"
+                  else
+                    let pArg atype =
+                      (pretty_typsig_like_typ None () atype)
+                    in
+                    (docList ~sep:(chr ',' ++ break) pArg) ()
+                      (match args with None -> [] | Some args -> args))
+                 ++ (if isvararg then break ++ text ", ..." else nil))
+              ++ unalign)
+          ++ text ")"))
+      ()
+      restyp
+
+(** Pretty-print typsig like typ, because
+    {!d_typsig} prints with CIL constructors. *)
+let pretty_typsig_like_typ = pretty_typsig_like_typ None
+
 (** HashSet of line numbers *)
 let locs = Hashtbl.create 200
 

--- a/tests/regression/04-mutex/49-type-invariants.c
+++ b/tests/regression/04-mutex/49-type-invariants.c
@@ -1,4 +1,3 @@
-//PARAM: --enable ana.race.direct-arithmetic
 #include <pthread.h>
 #include <stdio.h>
 

--- a/tests/regression/04-mutex/49-type-invariants.t
+++ b/tests/regression/04-mutex/49-type-invariants.t
@@ -1,47 +1,47 @@
   $ goblint --enable warn.deterministic --enable ana.race.direct-arithmetic --enable allglobs 49-type-invariants.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (49-type-invariants.c:22:3-22:21)
-  [Warning][Race] Memory location s.field (race with conf. 110): (49-type-invariants.c:9:10-9:11)
-    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:21:3-21:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:22:3-22:21)
-    read with [mhp:{tid=[main, t_fun@49-type-invariants.c:21:3-21:40#top]}, thread:[main, t_fun@49-type-invariants.c:21:3-21:40#top]] (conf. 110)  (exp: & s.field) (49-type-invariants.c:12:3-12:23)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (49-type-invariants.c:21:3-21:21)
+  [Warning][Race] Memory location s.field (race with conf. 110): (49-type-invariants.c:8:10-8:11)
+    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:20:3-20:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:21:3-21:21)
+    read with [mhp:{tid=[main, t_fun@49-type-invariants.c:20:3-20:40#top]}, thread:[main, t_fun@49-type-invariants.c:20:3-20:40#top]] (conf. 110)  (exp: & s.field) (49-type-invariants.c:11:3-11:23)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
   [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:21:3-21:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:22:3-22:21)
+    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:20:3-20:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:21:3-21:21)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
     dead: 0
     total lines: 7
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (49-type-invariants.c:22:3-22:21)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (49-type-invariants.c:22:3-22:21)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (49-type-invariants.c:22:3-22:21)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (49-type-invariants.c:22:3-22:21)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(s, NoOffset)) (49-type-invariants.c:22:3-22:21)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (49-type-invariants.c:22:3-22:21)
-  [Error][Imprecise][Unsound] Function definition missing for getS (49-type-invariants.c:22:3-22:21)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (49-type-invariants.c:21:3-21:21)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (49-type-invariants.c:21:3-21:21)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (49-type-invariants.c:21:3-21:21)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (49-type-invariants.c:21:3-21:21)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(s, NoOffset)) (49-type-invariants.c:21:3-21:21)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (49-type-invariants.c:21:3-21:21)
+  [Error][Imprecise][Unsound] Function definition missing for getS (49-type-invariants.c:21:3-21:21)
 
   $ goblint --enable warn.deterministic --disable ana.race.direct-arithmetic --enable allglobs 49-type-invariants.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (49-type-invariants.c:22:3-22:21)
-  [Warning][Race] Memory location s.field (race with conf. 110): (49-type-invariants.c:9:10-9:11)
-    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:21:3-21:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:22:3-22:21)
-    read with [mhp:{tid=[main, t_fun@49-type-invariants.c:21:3-21:40#top]}, thread:[main, t_fun@49-type-invariants.c:21:3-21:40#top]] (conf. 110)  (exp: & s.field) (49-type-invariants.c:12:3-12:23)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (49-type-invariants.c:21:3-21:21)
+  [Warning][Race] Memory location s.field (race with conf. 110): (49-type-invariants.c:8:10-8:11)
+    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:20:3-20:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:21:3-21:21)
+    read with [mhp:{tid=[main, t_fun@49-type-invariants.c:20:3-20:40#top]}, thread:[main, t_fun@49-type-invariants.c:20:3-20:40#top]] (conf. 110)  (exp: & s.field) (49-type-invariants.c:11:3-11:23)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
   [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:21:3-21:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:22:3-22:21)
+    write with [mhp:{tid=[main]; created={[main, t_fun@49-type-invariants.c:20:3-20:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->field) (49-type-invariants.c:21:3-21:21)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
     dead: 0
     total lines: 7
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (49-type-invariants.c:22:3-22:21)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (49-type-invariants.c:22:3-22:21)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (49-type-invariants.c:22:3-22:21)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (49-type-invariants.c:22:3-22:21)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(s, NoOffset)) (49-type-invariants.c:22:3-22:21)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (49-type-invariants.c:22:3-22:21)
-  [Error][Imprecise][Unsound] Function definition missing for getS (49-type-invariants.c:22:3-22:21)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (49-type-invariants.c:21:3-21:21)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (49-type-invariants.c:21:3-21:21)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (49-type-invariants.c:21:3-21:21)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (49-type-invariants.c:21:3-21:21)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(s, NoOffset)) (49-type-invariants.c:21:3-21:21)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (49-type-invariants.c:21:3-21:21)
+  [Error][Imprecise][Unsound] Function definition missing for getS (49-type-invariants.c:21:3-21:21)

--- a/tests/regression/04-mutex/77-type-nested-fields.c
+++ b/tests/regression/04-mutex/77-type-nested-fields.c
@@ -2,6 +2,14 @@
 #include <pthread.h>
 #include <stdio.h>
 
+// (int)   (S)     (T)     (U)
+//    \   /   \   /   \   / 
+//     >f<      s       t
+//        \   /   \   /  
+//         >f<      s
+//            \   /
+//              f
+
 struct S {
   int field;
 };

--- a/tests/regression/04-mutex/77-type-nested-fields.c
+++ b/tests/regression/04-mutex/77-type-nested-fields.c
@@ -1,11 +1,10 @@
-//PARAM: --enable ana.race.direct-arithmetic
 #include <pthread.h>
 #include <stdio.h>
 
 // (int)   (S)     (T)     (U)
-//    \   /   \   /   \   / 
+//    \   /   \   /   \   /
 //     >f<      s       t
-//        \   /   \   /  
+//        \   /   \   /
 //         >f<      s
 //            \   /
 //              f

--- a/tests/regression/04-mutex/77-type-nested-fields.t
+++ b/tests/regression/04-mutex/77-type-nested-fields.t
@@ -1,0 +1,29 @@
+  $ goblint --enable allglobs 77-type-nested-fields.c
+  [Error][Imprecise][Unsound] Function definition missing for getS (77-type-nested-fields.c:32:3-32:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (77-type-nested-fields.c:32:3-32:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (77-type-nested-fields.c:32:3-32:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (77-type-nested-fields.c:32:3-32:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (77-type-nested-fields.c:32:3-32:20)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (77-type-nested-fields.c:32:3-32:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (77-type-nested-fields.c:32:3-32:20)
+  [Error][Imprecise][Unsound] Function definition missing for getT (77-type-nested-fields.c:39:3-39:22)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (77-type-nested-fields.c:39:3-39:22)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (77-type-nested-fields.c:39:3-39:22)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (77-type-nested-fields.c:39:3-39:22)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (77-type-nested-fields.c:39:3-39:22)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (77-type-nested-fields.c:39:3-39:22)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (77-type-nested-fields.c:39:3-39:22)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Warning][Race] Memory location (struct T).s.field (race with conf. 100):
+    write with [mhp:{tid=[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]}, thread:[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (77-type-nested-fields.c:32:3-32:20)
+    write with [mhp:{tid=[main]; created={[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s.field) (77-type-nested-fields.c:39:3-39:22)
+  [Success][Race] Memory location (struct S).field (safe):
+    write with [mhp:{tid=[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]}, thread:[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (77-type-nested-fields.c:32:3-32:20)
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 2

--- a/tests/regression/04-mutex/77-type-nested-fields.t
+++ b/tests/regression/04-mutex/77-type-nested-fields.t
@@ -1,29 +1,29 @@
   $ goblint --enable warn.deterministic --enable allglobs 77-type-nested-fields.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (77-type-nested-fields.c:32:3-32:20)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (77-type-nested-fields.c:39:3-39:22)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (77-type-nested-fields.c:31:3-31:20)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (77-type-nested-fields.c:38:3-38:22)
   [Warning][Race] Memory location (struct T).s.field (race with conf. 100):
-    write with [mhp:{tid=[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]}, thread:[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (77-type-nested-fields.c:32:3-32:20)
-    write with [mhp:{tid=[main]; created={[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s.field) (77-type-nested-fields.c:39:3-39:22)
+    write with [mhp:{tid=[main, t_fun@77-type-nested-fields.c:37:3-37:40#top]}, thread:[main, t_fun@77-type-nested-fields.c:37:3-37:40#top]] (conf. 100)  (exp: & tmp->field) (77-type-nested-fields.c:31:3-31:20)
+    write with [mhp:{tid=[main]; created={[main, t_fun@77-type-nested-fields.c:37:3-37:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s.field) (77-type-nested-fields.c:38:3-38:22)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
   [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]}, thread:[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (77-type-nested-fields.c:32:3-32:20)
+    write with [mhp:{tid=[main, t_fun@77-type-nested-fields.c:37:3-37:40#top]}, thread:[main, t_fun@77-type-nested-fields.c:37:3-37:40#top]] (conf. 100)  (exp: & tmp->field) (77-type-nested-fields.c:31:3-31:20)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
     dead: 0
     total lines: 7
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (77-type-nested-fields.c:32:3-32:20)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (77-type-nested-fields.c:32:3-32:20)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (77-type-nested-fields.c:32:3-32:20)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (77-type-nested-fields.c:39:3-39:22)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (77-type-nested-fields.c:39:3-39:22)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (77-type-nested-fields.c:39:3-39:22)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (77-type-nested-fields.c:32:3-32:20)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (77-type-nested-fields.c:32:3-32:20)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (77-type-nested-fields.c:39:3-39:22)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (77-type-nested-fields.c:39:3-39:22)
-  [Error][Imprecise][Unsound] Function definition missing for getS (77-type-nested-fields.c:32:3-32:20)
-  [Error][Imprecise][Unsound] Function definition missing for getT (77-type-nested-fields.c:39:3-39:22)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (77-type-nested-fields.c:31:3-31:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (77-type-nested-fields.c:31:3-31:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (77-type-nested-fields.c:31:3-31:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (77-type-nested-fields.c:38:3-38:22)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (77-type-nested-fields.c:38:3-38:22)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (77-type-nested-fields.c:38:3-38:22)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (77-type-nested-fields.c:31:3-31:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (77-type-nested-fields.c:31:3-31:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (77-type-nested-fields.c:38:3-38:22)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (77-type-nested-fields.c:38:3-38:22)
+  [Error][Imprecise][Unsound] Function definition missing for getS (77-type-nested-fields.c:31:3-31:20)
+  [Error][Imprecise][Unsound] Function definition missing for getT (77-type-nested-fields.c:38:3-38:22)

--- a/tests/regression/04-mutex/77-type-nested-fields.t
+++ b/tests/regression/04-mutex/77-type-nested-fields.t
@@ -1,29 +1,29 @@
-  $ goblint --enable allglobs 77-type-nested-fields.c
-  [Error][Imprecise][Unsound] Function definition missing for getS (77-type-nested-fields.c:32:3-32:20)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (77-type-nested-fields.c:32:3-32:20)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (77-type-nested-fields.c:32:3-32:20)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (77-type-nested-fields.c:32:3-32:20)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (77-type-nested-fields.c:32:3-32:20)
+  $ goblint --enable warn.deterministic --enable allglobs 77-type-nested-fields.c
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (77-type-nested-fields.c:32:3-32:20)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (77-type-nested-fields.c:32:3-32:20)
-  [Error][Imprecise][Unsound] Function definition missing for getT (77-type-nested-fields.c:39:3-39:22)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (77-type-nested-fields.c:39:3-39:22)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (77-type-nested-fields.c:39:3-39:22)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (77-type-nested-fields.c:39:3-39:22)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (77-type-nested-fields.c:39:3-39:22)
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (77-type-nested-fields.c:39:3-39:22)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (77-type-nested-fields.c:39:3-39:22)
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 7
-    dead: 0
-    total lines: 7
   [Warning][Race] Memory location (struct T).s.field (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]}, thread:[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (77-type-nested-fields.c:32:3-32:20)
     write with [mhp:{tid=[main]; created={[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s.field) (77-type-nested-fields.c:39:3-39:22)
-  [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]}, thread:[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (77-type-nested-fields.c:32:3-32:20)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
+  [Success][Race] Memory location (struct S).field (safe):
+    write with [mhp:{tid=[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]}, thread:[main, t_fun@77-type-nested-fields.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (77-type-nested-fields.c:32:3-32:20)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (77-type-nested-fields.c:32:3-32:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (77-type-nested-fields.c:32:3-32:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (77-type-nested-fields.c:32:3-32:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (77-type-nested-fields.c:39:3-39:22)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (77-type-nested-fields.c:39:3-39:22)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (77-type-nested-fields.c:39:3-39:22)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (77-type-nested-fields.c:32:3-32:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (77-type-nested-fields.c:32:3-32:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (77-type-nested-fields.c:39:3-39:22)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (77-type-nested-fields.c:39:3-39:22)
+  [Error][Imprecise][Unsound] Function definition missing for getS (77-type-nested-fields.c:32:3-32:20)
+  [Error][Imprecise][Unsound] Function definition missing for getT (77-type-nested-fields.c:39:3-39:22)

--- a/tests/regression/04-mutex/78-type-array.c
+++ b/tests/regression/04-mutex/78-type-array.c
@@ -1,4 +1,3 @@
-//PARAM: --enable ana.race.direct-arithmetic
 #include <pthread.h>
 #include <stdio.h>
 

--- a/tests/regression/04-mutex/79-type-nested-fields-deep1.c
+++ b/tests/regression/04-mutex/79-type-nested-fields-deep1.c
@@ -1,11 +1,10 @@
-//PARAM: --enable ana.race.direct-arithmetic
 #include <pthread.h>
 #include <stdio.h>
 
 // (int)   (S)     (T)     (U)
-//    \   /   \   /   \   / 
+//    \   /   \   /   \   /
 //     >f<      s       t
-//        \   /   \   /  
+//        \   /   \   /
 //          f       s
 //            \   /
 //             >f<

--- a/tests/regression/04-mutex/79-type-nested-fields-deep1.c
+++ b/tests/regression/04-mutex/79-type-nested-fields-deep1.c
@@ -2,6 +2,14 @@
 #include <pthread.h>
 #include <stdio.h>
 
+// (int)   (S)     (T)     (U)
+//    \   /   \   /   \   / 
+//     >f<      s       t
+//        \   /   \   /  
+//          f       s
+//            \   /
+//             >f<
+
 struct S {
   int field;
 };

--- a/tests/regression/04-mutex/79-type-nested-fields-deep1.t
+++ b/tests/regression/04-mutex/79-type-nested-fields-deep1.t
@@ -1,24 +1,6 @@
-  $ goblint --enable allglobs 79-type-nested-fields-deep1.c
-  [Error][Imprecise][Unsound] Function definition missing for getS (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (79-type-nested-fields-deep1.c:37:3-37:20)
+  $ goblint --enable warn.deterministic --enable allglobs 79-type-nested-fields-deep1.c
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Error][Imprecise][Unsound] Function definition missing for getU (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (79-type-nested-fields-deep1.c:44:3-44:24)
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 7
-    dead: 0
-    total lines: 7
-  [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
   [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
     write with [mhp:{tid=[main]; created={[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (79-type-nested-fields-deep1.c:44:3-44:24)
@@ -27,3 +9,21 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
+  [Success][Race] Memory location (struct S).field (safe):
+    write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Error][Imprecise][Unsound] Function definition missing for getS (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Error][Imprecise][Unsound] Function definition missing for getU (79-type-nested-fields-deep1.c:44:3-44:24)

--- a/tests/regression/04-mutex/79-type-nested-fields-deep1.t
+++ b/tests/regression/04-mutex/79-type-nested-fields-deep1.t
@@ -1,29 +1,29 @@
   $ goblint --enable warn.deterministic --enable allglobs 79-type-nested-fields-deep1.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (79-type-nested-fields-deep1.c:36:3-36:20)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (79-type-nested-fields-deep1.c:43:3-43:24)
   [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
-    write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
-    write with [mhp:{tid=[main]; created={[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (79-type-nested-fields-deep1.c:44:3-44:24)
+    write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:42:3-42:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:42:3-42:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:36:3-36:20)
+    write with [mhp:{tid=[main]; created={[main, t_fun@79-type-nested-fields-deep1.c:42:3-42:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (79-type-nested-fields-deep1.c:43:3-43:24)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
   [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
+    write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:42:3-42:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:42:3-42:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:36:3-36:20)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
     dead: 0
     total lines: 7
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (79-type-nested-fields-deep1.c:44:3-44:24)
-  [Error][Imprecise][Unsound] Function definition missing for getS (79-type-nested-fields-deep1.c:37:3-37:20)
-  [Error][Imprecise][Unsound] Function definition missing for getU (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (79-type-nested-fields-deep1.c:36:3-36:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (79-type-nested-fields-deep1.c:36:3-36:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (79-type-nested-fields-deep1.c:36:3-36:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (79-type-nested-fields-deep1.c:43:3-43:24)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (79-type-nested-fields-deep1.c:43:3-43:24)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (79-type-nested-fields-deep1.c:43:3-43:24)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (79-type-nested-fields-deep1.c:36:3-36:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (79-type-nested-fields-deep1.c:36:3-36:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (79-type-nested-fields-deep1.c:43:3-43:24)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (79-type-nested-fields-deep1.c:43:3-43:24)
+  [Error][Imprecise][Unsound] Function definition missing for getS (79-type-nested-fields-deep1.c:36:3-36:20)
+  [Error][Imprecise][Unsound] Function definition missing for getU (79-type-nested-fields-deep1.c:43:3-43:24)

--- a/tests/regression/04-mutex/79-type-nested-fields-deep1.t
+++ b/tests/regression/04-mutex/79-type-nested-fields-deep1.t
@@ -23,9 +23,7 @@
     write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
     write with [mhp:{tid=[main]; created={[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (79-type-nested-fields-deep1.c:44:3-44:24)
   [Info][Race] Memory locations race summary:
-    safe: 2
+    safe: 1
     vulnerable: 0
     unsafe: 1
-    total memory locations: 3
-
-TODO: fix memory location numbers
+    total memory locations: 2

--- a/tests/regression/04-mutex/79-type-nested-fields-deep1.t
+++ b/tests/regression/04-mutex/79-type-nested-fields-deep1.t
@@ -1,0 +1,31 @@
+  $ goblint --enable allglobs 79-type-nested-fields-deep1.c
+  [Error][Imprecise][Unsound] Function definition missing for getS (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Error][Imprecise][Unsound] Function definition missing for getU (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Success][Race] Memory location (struct T).s.field (safe):
+    write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Success][Race] Memory location (struct S).field (safe):
+    write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
+  [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
+    write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
+    write with [mhp:{tid=[main]; created={[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (79-type-nested-fields-deep1.c:44:3-44:24)
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 3

--- a/tests/regression/04-mutex/79-type-nested-fields-deep1.t
+++ b/tests/regression/04-mutex/79-type-nested-fields-deep1.t
@@ -23,7 +23,9 @@
     write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
     write with [mhp:{tid=[main]; created={[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (79-type-nested-fields-deep1.c:44:3-44:24)
   [Info][Race] Memory locations race summary:
-    safe: 1
+    safe: 2
     vulnerable: 0
     unsafe: 1
-    total memory locations: 2
+    total memory locations: 3
+
+TODO: fix memory location numbers

--- a/tests/regression/04-mutex/79-type-nested-fields-deep1.t
+++ b/tests/regression/04-mutex/79-type-nested-fields-deep1.t
@@ -17,15 +17,13 @@
     live: 7
     dead: 0
     total lines: 7
-  [Success][Race] Memory location (struct T).s.field (safe):
-    write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
   [Success][Race] Memory location (struct S).field (safe):
     write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
   [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}, thread:[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (79-type-nested-fields-deep1.c:37:3-37:20)
     write with [mhp:{tid=[main]; created={[main, t_fun@79-type-nested-fields-deep1.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (79-type-nested-fields-deep1.c:44:3-44:24)
   [Info][Race] Memory locations race summary:
-    safe: 2
+    safe: 1
     vulnerable: 0
     unsafe: 1
-    total memory locations: 3
+    total memory locations: 2

--- a/tests/regression/04-mutex/80-type-nested-fields-deep2.c
+++ b/tests/regression/04-mutex/80-type-nested-fields-deep2.c
@@ -1,11 +1,10 @@
-//PARAM: --enable ana.race.direct-arithmetic
 #include <pthread.h>
 #include <stdio.h>
 
 // (int)   (S)     (T)     (U)
-//    \   /   \   /   \   / 
+//    \   /   \   /   \   /
 //      f       s       t
-//        \   /   \   /  
+//        \   /   \   /
 //         >f<      s
 //            \   /
 //             >f<

--- a/tests/regression/04-mutex/80-type-nested-fields-deep2.c
+++ b/tests/regression/04-mutex/80-type-nested-fields-deep2.c
@@ -2,6 +2,14 @@
 #include <pthread.h>
 #include <stdio.h>
 
+// (int)   (S)     (T)     (U)
+//    \   /   \   /   \   / 
+//      f       s       t
+//        \   /   \   /  
+//         >f<      s
+//            \   /
+//             >f<
+
 struct S {
   int field;
 };

--- a/tests/regression/04-mutex/80-type-nested-fields-deep2.t
+++ b/tests/regression/04-mutex/80-type-nested-fields-deep2.t
@@ -1,0 +1,29 @@
+  $ goblint --enable allglobs 80-type-nested-fields-deep2.c
+  [Error][Imprecise][Unsound] Function definition missing for getT (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Error][Imprecise][Unsound] Function definition missing for getU (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Success][Race] Memory location (struct T).s.field (safe):
+    write with [mhp:{tid=[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]}, thread:[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->s.field) (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
+    write with [mhp:{tid=[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]}, thread:[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->s.field) (80-type-nested-fields-deep2.c:37:3-37:22)
+    write with [mhp:{tid=[main]; created={[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 2

--- a/tests/regression/04-mutex/80-type-nested-fields-deep2.t
+++ b/tests/regression/04-mutex/80-type-nested-fields-deep2.t
@@ -1,24 +1,6 @@
-  $ goblint --enable allglobs 80-type-nested-fields-deep2.c
-  [Error][Imprecise][Unsound] Function definition missing for getT (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (80-type-nested-fields-deep2.c:37:3-37:22)
+  $ goblint --enable warn.deterministic --enable allglobs 80-type-nested-fields-deep2.c
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Error][Imprecise][Unsound] Function definition missing for getU (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (80-type-nested-fields-deep2.c:44:3-44:24)
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 7
-    dead: 0
-    total lines: 7
-  [Success][Race] Memory location (struct T).s.field (safe):
-    write with [mhp:{tid=[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]}, thread:[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->s.field) (80-type-nested-fields-deep2.c:37:3-37:22)
   [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]}, thread:[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->s.field) (80-type-nested-fields-deep2.c:37:3-37:22)
     write with [mhp:{tid=[main]; created={[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (80-type-nested-fields-deep2.c:44:3-44:24)
@@ -27,3 +9,21 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
+  [Success][Race] Memory location (struct T).s.field (safe):
+    write with [mhp:{tid=[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]}, thread:[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->s.field) (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Error][Imprecise][Unsound] Function definition missing for getT (80-type-nested-fields-deep2.c:37:3-37:22)
+  [Error][Imprecise][Unsound] Function definition missing for getU (80-type-nested-fields-deep2.c:44:3-44:24)

--- a/tests/regression/04-mutex/80-type-nested-fields-deep2.t
+++ b/tests/regression/04-mutex/80-type-nested-fields-deep2.t
@@ -1,29 +1,29 @@
   $ goblint --enable warn.deterministic --enable allglobs 80-type-nested-fields-deep2.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (80-type-nested-fields-deep2.c:36:3-36:22)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (80-type-nested-fields-deep2.c:43:3-43:24)
   [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
-    write with [mhp:{tid=[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]}, thread:[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->s.field) (80-type-nested-fields-deep2.c:37:3-37:22)
-    write with [mhp:{tid=[main]; created={[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (80-type-nested-fields-deep2.c:44:3-44:24)
+    write with [mhp:{tid=[main, t_fun@80-type-nested-fields-deep2.c:42:3-42:40#top]}, thread:[main, t_fun@80-type-nested-fields-deep2.c:42:3-42:40#top]] (conf. 100)  (exp: & tmp->s.field) (80-type-nested-fields-deep2.c:36:3-36:22)
+    write with [mhp:{tid=[main]; created={[main, t_fun@80-type-nested-fields-deep2.c:42:3-42:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t.s.field) (80-type-nested-fields-deep2.c:43:3-43:24)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
   [Success][Race] Memory location (struct T).s.field (safe):
-    write with [mhp:{tid=[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]}, thread:[main, t_fun@80-type-nested-fields-deep2.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->s.field) (80-type-nested-fields-deep2.c:37:3-37:22)
+    write with [mhp:{tid=[main, t_fun@80-type-nested-fields-deep2.c:42:3-42:40#top]}, thread:[main, t_fun@80-type-nested-fields-deep2.c:42:3-42:40#top]] (conf. 100)  (exp: & tmp->s.field) (80-type-nested-fields-deep2.c:36:3-36:22)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
     dead: 0
     total lines: 7
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (80-type-nested-fields-deep2.c:44:3-44:24)
-  [Error][Imprecise][Unsound] Function definition missing for getT (80-type-nested-fields-deep2.c:37:3-37:22)
-  [Error][Imprecise][Unsound] Function definition missing for getU (80-type-nested-fields-deep2.c:44:3-44:24)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (80-type-nested-fields-deep2.c:36:3-36:22)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (80-type-nested-fields-deep2.c:36:3-36:22)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (80-type-nested-fields-deep2.c:36:3-36:22)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (80-type-nested-fields-deep2.c:43:3-43:24)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (80-type-nested-fields-deep2.c:43:3-43:24)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (80-type-nested-fields-deep2.c:43:3-43:24)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (80-type-nested-fields-deep2.c:36:3-36:22)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (80-type-nested-fields-deep2.c:36:3-36:22)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (80-type-nested-fields-deep2.c:43:3-43:24)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (80-type-nested-fields-deep2.c:43:3-43:24)
+  [Error][Imprecise][Unsound] Function definition missing for getT (80-type-nested-fields-deep2.c:36:3-36:22)
+  [Error][Imprecise][Unsound] Function definition missing for getU (80-type-nested-fields-deep2.c:43:3-43:24)

--- a/tests/regression/04-mutex/84-distribute-fields-1.t
+++ b/tests/regression/04-mutex/84-distribute-fields-1.t
@@ -3,10 +3,10 @@
     live: 8
     dead: 0
     total lines: 8
+  [Success][Race] Memory location s@84-distribute-fields-1.c:9:10-9:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (84-distribute-fields-1.c:20:3-20:9)
   [Warning][Race] Memory location s.data@84-distribute-fields-1.c:9:10-9:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}, thread:[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]] (conf. 110)  (exp: & s.data) (84-distribute-fields-1.c:12:3-12:13)
-    write with [mhp:{tid=[main]; created={[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (84-distribute-fields-1.c:20:3-20:9)
-  [Success][Race] Memory location s@84-distribute-fields-1.c:9:10-9:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@84-distribute-fields-1.c:18:3-18:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (84-distribute-fields-1.c:20:3-20:9)
   [Info][Race] Memory locations race summary:
     safe: 1

--- a/tests/regression/04-mutex/85-distribute-fields-2.t
+++ b/tests/regression/04-mutex/85-distribute-fields-2.t
@@ -3,10 +3,10 @@
     live: 8
     dead: 0
     total lines: 8
+  [Success][Race] Memory location t.s@85-distribute-fields-2.c:15:10-15:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
   [Warning][Race] Memory location t.s.data@85-distribute-fields-2.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}, thread:[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (85-distribute-fields-2.c:18:3-18:15)
-    write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
-  [Success][Race] Memory location t.s@85-distribute-fields-2.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@85-distribute-fields-2.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t.s) (85-distribute-fields-2.c:26:3-26:11)
   [Info][Race] Memory locations race summary:
     safe: 1

--- a/tests/regression/04-mutex/86-distribute-fields-3.t
+++ b/tests/regression/04-mutex/86-distribute-fields-3.t
@@ -5,11 +5,15 @@
     total lines: 8
   [Success][Race] Memory location t@86-distribute-fields-3.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
+  [Success][Race] Memory location t.s@86-distribute-fields-3.c:15:10-15:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Warning][Race] Memory location t.s.data@86-distribute-fields-3.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}, thread:[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (86-distribute-fields-3.c:18:3-18:15)
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Info][Race] Memory locations race summary:
-    safe: 1
+    safe: 2
     vulnerable: 0
     unsafe: 1
-    total memory locations: 2
+    total memory locations: 3
+
+TODO: fix memory location numbers

--- a/tests/regression/04-mutex/86-distribute-fields-3.t
+++ b/tests/regression/04-mutex/86-distribute-fields-3.t
@@ -5,15 +5,11 @@
     total lines: 8
   [Success][Race] Memory location t@86-distribute-fields-3.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
-  [Success][Race] Memory location t.s@86-distribute-fields-3.c:15:10-15:11 (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Warning][Race] Memory location t.s.data@86-distribute-fields-3.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}, thread:[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (86-distribute-fields-3.c:18:3-18:15)
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Info][Race] Memory locations race summary:
-    safe: 2
+    safe: 1
     vulnerable: 0
     unsafe: 1
-    total memory locations: 3
-
-TODO: fix memory location numbers
+    total memory locations: 2

--- a/tests/regression/04-mutex/86-distribute-fields-3.t
+++ b/tests/regression/04-mutex/86-distribute-fields-3.t
@@ -3,10 +3,10 @@
     live: 8
     dead: 0
     total lines: 8
+  [Success][Race] Memory location t@86-distribute-fields-3.c:15:10-15:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Warning][Race] Memory location t.s.data@86-distribute-fields-3.c:15:10-15:11 (race with conf. 110):
     write with [mhp:{tid=[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}, thread:[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]] (conf. 110)  (exp: & t.s.data) (86-distribute-fields-3.c:18:3-18:15)
-    write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
-  [Success][Race] Memory location t@86-distribute-fields-3.c:15:10-15:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@86-distribute-fields-3.c:24:3-24:40#top]}}, thread:[main]] (conf. 110)  (exp: & t) (86-distribute-fields-3.c:26:3-26:9)
   [Info][Race] Memory locations race summary:
     safe: 1

--- a/tests/regression/04-mutex/90-distribute-fields-type-1.c
+++ b/tests/regression/04-mutex/90-distribute-fields-type-1.c
@@ -1,0 +1,42 @@
+//PARAM: --enable ana.race.direct-arithmetic
+#include <pthread.h>
+#include <stdio.h>
+
+// (int)   (S)     (T)     (U)
+//    \   /   \   /   \   / 
+//     >f<     >s<      t
+//        \   /   \   /  
+//          f       s
+//            \   /
+//              f
+
+struct S {
+  int field;
+};
+
+struct T {
+  struct S s;
+};
+
+// struct S s;
+// struct T t;
+
+extern struct S* getS();
+extern struct T* getT();
+
+// getS could return the same struct as is contained in getT
+
+void *t_fun(void *arg) {
+  // should write to (struct T).s.field in addition to (struct S).field
+  // but easier to implement the other way around?
+  getS()->field = 1; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  struct S s1;
+  getT()->s = s1; // RACE!
+  return 0;
+}

--- a/tests/regression/04-mutex/90-distribute-fields-type-1.c
+++ b/tests/regression/04-mutex/90-distribute-fields-type-1.c
@@ -1,11 +1,10 @@
-//PARAM: --enable ana.race.direct-arithmetic
 #include <pthread.h>
 #include <stdio.h>
 
 // (int)   (S)     (T)     (U)
-//    \   /   \   /   \   / 
+//    \   /   \   /   \   /
 //     >f<     >s<      t
-//        \   /   \   /  
+//        \   /   \   /
 //          f       s
 //            \   /
 //              f

--- a/tests/regression/04-mutex/90-distribute-fields-type-1.t
+++ b/tests/regression/04-mutex/90-distribute-fields-type-1.t
@@ -1,0 +1,31 @@
+  $ goblint --enable allglobs 90-distribute-fields-type-1.c
+  [Error][Imprecise][Unsound] Function definition missing for getS (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (90-distribute-fields-type-1.c:32:3-32:20)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (90-distribute-fields-type-1.c:32:3-32:20)
+  [Error][Imprecise][Unsound] Function definition missing for getT (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (90-distribute-fields-type-1.c:40:3-40:17)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Warning][Race] Memory location (struct T).s.field (race with conf. 100):
+    write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:32:3-32:20)
+    write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:40:3-40:17)
+  [Success][Race] Memory location (struct T).s (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:40:3-40:17)
+  [Success][Race] Memory location (struct S).field (safe):
+    write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 3

--- a/tests/regression/04-mutex/90-distribute-fields-type-1.t
+++ b/tests/regression/04-mutex/90-distribute-fields-type-1.t
@@ -1,31 +1,31 @@
   $ goblint --enable warn.deterministic --enable allglobs 90-distribute-fields-type-1.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (90-distribute-fields-type-1.c:32:3-32:20)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (90-distribute-fields-type-1.c:40:3-40:17)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (90-distribute-fields-type-1.c:31:3-31:20)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (90-distribute-fields-type-1.c:39:3-39:17)
   [Warning][Race] Memory location (struct T).s.field (race with conf. 100):
-    write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:32:3-32:20)
-    write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:40:3-40:17)
+    write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:37:3-37:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:37:3-37:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:31:3-31:20)
+    write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:37:3-37:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:39:3-39:17)
   [Info][Race] Memory locations race summary:
     safe: 2
     vulnerable: 0
     unsafe: 1
     total memory locations: 3
   [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:32:3-32:20)
+    write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:37:3-37:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:37:3-37:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:31:3-31:20)
   [Success][Race] Memory location (struct T).s (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:40:3-40:17)
+    write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:37:3-37:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:39:3-39:17)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
     dead: 0
     total lines: 7
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (90-distribute-fields-type-1.c:32:3-32:20)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (90-distribute-fields-type-1.c:32:3-32:20)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (90-distribute-fields-type-1.c:32:3-32:20)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (90-distribute-fields-type-1.c:40:3-40:17)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (90-distribute-fields-type-1.c:40:3-40:17)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (90-distribute-fields-type-1.c:40:3-40:17)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (90-distribute-fields-type-1.c:32:3-32:20)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (90-distribute-fields-type-1.c:32:3-32:20)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (90-distribute-fields-type-1.c:40:3-40:17)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (90-distribute-fields-type-1.c:40:3-40:17)
-  [Error][Imprecise][Unsound] Function definition missing for getS (90-distribute-fields-type-1.c:32:3-32:20)
-  [Error][Imprecise][Unsound] Function definition missing for getT (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (90-distribute-fields-type-1.c:31:3-31:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (90-distribute-fields-type-1.c:31:3-31:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (90-distribute-fields-type-1.c:31:3-31:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (90-distribute-fields-type-1.c:39:3-39:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (90-distribute-fields-type-1.c:39:3-39:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (90-distribute-fields-type-1.c:39:3-39:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (90-distribute-fields-type-1.c:31:3-31:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (90-distribute-fields-type-1.c:31:3-31:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (90-distribute-fields-type-1.c:39:3-39:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (90-distribute-fields-type-1.c:39:3-39:17)
+  [Error][Imprecise][Unsound] Function definition missing for getS (90-distribute-fields-type-1.c:31:3-31:20)
+  [Error][Imprecise][Unsound] Function definition missing for getT (90-distribute-fields-type-1.c:39:3-39:17)

--- a/tests/regression/04-mutex/90-distribute-fields-type-1.t
+++ b/tests/regression/04-mutex/90-distribute-fields-type-1.t
@@ -1,31 +1,31 @@
-  $ goblint --enable allglobs 90-distribute-fields-type-1.c
-  [Error][Imprecise][Unsound] Function definition missing for getS (90-distribute-fields-type-1.c:32:3-32:20)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (90-distribute-fields-type-1.c:32:3-32:20)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (90-distribute-fields-type-1.c:32:3-32:20)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (90-distribute-fields-type-1.c:32:3-32:20)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (90-distribute-fields-type-1.c:32:3-32:20)
+  $ goblint --enable warn.deterministic --enable allglobs 90-distribute-fields-type-1.c
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (90-distribute-fields-type-1.c:32:3-32:20)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (90-distribute-fields-type-1.c:32:3-32:20)
-  [Error][Imprecise][Unsound] Function definition missing for getT (90-distribute-fields-type-1.c:40:3-40:17)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (90-distribute-fields-type-1.c:40:3-40:17)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (90-distribute-fields-type-1.c:40:3-40:17)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (90-distribute-fields-type-1.c:40:3-40:17)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (90-distribute-fields-type-1.c:40:3-40:17)
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (90-distribute-fields-type-1.c:40:3-40:17)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (90-distribute-fields-type-1.c:40:3-40:17)
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 7
-    dead: 0
-    total lines: 7
-  [Success][Race] Memory location (struct T).s (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:40:3-40:17)
   [Warning][Race] Memory location (struct T).s.field (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:32:3-32:20)
     write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:40:3-40:17)
-  [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:32:3-32:20)
   [Info][Race] Memory locations race summary:
     safe: 2
     vulnerable: 0
     unsafe: 1
     total memory locations: 3
+  [Success][Race] Memory location (struct S).field (safe):
+    write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:32:3-32:20)
+  [Success][Race] Memory location (struct T).s (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (90-distribute-fields-type-1.c:32:3-32:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (90-distribute-fields-type-1.c:40:3-40:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (90-distribute-fields-type-1.c:40:3-40:17)
+  [Error][Imprecise][Unsound] Function definition missing for getS (90-distribute-fields-type-1.c:32:3-32:20)
+  [Error][Imprecise][Unsound] Function definition missing for getT (90-distribute-fields-type-1.c:40:3-40:17)

--- a/tests/regression/04-mutex/90-distribute-fields-type-1.t
+++ b/tests/regression/04-mutex/90-distribute-fields-type-1.t
@@ -17,10 +17,10 @@
     live: 7
     dead: 0
     total lines: 7
+  [Success][Race] Memory location (struct T).s (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:40:3-40:17)
   [Warning][Race] Memory location (struct T).s.field (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:32:3-32:20)
-    write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:40:3-40:17)
-  [Success][Race] Memory location (struct T).s (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->s) (90-distribute-fields-type-1.c:40:3-40:17)
   [Success][Race] Memory location (struct S).field (safe):
     write with [mhp:{tid=[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]}, thread:[main, t_fun@90-distribute-fields-type-1.c:38:3-38:40#top]] (conf. 100)  (exp: & tmp->field) (90-distribute-fields-type-1.c:32:3-32:20)

--- a/tests/regression/04-mutex/91-distribute-fields-type-2.c
+++ b/tests/regression/04-mutex/91-distribute-fields-type-2.c
@@ -1,11 +1,10 @@
-//PARAM: --enable ana.race.direct-arithmetic
 #include <pthread.h>
 #include <stdio.h>
 
 // (int)  >(S)<   >(T)<    (U)
-//    \   /   \   /   \   / 
+//    \   /   \   /   \   /
 //      f       s       t
-//        \   /   \   /  
+//        \   /   \   /
 //          f       s
 //            \   /
 //              f

--- a/tests/regression/04-mutex/91-distribute-fields-type-2.c
+++ b/tests/regression/04-mutex/91-distribute-fields-type-2.c
@@ -1,0 +1,43 @@
+//PARAM: --enable ana.race.direct-arithmetic
+#include <pthread.h>
+#include <stdio.h>
+
+// (int)  >(S)<   >(T)<    (U)
+//    \   /   \   /   \   / 
+//      f       s       t
+//        \   /   \   /  
+//          f       s
+//            \   /
+//              f
+
+struct S {
+  int field;
+};
+
+struct T {
+  struct S s;
+};
+
+// struct S s;
+// struct T t;
+
+extern struct S* getS();
+extern struct T* getT();
+
+// getS could return the same struct as is contained in getT
+
+void *t_fun(void *arg) {
+  // should write to (struct T).s.field in addition to (struct S).field
+  // but easier to implement the other way around?
+  struct S s1;
+  *(getS()) = s1; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  struct T t1;
+  *(getT()) = t1; // RACE!
+  return 0;
+}

--- a/tests/regression/04-mutex/91-distribute-fields-type-2.t
+++ b/tests/regression/04-mutex/91-distribute-fields-type-2.t
@@ -1,31 +1,31 @@
-  $ goblint --enable allglobs 91-distribute-fields-type-2.c
-  [Error][Imprecise][Unsound] Function definition missing for getS (91-distribute-fields-type-2.c:33:3-33:17)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (91-distribute-fields-type-2.c:33:3-33:17)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (91-distribute-fields-type-2.c:33:3-33:17)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (91-distribute-fields-type-2.c:33:3-33:17)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (91-distribute-fields-type-2.c:33:3-33:17)
+  $ goblint --enable warn.deterministic --enable allglobs 91-distribute-fields-type-2.c
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (91-distribute-fields-type-2.c:33:3-33:17)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (91-distribute-fields-type-2.c:33:3-33:17)
-  [Error][Imprecise][Unsound] Function definition missing for getT (91-distribute-fields-type-2.c:41:3-41:17)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (91-distribute-fields-type-2.c:41:3-41:17)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (91-distribute-fields-type-2.c:41:3-41:17)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (91-distribute-fields-type-2.c:41:3-41:17)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (91-distribute-fields-type-2.c:41:3-41:17)
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (91-distribute-fields-type-2.c:41:3-41:17)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (91-distribute-fields-type-2.c:41:3-41:17)
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 7
-    dead: 0
-    total lines: 7
-  [Success][Race] Memory location (struct T) (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:41:3-41:17)
   [Warning][Race] Memory location (struct T).s (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:33:3-33:17)
     write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:41:3-41:17)
-  [Success][Race] Memory location (struct S) (safe):
-    write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:33:3-33:17)
   [Info][Race] Memory locations race summary:
     safe: 2
     vulnerable: 0
     unsafe: 1
     total memory locations: 3
+  [Success][Race] Memory location (struct S) (safe):
+    write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:33:3-33:17)
+  [Success][Race] Memory location (struct T) (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (91-distribute-fields-type-2.c:41:3-41:17)
+  [Error][Imprecise][Unsound] Function definition missing for getS (91-distribute-fields-type-2.c:33:3-33:17)
+  [Error][Imprecise][Unsound] Function definition missing for getT (91-distribute-fields-type-2.c:41:3-41:17)

--- a/tests/regression/04-mutex/91-distribute-fields-type-2.t
+++ b/tests/regression/04-mutex/91-distribute-fields-type-2.t
@@ -1,0 +1,31 @@
+  $ goblint --enable allglobs 91-distribute-fields-type-2.c
+  [Error][Imprecise][Unsound] Function definition missing for getS (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (91-distribute-fields-type-2.c:33:3-33:17)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (91-distribute-fields-type-2.c:33:3-33:17)
+  [Error][Imprecise][Unsound] Function definition missing for getT (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (91-distribute-fields-type-2.c:41:3-41:17)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Warning][Race] Memory location (struct T).s (race with conf. 100):
+    write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:33:3-33:17)
+    write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:41:3-41:17)
+  [Success][Race] Memory location (struct T) (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:41:3-41:17)
+  [Success][Race] Memory location (struct S) (safe):
+    write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:33:3-33:17)
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 3

--- a/tests/regression/04-mutex/91-distribute-fields-type-2.t
+++ b/tests/regression/04-mutex/91-distribute-fields-type-2.t
@@ -17,10 +17,10 @@
     live: 7
     dead: 0
     total lines: 7
+  [Success][Race] Memory location (struct T) (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:41:3-41:17)
   [Warning][Race] Memory location (struct T).s (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:33:3-33:17)
-    write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:41:3-41:17)
-  [Success][Race] Memory location (struct T) (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:41:3-41:17)
   [Success][Race] Memory location (struct S) (safe):
     write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:33:3-33:17)

--- a/tests/regression/04-mutex/91-distribute-fields-type-2.t
+++ b/tests/regression/04-mutex/91-distribute-fields-type-2.t
@@ -1,31 +1,31 @@
   $ goblint --enable warn.deterministic --enable allglobs 91-distribute-fields-type-2.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (91-distribute-fields-type-2.c:33:3-33:17)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (91-distribute-fields-type-2.c:41:3-41:17)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (91-distribute-fields-type-2.c:32:3-32:17)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (91-distribute-fields-type-2.c:40:3-40:17)
   [Warning][Race] Memory location (struct T).s (race with conf. 100):
-    write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:33:3-33:17)
-    write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:41:3-41:17)
+    write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:38:3-38:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:38:3-38:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:32:3-32:17)
+    write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:40:3-40:17)
   [Info][Race] Memory locations race summary:
     safe: 2
     vulnerable: 0
     unsafe: 1
     total memory locations: 3
   [Success][Race] Memory location (struct S) (safe):
-    write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:33:3-33:17)
+    write with [mhp:{tid=[main, t_fun@91-distribute-fields-type-2.c:38:3-38:40#top]}, thread:[main, t_fun@91-distribute-fields-type-2.c:38:3-38:40#top]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:32:3-32:17)
   [Success][Race] Memory location (struct T) (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:39:3-39:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:41:3-41:17)
+    write with [mhp:{tid=[main]; created={[main, t_fun@91-distribute-fields-type-2.c:38:3-38:40#top]}}, thread:[main]] (conf. 100)  (exp: & *tmp) (91-distribute-fields-type-2.c:40:3-40:17)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
     dead: 0
     total lines: 7
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (91-distribute-fields-type-2.c:33:3-33:17)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (91-distribute-fields-type-2.c:33:3-33:17)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (91-distribute-fields-type-2.c:33:3-33:17)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (91-distribute-fields-type-2.c:41:3-41:17)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (91-distribute-fields-type-2.c:41:3-41:17)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (91-distribute-fields-type-2.c:41:3-41:17)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (91-distribute-fields-type-2.c:33:3-33:17)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (91-distribute-fields-type-2.c:33:3-33:17)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (91-distribute-fields-type-2.c:41:3-41:17)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (91-distribute-fields-type-2.c:41:3-41:17)
-  [Error][Imprecise][Unsound] Function definition missing for getS (91-distribute-fields-type-2.c:33:3-33:17)
-  [Error][Imprecise][Unsound] Function definition missing for getT (91-distribute-fields-type-2.c:41:3-41:17)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (91-distribute-fields-type-2.c:32:3-32:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (91-distribute-fields-type-2.c:32:3-32:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (91-distribute-fields-type-2.c:32:3-32:17)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (91-distribute-fields-type-2.c:40:3-40:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (91-distribute-fields-type-2.c:40:3-40:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (91-distribute-fields-type-2.c:40:3-40:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (91-distribute-fields-type-2.c:32:3-32:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (91-distribute-fields-type-2.c:32:3-32:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (91-distribute-fields-type-2.c:40:3-40:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (91-distribute-fields-type-2.c:40:3-40:17)
+  [Error][Imprecise][Unsound] Function definition missing for getS (91-distribute-fields-type-2.c:32:3-32:17)
+  [Error][Imprecise][Unsound] Function definition missing for getT (91-distribute-fields-type-2.c:40:3-40:17)

--- a/tests/regression/04-mutex/92-distribute-fields-type-deep.c
+++ b/tests/regression/04-mutex/92-distribute-fields-type-deep.c
@@ -1,11 +1,10 @@
-//PARAM: --enable ana.race.direct-arithmetic
 #include <pthread.h>
 #include <stdio.h>
 
 // (int)   (S)     (T)     (U)
-//    \   /   \   /   \   / 
+//    \   /   \   /   \   /
 //     >f<      s      >t<
-//        \   /   \   /  
+//        \   /   \   /
 //          f       s
 //            \   /
 //              f

--- a/tests/regression/04-mutex/92-distribute-fields-type-deep.c
+++ b/tests/regression/04-mutex/92-distribute-fields-type-deep.c
@@ -1,0 +1,47 @@
+//PARAM: --enable ana.race.direct-arithmetic
+#include <pthread.h>
+#include <stdio.h>
+
+// (int)   (S)     (T)     (U)
+//    \   /   \   /   \   / 
+//     >f<      s      >t<
+//        \   /   \   /  
+//          f       s
+//            \   /
+//              f
+
+struct S {
+  int field;
+};
+
+struct T {
+  struct S s;
+};
+
+struct U {
+  struct T t;
+};
+
+// struct S s;
+// struct T t;
+
+extern struct S* getS();
+extern struct T* getT();
+extern struct U* getU();
+
+// getS could return the same struct as is contained in getT
+
+void *t_fun(void *arg) {
+  // should write to (struct U).t.s.field in addition to (struct T).s.field
+  // but easier to implement the other way around?
+  getS()->field = 1; // RACE!
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  struct T t1;
+  getU()->t = t1; // RACE!
+  return 0;
+}

--- a/tests/regression/04-mutex/92-distribute-fields-type-deep.t
+++ b/tests/regression/04-mutex/92-distribute-fields-type-deep.t
@@ -17,17 +17,19 @@
     live: 7
     dead: 0
     total lines: 7
-  [Success][Race] Memory location (struct T).s.field (safe):
-    write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
   [Success][Race] Memory location (struct S).field (safe):
     write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Success][Race] Memory location (struct U).t (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Success][Race] Memory location (struct U).t.s (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
   [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
     write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Success][Race] Memory location (struct U).t (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
   [Info][Race] Memory locations race summary:
-    safe: 3
+    safe: 4
     vulnerable: 0
     unsafe: 1
-    total memory locations: 4
+    total memory locations: 5
+
+TODO: fix memory location numbers

--- a/tests/regression/04-mutex/92-distribute-fields-type-deep.t
+++ b/tests/regression/04-mutex/92-distribute-fields-type-deep.t
@@ -21,15 +21,11 @@
     write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
   [Success][Race] Memory location (struct U).t (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Success][Race] Memory location (struct U).t.s (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
   [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
     write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
   [Info][Race] Memory locations race summary:
-    safe: 4
+    safe: 2
     vulnerable: 0
     unsafe: 1
-    total memory locations: 5
-
-TODO: fix memory location numbers
+    total memory locations: 3

--- a/tests/regression/04-mutex/92-distribute-fields-type-deep.t
+++ b/tests/regression/04-mutex/92-distribute-fields-type-deep.t
@@ -1,0 +1,33 @@
+  $ goblint --enable allglobs 92-distribute-fields-type-deep.c
+  [Error][Imprecise][Unsound] Function definition missing for getS (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Error][Imprecise][Unsound] Function definition missing for getU (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Success][Race] Memory location (struct T).s.field (safe):
+    write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Success][Race] Memory location (struct S).field (safe):
+    write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
+    write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
+    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Success][Race] Memory location (struct U).t (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Race] Memory locations race summary:
+    safe: 3
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 4

--- a/tests/regression/04-mutex/92-distribute-fields-type-deep.t
+++ b/tests/regression/04-mutex/92-distribute-fields-type-deep.t
@@ -1,31 +1,31 @@
   $ goblint --enable warn.deterministic --enable allglobs 92-distribute-fields-type-deep.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (92-distribute-fields-type-deep.c:36:3-36:20)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (92-distribute-fields-type-deep.c:44:3-44:17)
   [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
-    write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
-    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
+    write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:42:3-42:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:42:3-42:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:36:3-36:20)
+    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:42:3-42:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:44:3-44:17)
   [Info][Race] Memory locations race summary:
     safe: 2
     vulnerable: 0
     unsafe: 1
     total memory locations: 3
   [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
+    write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:42:3-42:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:42:3-42:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:36:3-36:20)
   [Success][Race] Memory location (struct U).t (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
+    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:42:3-42:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:44:3-44:17)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
     dead: 0
     total lines: 7
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Error][Imprecise][Unsound] Function definition missing for getS (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Error][Imprecise][Unsound] Function definition missing for getU (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (92-distribute-fields-type-deep.c:36:3-36:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (92-distribute-fields-type-deep.c:36:3-36:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (92-distribute-fields-type-deep.c:36:3-36:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (92-distribute-fields-type-deep.c:44:3-44:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (92-distribute-fields-type-deep.c:44:3-44:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (92-distribute-fields-type-deep.c:44:3-44:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (92-distribute-fields-type-deep.c:36:3-36:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (92-distribute-fields-type-deep.c:36:3-36:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (92-distribute-fields-type-deep.c:44:3-44:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (92-distribute-fields-type-deep.c:44:3-44:17)
+  [Error][Imprecise][Unsound] Function definition missing for getS (92-distribute-fields-type-deep.c:36:3-36:20)
+  [Error][Imprecise][Unsound] Function definition missing for getU (92-distribute-fields-type-deep.c:44:3-44:17)

--- a/tests/regression/04-mutex/92-distribute-fields-type-deep.t
+++ b/tests/regression/04-mutex/92-distribute-fields-type-deep.t
@@ -1,26 +1,6 @@
-  $ goblint --enable allglobs 92-distribute-fields-type-deep.c
-  [Error][Imprecise][Unsound] Function definition missing for getS (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (92-distribute-fields-type-deep.c:37:3-37:20)
+  $ goblint --enable warn.deterministic --enable allglobs 92-distribute-fields-type-deep.c
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Error][Imprecise][Unsound] Function definition missing for getU (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (92-distribute-fields-type-deep.c:45:3-45:17)
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (92-distribute-fields-type-deep.c:45:3-45:17)
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 7
-    dead: 0
-    total lines: 7
-  [Success][Race] Memory location (struct S).field (safe):
-    write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
-  [Success][Race] Memory location (struct U).t (safe):
-    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
   [Warning][Race] Memory location (struct U).t.s.field (race with conf. 100):
     write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
     write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
@@ -29,3 +9,23 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 3
+  [Success][Race] Memory location (struct S).field (safe):
+    write with [mhp:{tid=[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}, thread:[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]] (conf. 100)  (exp: & tmp->field) (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Success][Race] Memory location (struct U).t (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@92-distribute-fields-type-deep.c:43:3-43:40#top]}}, thread:[main]] (conf. 100)  (exp: & tmp->t) (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (92-distribute-fields-type-deep.c:45:3-45:17)
+  [Error][Imprecise][Unsound] Function definition missing for getS (92-distribute-fields-type-deep.c:37:3-37:20)
+  [Error][Imprecise][Unsound] Function definition missing for getU (92-distribute-fields-type-deep.c:45:3-45:17)

--- a/tests/regression/04-mutex/93-distribute-fields-type-global.c
+++ b/tests/regression/04-mutex/93-distribute-fields-type-global.c
@@ -8,13 +8,13 @@ struct S {
 
 struct S s;
 
+extern struct S* getS();
+
 void *t_fun(void *arg) {
   printf("%d",getS()->field); // RACE!
 
   return NULL;
 }
-
-extern struct S* getS();
 
 int main(void) {
   pthread_t id;

--- a/tests/regression/04-mutex/93-distribute-fields-type-global.c
+++ b/tests/regression/04-mutex/93-distribute-fields-type-global.c
@@ -1,4 +1,3 @@
-//PARAM: --enable ana.race.direct-arithmetic
 #include <pthread.h>
 #include <stdio.h>
 

--- a/tests/regression/04-mutex/93-distribute-fields-type-global.c
+++ b/tests/regression/04-mutex/93-distribute-fields-type-global.c
@@ -1,0 +1,26 @@
+//PARAM: --enable ana.race.direct-arithmetic
+#include <pthread.h>
+#include <stdio.h>
+
+struct S {
+  int field;
+};
+
+struct S s;
+
+void *t_fun(void *arg) {
+  printf("%d",getS()->field); // RACE!
+
+  return NULL;
+}
+
+extern struct S* getS();
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  struct S s1;
+  s = s1; // RACE!
+  return 0;
+}
+

--- a/tests/regression/04-mutex/93-distribute-fields-type-global.t
+++ b/tests/regression/04-mutex/93-distribute-fields-type-global.t
@@ -11,10 +11,10 @@
     live: 7
     dead: 0
     total lines: 7
+  [Success][Race] Memory location s@93-distribute-fields-type-global.c:9:10-9:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:23:3-23:9)
   [Warning][Race] Memory location s.field@93-distribute-fields-type-global.c:9:10-9:11 (race with conf. 110):
     read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:14:3-14:29)
-    write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:23:3-23:9)
-  [Success][Race] Memory location s@93-distribute-fields-type-global.c:9:10-9:11 (safe):
     write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:23:3-23:9)
   [Success][Race] Memory location (struct S).field (safe):
     read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:14:3-14:29)

--- a/tests/regression/04-mutex/93-distribute-fields-type-global.t
+++ b/tests/regression/04-mutex/93-distribute-fields-type-global.t
@@ -1,25 +1,25 @@
-  $ goblint --enable allglobs 93-distribute-fields-type-global.c
-  [Error][Imprecise][Unsound] Function definition missing for getS (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(s, NoOffset)) (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (93-distribute-fields-type-global.c:14:3-14:29)
+  $ goblint --enable warn.deterministic --enable allglobs 93-distribute-fields-type-global.c
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Deadcode] Logical lines of code (LLoC) summary:
-    live: 7
-    dead: 0
-    total lines: 7
-  [Success][Race] Memory location s (safe): (93-distribute-fields-type-global.c:9:10-9:11)
-    write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:23:3-23:9)
   [Warning][Race] Memory location s.field (race with conf. 110): (93-distribute-fields-type-global.c:9:10-9:11)
     read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:14:3-14:29)
     write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:23:3-23:9)
-  [Success][Race] Memory location (struct S).field (safe):
-    read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:14:3-14:29)
   [Info][Race] Memory locations race summary:
     safe: 2
     vulnerable: 0
     unsafe: 1
     total memory locations: 3
+  [Success][Race] Memory location (struct S).field (safe):
+    read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:14:3-14:29)
+  [Success][Race] Memory location s (safe): (93-distribute-fields-type-global.c:9:10-9:11)
+    write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:23:3-23:9)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(s, NoOffset)) (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (93-distribute-fields-type-global.c:14:3-14:29)
+  [Error][Imprecise][Unsound] Function definition missing for getS (93-distribute-fields-type-global.c:14:3-14:29)

--- a/tests/regression/04-mutex/93-distribute-fields-type-global.t
+++ b/tests/regression/04-mutex/93-distribute-fields-type-global.t
@@ -1,0 +1,5 @@
+  $ goblint --enable allglobs 93-distribute-fields-type-global.c
+  93-distribute-fields-type-global.c:12: Error: expecting a pointer to a struct
+  Error: There were parsing errors in .goblint/preprocessed/93-distribute-fields-type-global.i
+  Fatal error: exception Goblint_lib__Maingoblint.FrontendError("Errormsg.Error")
+  [2]

--- a/tests/regression/04-mutex/93-distribute-fields-type-global.t
+++ b/tests/regression/04-mutex/93-distribute-fields-type-global.t
@@ -1,5 +1,25 @@
   $ goblint --enable allglobs 93-distribute-fields-type-global.c
-  93-distribute-fields-type-global.c:12: Error: expecting a pointer to a struct
-  Error: There were parsing errors in .goblint/preprocessed/93-distribute-fields-type-global.i
-  Fatal error: exception Goblint_lib__Maingoblint.FrontendError("Errormsg.Error")
-  [2]
+  [Error][Imprecise][Unsound] Function definition missing for getS (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(s, NoOffset)) (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (93-distribute-fields-type-global.c:14:3-14:29)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Warning][Race] Memory location s.field@93-distribute-fields-type-global.c:9:10-9:11 (race with conf. 110):
+    read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:14:3-14:29)
+    write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:23:3-23:9)
+  [Success][Race] Memory location s@93-distribute-fields-type-global.c:9:10-9:11 (safe):
+    write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:23:3-23:9)
+  [Success][Race] Memory location (struct S).field (safe):
+    read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 3

--- a/tests/regression/04-mutex/93-distribute-fields-type-global.t
+++ b/tests/regression/04-mutex/93-distribute-fields-type-global.t
@@ -1,25 +1,25 @@
   $ goblint --enable warn.deterministic --enable allglobs 93-distribute-fields-type-global.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (93-distribute-fields-type-global.c:14:3-14:29)
-  [Warning][Race] Memory location s.field (race with conf. 110): (93-distribute-fields-type-global.c:9:10-9:11)
-    read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:14:3-14:29)
-    write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:23:3-23:9)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (93-distribute-fields-type-global.c:13:3-13:29)
+  [Warning][Race] Memory location s.field (race with conf. 110): (93-distribute-fields-type-global.c:8:10-8:11)
+    read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:20:3-20:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:20:3-20:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:13:3-13:29)
+    write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:20:3-20:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:22:3-22:9)
   [Info][Race] Memory locations race summary:
     safe: 2
     vulnerable: 0
     unsafe: 1
     total memory locations: 3
   [Success][Race] Memory location (struct S).field (safe):
-    read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:14:3-14:29)
-  [Success][Race] Memory location s (safe): (93-distribute-fields-type-global.c:9:10-9:11)
-    write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:21:3-21:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:23:3-23:9)
+    read with [mhp:{tid=[main, t_fun@93-distribute-fields-type-global.c:20:3-20:40#top]}, thread:[main, t_fun@93-distribute-fields-type-global.c:20:3-20:40#top]] (conf. 100)  (exp: & tmp->field) (93-distribute-fields-type-global.c:13:3-13:29)
+  [Success][Race] Memory location s (safe): (93-distribute-fields-type-global.c:8:10-8:11)
+    write with [mhp:{tid=[main]; created={[main, t_fun@93-distribute-fields-type-global.c:20:3-20:40#top]}}, thread:[main]] (conf. 110)  (exp: & s) (93-distribute-fields-type-global.c:22:3-22:9)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 7
     dead: 0
     total lines: 7
-  [Info][Unsound] Unknown address in {&tmp} has escaped. (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Unsound] Write to unknown address: privatization is unsound. (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Imprecise] INVALIDATING ALL GLOBALS! (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(s, NoOffset)) (93-distribute-fields-type-global.c:14:3-14:29)
-  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (93-distribute-fields-type-global.c:14:3-14:29)
-  [Error][Imprecise][Unsound] Function definition missing for getS (93-distribute-fields-type-global.c:14:3-14:29)
+  [Info][Unsound] Unknown address in {&tmp} has escaped. (93-distribute-fields-type-global.c:13:3-13:29)
+  [Info][Unsound] Unknown value in {?} could be an escaped pointer address! (93-distribute-fields-type-global.c:13:3-13:29)
+  [Info][Unsound] Write to unknown address: privatization is unsound. (93-distribute-fields-type-global.c:13:3-13:29)
+  [Info][Imprecise] INVALIDATING ALL GLOBALS! (93-distribute-fields-type-global.c:13:3-13:29)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(s, NoOffset)) (93-distribute-fields-type-global.c:13:3-13:29)
+  [Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp, NoOffset)) (93-distribute-fields-type-global.c:13:3-13:29)
+  [Error][Imprecise][Unsound] Function definition missing for getS (93-distribute-fields-type-global.c:13:3-13:29)

--- a/tests/regression/06-symbeq/16-type_rc.c
+++ b/tests/regression/06-symbeq/16-type_rc.c
@@ -1,6 +1,14 @@
 // PARAM: --enable ana.race.direct-arithmetic --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'"
 #include<pthread.h>
 
+//>(int)<  (S)     (T)     (U)
+//    \   /   \   /   \   / 
+//     >f<      s       t
+//        \   /   \   /  
+//          f       s
+//            \   /
+//              f
+
 struct s {
   int datum;
   pthread_mutex_t mutex;

--- a/tests/regression/06-symbeq/16-type_rc.t
+++ b/tests/regression/06-symbeq/16-type_rc.t
@@ -1,22 +1,22 @@
 Disable info messages because race summary contains (safe) memory location count, which is different on Linux and OSX.
 
   $ goblint --enable warn.deterministic --disable warn.info --enable ana.race.direct-arithmetic --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'" 16-type_rc.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:13:3-13:15)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:24:3-24:16)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:25:3-25:16)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:28:3-28:9)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:21:3-21:15)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:32:3-32:16)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:33:3-33:16)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:36:3-36:9)
   [Warning][Race] Memory location (struct s).datum (race with conf. 100):
-    write with [mhp:{tid=[main, t_fun@16-type_rc.c:27:3-27:37#top]}, thread:[main, t_fun@16-type_rc.c:27:3-27:37#top]] (conf. 100)  (exp: & s->datum) (16-type_rc.c:13:3-13:15)
-    write with [mhp:{tid=[main]; created={[main, t_fun@16-type_rc.c:27:3-27:37#top]}}, thread:[main]] (conf. 100)  (exp: & *d) (16-type_rc.c:28:3-28:9)
-  [Error][Imprecise][Unsound] Function definition missing for get_s (16-type_rc.c:12:12-12:24)
-  [Error][Imprecise][Unsound] Function definition missing for get_s (16-type_rc.c:23:3-23:14)
+    write with [mhp:{tid=[main, t_fun@16-type_rc.c:35:3-35:37#top]}, thread:[main, t_fun@16-type_rc.c:35:3-35:37#top]] (conf. 100)  (exp: & s->datum) (16-type_rc.c:21:3-21:15)
+    write with [mhp:{tid=[main]; created={[main, t_fun@16-type_rc.c:35:3-35:37#top]}}, thread:[main]] (conf. 100)  (exp: & *d) (16-type_rc.c:36:3-36:9)
+  [Error][Imprecise][Unsound] Function definition missing for get_s (16-type_rc.c:20:12-20:24)
+  [Error][Imprecise][Unsound] Function definition missing for get_s (16-type_rc.c:31:3-31:14)
 
   $ goblint --enable warn.deterministic --disable warn.info --disable ana.race.direct-arithmetic --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'" --enable allglobs 16-type_rc.c
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:13:3-13:15)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:24:3-24:16)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:25:3-25:16)
-  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:28:3-28:9)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:21:3-21:15)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:32:3-32:16)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:33:3-33:16)
+  [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (16-type_rc.c:36:3-36:9)
   [Success][Race] Memory location (struct s).datum (safe):
-    write with [mhp:{tid=[main, t_fun@16-type_rc.c:27:3-27:37#top]}, thread:[main, t_fun@16-type_rc.c:27:3-27:37#top]] (conf. 100)  (exp: & s->datum) (16-type_rc.c:13:3-13:15)
-  [Error][Imprecise][Unsound] Function definition missing for get_s (16-type_rc.c:12:12-12:24)
-  [Error][Imprecise][Unsound] Function definition missing for get_s (16-type_rc.c:23:3-23:14)
+    write with [mhp:{tid=[main, t_fun@16-type_rc.c:35:3-35:37#top]}, thread:[main, t_fun@16-type_rc.c:35:3-35:37#top]] (conf. 100)  (exp: & s->datum) (16-type_rc.c:21:3-21:15)
+  [Error][Imprecise][Unsound] Function definition missing for get_s (16-type_rc.c:20:12-20:24)
+  [Error][Imprecise][Unsound] Function definition missing for get_s (16-type_rc.c:31:3-31:14)


### PR DESCRIPTION
This is a continuation of #1089, which made access inner distribution to fields lazy. This now also does the outer distribution to type-based memory locations.

Documentaton for the new race detection is in `raceAnalysis.ml`.

This halves the number of race warnings on silver searcher.