### PR TITLE
Generalize mutex-meet-tid privatization to arbitrary digest

### DIFF
--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -1198,24 +1198,17 @@ end
 
 let priv_module: (module S) Lazy.t =
   lazy (
-    let module TIDDigest = ThreadDigest (
-      struct
-        let exclude_not_started () = GobConfig.get_bool "ana.relation.priv.not-started"
-        let exclude_must_joined () = GobConfig.get_bool "ana.relation.priv.must-joined"
-      end
-      )
-    in
     let module Priv: S =
       (val match get_string "ana.relation.privatization" with
          | "top" -> (module Top : S)
          | "protection" -> (module ProtectionBasedPriv (struct let path_sensitive = false end))
          | "protection-path" -> (module ProtectionBasedPriv (struct let path_sensitive = true end))
          | "mutex-meet" -> (module PerMutexMeetPriv)
-         | "mutex-meet-tid" -> (module PerMutexMeetPrivTID (TIDDigest) (NoCluster))
-         | "mutex-meet-tid-cluster12" -> (module PerMutexMeetPrivTID (TIDDigest) (DownwardClosedCluster (Clustering12)))
-         | "mutex-meet-tid-cluster2" -> (module PerMutexMeetPrivTID (TIDDigest) (ArbitraryCluster (Clustering2)))
-         | "mutex-meet-tid-cluster-max" -> (module PerMutexMeetPrivTID (TIDDigest) (ArbitraryCluster (ClusteringMax)))
-         | "mutex-meet-tid-cluster-power" -> (module PerMutexMeetPrivTID (TIDDigest) (DownwardClosedCluster (ClusteringPower)))
+         | "mutex-meet-tid" -> (module PerMutexMeetPrivTID (ThreadDigest) (NoCluster))
+         | "mutex-meet-tid-cluster12" -> (module PerMutexMeetPrivTID (ThreadDigest) (DownwardClosedCluster (Clustering12)))
+         | "mutex-meet-tid-cluster2" -> (module PerMutexMeetPrivTID (ThreadDigest) (ArbitraryCluster (Clustering2)))
+         | "mutex-meet-tid-cluster-max" -> (module PerMutexMeetPrivTID (ThreadDigest) (ArbitraryCluster (ClusteringMax)))
+         | "mutex-meet-tid-cluster-power" -> (module PerMutexMeetPrivTID (ThreadDigest) (DownwardClosedCluster (ClusteringPower)))
          | _ -> failwith "ana.relation.privatization: illegal value"
       )
     in

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -864,7 +864,7 @@ struct
   let get_relevant_writes (ask:Q.ask) m v =
     let current = Digest.current ask in
     GMutex.fold (fun k v acc ->
-        if Digest.accounted_for ask ~current ~other:k then
+        if not (Digest.accounted_for ask ~current ~other:k) then
           LRD.join acc (Cluster.keep_only_protected_globals ask m v)
         else
           acc

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -864,7 +864,7 @@ struct
   let get_relevant_writes (ask:Q.ask) m v =
     let current = Digest.current ask in
     GMutex.fold (fun k v acc ->
-        if Digest.compatible ask current k then
+        if Digest.accounted_for ask ~current ~other:k then
           LRD.join acc (Cluster.keep_only_protected_globals ask m v)
         else
           acc

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -425,7 +425,7 @@ struct
     let current = Digest.current ask in
     let is_in_Gm x _ = is_protected_by ~protection:Weak ask m x in
     GMutex.fold (fun k v acc ->
-        if Digest.compatible ask current k then
+        if Digest.accounted_for ask ~current ~other:k then
           CPA.join acc (CPA.filter is_in_Gm v)
         else
           acc

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -1786,19 +1786,12 @@ end
 
 let priv_module: (module S) Lazy.t =
   lazy (
-    let module TIDDigest = ThreadDigest (
-      struct
-        let exclude_not_started () = GobConfig.get_bool "ana.relation.priv.not-started"
-        let exclude_must_joined () = GobConfig.get_bool "ana.relation.priv.must-joined"
-      end
-      )
-    in
     let module Priv: S =
       (val match get_string "ana.base.privatization" with
         | "none" -> (module NonePriv: S)
         | "mutex-oplus" -> (module PerMutexOplusPriv)
         | "mutex-meet" -> (module PerMutexMeetPriv)
-        | "mutex-meet-tid" -> (module PerMutexMeetTIDPriv (TIDDigest))
+        | "mutex-meet-tid" -> (module PerMutexMeetTIDPriv (ThreadDigest))
         | "protection" -> (module ProtectionBasedPriv (struct let check_read_unprotected = false end))
         | "protection-read" -> (module ProtectionBasedPriv (struct let check_read_unprotected = true end))
         | "mine" -> (module MinePriv)

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -425,7 +425,7 @@ struct
     let current = Digest.current ask in
     let is_in_Gm x _ = is_protected_by ~protection:Weak ask m x in
     GMutex.fold (fun k v acc ->
-        if Digest.accounted_for ask ~current ~other:k then
+        if not (Digest.accounted_for ask ~current ~other:k) then
           CPA.join acc (CPA.filter is_in_Gm v)
         else
           acc

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -391,14 +391,11 @@ struct
       st
 end
 
-module PerMutexMeetTIDPriv: S =
+module PerMutexMeetTIDPriv (Digest: Digest): S =
 struct
   open Queries.Protection
   include PerMutexMeetPrivBase
-  include PerMutexTidCommon(struct
-      let exclude_not_started () = GobConfig.get_bool "ana.base.priv.not-started"
-      let exclude_must_joined () = GobConfig.get_bool "ana.base.priv.must-joined"
-    end)(CPA)
+  include PerMutexTidCommon (Digest) (CPA)
 
   let iter_sys_vars getg vq vf =
     match vq with
@@ -425,11 +422,10 @@ struct
     r
 
   let get_relevant_writes (ask:Q.ask) m v =
-    let current = ThreadId.get_current ask in
-    let must_joined = ask.f Queries.MustJoinedThreads in
+    let current = Digest.current ask in
     let is_in_Gm x _ = is_protected_by ~protection:Weak ask m x in
     GMutex.fold (fun k v acc ->
-        if compatible ask current must_joined k then
+        if Digest.compatible ask current k then
           CPA.join acc (CPA.filter is_in_Gm v)
         else
           acc
@@ -474,8 +470,8 @@ struct
         CPA.add x v st.cpa
     in
     if M.tracing then M.tracel "priv" "WRITE GLOBAL SIDE %a = %a\n" CilType.Varinfo.pretty x VD.pretty v;
-    let tid = ThreadId.get_current ask in
-    let sidev = GMutex.singleton tid (CPA.singleton x v) in
+    let digest = Digest.current ask in
+    let sidev = GMutex.singleton digest (CPA.singleton x v) in
     let l' = L.add lm (CPA.singleton x v) l in
     let is_recovered_st = ask.f (Queries.MustBeSingleThreaded {since_start = false}) && not @@ ask.f (Queries.MustBeSingleThreaded {since_start = true}) in
     let l' = if is_recovered_st then
@@ -517,8 +513,8 @@ struct
       {st with cpa = cpa'; priv = (w',lmust,l)}
     else
       let is_in_Gm x _ = is_protected_by ~protection:Weak ask m x in
-      let tid = ThreadId.get_current ask in
-      let sidev = GMutex.singleton tid (CPA.filter is_in_Gm st.cpa) in
+      let digest = Digest.current ask in
+      let sidev = GMutex.singleton digest (CPA.filter is_in_Gm st.cpa) in
       sideg (V.mutex m) (G.create_mutex sidev);
       let lm = LLock.mutex m in
       let l' = L.add lm (CPA.filter is_in_Gm st.cpa) l in
@@ -568,13 +564,13 @@ struct
 
   let escape ask getg sideg (st: BaseComponents (D).t) escaped =
     let escaped_cpa = CPA.filter (fun x _ -> EscapeDomain.EscapedVars.mem x escaped) st.cpa in
-    let tid = ThreadId.get_current ask in
-    let sidev = GMutex.singleton tid escaped_cpa in
+    let digest = Digest.current ask in
+    let sidev = GMutex.singleton digest escaped_cpa in
     sideg V.mutex_inits (G.create_mutex sidev);
     let cpa' = CPA.fold (fun x v acc ->
         if EscapeDomain.EscapedVars.mem x escaped (* && is_unprotected ask x *) then (
           if M.tracing then M.tracel "priv" "ESCAPE SIDE %a = %a\n" CilType.Varinfo.pretty x VD.pretty v;
-          let sidev = GMutex.singleton tid (CPA.singleton x v) in
+          let sidev = GMutex.singleton digest (CPA.singleton x v) in
           sideg (V.global x) (G.create_global sidev);
           CPA.remove x acc
         )
@@ -587,8 +583,8 @@ struct
   let enter_multithreaded ask getg sideg (st: BaseComponents (D).t) =
     let cpa = st.cpa in
     let cpa_side = CPA.filter (fun x _ -> is_global ask x) cpa in
-    let tid = ThreadId.get_current ask in
-    let sidev = GMutex.singleton tid cpa_side in
+    let digest = Digest.current ask in
+    let sidev = GMutex.singleton digest cpa_side in
     sideg V.mutex_inits (G.create_mutex sidev);
     (* Introduction into local state not needed, will be read via initializer *)
     (* Also no side-effect to mutex globals needed, the value here will either by read via the initializer, *)
@@ -1790,12 +1786,19 @@ end
 
 let priv_module: (module S) Lazy.t =
   lazy (
+    let module TIDDigest = ThreadDigest (
+      struct
+        let exclude_not_started () = GobConfig.get_bool "ana.relation.priv.not-started"
+        let exclude_must_joined () = GobConfig.get_bool "ana.relation.priv.must-joined"
+      end
+      )
+    in
     let module Priv: S =
       (val match get_string "ana.base.privatization" with
         | "none" -> (module NonePriv: S)
         | "mutex-oplus" -> (module PerMutexOplusPriv)
         | "mutex-meet" -> (module PerMutexMeetPriv)
-        | "mutex-meet-tid" -> (module PerMutexMeetTIDPriv)
+        | "mutex-meet-tid" -> (module PerMutexMeetTIDPriv (TIDDigest))
         | "protection" -> (module ProtectionBasedPriv (struct let check_read_unprotected = false end))
         | "protection-read" -> (module ProtectionBasedPriv (struct let check_read_unprotected = true end))
         | "mine" -> (module MinePriv)

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -172,14 +172,13 @@ struct
     ThreadId.get_current ask
 
   let compatible (ask: Q.ask) (current: t) (other: t) =
-    let must_joined = ask.f Queries.MustJoinedThreads in
     match current, other with
     | `Lifted current, `Lifted other ->
-      if (TID.is_unique current) && (TID.equal current other) then
+      if TID.is_unique current && TID.equal current other then
         false (* self-read *)
       else if GobConfig.get_bool "ana.relation.priv.not-started" && MHP.definitely_not_started (current, ask.f Q.CreatedThreads) other then
         false (* other is not started yet *)
-      else if GobConfig.get_bool "ana.relation.priv.must-joined" && MHP.must_be_joined other must_joined then
+      else if GobConfig.get_bool "ana.relation.priv.must-joined" && MHP.must_be_joined other (ask.f Queries.MustJoinedThreads) then
         false (* accounted for in local information *)
       else
         true

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -159,7 +159,7 @@ sig
   include Printable.S
 
   val current: Q.ask -> t
-  val compatible: Q.ask -> t -> t -> bool
+  val accounted_for: Q.ask -> current:t -> other:t -> bool
 end
 
 module ThreadDigest: Digest =
@@ -171,7 +171,7 @@ struct
   let current (ask: Q.ask) =
     ThreadId.get_current ask
 
-  let compatible (ask: Q.ask) (current: t) (other: t) =
+  let accounted_for (ask: Q.ask) ~(current: t) ~(other: t) =
     match current, other with
     | `Lifted current, `Lifted other ->
       if TID.is_unique current && TID.equal current other then
@@ -247,7 +247,7 @@ struct
   let get_relevant_writes_nofilter (ask:Q.ask) v =
     let current = Digest.current ask in
     GMutex.fold (fun k v acc ->
-        if Digest.compatible ask current k then
+        if Digest.accounted_for ask ~current ~other:k then
           LD.join acc v
         else
           acc

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -162,12 +162,7 @@ sig
   val compatible: Q.ask -> t -> t -> bool
 end
 
-module type PerMutexTidCommonArg = sig
-  val exclude_not_started: unit -> bool
-  val exclude_must_joined: unit -> bool
-end
-
-module ThreadDigest (Conf: PerMutexTidCommonArg): Digest =
+module ThreadDigest: Digest =
 struct
   include ThreadIdDomain.ThreadLifted
 
@@ -182,9 +177,9 @@ struct
     | `Lifted current, `Lifted other ->
       if (TID.is_unique current) && (TID.equal current other) then
         false (* self-read *)
-      else if Conf.exclude_not_started () && MHP.definitely_not_started (current, ask.f Q.CreatedThreads) other then
+      else if GobConfig.get_bool "ana.relation.priv.not-started" && MHP.definitely_not_started (current, ask.f Q.CreatedThreads) other then
         false (* other is not started yet *)
-      else if Conf.exclude_must_joined () && MHP.must_be_joined other must_joined then
+      else if GobConfig.get_bool "ana.relation.priv.must-joined" && MHP.must_be_joined other must_joined then
         false (* accounted for in local information *)
       else
         true


### PR DESCRIPTION
The current implementation of `PerMutexMeetTIDPriv` for both base and relational analyses hard-codes thread IDs as the digest framework. This generalizes them over a digest module.