### PR TITLE
Experiment with path- and context-sensitivity for memLeak analysis

### DIFF
--- a/src/analyses/memLeak.ml
+++ b/src/analyses/memLeak.ml
@@ -14,9 +14,10 @@ struct
   let name () = "memLeak"
 
   module D = ToppedVarInfoSet
-  module C = Lattice.Unit
+  module C = D
+  module P = IdentityP (D)
 
-  let context _ _ = ()
+  let context _ d = d
 
   (* HELPER FUNCTIONS *)
   let warn_for_multi_threaded ctx =

--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -227,8 +227,8 @@ let focusOnMemSafetySpecification (spec: Svcomp.Specification.t) =
   | ValidMemcleanup -> (* Enable the memLeak analysis *)
     let memLeakAna = ["memLeak"] in
     if (get_int "ana.malloc.unique_address_count") < 1 then (
-      print_endline "Setting \"ana.malloc.unique_address_count\" to 1";
-      set_int "ana.malloc.unique_address_count" 1;
+      print_endline "Setting \"ana.malloc.unique_address_count\" to 5";
+      set_int "ana.malloc.unique_address_count" 5;
     );
     print_endline @@ "Specification: ValidMemtrack and ValidMemcleanup -> enabling memLeak analysis \"" ^ (String.concat ", " memLeakAna) ^ "\"";
     enableAnalyses memLeakAna

--- a/src/common/util/options.schema.json
+++ b/src/common/util/options.schema.json
@@ -352,7 +352,7 @@
           "description": "List of path-sensitive analyses",
           "type": "array",
           "items": { "type": "string" },
-          "default": [ "mutex", "malloc_null", "uninit", "expsplit","activeSetjmp" ]
+          "default": [ "mutex", "malloc_null", "uninit", "expsplit","activeSetjmp","memLeak" ]
         },
         "ctx_insens": {
           "title": "ana.ctx_insens",


### PR DESCRIPTION
I'll use this issue to document some of the steps towards coming up with a good config for sv-comp.

<details>
  <summary>Machine Config</summary>
  
```
parallel runs:           40
resource limits:
- memory:                3000.0 MB
- time:                  1800 s
- cpu cores:             1
hardware requirements:
- cpu cores:             1
- memory:                3000.0 MB
------------------------------------------------------------

   SYSTEM INFORMATION
host:                    goblint2
os:                      Linux-5.15.0-84-generic-x86_64-with-glibc2.29
cpu:                     Intel Xeon Platinum 8260 CPU @ 2.40GHz
- cores:                 96
- max frequency:         3900.0 MHz
- turbo boost enabled:   True
ram:                     540649.373696 MB
------------------------------------------------------------
```
</details>

**Results without any additional path- & context-sensitivity:**

```
Statistics:           3862 Files
  correct:            1082
    correct true:     1082
    correct false:       0
  incorrect:             0
    incorrect true:      0
    incorrect false:     0
  unknown:            2780
  Score:              2164 (max: 5857)
  ```
  
  **Results with full path- & context-sensitivity:**
  
  ```
Statistics:           3862 Files
  correct:            1104
    correct true:     1104
    correct false:       0
  incorrect:             0
    incorrect true:      0
    incorrect false:     0
  unknown:            2758
  Score:              2208 (max: 5857)
  ```
  
  **Results with full path- & context-sensitivity & unique count of 5:**
  
  ```
  Statistics:           3862 Files
  correct:            1131
    correct true:     1131
    correct false:       0
  incorrect:             0
    incorrect true:      0
    incorrect false:     0
  unknown:            2731
  Score:              2262 (max: 5857)
```

  **Results with full path- & context-sensitivity & unique count of 5 & fix for #1235 :**
 
```
Statistics:           3862 Files
  correct:            1158
    correct true:     1158
    correct false:       0
  incorrect:             0
    incorrect true:      0
    incorrect false:     0
  unknown:            2704
  Score:              2316 (max: 5857)
```