### PR TITLE
Check all offsets, attributes and `typedef`s for ignored race memory locations

### DIFF
--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -127,6 +127,10 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("setjmp", special [__ "env" [w]] @@ fun env -> Setjmp { env });
     ("longjmp", special [__ "env" [r]; __ "value" []] @@ fun env value -> Longjmp { env; value });
     ("atexit", unknown [drop "function" [s]]);
+    ("atomic_flag_clear", unknown [drop "obj" [w]]);
+    ("atomic_flag_clear_explicit", unknown [drop "obj" [w]; drop "order" []]);
+    ("atomic_flag_test_and_set", unknown [drop "obj" [r; w]]);
+    ("atomic_flag_test_and_set_explicit", unknown [drop "obj" [r; w]; drop "order" []]);
   ]
 
 (** C POSIX library functions.
@@ -435,6 +439,8 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_popcountll", unknown [drop "x" []]);
     ("__atomic_store_n", unknown [drop "ptr" [w]; drop "val" []; drop "memorder" []]);
     ("__atomic_load_n", unknown [drop "ptr" [r]; drop "memorder" []]);
+    ("__atomic_clear", unknown [drop "ptr" [w]; drop "memorder" []]);
+    ("__atomic_test_and_set", unknown [drop "ptr" [r; w]; drop "memorder" []]);
     ("__sync_fetch_and_add", unknown (drop "ptr" [r; w] :: drop "value" [] :: VarArgs (drop' [])));
     ("__sync_fetch_and_sub", unknown (drop "ptr" [r; w] :: drop "value" [] :: VarArgs (drop' [])));
     ("__builtin_va_copy", unknown [drop "dest" [w]; drop "src" [r]]);

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -12,7 +12,7 @@ module M = Messages
 
 let rec is_ignorable_type (t: typ): bool =
   match t with
-  | TNamed ({ tname = "atomic_t" | "pthread_mutex_t" | "pthread_rwlock_t" | "pthread_spinlock_t" | "spinlock_t" | "pthread_cond_t"; _ }, _) -> true
+  | TNamed ({ tname = "atomic_t" | "pthread_mutex_t" | "pthread_rwlock_t" | "pthread_spinlock_t" | "spinlock_t" | "pthread_cond_t" | "atomic_flag"; _ }, _) -> true
   | TComp ({ cname = "__pthread_mutex_s" | "__pthread_rwlock_arch_t" | "__jmp_buf_tag" | "_pthread_cleanup_buffer" | "__pthread_cleanup_frame" | "__cancel_jmp_buf_tag"; _}, _) -> true
   | TComp ({ cname; _}, _) when String.starts_with_stdlib ~prefix:"__anon" cname ->
     begin match Cilfacade.split_anoncomp_name cname with

--- a/tests/regression/04-mutex/62-simple_atomic_nr.c
+++ b/tests/regression/04-mutex/62-simple_atomic_nr.c
@@ -1,24 +1,83 @@
 #include <pthread.h>
-#include <stdio.h>
 #include <stdatomic.h>
 
-atomic_int myglobal;
-pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
-pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+atomic_int g1;
+_Atomic int g2;
+_Atomic(int) g3;
+
+atomic_int a1[1];
+_Atomic int a2[1];
+_Atomic(int) a3[1];
+
+struct s {
+  int f0;
+  atomic_int f1;
+  _Atomic int f2;
+  _Atomic(int) f3;
+};
+
+struct s s1;
+_Atomic struct s s2;
+_Atomic(struct s) s3;
+
+typedef atomic_int t_int1;
+typedef _Atomic int t_int2;
+typedef _Atomic(int) t_int3;
+
+t_int1 t1;
+t_int2 t2;
+t_int3 t3;
+
+typedef int t_int0;
+
+_Atomic t_int0 t0;
+_Atomic(t_int0) t00;
+
+atomic_int *p0 = &g1;
+int x;
+// int * _Atomic p1 = &x; // TODO: https://github.com/goblint/cil/issues/64
+// _Atomic(int*) p2 = &x; // TODO: https://github.com/goblint/cil/issues/64
+// atomic_int * _Atomic p3 = &g1; // TODO: https://github.com/goblint/cil/issues/64
+
+atomic_flag flag = ATOMIC_FLAG_INIT;
 
 void *t_fun(void *arg) {
-  pthread_mutex_lock(&mutex1);
-  myglobal=myglobal+1; // NORACE
-  pthread_mutex_unlock(&mutex1);
+  g1++; // NORACE
+  g2++; // NORACE
+  g3++; // NORACE
+  a1[0]++; // NORACE
+  a2[0]++; // NORACE
+  a3[0]++; // NORACE
+  s1.f1++; // NORACE
+  s1.f2++; // NORACE
+  s1.f3++; // NORACE
+  s2.f0++; // NORACE
+  s3.f0++; // NORACE
+  t1++; // NORACE
+  t2++; // NORACE
+  t3++; // NORACE
+  t0++; // NORACE
+  t00++; // NORACE
+  (*p0)++; // NORACE
+  // p1++; // TODO NORACE: https://github.com/goblint/cil/issues/64
+  // p2++; // TODO NORACE: https://github.com/goblint/cil/issues/64
+  // p3++; // TODO NORACE: https://github.com/goblint/cil/issues/64
+  // (*p3)++; // TODO NORACE: https://github.com/goblint/cil/issues/64
+
+  struct s ss = {0};
+  s2 = ss; // NORACE
+  s3 = ss; // NORACE
+
+  atomic_flag_clear(&flag); // NORACE
+  atomic_flag_test_and_set(&flag); // NORACE
   return NULL;
 }
 
 int main(void) {
-  pthread_t id;
+  pthread_t id, id2;
   pthread_create(&id, NULL, t_fun, NULL);
-  pthread_mutex_lock(&mutex2);
-  myglobal=myglobal+1; // NORACE
-  pthread_mutex_unlock(&mutex2);
-  pthread_join (id, NULL);
+  pthread_create(&id2, NULL, t_fun, NULL);
+  pthread_join(id, NULL);
+  pthread_join(id2, NULL);
   return 0;
 }

--- a/tests/regression/04-mutex/99-volatile.c
+++ b/tests/regression/04-mutex/99-volatile.c
@@ -1,18 +1,53 @@
 // PARAM: --disable ana.race.volatile
 #include <pthread.h>
-#include <stdio.h>
 
-volatile int myglobal;
+volatile int g1;
+
+volatile int a1[1];
+
+struct s {
+  int f0;
+  volatile int f1;
+};
+
+struct s s1;
+volatile struct s s2;
+
+typedef volatile int t_int1;
+
+t_int1 t1;
+
+typedef int t_int0;
+
+volatile t_int0 t0;
+
+volatile int *p0 = &g1;
+int x;
+int * volatile p1 = &x;
+volatile int * volatile p2 = &g1;
 
 void *t_fun(void *arg) {
-  myglobal= 8; //NORACE
+  g1++; // NORACE
+  a1[0]++; // NORACE
+  s1.f1++; // NORACE
+  s2.f0++; // NORACE
+  t1++; // NORACE
+  t0++; // NORACE
+  (*p0)++; // NORACE
+  p1++; // NORACE
+  p2++; // NORACE
+  (*p2)++; // NORACE
+
+  struct s ss = {0};
+  s2 = ss; // NORACE
   return NULL;
 }
 
 int main(void) {
-  pthread_t id;
-  pthread_create(&id, NULL, t_fun, (void*) &myglobal);
-  myglobal = 42; //NORACE
-  pthread_join (id, NULL);
+  pthread_t id, id2;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_create(&id2, NULL, t_fun, NULL);
+  pthread_join(id, NULL);
+  pthread_join(id2, NULL);
   return 0;
 }


### PR DESCRIPTION
Inspired by arrays of atomic variables in https://github.com/goblint/bench/issues/60, this improves the ignored race memory location check. This largely refactors those checks to make them thoroughly consider all of the following:
1. The type of value at every (intermediate) offset on a variable. Previously we only looked at the variable's type but not even the type of the offset (which is different). `typeOffset` wouldn't be complete for this because it only returns the type of the entire offset, so a similar iteration over all offsets is implemented for races.
2. The name of every (intermediate) `typedef`. Previously we only checked the outermost one. `unrollType` wouldn't be complete for this because it skips over all `typedefs`, so a recursive iteration is implemented to check at all levels.
3. Combined with the above two, attributes are checked at all offsets and `typedef`s.