### PR TITLE
Add support for YAML witness entry type `invariant_set`

### DIFF
--- a/src/analyses/unassumeAnalysis.ml
+++ b/src/analyses/unassumeAnalysis.ml
@@ -200,6 +200,46 @@ struct
           M.warn ~category:Witness ~loc:msgLoc "couldn't locate invariant: %s" inv
       in
 
+      let unassume_invariant_set (invariant_set: YamlWitnessType.InvariantSet.t) =
+
+        let unassume_location_invariant (location_invariant: YamlWitnessType.InvariantSet.LocationInvariant.t) =
+          let loc = loc_of_location location_invariant.location in
+          let inv = location_invariant.value in
+          let msgLoc: M.Location.t = CilLocation loc in
+
+          match Locator.find_opt locator loc with
+          | Some nodes ->
+            unassume_nodes_invariant ~loc ~nodes inv
+          | None ->
+            M.warn ~category:Witness ~loc:msgLoc "couldn't locate invariant: %s" inv
+        in
+
+        let unassume_loop_invariant (loop_invariant: YamlWitnessType.InvariantSet.LoopInvariant.t) =
+          let loc = loc_of_location loop_invariant.location in
+          let inv = loop_invariant.value in
+          let msgLoc: M.Location.t = CilLocation loc in
+
+          match Locator.find_opt loop_locator loc with
+          | Some nodes ->
+            unassume_nodes_invariant ~loc ~nodes inv
+          | None ->
+            M.warn ~category:Witness ~loc:msgLoc "couldn't locate invariant: %s" inv
+        in
+
+        let validate_invariant (invariant: YamlWitnessType.InvariantSet.Invariant.t) =
+          let target_type = YamlWitnessType.InvariantSet.InvariantType.invariant_type invariant.invariant_type in
+          match YamlWitness.invariant_type_enabled target_type, invariant.invariant_type with
+          | true, LocationInvariant x ->
+            unassume_location_invariant x
+          | true, LoopInvariant x ->
+            unassume_loop_invariant x
+          | false, (LocationInvariant _ | LoopInvariant _) ->
+            M.info_noloc ~category:Witness "disabled invariant of type %s" target_type
+        in
+
+        List.iter validate_invariant invariant_set.content
+      in
+
       match YamlWitness.entry_type_enabled target_type, entry.entry_type with
       | true, LocationInvariant x ->
         unassume_location_invariant x
@@ -207,7 +247,9 @@ struct
         unassume_loop_invariant x
       | true, PreconditionLoopInvariant x ->
         unassume_precondition_loop_invariant x
-      | false, (LocationInvariant _ | LoopInvariant _ | PreconditionLoopInvariant _) ->
+      | true, InvariantSet x ->
+        unassume_invariant_set x
+      | false, (LocationInvariant _ | LoopInvariant _ | PreconditionLoopInvariant _ | InvariantSet _) ->
         M.info_noloc ~category:Witness "disabled entry of type %s" target_type
       | _ ->
         M.info_noloc ~category:Witness "cannot unassume entry of type %s" target_type

--- a/src/common/util/options.schema.json
+++ b/src/common/util/options.schema.json
@@ -2430,7 +2430,8 @@
                   "flow_insensitive_invariant",
                   "precondition_loop_invariant",
                   "loop_invariant_certificate",
-                  "precondition_loop_invariant_certificate"
+                  "precondition_loop_invariant_certificate",
+                  "invariant_set"
                 ]
               },
               "default": [
@@ -2438,7 +2439,24 @@
                 "loop_invariant",
                 "flow_insensitive_invariant",
                 "loop_invariant_certificate",
-                "precondition_loop_invariant_certificate"
+                "precondition_loop_invariant_certificate",
+                "invariant_set"
+              ]
+            },
+            "invariant-types": {
+              "title": "witness.yaml.invariant-types",
+              "description": "YAML witness invariant types to output/input.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "location_invariant",
+                  "loop_invariant"
+                ]
+              },
+              "default": [
+                "location_invariant",
+                "loop_invariant"
               ]
             },
             "path": {

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -471,6 +471,7 @@ struct
             invariants
         in
 
+        let invariants = List.rev invariants in
         let entry = Entry.invariant_set ~task ~invariants in
         entry :: entries
       )

--- a/src/witness/yamlWitnessType.ml
+++ b/src/witness/yamlWitnessType.ml
@@ -332,7 +332,7 @@ struct
 
   let of_yaml y =
     let open GobYaml in
-    let+ content = y |> list >>= list_map Invariant.of_yaml in
+    let+ content = y |> find "content" >>= list >>= list_map Invariant.of_yaml in
     {content}
 end
 

--- a/src/witness/yamlWitnessType.ml
+++ b/src/witness/yamlWitnessType.ml
@@ -242,6 +242,100 @@ struct
     {location; loop_invariant; precondition}
 end
 
