### PR TITLE
Fix `BlobSize` for calloc

### DIFF
--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -69,17 +69,17 @@ struct
     in
     host_contains_a_ptr host || offset_contains_a_ptr offset
 
-  let points_to_heap_only ctx ptr =
+  let points_to_alloc_only ctx ptr =
     match ctx.ask (Queries.MayPointTo ptr) with
     | a when not (Queries.AD.is_top a)->
       Queries.AD.for_all (function
-          | Addr (v, o) -> ctx.ask (Queries.IsHeapVar v)
+          | Addr (v, o) -> ctx.ask (Queries.IsAllocVar v)
           | _ -> false
         ) a
     | _ -> false
 
   let get_size_of_ptr_target ctx ptr =
-    if points_to_heap_only ctx ptr then
+    if points_to_alloc_only ctx ptr then
       (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
       ctx.ask (Queries.BlobSize {exp = ptr; base_address = true})
     else

--- a/tests/regression/74-invalid_deref/30-calloc.c
+++ b/tests/regression/74-invalid_deref/30-calloc.c
@@ -1,0 +1,9 @@
+//PARAM: --set ana.activated[+] useAfterFree --set ana.activated[+] threadJoins --set ana.activated[+] memOutOfBounds --enable ana.int.interval --set ana.base.arrays.domain partitioned
+#include <pthread.h>
+#include <goblint.h>
+
+int main(int argc, char **argv)
+{
+  int* ptrCalloc = calloc(100UL,8UL);
+  *ptrCalloc = 8; //NOWARN
+}


### PR DESCRIPTION
This fixes the calls to `BlobSize` for `calloc` and should yield some additional tasks for sv-comp.