### PR TITLE
Fix thread analysis termination with a self-creating thread

### DIFF
--- a/tests/regression/10-synch/07-thread_self_create.c
+++ b/tests/regression/10-synch/07-thread_self_create.c
@@ -1,0 +1,15 @@
+// PARAM: --set ana.activated[+] thread
+// Checks termination of thread analysis with a thread who is its own single parent.
+#include <pthread.h>
+
+void *t_fun(void *arg) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  return 0;
+}


### PR DESCRIPTION
This non-termination occurred in libaco from Concrat benchmarks, possibly others. The Concrat conf uses the thread analysis.

When a thread is created by just one thread which happens to be itself `is_not_unique` went into infinite recursion.