### PR TITLE
Detect memory deallocation at offset from memory start

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2016,7 +2016,7 @@ struct
         M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Points-to set for pointer %a in function %s is top. Potentially invalid memory deallocation may occur" d_exp ptr special_fn.vname
       else if (Q.LS.exists (fun (v, _) -> not (ctx.ask (Q.IsHeapVar v))) points_to_set) || (AD.mem Addr.UnknownPtr a) then
         M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Free of non-dynamically allocated memory in function %s for pointer %a" special_fn.vname d_exp ptr
-      else if Q.LS.exists (fun (_, o) -> o <> `NoOffset) points_to_set then
+      else if Q.LS.exists (fun (_, o) -> Offset.Exp.cmp_zero_offset o <> `MustZero) points_to_set then
         M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 761] "Free of memory not at start of buffer in function %s for pointer %a" special_fn.vname d_exp ptr
     | _ -> M.warn ~category:MessageCategory.Analyzer "Pointer %a in function %s doesn't evaluate to a valid address." d_exp ptr special_fn.vname
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -138,6 +138,11 @@ struct
   let project ask p_opt cpa fundec =
     CPA.mapi (fun varinfo value -> project_val ask (attributes_varinfo varinfo fundec) p_opt value (is_privglob varinfo)) cpa
 
+  let has_offset = function
+    | `NoOffset -> false
+    | `Field _
+    | `Index _ -> true
+
 
   (**************************************************************************
    * Initializing my variables
@@ -1262,11 +1267,6 @@ struct
         match p with
         | Address a ->
           let s = addrToLvalSet a in
-          let has_offset = function
-            | `NoOffset -> false
-            | `Field _
-            | `Index _ -> true
-          in
           (* If there's a non-heap var or an offset in the lval set, we answer with bottom *)
           if ValueDomainQueries.LS.exists (fun (v, o) -> (not @@ ctx.ask (Queries.IsHeapVar v)) || has_offset o) s then
             Queries.Result.bot q
@@ -2014,11 +2014,6 @@ struct
     invalidate ~deep:true ~ctx (Analyses.ask_of_ctx ctx) gs st' deep_addrs
 
   let check_invalid_mem_dealloc ctx special_fn ptr =
-    let has_offset = function
-      | `NoOffset -> false
-      | `Field _
-      | `Index _ -> true
-    in
     match eval_rv_address (Analyses.ask_of_ctx ctx) ctx.global ctx.local ptr with
     | Address a ->
       let points_to_set = addrToLvalSet a in

--- a/tests/regression/75-invalid_dealloc/05-free-at-offset.c
+++ b/tests/regression/75-invalid_dealloc/05-free-at-offset.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+
+int main(int argc, char const *argv[]) {
+    char *ptr = malloc(42 * sizeof(char));
+    ptr = ptr + 7;
+    free(ptr); //WARN
+
+    return 0;
+}

--- a/tests/regression/75-invalid_dealloc/06-realloc-at-offset.c
+++ b/tests/regression/75-invalid_dealloc/06-realloc-at-offset.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+#define MAX_SIZE 5000
+
+int main(int argc, char const *argv[]) {
+    char *ptr = malloc(42 * sizeof(char));
+    ptr = ptr + 7;
+    realloc(ptr, MAX_SIZE); //WARN
+
+    return 0;
+}

--- a/tests/regression/75-invalid_dealloc/07-free-at-struct-offset.c
+++ b/tests/regression/75-invalid_dealloc/07-free-at-struct-offset.c
@@ -8,8 +8,8 @@ typedef struct custom_t {
 int main(int argc, char const *argv[]) {
     custom_t *struct_ptr = malloc(sizeof(custom_t));
     struct_ptr->x = malloc(10 * sizeof(char));
-    free(struct_ptr->x); //NOWARN
-    free(struct_ptr->y); //WARN
+    free(&struct_ptr->x); //NOWARN
+    free(&struct_ptr->y); //WARN
     free(struct_ptr); //NOWARN
     return 0;
 }

--- a/tests/regression/75-invalid_dealloc/07-free-at-struct-offset.c
+++ b/tests/regression/75-invalid_dealloc/07-free-at-struct-offset.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+
+typedef struct custom_t {
+    char *x;
+    int y;
+} custom_t;
+
+int main(int argc, char const *argv[]) {
+    custom_t *struct_ptr = malloc(sizeof(custom_t));
+    struct_ptr->x = malloc(10 * sizeof(char));
+    free(struct_ptr->x); //NOWARN
+    free(struct_ptr->y); //WARN
+    free(struct_ptr); //NOWARN
+    return 0;
+}

--- a/tests/regression/75-invalid_dealloc/08-realloc-at-struct-offset.c
+++ b/tests/regression/75-invalid_dealloc/08-realloc-at-struct-offset.c
@@ -8,8 +8,8 @@ typedef struct custom_t {
 int main(int argc, char const *argv[]) {
     custom_t *struct_ptr = malloc(sizeof(custom_t));
     struct_ptr->x = malloc(10 * sizeof(char));
-    realloc(struct_ptr->x, 50); //NOWARN
-    realloc(struct_ptr->y, 50); //WARN
+    realloc(&struct_ptr->x, 50); //NOWARN
+    realloc(&struct_ptr->y, 50); //WARN
     realloc(struct_ptr, 2 * sizeof(custom_t)); //NOWARN
     return 0;
 }

--- a/tests/regression/75-invalid_dealloc/08-realloc-at-struct-offset.c
+++ b/tests/regression/75-invalid_dealloc/08-realloc-at-struct-offset.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+
+typedef struct custom_t {
+    char *x;
+    int y;
+} custom_t;
+
+int main(int argc, char const *argv[]) {
+    custom_t *struct_ptr = malloc(sizeof(custom_t));
+    struct_ptr->x = malloc(10 * sizeof(char));
+    realloc(struct_ptr->x, 50); //NOWARN
+    realloc(struct_ptr->y, 50); //WARN
+    realloc(struct_ptr, 2 * sizeof(custom_t)); //NOWARN
+    return 0;
+}


### PR DESCRIPTION
This PR is supposed to improve Goblint's detection of `invalid-free` bugs by adding a check for memory deallocation which happens at an offset from the memory's start address instead of at the start address itself.

Added a few more regression test cases for this as well. `make test` runs through successfully

Cf. https://cwe.mitre.org/data/definitions/761.html