### PR TITLE
Fix no-overflow cram test expected output

### DIFF
--- a/tests/regression/29-svcomp/32-no-ov.t
+++ b/tests/regression/29-svcomp/32-no-ov.t
@@ -1,7 +1,7 @@
   $ goblint --enable ana.int.interval --enable ana.sv-comp.enabled --enable ana.sv-comp.functions --set ana.specification "CHECK( init(main()), LTL(G ! overflow) )"  32-no-ov.c
   SV-COMP specification: CHECK( init(main()), LTL(G ! overflow) )
-  [Warning][Integer > Overflow][CWE-190][CWE-191] Unsigned integer overflow and underflow (32-no-ov.c:5:6-5:159)
-  [Warning][Integer > Overflow][CWE-190][CWE-191] Unsigned integer overflow and underflow (32-no-ov.c:5:6-5:159)
+  [Warning][Integer > Overflow][CWE-190] Unsigned integer overflow (32-no-ov.c:5:6-5:159)
+  [Warning][Integer > Overflow][CWE-190] Unsigned integer overflow (32-no-ov.c:5:6-5:159)
   [Warning][Integer > Overflow][CWE-191] Unsigned integer underflow (32-no-ov.c:5:6-5:159)
   [Warning][Integer > Overflow][CWE-190] Signed integer overflow (32-no-ov.c:5:6-5:159)
   [Info][Deadcode] Logical lines of code (LLoC) summary:


### PR DESCRIPTION
Fixes the expected output of a test that for sv-comp property no-overflow.