### PR TITLE
Selenium

### DIFF
--- a/.github/workflows/locked.yml
+++ b/.github/workflows/locked.yml
@@ -176,3 +176,8 @@ jobs:
         run: |
           ./goblint --enable gobview tests/regression/00-sanity/01-assert.c
           python3 scripts/test-gobview.py
+
+      - name: Test Gobview with Compilation Database
+        run: |
+          ./goblint --enable gobview tests/others/compile_commands.json
+          python3 scripts/test-gobview.py

--- a/scripts/test-gobview.py
+++ b/scripts/test-gobview.py
@@ -62,6 +62,20 @@ try:
     panel = browser.find_element(By.CLASS_NAME, "panel")
     print("found DOM elements main, sidebar-left, sidebar-right, content and panel")
 
+    # Navigate to a file and check wether the Graph panel exists
+    leftS.find_element(By.CLASS_NAME,"text-link").click()
+    print("Executed file navigation")
+    breadcrumb = browser.find_element(By.CLASS_NAME,"breadcrumb-item")
+    assert(".c" in breadcrumb.text)
+    print("sucessfully opened file")
+
+    graph_button = browser.find_element(By.ID,"Graph")
+    assert(graph_button.text == "Graph")
+    print("found DOM element for Callgraph panel")
+
+
+
+
     cleanup(browser, httpd, thread)
 
 except Exception as e:

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -418,7 +418,7 @@ let parse_preprocessed preprocessed =
   let goblint_cwd = GobFpath.cwd () in
   let get_ast_and_record_deps (preprocessed_file, task_opt) =
     let transform_file (path_str, system_header) = match path_str with
-      | "<built-in>" | "<command-line>" ->
+      | "<built-in>" | "<command-line>" | "<command line>"  ->
         (path_str, system_header) (* ignore special "paths" *)
       | _ ->
         let path = Fpath.v path_str in

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -417,10 +417,9 @@ let parse_preprocessed preprocessed =
 
   let goblint_cwd = GobFpath.cwd () in
   let get_ast_and_record_deps (preprocessed_file, task_opt) =
-    let transform_file (path_str, system_header) = match path_str with
-      | "<built-in>" | "<command-line>" | "<command line>"  ->
+    let transform_file (path_str, system_header) = if Str.string_match (Str.regexp "<.+>") path_str 0 then
         (path_str, system_header) (* ignore special "paths" *)
-      | _ ->
+      else
         let path = Fpath.v path_str in
         let path' = if get_bool "pre.transform-paths" then (
             let cwd_opt =

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -591,7 +591,7 @@ let do_gobview cilfile =
           | Some p -> Fpath.to_string p
           | None -> failwith "The gobview directory should be a prefix of the paths of c files copied to the gobview directory" in
         Hashtbl.add file_loc (Fpath.to_string path) gobview_path;
-        FileUtil.cp ~recurse:true [Fpath.to_string path] (Fpath.to_string dest) in
+        FileUtil.cp [Fpath.to_string path] (Fpath.to_string dest) in
       let source_paths = Preprocessor.FpathH.to_list Preprocessor.dependencies |> List.concat_map (fun (_, m) -> Fpath.Map.fold (fun p _ acc -> p::acc) m []) |>  List.mapi (fun i e ->(e, i)) |> List.filter (fun (e,_) -> Fpath.is_file_path e) in
       List.iter copy source_paths;
       Serialize.marshal file_loc (Fpath.(run_dir / "file_loc.marshalled"));

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -594,7 +594,7 @@ let do_gobview cilfile =
           | None -> failwith "The gobview directory should be a prefix of the paths of c files copied to the gobview directory" in
         Hashtbl.add file_loc (Fpath.to_string path) gobview_path;
         FileUtil.cp [Fpath.to_string path] (Fpath.to_string dest) in
-      let source_paths = Preprocessor.FpathH.to_list Preprocessor.dependencies |> List.concat_map (fun (_, m) -> Fpath.Map.fold (fun p _ acc -> p::acc) m []) in
+      let source_paths = Preprocessor.FpathH.to_list Preprocessor.dependencies |> List.concat_map (fun (_, m) -> Fpath.Map.fold (fun p _ acc -> p::acc) m []) |> List.filter Fpath.is_file_path in
       List.iter copy source_paths;
       Serialize.marshal file_loc (Fpath.(run_dir / "file_loc.marshalled"));
       (* marshal timing statistics *)

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -583,18 +583,16 @@ let do_gobview cilfile =
       let file_dir = Fpath.(run_dir / "files") in
       GobSys.mkdir_or_exists file_dir;
       let file_loc = Hashtbl.create 113 in
-      let counter = ref 0 in
-      let copy path =
+      let copy (path,i) =
         let name, ext = Fpath.split_ext (Fpath.base path) in
-        let unique_name = Fpath.add_ext ext (Fpath.add_ext (string_of_int !counter) name) in
-        counter := !counter + 1;
+        let unique_name = Fpath.add_ext ext (Fpath.add_ext (string_of_int i) name) in
         let dest = Fpath.(file_dir // unique_name) in
         let gobview_path = match Fpath.relativize ~root:run_dir dest with
           | Some p -> Fpath.to_string p
           | None -> failwith "The gobview directory should be a prefix of the paths of c files copied to the gobview directory" in
         Hashtbl.add file_loc (Fpath.to_string path) gobview_path;
-        FileUtil.cp [Fpath.to_string path] (Fpath.to_string dest) in
-      let source_paths = Preprocessor.FpathH.to_list Preprocessor.dependencies |> List.concat_map (fun (_, m) -> Fpath.Map.fold (fun p _ acc -> p::acc) m []) |> List.filter Fpath.is_file_path in
+        FileUtil.cp ~recurse:true [Fpath.to_string path] (Fpath.to_string dest) in
+      let source_paths = Preprocessor.FpathH.to_list Preprocessor.dependencies |> List.concat_map (fun (_, m) -> Fpath.Map.fold (fun p _ acc -> p::acc) m []) |>  List.mapi (fun i e ->(e, i)) |> List.filter (fun (e,_) -> Fpath.is_file_path e) in
       List.iter copy source_paths;
       Serialize.marshal file_loc (Fpath.(run_dir / "file_loc.marshalled"));
       (* marshal timing statistics *)

--- a/tests/others/compile_commands.json
+++ b/tests/others/compile_commands.json
@@ -1,0 +1,14 @@
+[
+  {
+    "arguments": [
+      "/usr/bin/gcc",
+      "-Wall",
+      "-g",
+      "-c",
+      "-pthread",
+      "06-callback.c"
+    ],
+    "directory": "./tests/regression/03-practical",
+    "file": "./tests/regression/03-practical/06-callback.c"
+  }
+]


### PR DESCRIPTION
depends on #1143 and https://github.com/goblint/gobview/pull/28

adds a E2E test for compilation databases
also expands test to check wether files can be opened and the graph tab and breadcrumb exist