### PR TITLE
Generalize and clean up `abs` invariant in base analysis

### DIFF
--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -709,35 +709,31 @@ struct
                 | _ -> Int c
               in
               (* handle special calls *)
-              begin match t with
-                | TInt (ik, _) ->
-                  begin match x with
-                    | ((Var v), offs) ->
-                      if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty (ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)));
-                      begin match ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) with
-                        | `Lifted (Abs (_ik, xInt)) ->
-                          inv_exp (Int (ID.join c (ID.neg c))) xInt st (* TODO: deduplicate *)
-                        | tmpSpecial ->
-                          let tv_opt = ID.to_bool c in (* TODO: simplify *)
-                          begin match tv_opt with
-                            | Some tv ->
-                              begin match tmpSpecial with
-                                | `Lifted (Isfinite xFloat) when tv -> inv_exp (Float (FD.finite (unroll_fk_of_exp xFloat))) xFloat st
-                                | `Lifted (Isnan xFloat) when tv -> inv_exp (Float (FD.nan_of (unroll_fk_of_exp xFloat))) xFloat st
-                                (* should be correct according to C99 standard*)
-                                | `Lifted (Isgreater (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Gt, xFloat, yFloat, (typeOf xFloat))) st
-                                | `Lifted (Isgreaterequal (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Ge, xFloat, yFloat, (typeOf xFloat))) st
-                                | `Lifted (Isless (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Lt, xFloat, yFloat, (typeOf xFloat))) st
-                                | `Lifted (Islessequal (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Le, xFloat, yFloat, (typeOf xFloat))) st
-                                | `Lifted (Islessgreater (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (LOr, (BinOp (Lt, xFloat, yFloat, (typeOf xFloat))), (BinOp (Gt, xFloat, yFloat, (typeOf xFloat))), (TInt (IBool, [])))) st
-                                | _ -> update_lval c x c' ID.pretty
-                              end
-                            | None -> update_lval c x c' ID.pretty
+              begin match x, t with
+                | (Var v, offs), TInt (ik, _) ->
+                  if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty (ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)));
+                  begin match ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) with
+                    | `Lifted (Abs (_ik, xInt)) ->
+                      inv_exp (Int (ID.join c (ID.neg c))) xInt st (* TODO: deduplicate *)
+                    | tmpSpecial ->
+                      let tv_opt = ID.to_bool c in (* TODO: simplify *)
+                      begin match tv_opt with
+                        | Some tv ->
+                          begin match tmpSpecial with
+                            | `Lifted (Isfinite xFloat) when tv -> inv_exp (Float (FD.finite (unroll_fk_of_exp xFloat))) xFloat st
+                            | `Lifted (Isnan xFloat) when tv -> inv_exp (Float (FD.nan_of (unroll_fk_of_exp xFloat))) xFloat st
+                            (* should be correct according to C99 standard*)
+                            | `Lifted (Isgreater (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Gt, xFloat, yFloat, (typeOf xFloat))) st
+                            | `Lifted (Isgreaterequal (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Ge, xFloat, yFloat, (typeOf xFloat))) st
+                            | `Lifted (Isless (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Lt, xFloat, yFloat, (typeOf xFloat))) st
+                            | `Lifted (Islessequal (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Le, xFloat, yFloat, (typeOf xFloat))) st
+                            | `Lifted (Islessgreater (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (LOr, (BinOp (Lt, xFloat, yFloat, (typeOf xFloat))), (BinOp (Gt, xFloat, yFloat, (typeOf xFloat))), (TInt (IBool, [])))) st
+                            | _ -> update_lval c x c' ID.pretty
                           end
+                        | None -> update_lval c x c' ID.pretty
                       end
-                    | _ -> update_lval c x c' ID.pretty
                   end
-                | _ -> update_lval c x c' ID.pretty
+                | _, _ -> update_lval c x c' ID.pretty
               end
             | Float c ->
               let c' = match t with
@@ -749,22 +745,18 @@ struct
                 | _ -> Float c
               in
               (* handle special calls *)
-              begin match t with
-                | TFloat (fk, _) ->
-                  begin match x with
-                    | ((Var v), offs) ->
-                      if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty (ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)));
-                      begin match ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) with
-                        | `Lifted (Ceil (ret_fk, xFloat)) -> inv_exp (Float (FD.inv_ceil (FD.cast_to ret_fk c))) xFloat st
-                        | `Lifted (Floor (ret_fk, xFloat)) -> inv_exp (Float (FD.inv_floor (FD.cast_to ret_fk c))) xFloat st
-                        | `Lifted (Fabs (ret_fk, xFloat)) ->
-                          let inv = FD.inv_fabs (FD.cast_to ret_fk c) in
-                          if FD.is_bot inv then
-                            raise Analyses.Deadcode
-                          else
-                            inv_exp (Float inv) xFloat st
-                        | _ -> update_lval c x c' FD.pretty
-                      end
+              begin match x, t with
+                | (Var v, offs), TFloat (fk, _) ->
+                  if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty (ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)));
+                  begin match ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) with
+                    | `Lifted (Ceil (ret_fk, xFloat)) -> inv_exp (Float (FD.inv_ceil (FD.cast_to ret_fk c))) xFloat st
+                    | `Lifted (Floor (ret_fk, xFloat)) -> inv_exp (Float (FD.inv_floor (FD.cast_to ret_fk c))) xFloat st
+                    | `Lifted (Fabs (ret_fk, xFloat)) ->
+                      let inv = FD.inv_fabs (FD.cast_to ret_fk c) in
+                      if FD.is_bot inv then
+                        raise Analyses.Deadcode
+                      else
+                        inv_exp (Float inv) xFloat st
                     | _ -> update_lval c x c' FD.pretty
                   end
                 | _ -> update_lval c x c' FD.pretty

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -711,8 +711,9 @@ struct
               (* handle special calls *)
               begin match x, t with
                 | (Var v, offs), TInt (ik, _) ->
