### PR TITLE
Use inlined ARG edges for unambiguous stacked ARG function return

### DIFF
--- a/src/analyses/memLeak.ml
+++ b/src/analyses/memLeak.ml
@@ -14,9 +14,10 @@ struct
   let name () = "memLeak"
 
   module D = ToppedVarInfoSet
-  module C = Lattice.Unit
+  module C = D
+  module P = IdentityP (D)
 
-  let context _ _ = ()
+  let context _ d = d
 
   (* HELPER FUNCTIONS *)
   let warn_for_multi_threaded ctx =

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -141,7 +141,7 @@ struct
   let equal_node_context _ _ = failwith "StackNode: equal_node_context"
 end
 
-module Stack (Cfg:CfgForward) (Arg: S with module Edge = InlineEdge):
+module Stack (Arg: S with module Edge = InlineEdge):
   S with module Node = StackNode (Arg.Node) and module Edge = Arg.Edge =
 struct
   module Node = StackNode (Arg.Node)
@@ -156,7 +156,7 @@ struct
     | n :: stack ->
       let cfgnode = Arg.Node.cfgnode n in
       match cfgnode with
-      | Function _ -> (* TODO: can this be done without Cfg? *)
+      | Function _ -> (* TODO: can this be done without cfgnode? *)
         begin match stack with
           (* | [] -> failwith "StackArg.next: return stack empty" *)
           | [] -> [] (* main return *)

--- a/src/witness/myARG.ml
+++ b/src/witness/myARG.ml
@@ -141,7 +141,7 @@ struct
   let equal_node_context _ _ = failwith "StackNode: equal_node_context"
 end
 
-module Stack (Cfg:CfgForward) (Arg: S):
+module Stack (Cfg:CfgForward) (Arg: S with module Edge = InlineEdge):
   S with module Node = StackNode (Arg.Node) and module Edge = Arg.Edge =
 struct
   module Node = StackNode (Arg.Node)

--- a/src/witness/svcomp.ml
+++ b/src/witness/svcomp.ml
@@ -76,7 +76,7 @@ sig
   val is_sink: Arg.Node.t -> bool
 end
 
-module StackTaskResult (Cfg:MyCFG.CfgForward) (TaskResult: TaskResult) =
+module StackTaskResult (Cfg:MyCFG.CfgForward) (TaskResult: TaskResult with module Arg.Edge = MyARG.InlineEdge) =
 struct
   module Arg = MyARG.Stack (Cfg) (TaskResult.Arg)
 

--- a/src/witness/svcomp.ml
+++ b/src/witness/svcomp.ml
@@ -76,9 +76,9 @@ sig
   val is_sink: Arg.Node.t -> bool
 end
 
-module StackTaskResult (Cfg:MyCFG.CfgForward) (TaskResult: TaskResult with module Arg.Edge = MyARG.InlineEdge) =
+module StackTaskResult (TaskResult: TaskResult with module Arg.Edge = MyARG.InlineEdge) =
 struct
-  module Arg = MyARG.Stack (Cfg) (TaskResult.Arg)
+  module Arg = MyARG.Stack (TaskResult.Arg)
 
   let result = TaskResult.result
 

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -14,7 +14,7 @@ let write_file filename (module Task:Task) (module TaskResult:WitnessTaskResult)
 
   let module TaskResult =
     (val if get_bool "witness.graphml.stack" then
-        (module StackTaskResult (Task.Cfg) (TaskResult) : WitnessTaskResult)
+        (module StackTaskResult (TaskResult) : WitnessTaskResult)
       else
         (module TaskResult)
     )

--- a/tests/regression/56-witness/52-witness-lifter-ps2.c
+++ b/tests/regression/56-witness/52-witness-lifter-ps2.c
@@ -1,0 +1,35 @@
+// PARAM: --enable ana.sv-comp.enabled --enable ana.sv-comp.functions --enable witness.graphml.enabled --set ana.specification 'CHECK( init(main()), LTL(G valid-memtrack) )' --set ana.activated[+] memLeak --set ana.path_sens[+] memLeak --set ana.malloc.unique_address_count 1
+struct _twoIntsStruct {
+   int intOne ;
+   int intTwo ;
+};
+
+typedef struct _twoIntsStruct twoIntsStruct;
+
+void printStructLine(twoIntsStruct const *structTwoIntsStruct)
+{
+  return;
+}
+
+
+int main(int argc, char **argv)
+{
+  twoIntsStruct *data;
+  int tmp_1;
+
+
+  if (tmp_1 != 0) {
+    twoIntsStruct *dataBuffer = malloc(800UL);
+    data = dataBuffer;
+  }
+  else {
+
+    twoIntsStruct *dataBuffer_0 = malloc(800UL);
+    data = dataBuffer_0;
+  }
+
+  printStructLine((twoIntsStruct const *)data);
+  free((void *)data);
+
+  return;
+}

--- a/tests/regression/56-witness/53-witness-lifter-ps3.c
+++ b/tests/regression/56-witness/53-witness-lifter-ps3.c
@@ -1,0 +1,39 @@
+// PARAM: --enable ana.sv-comp.enabled --enable ana.sv-comp.functions --enable witness.graphml.enabled --set ana.specification 'CHECK( init(main()), LTL(G valid-memtrack) )' --set ana.activated[+] memLeak --set ana.path_sens[+] memLeak --set ana.malloc.unique_address_count 1
+struct _twoIntsStruct {
+   int intOne ;
+   int intTwo ;
+};
+
+typedef struct _twoIntsStruct twoIntsStruct;
+
+void printStructLine(twoIntsStruct const *structTwoIntsStruct)
+{
+  return;
+}
+
+twoIntsStruct *foo() {
+  twoIntsStruct *data;
+  int tmp_1;
+
+  if (tmp_1 != 0) {
+    twoIntsStruct *dataBuffer = malloc(800UL);
+    data = dataBuffer;
+  }
+  else {
+
+    twoIntsStruct *dataBuffer_0 = malloc(800UL);
+    data = dataBuffer_0;
+  }
+  return data;
+}
+
+int main(int argc, char **argv)
+{
+  twoIntsStruct *data;
+  data = foo();
+
+  printStructLine((twoIntsStruct const *)data);
+  free((void *)data);
+
+  return;
+}


### PR DESCRIPTION
Closes #1235.

The ambiguity is fixed by using the inlined ARG edges added in #1001.