### PR TITLE
Fix ordering of queries by deduplicating indices.

### DIFF
--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -331,8 +331,8 @@ struct
     | Any (MustTermLoop _) -> 53
     | Any MustTermAllLoops -> 54
     | Any IsEverMultiThreaded -> 55
-    | Any (TmpSpecial _) -> 53
-    | Any (IsAllocVar _) -> 54
+    | Any (TmpSpecial _) -> 56
+    | Any (IsAllocVar _) -> 57
 
   let rec compare a b =
     let r = Stdlib.compare (order a) (order b) in


### PR DESCRIPTION
Due to merging, there were some types of queries had the same integer index. This PR deduplicates the indices of these query types. 