### PR TITLE
Add some `setjump/longjump` tests for race detection

### DIFF
--- a/tests/regression/68-longjmp/52-races.c
+++ b/tests/regression/68-longjmp/52-races.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <setjmp.h>
-#include <goblint.h>
 #include <pthread.h>
 
 jmp_buf env_buffer;

--- a/tests/regression/68-longjmp/52-races.c
+++ b/tests/regression/68-longjmp/52-races.c
@@ -1,0 +1,36 @@
+// PARAM: --enable ana.int.interval
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <goblint.h>
+#include <pthread.h>
+
+jmp_buf env_buffer;
+int global = 0;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  global = 3; // NORACE
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int bar() {
+   pthread_mutex_lock(&mutex1);
+   longjmp(env_buffer, 2);
+   pthread_mutex_unlock(&mutex1);
+   return 8;
+}
+
+int main() {
+   pthread_t id;
+   pthread_create(&id, NULL, t_fun, NULL);
+
+   if(!setjmp( env_buffer )) {
+      bar();
+   }
+
+   global = 5; // NORACE
+   pthread_mutex_unlock(&mutex1);
+}

--- a/tests/regression/68-longjmp/53-races-no.c
+++ b/tests/regression/68-longjmp/53-races-no.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <setjmp.h>
-#include <goblint.h>
 #include <pthread.h>
 
 jmp_buf env_buffer;

--- a/tests/regression/68-longjmp/53-races-no.c
+++ b/tests/regression/68-longjmp/53-races-no.c
@@ -1,0 +1,37 @@
+// PARAM: --enable ana.int.interval
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <goblint.h>
+#include <pthread.h>
+
+jmp_buf env_buffer;
+int global = 0;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  global = 3; // NORACE
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int bar() {
+   pthread_mutex_lock(&mutex1);
+   if(global ==3) {
+      longjmp(env_buffer, 2);
+   }
+   return 8;
+}
+
+int main() {
+   pthread_t id;
+   pthread_create(&id, NULL, t_fun, NULL);
+
+   if(!setjmp( env_buffer )) {
+      bar();
+   }
+
+   global = 5; // NORACE
+   pthread_mutex_unlock(&mutex1);
+}

--- a/tests/regression/68-longjmp/54-races-actually.c
+++ b/tests/regression/68-longjmp/54-races-actually.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <setjmp.h>
-#include <goblint.h>
 #include <pthread.h>
 
 jmp_buf env_buffer;
@@ -44,7 +43,7 @@ int main() {
    }
 
    global = 5; //RACE
-   
+
    if(n == 0) {
       pthread_mutex_unlock(&mutex1);
    }

--- a/tests/regression/68-longjmp/54-races-actually.c
+++ b/tests/regression/68-longjmp/54-races-actually.c
@@ -1,0 +1,51 @@
+// PARAM: --enable ana.int.interval
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <goblint.h>
+#include <pthread.h>
+
+jmp_buf env_buffer;
+int global = 0;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  global = 3; // RACE
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int bar() {
+   pthread_mutex_lock(&mutex1);
+   if(global == 3) {
+      longjmp(env_buffer, 2);
+   } else {
+      longjmp(env_buffer, 4);
+   }
+   return 8;
+}
+
+int main() {
+   pthread_t id;
+   pthread_create(&id, NULL, t_fun, NULL);
+   int n = 0;
+
+   switch(setjmp( env_buffer )) {
+      case 0:
+         bar();
+         break;
+      case 2:
+         n=1;
+         pthread_mutex_unlock(&mutex1);
+         break;
+      default:
+         break;
+   }
+
+   global = 5; //RACE
+   
+   if(n == 0) {
+      pthread_mutex_unlock(&mutex1);
+   }
+}

--- a/tests/regression/68-longjmp/55-races-no-return.c
+++ b/tests/regression/68-longjmp/55-races-no-return.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <setjmp.h>
-#include <goblint.h>
 #include <pthread.h>
 
 jmp_buf env_buffer;

--- a/tests/regression/68-longjmp/55-races-no-return.c
+++ b/tests/regression/68-longjmp/55-races-no-return.c
@@ -1,0 +1,51 @@
+// PARAM: --enable ana.int.interval
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <goblint.h>
+#include <pthread.h>
+
+jmp_buf env_buffer;
+int global = 0;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  global = 3; //NORACE
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int bar() {
+   pthread_mutex_lock(&mutex1);
+   if(global == 7) {
+      longjmp(env_buffer, 2);
+   } else {
+      longjmp(env_buffer, 4);
+   }
+   return 8;
+}
+
+int main() {
+   pthread_t id;
+   pthread_create(&id, NULL, t_fun, NULL);
+   int n = 0;
+
+   switch(setjmp( env_buffer )) {
+      case 0:
+         bar();
+         break;
+      case 2:
+         n=1;
+         pthread_mutex_unlock(&mutex1);
+         break;
+      default:
+         break;
+   }
+
+   global = 5; //NORACE
+
+   if(n == 0) {
+      pthread_mutex_unlock(&mutex1);
+   }
+}


### PR DESCRIPTION
While preparing a talk which (among many other things) will tout how generic our sj/lj solution is, I realized we don't have any examples that highlight that it works for analyses such as locksets (and thus races) as well.

This adds a few such examples, that we might also want to add to sv-comp.