### PR TITLE
Fix `Not_found` exception in autotuner with congruences and termination.

### DIFF
--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -99,9 +99,9 @@ let rec setCongruenceRecursive fd depth neigbourFunction =
     FunctionSet.iter
       (fun vinfo ->
          print_endline ("    " ^ vinfo.vname);
-         match (Cilfacade.find_varinfo_fundec vinfo) with
+         match Cilfacade.find_varinfo_fundec vinfo with
          | fd -> setCongruenceRecursive fd (depth -1) neigbourFunction
-         | exception Not_found -> () (* Happens for __goblint_bounded*)
+         | exception Not_found -> () (* Happens for __goblint_bounded *)
       )
       (FunctionSet.filter (*for extern and builtin functions there is no function definition in CIL*)
          (fun x -> not (isExtern x.vstorage || BatString.starts_with x.vname "__builtin"))

--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -99,7 +99,9 @@ let rec setCongruenceRecursive fd depth neigbourFunction =
     FunctionSet.iter
       (fun vinfo ->
          print_endline ("    " ^ vinfo.vname);
-         setCongruenceRecursive (Cilfacade.find_varinfo_fundec vinfo) (depth -1) neigbourFunction
+         match (Cilfacade.find_varinfo_fundec vinfo) with
+         | fd -> setCongruenceRecursive fd (depth -1) neigbourFunction
+         | exception Not_found -> () (* Happens for __goblint_bounded*)
       )
       (FunctionSet.filter (*for extern and builtin functions there is no function definition in CIL*)
          (fun x -> not (isExtern x.vstorage || BatString.starts_with x.vname "__builtin"))

--- a/tests/regression/78-termination/51-modulo.c
+++ b/tests/regression/78-termination/51-modulo.c
@@ -1,0 +1,14 @@
+// SKIP TERM PARAM: --enable ana.autotune.enabled --enable ana.sv-comp.functions --enable ana.sv-comp.enabled  --set ana.autotune.activated "['congruence']" --set ana.specification "CHECK( init(main()), LTL(F end) )"
+
+// This task previously crashed due to the autotuner
+int main() {
+	int a;
+    int odd, count = 0;
+    while(a > 1) {
+      odd = a % 2;
+      if(!odd) a = a / 2;
+      else a = a - 1;
+      count++;
+    }
+    return count;
+}


### PR DESCRIPTION
Previously, there a `Not_found` exception was raised by the autotuner when it tried to activate the `congruence` domain for the `__goblint_bounded` function used in the termination analysis, as the `fundec` for this function could not be found. 

This PR fixes this, by catching the exception, and not trying to enable the `congruence` domain for functions for which there are no declarations.