+module InvariantSet =
+struct
+  module LoopInvariant =
+  struct
+    type t = {
+      location: Location.t;
+      value: string;
+      format: string;
+    }
+
+    let invariant_type = "loop_invariant"
+
+    let to_yaml' {location; value; format} =
+      [
+        ("location", Location.to_yaml location);
+        ("value", `String value);
+        ("format", `String format);
+      ]
+
+    let of_yaml y =
+      let open GobYaml in
+      let+ location = y |> find "location" >>= Location.of_yaml
+      and+ value = y |> find "value" >>= to_string
+      and+ format = y |> find "format" >>= to_string in
+      {location; value; format}
+  end
+
+  module LocationInvariant =
+  struct
+    include LoopInvariant
+
+    let invariant_type = "location_invariant"
+  end
+
+  (* TODO: could maybe use GADT, but adds ugly existential layer to entry type pattern matching *)
+  module InvariantType =
+  struct
+    type t =
+      | LocationInvariant of LocationInvariant.t
+      | LoopInvariant of LoopInvariant.t
+
+    let invariant_type = function
+      | LocationInvariant _ -> LocationInvariant.invariant_type
+      | LoopInvariant _ -> LoopInvariant.invariant_type
+
+    let to_yaml' = function
+      | LocationInvariant x -> LocationInvariant.to_yaml' x
+      | LoopInvariant x -> LoopInvariant.to_yaml' x
+
+    let of_yaml y =
+      let open GobYaml in
+      let* invariant_type = y |> find "type" >>= to_string in
+      if invariant_type = LocationInvariant.invariant_type then
+        let+ x = y |> LocationInvariant.of_yaml in
+        LocationInvariant x
+      else if invariant_type = LoopInvariant.invariant_type then
+        let+ x = y |> LoopInvariant.of_yaml in
+        LoopInvariant x
+      else
+        Error (`Msg "type")
+  end
+
+  module Invariant =
+  struct
+    type t = {
+      invariant_type: InvariantType.t;
+    }
+
+    let to_yaml {invariant_type} =
+      `O ([
+          ("type", `String (InvariantType.invariant_type invariant_type));
+        ] @ InvariantType.to_yaml' invariant_type)
+
+    let of_yaml y =
+      let open GobYaml in
+      let+ invariant_type = y |> InvariantType.of_yaml in
+      {invariant_type}
+  end
+
+  type t = {
+    content: Invariant.t list;
+  }
+
+  let entry_type = "invariant_set"
+
+  let to_yaml' {content} =
+    [("content", `A (List.map Invariant.to_yaml content))]
+
+  let of_yaml y =
+    let open GobYaml in
+    let+ content = y |> list >>= list_map Invariant.of_yaml in
+    {content}
+end
+
 module Target =
 struct
   type t = {
@@ -326,6 +420,7 @@ struct
     | PreconditionLoopInvariant of PreconditionLoopInvariant.t
     | LoopInvariantCertificate of LoopInvariantCertificate.t
     | PreconditionLoopInvariantCertificate of PreconditionLoopInvariantCertificate.t
+    | InvariantSet of InvariantSet.t
 
   let entry_type = function
     | LocationInvariant _ -> LocationInvariant.entry_type
@@ -334,6 +429,7 @@ struct
     | PreconditionLoopInvariant _ -> PreconditionLoopInvariant.entry_type
     | LoopInvariantCertificate _ -> LoopInvariantCertificate.entry_type
     | PreconditionLoopInvariantCertificate _ -> PreconditionLoopInvariantCertificate.entry_type
+    | InvariantSet _ -> InvariantSet.entry_type
 
   let to_yaml' = function
     | LocationInvariant x -> LocationInvariant.to_yaml' x
@@ -342,6 +438,7 @@ struct
     | PreconditionLoopInvariant x -> PreconditionLoopInvariant.to_yaml' x
     | LoopInvariantCertificate x -> LoopInvariantCertificate.to_yaml' x
     | PreconditionLoopInvariantCertificate x -> PreconditionLoopInvariantCertificate.to_yaml' x
+    | InvariantSet x -> InvariantSet.to_yaml' x
 
   let of_yaml y =
     let open GobYaml in
@@ -364,6 +461,9 @@ struct
     else if entry_type = PreconditionLoopInvariantCertificate.entry_type then
       let+ x = y |> PreconditionLoopInvariantCertificate.of_yaml in
       PreconditionLoopInvariantCertificate x
+    else if entry_type = InvariantSet.entry_type then
+      let+ x = y |> InvariantSet.of_yaml in
+      InvariantSet x
     else
       Error (`Msg "entry_type")
 end


### PR DESCRIPTION
Closes #1238.

This is a quick copy-paste implementation that preserves the support for top-level `location_invariant` and `loop_invariant` entries. I want to remain backward-compatible for now because we have lots of YAML witnesses in regression tests and in Goblint's bench repo (both for unassume and some traces-rel stuff at one point). For SV-COMP, all other entry types can simply be disabled.