### PR TITLE
goblint: fix lower bound on yaml

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -42,7 +42,7 @@
     (sha (>= 1.12))
     cpu
     arg-complete
-    yaml
+    (yaml (>= 3.0.0))
     uuidm
     catapult
     catapult-file

--- a/goblint.opam
+++ b/goblint.opam
@@ -39,7 +39,7 @@ depends: [
   "sha" {>= "1.12"}
   "cpu"
   "arg-complete"
-  "yaml"
+  "yaml" {>= "3.0.0"}
   "uuidm"
   "catapult"
   "catapult-file"


### PR DESCRIPTION
See build failure at https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b49e6de20d0a04ef393c2e153d87d6e00f63c455

'opam-ci' would otherwise try 'yaml.1.0.0' which doesn't work:

```
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.goblint_lib.objs/byte -I /home/opam/.opam/4.13/lib/arg-complete -I /home/opam/.opam/4.13/lib/astring -I /home/opam/.opam/4.13/lib/base/caml -I /home/opam/.opam/4.13/lib/batteries -I /home/opam/.opam/4.13/lib/bos -I /home/opam/.opam/4.13/lib/catapult -I /home/opam/.opam/4.13/lib/catapult-file -I /home/opam/.opam/4.13/lib/catapult/utils -I /home/opam/.opam/4.13/lib/cpu -I /home/opam/.opam/4.13/lib/ctypes -I /home/opam/.opam/4.13/lib/findlib -I /home/opam/.opam/4.13/lib/fmt -I /home/opam/.opam/4.13/lib/fpath -I /home/opam/.opam/4.13/lib/goblint-cil -I /home/opam/.opam/4.13/lib/goblint-cil/dataslicing -I /home/opam/.opam/4.13/lib/goblint-cil/liveness -I /home/opam/.opam/4.13/lib/goblint-cil/makecfg -I /home/opam/.opam/4.13/lib/goblint-cil/pta -I /home/opam/.opam/4.13/lib/goblint-cil/syntacticsearch -I /home/opam/.opam/4.13/lib/goblint-cil/zrapp -I /home/opam/.opam/4.13/lib/integers -I /home/opam/.opam/4.13/lib/json-data-encoding -I /home/opam/.opam/4.13/lib/jsonrpc -I /home/opam/.opam/4.13/lib/logs -I /home/opam/.opam/4.13/lib/ocaml/threads -I /home/opam/.opam/4.13/lib/parsexp -I /home/opam/.opam/4.13/lib/ppx_deriving/runtime -I /home/opam/.opam/4.13/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.13/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.13/lib/qcheck-core -I /home/opam/.opam/4.13/lib/qcheck-core/runner -I /home/opam/.opam/4.13/lib/re -I /home/opam/.opam/4.13/lib/re/posix -I /home/opam/.opam/4.13/lib/result -I /home/opam/.opam/4.13/lib/rresult -I /home/opam/.opam/4.13/lib/seq -I /home/opam/.opam/4.13/lib/sexplib -I /home/opam/.opam/4.13/lib/sexplib0 -I /home/opam/.opam/4.13/lib/sha -I /home/opam/.opam/4.13/lib/stdlib-shims -I /home/opam/.opam/4.13/lib/stringext -I /home/opam/.opam/4.13/lib/uri -I /home/opam/.opam/4.13/lib/uuidm -I /home/opam/.opam/4.13/lib/yaml -I /home/opam/.opam/4.13/lib/yaml/bindings -I /home/opam/.opam/4.13/lib/yaml/bindings/types -I /home/opam/.opam/4.13/lib/yaml/c -I /home/opam/.opam/4.13/lib/yaml/ffi -I /home/opam/.opam/4.13/lib/yaml/types -I /home/opam/.opam/4.13/lib/yaml/unix -I /home/opam/.opam/4.13/lib/yojson -I /home/opam/.opam/4.13/lib/zarith -I src/sites/.goblint_sites.objs/byte -I src/util/timing/.goblint_timing.objs/byte -no-alias-deps -open Goblint_lib -o src/.goblint_lib.objs/byte/goblint_lib__GobYaml.cmo -c -impl src/util/gobYaml.pp.ml)
# File "src/util/gobYaml.ml", line 1, characters 8-17:
# 1 | include Yaml.Util
#             ^^^^^^^^^
# Error: Unbound module Yaml.Util

<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build goblint 2.1.0
+-
```