-                  if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty (ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)));
-                  begin match ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) with
+                  let tmpSpecial = ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) in
+                  if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty tmpSpecial;
+                  begin match tmpSpecial with
                     | `Lifted (Abs (_ik, xInt)) ->
                       inv_exp (Int (ID.join c (ID.neg c))) xInt st (* TODO: deduplicate *)
                     | tmpSpecial ->
@@ -747,8 +748,9 @@ struct
               (* handle special calls *)
               begin match x, t with
                 | (Var v, offs), TFloat (fk, _) ->
-                  if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty (ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)));
-                  begin match ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) with
+                  let tmpSpecial = ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) in
+                  if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty tmpSpecial;
+                  begin match tmpSpecial with
                     | `Lifted (Ceil (ret_fk, xFloat)) -> inv_exp (Float (FD.inv_ceil (FD.cast_to ret_fk c))) xFloat st
                     | `Lifted (Floor (ret_fk, xFloat)) -> inv_exp (Float (FD.inv_floor (FD.cast_to ret_fk c))) xFloat st
                     | `Lifted (Fabs (ret_fk, xFloat)) ->

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -714,27 +714,25 @@ struct
                   begin match x with
                     | ((Var v), offs) ->
                       if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty (ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)));
-                      let tv_opt = ID.to_bool c in
-                      begin match tv_opt with
-                        | Some tv ->
-                          begin match ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) with
-                            | `Lifted (Isfinite xFloat) when tv -> inv_exp (Float (FD.finite (unroll_fk_of_exp xFloat))) xFloat st
-                            | `Lifted (Isnan xFloat) when tv -> inv_exp (Float (FD.nan_of (unroll_fk_of_exp xFloat))) xFloat st
-                            (* should be correct according to C99 standard*)
-                            | `Lifted (Isgreater (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Gt, xFloat, yFloat, (typeOf xFloat))) st
-                            | `Lifted (Isgreaterequal (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Ge, xFloat, yFloat, (typeOf xFloat))) st
-                            | `Lifted (Isless (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Lt, xFloat, yFloat, (typeOf xFloat))) st
-                            | `Lifted (Islessequal (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Le, xFloat, yFloat, (typeOf xFloat))) st
-                            | `Lifted (Islessgreater (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (LOr, (BinOp (Lt, xFloat, yFloat, (typeOf xFloat))), (BinOp (Gt, xFloat, yFloat, (typeOf xFloat))), (TInt (IBool, [])))) st
-                            | `Lifted (Abs (_ik, xInt)) ->
-                              inv_exp (Int (ID.join c (ID.neg c))) xInt st (* TODO: deduplicate *)
-                            | _ -> update_lval c x c' ID.pretty
-                          end
-                        | None ->
-                          begin match ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) with
-                            | `Lifted (Abs (_ik, xInt)) ->
-                              inv_exp (Int (ID.join c (ID.neg c))) xInt st (* TODO: deduplicate *)
-                            | _ -> update_lval c x c' ID.pretty
+                      begin match ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) with
+                        | `Lifted (Abs (_ik, xInt)) ->
+                          inv_exp (Int (ID.join c (ID.neg c))) xInt st (* TODO: deduplicate *)
+                        | tmpSpecial ->
+                          let tv_opt = ID.to_bool c in (* TODO: simplify *)
+                          begin match tv_opt with
+                            | Some tv ->
+                              begin match tmpSpecial with
+                                | `Lifted (Isfinite xFloat) when tv -> inv_exp (Float (FD.finite (unroll_fk_of_exp xFloat))) xFloat st
+                                | `Lifted (Isnan xFloat) when tv -> inv_exp (Float (FD.nan_of (unroll_fk_of_exp xFloat))) xFloat st
+                                (* should be correct according to C99 standard*)
+                                | `Lifted (Isgreater (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Gt, xFloat, yFloat, (typeOf xFloat))) st
+                                | `Lifted (Isgreaterequal (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Ge, xFloat, yFloat, (typeOf xFloat))) st
+                                | `Lifted (Isless (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Lt, xFloat, yFloat, (typeOf xFloat))) st
+                                | `Lifted (Islessequal (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (Le, xFloat, yFloat, (typeOf xFloat))) st
+                                | `Lifted (Islessgreater (xFloat, yFloat)) -> inv_exp (Int (ID.of_bool ik tv)) (BinOp (LOr, (BinOp (Lt, xFloat, yFloat, (typeOf xFloat))), (BinOp (Gt, xFloat, yFloat, (typeOf xFloat))), (TInt (IBool, [])))) st
+                                | _ -> update_lval c x c' ID.pretty
+                              end
+                            | None -> update_lval c x c' ID.pretty
                           end
                       end
                     | _ -> update_lval c x c' ID.pretty

--- a/tests/regression/39-signed-overflows/06-abs.c
+++ b/tests/regression/39-signed-overflows/06-abs.c
@@ -17,6 +17,13 @@ int main() {
             __goblint_check(-100 <= data);
             int result = data * data; //NOWARN
         }
+
+        if(abs(data) - 1 <= 99)
+        {
+            __goblint_check(data <= 100);
+            __goblint_check(-100 <= data);
+            int result = data * data; //NOWARN
+        }
     }
     return 8;
 }


### PR DESCRIPTION
This generalizes the `abs` handling from #1253 and #1254 to happen at any level of the expression, just like other tmpSpecials. This change is in the first commit.

The rest are some refactoring of the surrounding code because the indentation is already 14 tabs deep. I wanted to clean it up more, but the implementation of `__builtin_isgreater`, etc is implemented hackily to convert `Not{0}` to `1` to `1.0` to represent it as the expected value for float domains.