### PR TITLE
First steps towards a Proof-of-Concept for analyzing threadpools

### DIFF
--- a/src/cdomains/concDomain.ml
+++ b/src/cdomains/concDomain.ml
@@ -2,6 +2,7 @@
 
 module ThreadSet = SetDomain.ToppedSet (ThreadIdDomain.Thread) (struct let topname = "All Threads" end)
 module MustThreadSet = SetDomain.Reverse(ThreadSet)
+module ThreadSetMustJoined = Lattice.Prod (BoolDomain.MustBool) (ThreadSet)
 
 module CreatedThreadSet = ThreadSet
 

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -73,7 +73,7 @@ struct
   let invalidate_value ask t (v, s, o) = Value.invalidate_value ask t v, s, o
 end
 
-module Threads = ConcDomain.ThreadSet
+module Threads = ConcDomain.ThreadSetMustJoined
 module JmpBufs = JmpBufDomain.JmpBufSetTaint
 
 module rec Compound: sig
@@ -146,7 +146,7 @@ struct
       let typAttr = typeAttrs ai in
       let len = array_length_idx (IndexDomain.bot ()) length in
       Array (CArrays.make ~varAttr ~typAttr len (bot_value ai))
-    | t when is_thread_type t -> Thread (ConcDomain.ThreadSet.empty ())
+    | t when is_thread_type t -> Thread (true, ConcDomain.ThreadSet.empty ())
     | t when is_mutexattr_type t -> MutexAttr (MutexAttrDomain.bot ())
     | t when is_jmp_buf_type t -> JmpBuf (JmpBufs.Bufs.empty (), false)
     | TNamed ({ttype=t; _}, _) -> bot_value ~varAttr (unrollType t)
@@ -958,7 +958,7 @@ struct
           | Thread t -> value (* if actually assigning thread, use value *)
           | _ ->
             if !AnalysisState.global_initialization then
-              Thread (ConcDomain.ThreadSet.empty ()) (* if assigning global init (int on linux, ptr to struct on mac), use empty set instead *)
+              Thread (true, ConcDomain.ThreadSet.empty ()) (* if assigning global init (int on linux, ptr to struct on mac), use empty set instead *)
             else
               Top
         end

--- a/tests/regression/40-threadid/09-poc.c
+++ b/tests/regression/40-threadid/09-poc.c
@@ -1,0 +1,36 @@
+// PARAM: --set ana.base.arrays.domain partitioned --enable ana.int.interval
+#include <goblint.h>
+#include <pthread.h>
+
+
+void *t_fun(void *arg) {
+  return 5;
+}
+
+int main() {
+  pthread_t idtmp;
+  pthread_t id[10];
+  int x;
+
+  pthread_create(&id[0], NULL, t_fun, NULL);
+  x = 8;
+
+  for(int i =0; i < 10; i++) {
+    pthread_create(&idtmp, NULL, t_fun, NULL);
+    id[i] = idtmp;
+  }
+
+  x = 2;
+
+  for(int i =0; i < 10; i++) {
+    // Pulled into temporary assignment, as set in pthread_join does not provide needed information to
+    // partitioned arrays
+    idtmp = id[i];
+    pthread_join(idtmp, &x); //Providing a pointer to x to go into the code that handles it
+    id[i] = idtmp;
+  }
+
+  // We know all threads who have their tids in the array id have been joined
+  // Only additional thing that is needed is proof that the array contains all thread ids that have been created
+  // e.g. by all distinct
+}


### PR DESCRIPTION
Since we constantly talk about it (today again in Munich), and I started thinking about it on the subway, I spent a few minutes implementing a Proof-of-Concept of the first part of an analysis:

In it's current state it can determine that `pthread_join` has been called for all members of an array, by lugging around a boolean and employing the partitioned array domain.

The other piece that is missing is an analysis that shows that all created threads of a given abstract thread id is indeed contained in the array.

After we have this, we would be able to handle thread pools of constant size.

This is not meant to be merged, but as a simple Proof-of-Concept that anyone is free to adopt and develop into a proper analysis.