### PR TITLE
Remove duplicate ctx-derived arguments in base analysis

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1678,7 +1678,7 @@ struct
   let invariant = Invariant.invariant
 
 
-  let set_savetop ~ctx ?lval_raw ?rval_raw ask (gs:glob_fun) st adr lval_t v : store =
+  let set_savetop ~ctx ?lval_raw ?rval_raw st adr lval_t v : store =
     if M.tracing then M.tracel "set" "savetop %a %a %a\n" AD.pretty adr d_type lval_t VD.pretty v;
     match v with
     | Top -> set ~ctx st adr lval_t (VD.top_value (AD.type_of adr)) ?lval_raw ?rval_raw
@@ -1769,15 +1769,15 @@ struct
               let iv = VD.bot_value ~varAttr:v.vattr t in (* correct bottom value for top level variable *)
               if M.tracing then M.tracel "set" "init bot value: %a\n" VD.pretty iv;
               let nv = VD.update_offset (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) iv offs rval_val (Some  (Lval lval)) lval t in (* do desired update to value *)
-              set_savetop ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local (AD.of_var v) lval_t nv ~lval_raw:lval ~rval_raw:rval (* set top-level variable to updated value *)
+              set_savetop ~ctx  ctx.local (AD.of_var v) lval_t nv ~lval_raw:lval ~rval_raw:rval (* set top-level variable to updated value *)
             | None ->
-              set_savetop ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local lval_val lval_t rval_val ~lval_raw:lval ~rval_raw:rval
+              set_savetop ~ctx ctx.local lval_val lval_t rval_val ~lval_raw:lval ~rval_raw:rval
           end
         | _ ->
-          set_savetop ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local lval_val lval_t rval_val ~lval_raw:lval ~rval_raw:rval
+          set_savetop ~ctx ctx.local lval_val lval_t rval_val ~lval_raw:lval ~rval_raw:rval
       end
     | _ ->
-      set_savetop ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local lval_val lval_t rval_val ~lval_raw:lval ~rval_raw:rval
+      set_savetop ~ctx ctx.local lval_val lval_t rval_val ~lval_raw:lval ~rval_raw:rval
 
 
   let branch ctx (exp:exp) (tv:bool) : store =
@@ -2666,7 +2666,7 @@ struct
             | _, _ -> begin
                 let new_val = get ask ctx.global fun_st address None in
                 if M.tracing then M.trace "taintPC" "update val: %a\n\n" VD.pretty new_val;
-                let st' = set_savetop ~ctx ask ctx.global st address lval_type new_val in
+                let st' = set_savetop ~ctx st address lval_type new_val in
                 let partDep = Dep.find_opt v fun_st.deps in
                 match partDep with
                 | None -> st'
@@ -2753,7 +2753,7 @@ struct
 
       match lval with
       | None      -> st
-      | Some lval -> set_savetop ~ctx (Analyses.ask_of_ctx ctx) ctx.global st (eval_lv ~ctx lval) (Cilfacade.typeOfLval lval) return_val
+      | Some lval -> set_savetop ~ctx st (eval_lv ~ctx lval) (Cilfacade.typeOfLval lval) return_val
     in
     combine_one ctx.local after
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2021,7 +2021,7 @@ struct
       newst
     end
 
-  let special_unknown_invalidate ctx ask gs st f args =
+  let special_unknown_invalidate ctx ask st f args =
     (if CilType.Varinfo.equal f dummyFunDec.svar then M.warn ~category:Imprecise ~tags:[Category Call] "Unknown function ptr called");
     let desc = LF.find f in
     let shallow_addrs = LibraryDesc.Accesses.find desc.accs { kind = Write; deep = false } args in
@@ -2614,7 +2614,7 @@ struct
       end
     | _, _ ->
       let st =
-        special_unknown_invalidate ctx (Analyses.ask_of_ctx ctx) gs st f args
+        special_unknown_invalidate ctx (Analyses.ask_of_ctx ctx) st f args
         (*
           *  TODO: invalidate vars reachable via args
           *  publish globals
@@ -2744,7 +2744,7 @@ struct
     | exception Not_found ->
       (* Unknown functions *)
       let st = ctx.local in
-      let st = special_unknown_invalidate ctx (Analyses.ask_of_ctx ctx) ctx.global st f args in
+      let st = special_unknown_invalidate ctx (Analyses.ask_of_ctx ctx) st f args in
       [st]
 
   let threadspawn ctx ~multiple (lval: lval option) (f: varinfo) (args: exp list) fctx: D.t =

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1876,11 +1876,12 @@ struct
       List.map mpt exps
     )
 
-  let invalidate ?(deep=true) ~ctx ask (gs:glob_fun) (st:store) (exps: exp list): store =
+  let invalidate ?(deep=true) ~ctx ask (st:store) (exps: exp list): store =
     if M.tracing && exps <> [] then M.tracel "invalidate" "Will invalidate expressions [%a]\n" (d_list ", " d_plainexp) exps;
     if exps <> [] then M.info ~category:Imprecise "Invalidating expressions: %a" (d_list ", " d_exp) exps;
     (* To invalidate a single address, we create a pair with its corresponding
      * top value. *)
+    let gs = ctx.global in
     let invalidate_address st a =
       let t = AD.type_of a in
       let v = get ask gs st a None in (* None here is ok, just causes us to be a bit less precise *)
@@ -2041,8 +2042,8 @@ struct
     in
     (* TODO: what about escaped local variables? *)
     (* invalidate arguments and non-static globals for unknown functions *)
-    let st' = invalidate ~deep:false ~ctx (Analyses.ask_of_ctx ctx) gs st shallow_addrs in
-    invalidate ~deep:true ~ctx (Analyses.ask_of_ctx ctx) gs st' deep_addrs
+    let st' = invalidate ~deep:false ~ctx (Analyses.ask_of_ctx ctx) st shallow_addrs in
+    invalidate ~deep:true ~ctx (Analyses.ask_of_ctx ctx) st' deep_addrs
 
   let check_invalid_mem_dealloc ctx special_fn ptr =
     let has_non_heap_var = AD.exists (function
@@ -2132,7 +2133,7 @@ struct
     let invalidate_ret_lv st = match lv with
       | Some lv ->
         if M.tracing then M.tracel "invalidate" "Invalidating lhs %a for function call %s\n" d_plainlval lv f.vname;
-        invalidate ~deep:false ~ctx (Analyses.ask_of_ctx ctx) ctx.global st [Cil.mkAddrOrStartOf lv]
+        invalidate ~deep:false ~ctx (Analyses.ask_of_ctx ctx) st [Cil.mkAddrOrStartOf lv]
       | None -> st
     in
     let addr_type_of_exp exp =
@@ -2466,14 +2467,14 @@ struct
         | Int n when GobOption.exists (BI.equal BI.zero) (ID.to_int n) -> st
         | Address ret_a ->
           begin match eval_rv (Analyses.ask_of_ctx ctx) gs st id with
-            | Thread a when ValueDomain.Threads.is_top a -> invalidate ~ctx (Analyses.ask_of_ctx ctx) gs st [ret_var]
+            | Thread a when ValueDomain.Threads.is_top a -> invalidate ~ctx (Analyses.ask_of_ctx ctx) st [ret_var]
             | Thread a ->
               let v = List.fold VD.join (VD.bot ()) (List.map (fun x -> G.thread (ctx.global (V.thread x))) (ValueDomain.Threads.elements a)) in
               (* TODO: is this type right? *)
               set ~ctx (Analyses.ask_of_ctx ctx) st ret_a (Cilfacade.typeOf ret_var) v
-            | _      -> invalidate ~ctx (Analyses.ask_of_ctx ctx) gs st [ret_var]
+            | _      -> invalidate ~ctx (Analyses.ask_of_ctx ctx) st [ret_var]
           end
-        | _      -> invalidate ~ctx (Analyses.ask_of_ctx ctx) gs st [ret_var]
+        | _      -> invalidate ~ctx (Analyses.ask_of_ctx ctx) st [ret_var]
       in
       let st' = invalidate_ret_lv st' in
       Priv.thread_join (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) id st'

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2023,7 +2023,7 @@ struct
       newst
     end
 
-  let special_unknown_invalidate ctx ask st f args =
+  let special_unknown_invalidate ctx st f args =
     (if CilType.Varinfo.equal f dummyFunDec.svar then M.warn ~category:Imprecise ~tags:[Category Call] "Unknown function ptr called");
     let desc = LF.find f in
     let shallow_addrs = LibraryDesc.Accesses.find desc.accs { kind = Write; deep = false } args in
@@ -2616,7 +2616,7 @@ struct
       end
     | _, _ ->
       let st =
-        special_unknown_invalidate ctx (Analyses.ask_of_ctx ctx) st f args
+        special_unknown_invalidate ctx st f args
         (*
           *  TODO: invalidate vars reachable via args
           *  publish globals
@@ -2746,7 +2746,7 @@ struct
     | exception Not_found ->
       (* Unknown functions *)
       let st = ctx.local in
-      let st = special_unknown_invalidate ctx (Analyses.ask_of_ctx ctx) st f args in
+      let st = special_unknown_invalidate ctx st f args in
       [st]
 
   let threadspawn ctx ~multiple (lval: lval option) (f: varinfo) (args: exp list) fctx: D.t =

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -905,7 +905,7 @@ struct
   and eval_rv_base_lval ~eval_lv ~ctx (a: Q.ask) (gs:glob_fun) (st: store) (exp: exp) (lv: lval): value =
     match lv with
     | (Var v, ofs) -> get a gs st (eval_lv ~ctx (Var v, ofs)) (Some exp)
-    (*| Lval (Mem e, ofs) -> get a gs st (eval_lv a gs st (Mem e, ofs)) *)
+    (* | Lval (Mem e, ofs) -> get a gs st (eval_lv ~ctx (Mem e, ofs)) *)
     | (Mem e, ofs) ->
       (*M.tracel "cast" "Deref: lval: %a\n" d_plainlval lv;*)
       let rec contains_vla (t:typ) = match t with
@@ -2515,7 +2515,7 @@ struct
         match lv with
         | Some lv ->
           let heap_var = AD.of_var (heap_var true ctx) in
-          (* ignore @@ printf "alloca will allocate %a bytes\n" ID.pretty (eval_int ctx.ask gs st size); *)
+          (* ignore @@ printf "alloca will allocate %a bytes\n" ID.pretty (eval_int ~ctx size); *)
           set_many ~ctx st [(heap_var, TVoid [], Blob (VD.bot (), eval_int ~ctx size, true));
                             (eval_lv ~ctx lv, (Cilfacade.typeOfLval lv), Address heap_var)]
         | _ -> st
@@ -2528,7 +2528,7 @@ struct
             then AD.join (AD.of_var (heap_var false ctx)) AD.null_ptr
             else AD.of_var (heap_var false ctx)
           in
-          (* ignore @@ printf "malloc will allocate %a bytes\n" ID.pretty (eval_int ctx.ask gs st size); *)
+          (* ignore @@ printf "malloc will allocate %a bytes\n" ID.pretty (eval_int ~ctx size); *)
           set_many ~ctx st [(heap_var, TVoid [], Blob (VD.bot (), eval_int ~ctx size, true));
                             (eval_lv ~ctx lv, (Cilfacade.typeOfLval lv), Address heap_var)]
         | _ -> st

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -249,7 +249,7 @@ struct
     | _ -> false
 
   (* Evaluate binop for two abstract values: *)
-  let evalbinop_base (a: Q.ask) (st: store) (op: binop) (t1:typ) (a1:value) (t2:typ) (a2:value) (t:typ) :value =
+  let evalbinop_base (a: Q.ask) (op: binop) (t1:typ) (a1:value) (t2:typ) (a2:value) (t:typ) :value =
     if M.tracing then M.tracel "eval" "evalbinop %a %a %a\n" d_binop op VD.pretty a1 VD.pretty a2;
     (* We define a conversion function for the easy cases when we can just use
      * the integer domain operations. *)
@@ -785,7 +785,7 @@ struct
         let a1 = eval_rv ~ctx e1 in
         let a2 = eval_rv ~ctx e2 in
         let extra_is_safe =
-          match evalbinop_base a st op t1 a1 t2 a2 typ with
+          match evalbinop_base a op t1 a1 t2 a2 typ with
           | Int i -> ID.to_bool i = Some true
           | _
           | exception IntDomain.IncompatibleIKinds _ -> false
@@ -970,7 +970,7 @@ struct
     let a2 = eval_rv ~ctx e2 in
     let t1 = Option.default_delayed (fun () -> Cilfacade.typeOf e1) t1 in
     let t2 = Option.default_delayed (fun () -> Cilfacade.typeOf e2) t2 in
-    let r = evalbinop_base a st op t1 a1 t2 a2 t in
+    let r = evalbinop_base a op t1 a1 t2 a2 t in
     if Cil.isIntegralType t then (
       match r with
       | Int i when ID.to_int i <> None -> r (* Avoid fallback, cannot become any more precise. *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -443,7 +443,7 @@ struct
   let publish_all ctx reason =
     ignore (sync' reason ctx)
 
-  let get_var (a: Q.ask) (gs: glob_fun) (st: store) (x: varinfo): value =
+  let get_var ~ctx (a: Q.ask) (gs: glob_fun) (st: store) (x: varinfo): value =
     if (!earlyglobs || ThreadFlag.has_ever_been_multi a) && is_global a x then
       Priv.read_global a (priv_getg gs) st x
     else begin
@@ -463,7 +463,7 @@ struct
     let res =
       let f_addr (x, offs) =
         (* get hold of the variable value, either from local or global state *)
-        let var = get_var a gs st x in
+        let var = get_var ~ctx a gs st x in
         let v = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get ~ctx a gs st x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
         if M.tracing then M.tracec "get" "var = %a, %a = %a\n" VD.pretty var AD.pretty (AD.of_mval (x, offs)) VD.pretty v;
         if full then var else match v with
@@ -1172,7 +1172,7 @@ struct
     struct
       let context = context
       let scope = Node.find_fundec ctx.node
-      let find v = get_var ask ctx.global ctx.local v
+      let find v = get_var ~ctx ask ctx.global ctx.local v
     end
     in
     let module I = ValueDomain.ValueInvariant (Arg) in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1107,12 +1107,12 @@ struct
         Queries.Result.top q (* query cycle *)
       else (
         match q with
-        | EvalInt e -> query_evalint ~ctx st e (* mimic EvalInt query since eval_rv needs it *)
+        | EvalInt e -> query_evalint ~ctx:(ctx' (Queries.Set.add anyq asked)) st e (* mimic EvalInt query since eval_rv needs it *)
         | _ -> Queries.Result.top q
       )
     and gs = function `Left _ -> `Lifted1 (Priv.G.top ()) | `Right _ -> `Lifted2 (VD.top ()) (* the expression is guaranteed to not contain globals *)
-    and ctx =
-      { ask = (fun (type a) (q: a Queries.t) -> query Queries.Set.empty q)
+    and ctx' asked =
+      { ask = (fun (type a) (q: a Queries.t) -> query asked q)
       ; emit   = (fun _ -> failwith "Cannot \"emit\" in base eval_exp context.")
       ; node    = MyCFG.dummy_node
       ; prev_node = MyCFG.dummy_node
@@ -1126,7 +1126,7 @@ struct
       ; sideg   = (fun g d -> failwith "Base eval_exp trying to side effect.")
       }
     in
-    match eval_rv ~ctx st exp with
+    match eval_rv ~ctx:(ctx' Queries.Set.empty) st exp with
     | Int x -> ValueDomain.ID.to_int x
     | _ -> None
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2023,7 +2023,7 @@ struct
       newst
     end
 
-  let special_unknown_invalidate ctx st f args =
+  let special_unknown_invalidate ctx f args =
     (if CilType.Varinfo.equal f dummyFunDec.svar then M.warn ~category:Imprecise ~tags:[Category Call] "Unknown function ptr called");
     let desc = LF.find f in
     let shallow_addrs = LibraryDesc.Accesses.find desc.accs { kind = Write; deep = false } args in
@@ -2044,7 +2044,7 @@ struct
     in
     (* TODO: what about escaped local variables? *)
     (* invalidate arguments and non-static globals for unknown functions *)
-    let st' = invalidate ~deep:false ~ctx st shallow_addrs in
+    let st' = invalidate ~deep:false ~ctx ctx.local shallow_addrs in
     invalidate ~deep:true ~ctx st' deep_addrs
 
   let check_invalid_mem_dealloc ctx special_fn ptr =
@@ -2616,7 +2616,7 @@ struct
       end
     | _, _ ->
       let st =
-        special_unknown_invalidate ctx st f args
+        special_unknown_invalidate ctx f args
         (*
           *  TODO: invalidate vars reachable via args
           *  publish globals
@@ -2745,8 +2745,7 @@ struct
       [make_entry ~thread:true ctx fd args]
     | exception Not_found ->
       (* Unknown functions *)
-      let st = ctx.local in
-      let st = special_unknown_invalidate ctx st f args in
+      let st = special_unknown_invalidate ctx f args in
       [st]
 
   let threadspawn ctx ~multiple (lval: lval option) (f: varinfo) (args: exp list) fctx: D.t =

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1417,7 +1417,7 @@ struct
   (** [set st addr val] returns a state where [addr] is set to [val]
    * it is always ok to put None for lval_raw and rval_raw, this amounts to not using/maintaining
    * precise information about arrays. *)
-  let set (a: Q.ask) ~(ctx: _ ctx) ?(invariant=false) ?(blob_destructive=false) ?lval_raw ?rval_raw ?t_override (gs:glob_fun) (st: store) (lval: AD.t) (lval_type: Cil.typ) (value: value) : store =
+  let set (a: Q.ask) ~(ctx: _ ctx) ?(invariant=false) ?(blob_destructive=false) ?lval_raw ?rval_raw ?t_override (st: store) (lval: AD.t) (lval_type: Cil.typ) (value: value) : store =
     let update_variable x t y z =
       if M.tracing then M.tracel "set" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a\n\n" x.vname VD.pretty y CPA.pretty z;
       let r = update_variable x t y z in (* refers to defintion that is outside of set *)
@@ -1476,7 +1476,7 @@ struct
          * side-effects here, but the code still distinguishes these cases. *)
       if (!earlyglobs || ThreadFlag.has_ever_been_multi a) && is_global a x then begin
         if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: update a global var '%s' ...\n" x.vname;
-        let priv_getg = priv_getg gs in
+        let priv_getg = priv_getg ctx.global in
         (* Optimization to avoid evaluating integer values when setting them.
            The case when invariant = true requires the old_value to be sound for the meet.
            Allocated blocks are representend by Blobs with additional information, so they need to be looked-up. *)
@@ -1590,7 +1590,7 @@ struct
   let set_many ~ctx a (gs:glob_fun) (st: store) lval_value_list: store =
     (* Maybe this can be done with a simple fold *)
     let f (acc: store) ((lval:AD.t),(typ:Cil.typ),(value:value)): store =
-      set ~ctx a gs acc lval typ value
+      set ~ctx a acc lval typ value
     in
     (* And fold over the list starting from the store turned wstore: *)
     List.fold_left f st lval_value_list
@@ -1640,7 +1640,7 @@ struct
 
     let get_var = get_var
     let get a gs st addrs exp = get a gs st addrs exp
-    let set a ~ctx gs st lval lval_type ?lval_raw value = set a ~ctx ~invariant:true gs st lval lval_type ?lval_raw value
+    let set a ~ctx gs st lval lval_type ?lval_raw value = set a ~ctx ~invariant:true st lval lval_type ?lval_raw value
 
     let refine_entire_var = true
     let map_oldval oldval _ = oldval
@@ -1660,8 +1660,8 @@ struct
   let set_savetop ~ctx ?lval_raw ?rval_raw ask (gs:glob_fun) st adr lval_t v : store =
     if M.tracing then M.tracel "set" "savetop %a %a %a\n" AD.pretty adr d_type lval_t VD.pretty v;
     match v with
-    | Top -> set ~ctx ask gs st adr lval_t (VD.top_value (AD.type_of adr)) ?lval_raw ?rval_raw
-    | v -> set ~ctx ask gs st adr lval_t v ?lval_raw ?rval_raw
+    | Top -> set ~ctx ask st adr lval_t (VD.top_value (AD.type_of adr)) ?lval_raw ?rval_raw
+    | v -> set ~ctx ask st adr lval_t v ?lval_raw ?rval_raw
 
 
   (**************************************************************************
@@ -1834,7 +1834,7 @@ struct
           | ret -> ret
         in
         let rv = eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local exp in
-        let st' = set ~ctx ~t_override (Analyses.ask_of_ctx ctx) ctx.global nst (return_var ()) t_override rv in
+        let st' = set ~ctx ~t_override (Analyses.ask_of_ctx ctx) nst (return_var ()) t_override rv in
         match ThreadId.get_current (Analyses.ask_of_ctx ctx) with
         | `Lifted tid when ThreadReturn.is_current (Analyses.ask_of_ctx ctx) ->
           (* Evaluate exp and cast the resulting value to the void-pointer-type.
@@ -1851,7 +1851,7 @@ struct
       let lval = eval_lv (Analyses.ask_of_ctx ctx) ctx.global ctx.local (Var v, NoOffset) in
       let current_value = eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local (Lval (Var v, NoOffset)) in
       let new_value = VD.update_array_lengths (eval_rv (Analyses.ask_of_ctx ctx) ctx.global ctx.local) current_value v.vtype in
-      set ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local lval v.vtype new_value
+      set ~ctx (Analyses.ask_of_ctx ctx) ctx.local lval v.vtype new_value
 
   (**************************************************************************
    * Function calls
@@ -2173,7 +2173,7 @@ struct
         else
           VD.top_value (unrollType dest_typ)
       in
-      set ~ctx (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ value in
+      set ~ctx (Analyses.ask_of_ctx ctx) st dest_a dest_typ value in
     (* for string functions *)
     let eval_n = function
       (* if only n characters of a given string are needed, evaluate expression n to an integer option *)
@@ -2219,15 +2219,15 @@ struct
             let lv_a = eval_lv (Analyses.ask_of_ctx ctx) gs st lv_val in
             let lv_typ = Cilfacade.typeOfLval lv_val in
             if all && typeSig s1_typ = typeSig s2_typ && typeSig s2_typ = typeSig lv_typ then (* all types need to coincide *)
-              set ~ctx (Analyses.ask_of_ctx ctx) gs st lv_a lv_typ (f s1_a s2_a)
+              set ~ctx (Analyses.ask_of_ctx ctx) st lv_a lv_typ (f s1_a s2_a)
             else if not all && typeSig s1_typ = typeSig s2_typ then (* only the types of s1 and s2 need to coincide *)
-              set ~ctx (Analyses.ask_of_ctx ctx) gs st lv_a lv_typ (f s1_a s2_a)
+              set ~ctx (Analyses.ask_of_ctx ctx) st lv_a lv_typ (f s1_a s2_a)
             else
-              set ~ctx (Analyses.ask_of_ctx ctx) gs st lv_a lv_typ (VD.top_value (unrollType lv_typ))
+              set ~ctx (Analyses.ask_of_ctx ctx) st lv_a lv_typ (VD.top_value (unrollType lv_typ))
           | _ ->
             (* check if s1 is potentially a string literal as writing to it would be undefined behavior; then return top *)
             let _ = AD.string_writing_defined s1_a in
-            set ~ctx (Analyses.ask_of_ctx ctx) gs st s1_a s1_typ (VD.top_value (unrollType s1_typ))
+            set ~ctx (Analyses.ask_of_ctx ctx) st s1_a s1_typ (VD.top_value (unrollType s1_typ))
         end
         (* else compute value in array domain *)
       else
@@ -2235,11 +2235,11 @@ struct
           | Some lv_val -> eval_lv (Analyses.ask_of_ctx ctx) gs st lv_val, Cilfacade.typeOfLval lv_val
           | None -> s1_a, s1_typ in
         begin match (get (Analyses.ask_of_ctx ctx) gs st s1_a None), get (Analyses.ask_of_ctx ctx) gs st s2_a None with
-          | Array array_s1, Array array_s2 -> set ~ctx ~blob_destructive:true (Analyses.ask_of_ctx ctx) gs st lv_a lv_typ (op_array array_s1 array_s2)
+          | Array array_s1, Array array_s2 -> set ~ctx ~blob_destructive:true (Analyses.ask_of_ctx ctx) st lv_a lv_typ (op_array array_s1 array_s2)
           | Array array_s1, _ when CilType.Typ.equal s2_typ charPtrType ->
             let s2_null_bytes = List.map CArrays.to_null_byte_domain (AD.to_string s2_a) in
             let array_s2 = List.fold_left CArrays.join (CArrays.bot ()) s2_null_bytes in
-            set ~ctx ~blob_destructive:true (Analyses.ask_of_ctx ctx) gs st lv_a lv_typ (op_array array_s1 array_s2)
+            set ~ctx ~blob_destructive:true (Analyses.ask_of_ctx ctx) st lv_a lv_typ (op_array array_s1 array_s2)
           | Bot, Array array_s2 ->
             (* If we have bot inside here, we assume the blob is used as a char array and create one inside *)
             let ptrdiff_ik = Cilfacade.ptrdiff_ikind () in
@@ -2248,7 +2248,7 @@ struct
               try ValueDomainQueries.ID.unlift (ID.cast_to ptrdiff_ik) size
               with Failure _ -> ID.top_of ptrdiff_ik in
             let empty_array = CArrays.make s_id (Int (ID.top_of IChar)) in
-            set ~ctx (Analyses.ask_of_ctx ctx) gs st lv_a lv_typ (op_array empty_array array_s2)
+            set ~ctx (Analyses.ask_of_ctx ctx) st lv_a lv_typ (op_array empty_array array_s2)
           | Bot , _ when CilType.Typ.equal s2_typ charPtrType ->
             (* If we have bot inside here, we assume the blob is used as a char array and create one inside *)
             let ptrdiff_ik = Cilfacade.ptrdiff_ikind () in
@@ -2259,19 +2259,19 @@ struct
             let empty_array = CArrays.make s_id (Int (ID.top_of IChar)) in
             let s2_null_bytes = List.map CArrays.to_null_byte_domain (AD.to_string s2_a) in
             let array_s2 = List.fold_left CArrays.join (CArrays.bot ()) s2_null_bytes in
-            set ~ctx (Analyses.ask_of_ctx ctx) gs st lv_a lv_typ (op_array empty_array array_s2)
+            set ~ctx (Analyses.ask_of_ctx ctx) st lv_a lv_typ (op_array empty_array array_s2)
           | _, Array array_s2 when CilType.Typ.equal s1_typ charPtrType ->
             (* if s1 is string literal, str(n)cpy and str(n)cat are undefined *)
             if op_addr = None then
               (* triggers warning, function only evaluated for side-effects *)
               let _ = AD.string_writing_defined s1_a in
-              set ~ctx (Analyses.ask_of_ctx ctx) gs st s1_a s1_typ (VD.top_value (unrollType s1_typ))
+              set ~ctx (Analyses.ask_of_ctx ctx) st s1_a s1_typ (VD.top_value (unrollType s1_typ))
             else
               let s1_null_bytes = List.map CArrays.to_null_byte_domain (AD.to_string s1_a) in
               let array_s1 = List.fold_left CArrays.join (CArrays.bot ()) s1_null_bytes in
-              set ~ctx (Analyses.ask_of_ctx ctx) gs st lv_a lv_typ (op_array array_s1 array_s2)
+              set ~ctx (Analyses.ask_of_ctx ctx) st lv_a lv_typ (op_array array_s1 array_s2)
           | _ ->
-            set ~ctx (Analyses.ask_of_ctx ctx) gs st lv_a lv_typ (VD.top_value (unrollType lv_typ))
+            set ~ctx (Analyses.ask_of_ctx ctx) st lv_a lv_typ (VD.top_value (unrollType lv_typ))
         end
     in
     let st = match desc.special args, f.vname with
@@ -2286,13 +2286,13 @@ struct
         | _ ->
           VD.top_value dest_typ
       in
-      set ~ctx (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ value
+      set ~ctx (Analyses.ask_of_ctx ctx) st dest_a dest_typ value
     | Bzero { dest; count; }, _ ->
       (* TODO: share something with memset special case? *)
       (* TODO: check count *)
       let dest_a, dest_typ = addr_type_of_exp dest in
       let value = VD.zero_init_value dest_typ in
-      set ~ctx (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ value
+      set ~ctx (Analyses.ask_of_ctx ctx) st dest_a dest_typ value
     | Memcpy { dest = dst; src; n; }, _ -> (* TODO: use n *)
       memory_copying dst src (Some n)
     | Strcpy { dest = dst; src; n }, _ -> string_manipulation dst src None false None (fun ar1 ar2 -> Array (CArrays.string_copy ar1 ar2 (eval_n n)))
@@ -2315,7 +2315,7 @@ struct
                 | Array array_s -> Int (CArrays.to_string_length array_s)
                 | _ -> VD.top_value (unrollType dest_typ)
               end in
-          set ~ctx (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ value
+          set ~ctx (Analyses.ask_of_ctx ctx) st dest_a dest_typ value
         | None -> st
       end
     | Strstr { haystack; needle }, _ ->
@@ -2374,10 +2374,10 @@ struct
             match ID.to_int x with
             | Some z ->
               if M.tracing then M.tracel "attr" "setting\n";
-              set ~ctx (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ (MutexAttr (ValueDomain.MutexAttr.of_int z))
-            | None -> set ~ctx (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ (MutexAttr (ValueDomain.MutexAttr.top ()))
+              set ~ctx (Analyses.ask_of_ctx ctx) st dest_a dest_typ (MutexAttr (ValueDomain.MutexAttr.of_int z))
+            | None -> set ~ctx (Analyses.ask_of_ctx ctx) st dest_a dest_typ (MutexAttr (ValueDomain.MutexAttr.top ()))
           end
-        | _ -> set ~ctx (Analyses.ask_of_ctx ctx) gs st dest_a dest_typ (MutexAttr (ValueDomain.MutexAttr.top ()))
+        | _ -> set ~ctx (Analyses.ask_of_ctx ctx) st dest_a dest_typ (MutexAttr (ValueDomain.MutexAttr.top ()))
       end
     | Identity e, _ ->
       begin match lv with
@@ -2452,7 +2452,7 @@ struct
         end
       in
       begin match lv with
-        | Some lv_val -> set ~ctx (Analyses.ask_of_ctx ctx) gs st (eval_lv (Analyses.ask_of_ctx ctx) ctx.global st lv_val) (Cilfacade.typeOfLval lv_val) result
+        | Some lv_val -> set ~ctx (Analyses.ask_of_ctx ctx) st (eval_lv (Analyses.ask_of_ctx ctx) ctx.global st lv_val) (Cilfacade.typeOfLval lv_val) result
         | None -> st
       end
     (* handling thread creations *)
@@ -2470,7 +2470,7 @@ struct
             | Thread a ->
               let v = List.fold VD.join (VD.bot ()) (List.map (fun x -> G.thread (ctx.global (V.thread x))) (ValueDomain.Threads.elements a)) in
               (* TODO: is this type right? *)
-              set ~ctx (Analyses.ask_of_ctx ctx) gs st ret_a (Cilfacade.typeOf ret_var) v
+              set ~ctx (Analyses.ask_of_ctx ctx) st ret_a (Cilfacade.typeOf ret_var) v
             | _      -> invalidate ~ctx (Analyses.ask_of_ctx ctx) gs st [ret_var]
           end
         | _      -> invalidate ~ctx (Analyses.ask_of_ctx ctx) gs st [ret_var]
@@ -2573,14 +2573,14 @@ struct
       let st' = match eval_rv ask gs st env with
         | Address jmp_buf ->
           let value = VD.JmpBuf (ValueDomain.JmpBufs.Bufs.singleton (Target (ctx.prev_node, ctx.control_context ())), false) in
-          let r = set ~ctx ask gs st jmp_buf (Cilfacade.typeOf env) value in
+          let r = set ~ctx ask st jmp_buf (Cilfacade.typeOf env) value in
           if M.tracing then M.tracel "setjmp" "setting setjmp %a on %a -> %a\n" d_exp env D.pretty st D.pretty r;
           r
         | _ -> failwith "problem?!"
       in
       begin match lv with
         | Some lv ->
-          set ~ctx ask gs st' (eval_lv ask ctx.global st lv) (Cilfacade.typeOfLval lv) (Int (ID.of_int IInt BI.zero))
+          set ~ctx ask st' (eval_lv ask ctx.global st lv) (Cilfacade.typeOfLval lv) (Int (ID.of_int IInt BI.zero))
         | None -> st'
       end
     | Longjmp {env; value}, _ ->
@@ -2603,12 +2603,12 @@ struct
       in
       let rv = ensure_not_zero @@ eval_rv ask ctx.global ctx.local value in
       let t = Cilfacade.typeOf value in
-      set ~ctx ~t_override:t ask ctx.global ctx.local (AD.of_var !longjmp_return) t rv (* Not raising Deadcode here, deadcode is raised at a higher level! *)
+      set ~ctx ~t_override:t ask ctx.local (AD.of_var !longjmp_return) t rv (* Not raising Deadcode here, deadcode is raised at a higher level! *)
     | Rand, _ ->
       begin match lv with
         | Some x ->
           let result:value = (Int (ID.starting IInt Z.zero)) in
-          set ~ctx (Analyses.ask_of_ctx ctx) gs st (eval_lv (Analyses.ask_of_ctx ctx) ctx.global st x) (Cilfacade.typeOfLval x) result
+          set ~ctx (Analyses.ask_of_ctx ctx) st (eval_lv (Analyses.ask_of_ctx ctx) ctx.global st x) (Cilfacade.typeOfLval x) result
         | None -> st
       end
     | _, _ ->
@@ -2843,7 +2843,7 @@ struct
           (* all updates happen in ctx with top values *)
           let get_var = get_var
           let get a gs st addrs exp = get a gs st addrs exp
-          let set a ~ctx gs st lval lval_type ?lval_raw value = set a ~ctx ~invariant:false gs st lval lval_type ?lval_raw value (* TODO: should have invariant false? doesn't work with empty cpa then, because meets *)
+          let set a ~ctx gs st lval lval_type ?lval_raw value = set a ~ctx ~invariant:false st lval lval_type ?lval_raw value (* TODO: should have invariant false? doesn't work with empty cpa then, because meets *)
 
           let refine_entire_var = false
           let map_oldval oldval t_lval =
@@ -2887,7 +2887,7 @@ struct
       WideningTokens.with_side_tokens (WideningTokens.TS.of_list uuids) (fun () ->
           CPA.fold (fun x v acc ->
               let addr: AD.t = AD.of_mval (x, `NoOffset) in
-              set (Analyses.ask_of_ctx ctx) ~ctx ~invariant:false ctx.global acc addr x.vtype v
+              set (Analyses.ask_of_ctx ctx) ~ctx ~invariant:false acc addr x.vtype v
             ) e_d.cpa ctx.local
         )
     in
@@ -2911,7 +2911,7 @@ struct
       Priv.enter_multithreaded (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) st
     | Events.AssignSpawnedThread (lval, tid) ->
       (* TODO: is this type right? *)
-      set ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local (eval_lv (Analyses.ask_of_ctx ctx) ctx.global ctx.local lval) (Cilfacade.typeOfLval lval) (Thread (ValueDomain.Threads.singleton tid))
+      set ~ctx (Analyses.ask_of_ctx ctx) ctx.local (eval_lv (Analyses.ask_of_ctx ctx) ctx.global ctx.local lval) (Cilfacade.typeOfLval lval) (Thread (ValueDomain.Threads.singleton tid))
     | Events.Assert exp ->
       assert_fn ctx exp true
     | Events.Unassume {exp; uuids} ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1875,8 +1875,9 @@ struct
 
   (** From a list of expressions, collect a list of addresses that they might point to, or contain pointers to. *)
   let collect_funargs ~ctx ?(warn=false) (st:store) (exps: exp list) =
+    let ask = Analyses.ask_of_ctx ctx in
     let do_exp e =
-      let immediately_reachable = reachable_from_value (Analyses.ask_of_ctx ctx) (eval_rv ~ctx st e) (Cilfacade.typeOf e) (CilType.Exp.show e) in
+      let immediately_reachable = reachable_from_value ask (eval_rv ~ctx st e) (Cilfacade.typeOf e) (CilType.Exp.show e) in
       reachable_vars ~ctx st [immediately_reachable]
     in
     List.concat_map do_exp exps

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1587,7 +1587,7 @@ struct
       (* if M.tracing then M.tracel "set" ~var:firstvar "set got an exception '%s'\n" x; *)
       M.info ~category:Unsound "Assignment to unknown address, assuming no write happened."; st
 
-  let set_many ~ctx a (gs:glob_fun) (st: store) lval_value_list: store =
+  let set_many ~ctx a (st: store) lval_value_list: store =
     (* Maybe this can be done with a simple fold *)
     let f (acc: store) ((lval:AD.t),(typ:Cil.typ),(value:value)): store =
       set ~ctx a acc lval typ value
@@ -1809,7 +1809,7 @@ struct
     let init_var v = (AD.of_var v, v.vtype, VD.init_value ~varAttr:v.vattr v.vtype) in
     (* Apply it to all the locals and then assign them all *)
     let inits = List.map init_var f.slocals in
-    set_many ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local inits
+    set_many ~ctx (Analyses.ask_of_ctx ctx) ctx.local inits
 
   let return ctx exp fundec: store =
     if Cil.hasAttribute "noreturn" fundec.svar.vattr then
@@ -1903,7 +1903,7 @@ struct
       let vs = List.map (Tuple3.third) invalids' in
       M.tracel "invalidate" "Setting addresses [%a] to values [%a]\n" (d_list ", " AD.pretty) addrs (d_list ", " VD.pretty) vs
     );
-    set_many ~ctx ask gs st invalids'
+    set_many ~ctx ask st invalids'
 
 
   let make_entry ?(thread=false) (ctx:(D.t, G.t, C.t, V.t) Analyses.ctx) fundec args: D.t =
@@ -2485,7 +2485,7 @@ struct
         | Some lv ->
           let heap_var = AD.of_var (heap_var true ctx) in
           (* ignore @@ printf "alloca will allocate %a bytes\n" ID.pretty (eval_int ctx.ask gs st size); *)
-          set_many ~ctx (Analyses.ask_of_ctx ctx) gs st [(heap_var, TVoid [], Blob (VD.bot (), eval_int (Analyses.ask_of_ctx ctx) gs st size, true));
+          set_many ~ctx (Analyses.ask_of_ctx ctx) st [(heap_var, TVoid [], Blob (VD.bot (), eval_int (Analyses.ask_of_ctx ctx) gs st size, true));
                                                          (eval_lv (Analyses.ask_of_ctx ctx) gs st lv, (Cilfacade.typeOfLval lv), Address heap_var)]
         | _ -> st
       end
@@ -2498,7 +2498,7 @@ struct
             else AD.of_var (heap_var false ctx)
           in
           (* ignore @@ printf "malloc will allocate %a bytes\n" ID.pretty (eval_int ctx.ask gs st size); *)
-          set_many ~ctx (Analyses.ask_of_ctx ctx) gs st [(heap_var, TVoid [], Blob (VD.bot (), eval_int (Analyses.ask_of_ctx ctx) gs st size, true));
+          set_many ~ctx (Analyses.ask_of_ctx ctx) st [(heap_var, TVoid [], Blob (VD.bot (), eval_int (Analyses.ask_of_ctx ctx) gs st size, true));
                                                          (eval_lv (Analyses.ask_of_ctx ctx) gs st lv, (Cilfacade.typeOfLval lv), Address heap_var)]
         | _ -> st
       end
@@ -2514,7 +2514,7 @@ struct
           let sizeval = eval_int (Analyses.ask_of_ctx ctx) gs st size in
           let countval = eval_int (Analyses.ask_of_ctx ctx) gs st n in
           if ID.to_int countval = Some Z.one then (
-            set_many ~ctx (Analyses.ask_of_ctx ctx) gs st [
+            set_many ~ctx (Analyses.ask_of_ctx ctx) st [
               (add_null (AD.of_var heap_var), TVoid [], Blob (VD.bot (), sizeval, false));
               (eval_lv (Analyses.ask_of_ctx ctx) gs st lv, (Cilfacade.typeOfLval lv), Address (add_null (AD.of_var heap_var)))
             ]
@@ -2522,7 +2522,7 @@ struct
           else (
             let blobsize = ID.mul (ID.cast_to ik @@ sizeval) (ID.cast_to ik @@ countval) in
             (* the memory that was allocated by calloc is set to bottom, but we keep track that it originated from calloc, so when bottom is read from memory allocated by calloc it is turned to zero *)
-            set_many ~ctx (Analyses.ask_of_ctx ctx) gs st [
+            set_many ~ctx (Analyses.ask_of_ctx ctx) st [
               (add_null (AD.of_var heap_var), TVoid [], Array (CArrays.make (IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) BI.one) (Blob (VD.bot (), blobsize, false))));
               (eval_lv (Analyses.ask_of_ctx ctx) gs st lv, (Cilfacade.typeOfLval lv), Address (add_null (AD.of_mval (heap_var, `Index (IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) BI.zero, `NoOffset)))))
             ]
@@ -2556,7 +2556,7 @@ struct
               heap_addr
           in
           let lv_addr = eval_lv ask gs st lv in
-          set_many ~ctx ask gs st [
+          set_many ~ctx ask st [
             (heap_addr, TVoid [], heap_val);
             (lv_addr, Cilfacade.typeOfLval lv, Address heap_addr');
           ] (* TODO: free (i.e. invalidate) old blob if successful? *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -903,7 +903,7 @@ struct
   and eval_rv_base_lval ~eval_lv ~ctx (st: store) (exp: exp) (lv: lval): value =
     match lv with
     | (Var v, ofs) -> get ~ctx st (eval_lv ~ctx (Var v, ofs)) (Some exp)
-    (* | Lval (Mem e, ofs) -> get a gs st (eval_lv ~ctx (Mem e, ofs)) *)
+    (* | Lval (Mem e, ofs) -> get ~ctx st (eval_lv ~ctx (Mem e, ofs)) *)
     | (Mem e, ofs) ->
       (*M.tracel "cast" "Deref: lval: %a\n" d_plainlval lv;*)
       let rec contains_vla (t:typ) = match t with

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -739,7 +739,6 @@ struct
       Subexpressions delegate to [eval_rv], which may use queries on them. *)
   and eval_rv_base ~ctx (exp:exp): value =
     let a = Analyses.ask_of_ctx ctx in
-    let gs = ctx.global in
     let st = ctx.local in
     let eval_rv = eval_rv_back_up in
     if M.tracing then M.traceli "evalint" "base eval_rv_base %a\n" d_exp exp;
@@ -778,7 +777,7 @@ struct
       | Const _ -> VD.top ()
       (* Variables and address expressions *)
       | Lval lv ->
-        eval_rv_base_lval ~eval_lv ~ctx a gs st exp lv
+        eval_rv_base_lval ~eval_lv ~ctx a st exp lv
       (* Binary operators *)
       (* Eq/Ne when both values are equal and casted to the same type *)
       | BinOp ((Eq | Ne) as op, (CastE (t1, e1) as c1), (CastE (t2, e2) as c2), typ) when typeSig t1 = typeSig t2 ->
@@ -902,7 +901,7 @@ struct
     if M.tracing then M.traceu "evalint" "base eval_rv_base %a -> %a\n" d_exp exp VD.pretty r;
     r
 
-  and eval_rv_base_lval ~eval_lv ~ctx (a: Q.ask) (gs:glob_fun) (st: store) (exp: exp) (lv: lval): value =
+  and eval_rv_base_lval ~eval_lv ~ctx (a: Q.ask) (st: store) (exp: exp) (lv: lval): value =
     match lv with
     | (Var v, ofs) -> get ~ctx st (eval_lv ~ctx (Var v, ofs)) (Some exp)
     (* | Lval (Mem e, ofs) -> get a gs st (eval_lv ~ctx (Mem e, ofs)) *)
@@ -2866,7 +2865,7 @@ struct
             if VD.is_bot oldval then VD.top_value t_lval else oldval
           let eval_rv_lval_refine ~ctx st exp lv =
             (* new, use different ctx for eval_lv (for Mem): *)
-            eval_rv_base_lval ~eval_lv ~ctx (Analyses.ask_of_ctx ctx) ctx.global st exp lv
+            eval_rv_base_lval ~eval_lv ~ctx (Analyses.ask_of_ctx ctx) st exp lv
 
           (* don't meet with current octx values when propagating inverse operands down *)
           let id_meet_down ~old ~c = c

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2647,8 +2647,7 @@ struct
         match addr with
         | Addr.Addr (v,o) ->
           if CPA.mem v fun_st.cpa then
-            let lval = Addr.Mval.to_cil (v,o) in
-            let address = eval_lv ~ctx lval in
+            let address = AD.singleton addr in
             let lval_type = Addr.type_of addr in
             if M.tracing then M.trace "taintPC" "updating %a; type: %a\n" Addr.Mval.pretty (v,o) d_type lval_type;
             match (CPA.find_opt v (fun_st.cpa)), lval_type with

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -573,7 +573,7 @@ struct
     if M.tracing then M.traceu "reachability" "All reachable vars: %a\n" AD.pretty !visited;
     List.map AD.singleton (AD.elements !visited)
 
-  let reachable_vars ~ctx args = Timing.wrap "reachability" (reachable_vars ~ctx) args
+  let reachable_vars ~ctx st args = Timing.wrap "reachability" (reachable_vars ~ctx st) args
 
   let drop_non_ptrs (st:CPA.t) : CPA.t =
     if CPA.is_top st then st else

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1657,7 +1657,7 @@ struct
 
     let get_var = get_var
     let get ~ctx st addrs exp = get ~ctx st addrs exp
-    let set a ~ctx gs st lval lval_type ?lval_raw value = set ~ctx ~invariant:true st lval lval_type ?lval_raw value
+    let set ~ctx st lval lval_type ?lval_raw value = set ~ctx ~invariant:true st lval lval_type ?lval_raw value
 
     let refine_entire_var = true
     let map_oldval oldval _ = oldval
@@ -2854,7 +2854,7 @@ struct
           (* all updates happen in ctx with top values *)
           let get_var = get_var
           let get ~ctx st addrs exp = get ~ctx st addrs exp
-          let set a ~ctx gs st lval lval_type ?lval_raw value = set ~ctx ~invariant:false st lval lval_type ?lval_raw value (* TODO: should have invariant false? doesn't work with empty cpa then, because meets *)
+          let set ~ctx st lval lval_type ?lval_raw value = set ~ctx ~invariant:false st lval lval_type ?lval_raw value (* TODO: should have invariant false? doesn't work with empty cpa then, because meets *)
 
           let refine_entire_var = false
           let map_oldval oldval t_lval =

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1780,14 +1780,14 @@ struct
     let valu = eval_rv ~ctx exp in
     let refine () =
       let ask = Analyses.ask_of_ctx ctx in
-      let res = invariant ctx ask ctx.global ctx.local exp tv in
+      let res = invariant ctx ask ctx.local exp tv in
       if M.tracing then M.tracec "branch" "EqualSet result for expression %a is %a\n" d_exp exp Queries.ES.pretty (ctx.ask (Queries.EqualSet exp));
       if M.tracing then M.tracec "branch" "CondVars result for expression %a is %a\n" d_exp exp Queries.ES.pretty (ctx.ask (Queries.CondVars exp));
       if M.tracing then M.traceu "branch" "Invariant enforced!\n";
       match ctx.ask (Queries.CondVars exp) with
       | s when Queries.ES.cardinal s = 1 ->
         let e = Queries.ES.choose s in
-        invariant ctx ask ctx.global res e tv
+        invariant ctx ask res e tv
       | _ -> res
     in
     if M.tracing then M.traceli "branch" ~subsys:["invariant"] "Evaluating branch for expression %a with value %a\n" d_exp exp VD.pretty valu;
@@ -2034,7 +2034,7 @@ struct
   let assert_fn ctx e refine =
     (* make the state meet the assertion in the rest of the code *)
     if not refine then ctx.local else begin
-      let newst = invariant ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local e true in
+      let newst = invariant ctx (Analyses.ask_of_ctx ctx) ctx.local e true in
       (* if check_assert e newst <> `Lifted true then
           M.warn ~category:Assert ~msg:("Invariant \"" ^ expr ^ "\" does not stick.") (); *)
       newst
@@ -2873,7 +2873,7 @@ struct
         in
         let module Unassume = BaseInvariant.Make (UnassumeEval) in
         try
-          Unassume.invariant ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local e true
+          Unassume.invariant ctx (Analyses.ask_of_ctx ctx) ctx.local e true
         with Deadcode -> (* contradiction in unassume *)
           D.bot ()
       in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -512,7 +512,7 @@ struct
     in
     List.fold_right f vals []
 
-  let rec reachable_from_value (ask: Q.ask) (gs:glob_fun) st (value: value) (t: typ) (description: string)  =
+  let rec reachable_from_value ~ctx (ask: Q.ask) (gs:glob_fun) st (value: value) (t: typ) (description: string)  =
     let empty = AD.empty () in
     if M.tracing then M.trace "reachability" "Checking value %a\n" VD.pretty value;
     match value with
@@ -524,12 +524,12 @@ struct
     (* The main thing is to track where pointers go: *)
     | Address adrs -> AD.remove Addr.NullPtr adrs
     (* Unions are easy, I just ingore the type info. *)
-    | Union (f,e) -> reachable_from_value ask gs st e t description
+    | Union (f,e) -> reachable_from_value ~ctx ask gs st e t description
     (* For arrays, we ask to read from an unknown index, this will cause it
      * join all its values. *)
-    | Array a -> reachable_from_value ask gs st (ValueDomain.CArrays.get (Queries.to_value_domain_ask ask) a (None, ValueDomain.ArrIdxDomain.top ())) t description
-    | Blob (e,_,_) -> reachable_from_value ask gs st e t description
-    | Struct s -> ValueDomain.Structs.fold (fun k v acc -> AD.join (reachable_from_value ask gs st v t description) acc) s empty
+    | Array a -> reachable_from_value ~ctx ask gs st (ValueDomain.CArrays.get (Queries.to_value_domain_ask ask) a (None, ValueDomain.ArrIdxDomain.top ())) t description
+    | Blob (e,_,_) -> reachable_from_value ~ctx ask gs st e t description
+    | Struct s -> ValueDomain.Structs.fold (fun k v acc -> AD.join (reachable_from_value ~ctx ask gs st v t description) acc) s empty
     | Int _ -> empty
     | Float _ -> empty
     | MutexAttr _ -> empty
@@ -540,9 +540,9 @@ struct
   (* Get the list of addresses accessable immediately from a given address, thus
    * all pointers within a structure should be considered, but we don't follow
    * pointers. We return a flattend representation, thus simply an address (set). *)
-  let reachable_from_address (ask: Q.ask) (gs:glob_fun) st (adr: address): address =
+  let reachable_from_address ~ctx (ask: Q.ask) (gs:glob_fun) st (adr: address): address =
     if M.tracing then M.tracei "reachability" "Checking for %a\n" AD.pretty adr;
-    let res = reachable_from_value ask gs st (get ask gs st adr None) (AD.type_of adr) (AD.show adr) in
+    let res = reachable_from_value ~ctx ask gs st (get ask gs st adr None) (AD.type_of adr) (AD.show adr) in
     if M.tracing then M.traceu "reachability" "Reachable addresses: %a\n" AD.pretty res;
     res
 
@@ -550,7 +550,7 @@ struct
    * This section is very confusing, because I use the same construct, a set of
    * addresses, as both AD elements abstracting individual (ambiguous) addresses
    * and the workset of visited addresses. *)
-  let reachable_vars (ask: Q.ask) (args: address list) (gs:glob_fun) (st: store): address list =
+  let reachable_vars ~ctx (ask: Q.ask) (args: address list) (gs:glob_fun) (st: store): address list =
     if M.tracing then M.traceli "reachability" "Checking reachable arguments from [%a]!\n" (d_list ", " AD.pretty) args;
     let empty = AD.empty () in
     (* We begin looking at the parameters: *)
@@ -563,7 +563,7 @@ struct
       (* ok, let's visit all the variables in the workset and collect the new variables *)
       let visit_and_collect var (acc: address): address =
         let var = AD.singleton var in (* Very bad hack! Pathetic really! *)
-        AD.union (reachable_from_address ask gs st var) acc in
+        AD.union (reachable_from_address ~ctx ask gs st var) acc in
       let collected = AD.fold visit_and_collect !workset empty in
       (* And here we remove the already visited variables *)
       workset := AD.diff collected !visited
@@ -572,7 +572,7 @@ struct
     if M.tracing then M.traceu "reachability" "All reachable vars: %a\n" AD.pretty !visited;
     List.map AD.singleton (AD.elements !visited)
 
-  let reachable_vars ask args gs st = Timing.wrap "reachability" (reachable_vars ask args gs) st
+  let reachable_vars ~ctx ask args gs st = Timing.wrap "reachability" (reachable_vars ~ctx ask args gs) st
 
   let drop_non_ptrs (st:CPA.t) : CPA.t =
     if CPA.is_top st then st else
@@ -1348,7 +1348,7 @@ struct
         | Bot -> Queries.Result.bot q (* TODO: remove *)
         | Address a ->
           let a' = AD.remove Addr.UnknownPtr a in (* run reachable_vars without unknown just to be safe: TODO why? *)
-          let addrs = reachable_vars ask [a'] ctx.global ctx.local in
+          let addrs = reachable_vars ~ctx ask [a'] ctx.global ctx.local in
           let addrs' = List.fold_left (AD.join) (AD.empty ()) addrs in
           if AD.may_be_unknown a then
             AD.add UnknownPtr addrs' (* add unknown back *)
@@ -1887,8 +1887,8 @@ struct
     let gs = ctx.global in
     let st = ctx.local in
     let do_exp e =
-      let immediately_reachable = reachable_from_value ask gs st (eval_rv ~ctx e) (Cilfacade.typeOf e) (CilType.Exp.show e) in
-      reachable_vars ask [immediately_reachable] gs st
+      let immediately_reachable = reachable_from_value ~ctx ask gs st (eval_rv ~ctx e) (Cilfacade.typeOf e) (CilType.Exp.show e) in
+      reachable_vars ~ctx ask [immediately_reachable] gs st
     in
     List.concat_map do_exp exps
 
@@ -1964,7 +1964,7 @@ struct
     add_to_array_map fundec pa;
     let new_cpa = CPA.add_list pa st'.cpa in
     (* List of reachable variables *)
-    let reachable = List.concat_map AD.to_var_may (reachable_vars ask (get_ptrs vals) ctx.global st) in
+    let reachable = List.concat_map AD.to_var_may (reachable_vars ~ctx ask (get_ptrs vals) ctx.global st) in
     let reachable = List.filter (fun v -> CPA.mem v st.cpa) reachable in
     let new_cpa = CPA.add_list_fun reachable (fun v -> CPA.find v st.cpa) new_cpa in
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1779,15 +1779,14 @@ struct
   let branch ctx (exp:exp) (tv:bool) : store =
     let valu = eval_rv ~ctx exp in
     let refine () =
-      let ask = Analyses.ask_of_ctx ctx in
-      let res = invariant ctx ask ctx.local exp tv in
+      let res = invariant ctx ctx.local exp tv in
       if M.tracing then M.tracec "branch" "EqualSet result for expression %a is %a\n" d_exp exp Queries.ES.pretty (ctx.ask (Queries.EqualSet exp));
       if M.tracing then M.tracec "branch" "CondVars result for expression %a is %a\n" d_exp exp Queries.ES.pretty (ctx.ask (Queries.CondVars exp));
       if M.tracing then M.traceu "branch" "Invariant enforced!\n";
       match ctx.ask (Queries.CondVars exp) with
       | s when Queries.ES.cardinal s = 1 ->
         let e = Queries.ES.choose s in
-        invariant ctx ask res e tv
+        invariant ctx res e tv
       | _ -> res
     in
     if M.tracing then M.traceli "branch" ~subsys:["invariant"] "Evaluating branch for expression %a with value %a\n" d_exp exp VD.pretty valu;
@@ -2034,7 +2033,7 @@ struct
   let assert_fn ctx e refine =
     (* make the state meet the assertion in the rest of the code *)
     if not refine then ctx.local else begin
-      let newst = invariant ctx (Analyses.ask_of_ctx ctx) ctx.local e true in
+      let newst = invariant ctx ctx.local e true in
       (* if check_assert e newst <> `Lifted true then
           M.warn ~category:Assert ~msg:("Invariant \"" ^ expr ^ "\" does not stick.") (); *)
       newst
@@ -2873,7 +2872,7 @@ struct
         in
         let module Unassume = BaseInvariant.Make (UnassumeEval) in
         try
-          Unassume.invariant ctx (Analyses.ask_of_ctx ctx) ctx.local e true
+          Unassume.invariant ctx ctx.local e true
         with Deadcode -> (* contradiction in unassume *)
           D.bot ()
       in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -455,7 +455,7 @@ struct
    *  adding proper dependencies.
    *  For the exp argument it is always ok to put None. This means not using precise information about
    *  which part of an array is involved.  *)
-  let rec get ?(top=VD.top ()) ?(full=false) a (gs: glob_fun) (st: store) (addrs:address) (exp:exp option): value =
+  let rec get ~ctx ?(top=VD.top ()) ?(full=false) a (gs: glob_fun) (st: store) (addrs:address) (exp:exp option): value =
     let at = AD.type_of addrs in
     let firstvar = if M.tracing then match AD.to_var_may addrs with [] -> "" | x :: _ -> x.vname else "" in
     if M.tracing then M.traceli "get" ~var:firstvar "Address: %a\nState: %a\n" AD.pretty addrs CPA.pretty st.cpa;
@@ -464,7 +464,7 @@ struct
       let f_addr (x, offs) =
         (* get hold of the variable value, either from local or global state *)
         let var = get_var a gs st x in
-        let v = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get a gs st x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
+        let v = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get ~ctx a gs st x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
         if M.tracing then M.tracec "get" "var = %a, %a = %a\n" VD.pretty var AD.pretty (AD.of_mval (x, offs)) VD.pretty v;
         if full then var else match v with
           | Blob (c,s,_) -> c
@@ -542,7 +542,7 @@ struct
    * pointers. We return a flattend representation, thus simply an address (set). *)
   let reachable_from_address ~ctx (adr: address): address =
     if M.tracing then M.tracei "reachability" "Checking for %a\n" AD.pretty adr;
-    let res = reachable_from_value ~ctx (get (Analyses.ask_of_ctx ctx) ctx.global ctx.local adr None) (AD.type_of adr) (AD.show adr) in
+    let res = reachable_from_value ~ctx (get ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local adr None) (AD.type_of adr) (AD.show adr) in
     if M.tracing then M.traceu "reachability" "Reachable addresses: %a\n" AD.pretty res;
     res
 
@@ -659,7 +659,7 @@ struct
         | JmpBuf _ -> (empty, TS.bot (), false) (* TODO: is this right? *)
         | Mutex -> (empty, TS.bot (), false) (* TODO: is this right? *)
       in
-      reachable_from_value (get (Analyses.ask_of_ctx ctx) ctx.global ctx.local adr None)
+      reachable_from_value (get ~ctx (Analyses.ask_of_ctx ctx) ctx.global ctx.local adr None)
     in
     let visited = ref empty in
     let work = ref ps in
@@ -904,7 +904,7 @@ struct
 
   and eval_rv_base_lval ~eval_lv ~ctx (a: Q.ask) (gs:glob_fun) (st: store) (exp: exp) (lv: lval): value =
     match lv with
-    | (Var v, ofs) -> get a gs st (eval_lv ~ctx (Var v, ofs)) (Some exp)
+    | (Var v, ofs) -> get ~ctx a gs st (eval_lv ~ctx (Var v, ofs)) (Some exp)
     (* | Lval (Mem e, ofs) -> get a gs st (eval_lv ~ctx (Mem e, ofs)) *)
     | (Mem e, ofs) ->
       (*M.tracel "cast" "Deref: lval: %a\n" d_plainlval lv;*)
@@ -949,13 +949,13 @@ struct
       let lookup_with_offs addr =
         let v = (* abstract base value *)
           if cast_ok addr then
-            get ~top:(VD.top_value t) a gs st (AD.singleton addr) (Some exp)  (* downcasts are safe *)
+            get ~ctx ~top:(VD.top_value t) a gs st (AD.singleton addr) (Some exp)  (* downcasts are safe *)
           else
             VD.top () (* upcasts not! *)
         in
         let v' = VD.cast t v in (* cast to the expected type (the abstract type might be something other than t since we don't change addresses upon casts!) *)
         if M.tracing then M.tracel "cast" "Ptr-Deref: cast %a to %a = %a!\n" VD.pretty v d_type t VD.pretty v';
-        let v' = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get a gs st x (Some exp)) v' (convert_offset ~ctx ofs) (Some exp) None t in (* handle offset *)
+        let v' = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get ~ctx a gs st x (Some exp)) v' (convert_offset ~ctx ofs) (Some exp) None t in (* handle offset *)
         v'
       in
       AD.fold (fun a acc -> VD.join acc (lookup_with_offs a)) p (VD.bot ())
@@ -1250,7 +1250,7 @@ struct
         | Address jmp_buf ->
           if AD.mem Addr.UnknownPtr jmp_buf then
             M.warn ~category:Imprecise "Jump buffer %a may contain unknown pointers." d_exp e;
-          begin match get ~top:(VD.bot ()) ask ctx.global ctx.local jmp_buf None with
+          begin match get ~ctx ~top:(VD.bot ()) ask ctx.global ctx.local jmp_buf None with
             | JmpBuf (x, copied) ->
               if copied then
                 M.warn ~category:(Behavior (Undefined Other)) "The jump buffer %a contains values that were copied here instead of being set by setjmp. This is Undefined Behavior." d_exp e;
@@ -1311,7 +1311,7 @@ struct
               else
                 a
             in
-            let r = get ~full:true ask ctx.global ctx.local a None in
+            let r = get ~ctx ~full:true ask ctx.global ctx.local a None in
             (* ignore @@ printf "BlobSize %a = %a\n" d_plainexp e VD.pretty r; *)
             (match r with
              | Array a ->
@@ -1659,7 +1659,7 @@ struct
     let convert_offset = convert_offset
 
     let get_var = get_var
-    let get a gs st addrs exp = get a gs st addrs exp
+    let get ~ctx a gs st addrs exp = get ~ctx a gs st addrs exp
     let set a ~ctx gs st lval lval_type ?lval_raw value = set ~ctx ~invariant:true st lval lval_type ?lval_raw value
 
     let refine_entire_var = true
@@ -1907,7 +1907,7 @@ struct
     let ask = Analyses.ask_of_ctx ctx in
     let invalidate_address st a =
       let t = AD.type_of a in
-      let v = get ask gs st a None in (* None here is ok, just causes us to be a bit less precise *)
+      let v = get ~ctx ask gs st a None in (* None here is ok, just causes us to be a bit less precise *)
       let nv =  VD.invalidate_value (Queries.to_value_domain_ask ask) t v in
       (a, t, nv)
     in
@@ -2259,7 +2259,7 @@ struct
         let lv_a, lv_typ = match lv with
           | Some lv_val -> eval_lv ~ctx lv_val, Cilfacade.typeOfLval lv_val
           | None -> s1_a, s1_typ in
-        begin match (get (Analyses.ask_of_ctx ctx) gs st s1_a None), get (Analyses.ask_of_ctx ctx) gs st s2_a None with
+        begin match (get ~ctx (Analyses.ask_of_ctx ctx) gs st s1_a None), get ~ctx (Analyses.ask_of_ctx ctx) gs st s2_a None with
           | Array array_s1, Array array_s2 -> set ~ctx ~blob_destructive:true st lv_a lv_typ (op_array array_s1 array_s2)
           | Array array_s1, _ when CilType.Typ.equal s2_typ charPtrType ->
             let s2_null_bytes = List.map CArrays.to_null_byte_domain (AD.to_string s2_a) in
@@ -2336,7 +2336,7 @@ struct
               Int (AD.to_string_length a)
               (* else compute strlen in array domain *)
             else
-              begin match get (Analyses.ask_of_ctx ctx) gs st a None with
+              begin match get ~ctx (Analyses.ask_of_ctx ctx) gs st a None with
                 | Array array_s -> Int (CArrays.to_string_length array_s)
                 | _ -> VD.top_value (unrollType dest_typ)
               end in
@@ -2571,7 +2571,7 @@ struct
             | _ -> AD.top_ptr (* TODO: why does this ever happen? *)
           in
           let p_addr' = AD.remove NullPtr p_addr in (* realloc with NULL is same as malloc, remove to avoid unknown value from NullPtr access *)
-          let p_addr_get = get ask gs st p_addr' None in (* implicitly includes join of malloc value (VD.bot) *)
+          let p_addr_get = get ~ctx ask gs st p_addr' None in (* implicitly includes join of malloc value (VD.bot) *)
           let size_int = eval_int ~ctx size in
           let heap_val:value = Blob (p_addr_get, size_int, true) in (* copy old contents with new size *)
           let heap_addr = AD.of_var (heap_var false ctx) in
@@ -2667,7 +2667,7 @@ struct
             (* "get" returned "unknown" when applied to a void type, so special case void types. This caused problems with some sv-comps (e.g. regtest 64 11) *)
             | Some voidVal, TVoid _ -> {st with cpa = CPA.add v voidVal st.cpa}
             | _, _ -> begin
-                let new_val = get ask ctx.global fun_st address None in
+                let new_val = get ~ctx ask ctx.global fun_st address None in
                 if M.tracing then M.trace "taintPC" "update val: %a\n\n" VD.pretty new_val;
                 let st' = set_savetop ~ctx st address lval_type new_val in
                 let partDep = Dep.find_opt v fun_st.deps in
@@ -2742,7 +2742,7 @@ struct
       let return_var = return_var () in
       let return_val =
         if CPA.mem (return_varinfo ()) fun_st.cpa
-        then get (Analyses.ask_of_ctx ctx) ctx.global fun_st return_var None
+        then get ~ctx (Analyses.ask_of_ctx ctx) ctx.global fun_st return_var None
         else VD.top ()
       in
 
@@ -2862,7 +2862,7 @@ struct
 
           (* all updates happen in ctx with top values *)
           let get_var = get_var
-          let get a gs st addrs exp = get a gs st addrs exp
+          let get ~ctx a gs st addrs exp = get ~ctx a gs st addrs exp
           let set a ~ctx gs st lval lval_type ?lval_raw value = set ~ctx ~invariant:false st lval lval_type ?lval_raw value (* TODO: should have invariant false? doesn't work with empty cpa then, because meets *)
 
           let refine_entire_var = false

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -443,9 +443,10 @@ struct
   let publish_all ctx reason =
     ignore (sync' reason ctx)
 
-  let get_var ~ctx (a: Q.ask) (st: store) (x: varinfo): value =
-    if (!earlyglobs || ThreadFlag.has_ever_been_multi a) && is_global a x then
-      Priv.read_global a (priv_getg ctx.global) st x
+  let get_var ~ctx (st: store) (x: varinfo): value =
+    let ask = Analyses.ask_of_ctx ctx in
+    if (!earlyglobs || ThreadFlag.has_ever_been_multi ask) && is_global ask x then
+      Priv.read_global ask (priv_getg ctx.global) st x
     else begin
       if M.tracing then M.tracec "get" "Singlethreaded mode.\n";
       CPA.find x st.cpa
@@ -455,7 +456,7 @@ struct
    *  adding proper dependencies.
    *  For the exp argument it is always ok to put None. This means not using precise information about
    *  which part of an array is involved.  *)
-  let rec get ~ctx ?(top=VD.top ()) ?(full=false) a (st: store) (addrs:address) (exp:exp option): value =
+  let rec get ~ctx ?(top=VD.top ()) ?(full=false) (st: store) (addrs:address) (exp:exp option): value =
     let at = AD.type_of addrs in
     let firstvar = if M.tracing then match AD.to_var_may addrs with [] -> "" | x :: _ -> x.vname else "" in
     if M.tracing then M.traceli "get" ~var:firstvar "Address: %a\nState: %a\n" AD.pretty addrs CPA.pretty st.cpa;
@@ -463,8 +464,8 @@ struct
     let res =
       let f_addr (x, offs) =
         (* get hold of the variable value, either from local or global state *)
-        let var = get_var ~ctx a st x in
-        let v = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get ~ctx a st x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
+        let var = get_var ~ctx st x in
+        let v = VD.eval_offset (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) (fun x -> get ~ctx st x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
         if M.tracing then M.tracec "get" "var = %a, %a = %a\n" VD.pretty var AD.pretty (AD.of_mval (x, offs)) VD.pretty v;
         if full then var else match v with
           | Blob (c,s,_) -> c
@@ -542,7 +543,7 @@ struct
    * pointers. We return a flattend representation, thus simply an address (set). *)
   let reachable_from_address ~ctx (adr: address): address =
     if M.tracing then M.tracei "reachability" "Checking for %a\n" AD.pretty adr;
-    let res = reachable_from_value ~ctx (get ~ctx (Analyses.ask_of_ctx ctx) ctx.local adr None) (AD.type_of adr) (AD.show adr) in
+    let res = reachable_from_value ~ctx (get ~ctx ctx.local adr None) (AD.type_of adr) (AD.show adr) in
     if M.tracing then M.traceu "reachability" "Reachable addresses: %a\n" AD.pretty res;
     res
 
@@ -659,7 +660,7 @@ struct
         | JmpBuf _ -> (empty, TS.bot (), false) (* TODO: is this right? *)
         | Mutex -> (empty, TS.bot (), false) (* TODO: is this right? *)
       in
-      reachable_from_value (get ~ctx (Analyses.ask_of_ctx ctx) ctx.local adr None)
+      reachable_from_value (get ~ctx ctx.local adr None)
     in
     let visited = ref empty in
     let work = ref ps in
@@ -904,7 +905,7 @@ struct
 
   and eval_rv_base_lval ~eval_lv ~ctx (a: Q.ask) (gs:glob_fun) (st: store) (exp: exp) (lv: lval): value =
     match lv with
-    | (Var v, ofs) -> get ~ctx a st (eval_lv ~ctx (Var v, ofs)) (Some exp)
+    | (Var v, ofs) -> get ~ctx st (eval_lv ~ctx (Var v, ofs)) (Some exp)
     (* | Lval (Mem e, ofs) -> get a gs st (eval_lv ~ctx (Mem e, ofs)) *)
     | (Mem e, ofs) ->
       (*M.tracel "cast" "Deref: lval: %a\n" d_plainlval lv;*)
@@ -949,13 +950,13 @@ struct
       let lookup_with_offs addr =
         let v = (* abstract base value *)
           if cast_ok addr then
-            get ~ctx ~top:(VD.top_value t) a st (AD.singleton addr) (Some exp)  (* downcasts are safe *)
+            get ~ctx ~top:(VD.top_value t) st (AD.singleton addr) (Some exp)  (* downcasts are safe *)
           else
             VD.top () (* upcasts not! *)
         in
         let v' = VD.cast t v in (* cast to the expected type (the abstract type might be something other than t since we don't change addresses upon casts!) *)
         if M.tracing then M.tracel "cast" "Ptr-Deref: cast %a to %a = %a!\n" VD.pretty v d_type t VD.pretty v';
-        let v' = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get ~ctx a st x (Some exp)) v' (convert_offset ~ctx ofs) (Some exp) None t in (* handle offset *)
+        let v' = VD.eval_offset (Queries.to_value_domain_ask a) (fun x -> get ~ctx st x (Some exp)) v' (convert_offset ~ctx ofs) (Some exp) None t in (* handle offset *)
         v'
       in
       AD.fold (fun a acc -> VD.join acc (lookup_with_offs a)) p (VD.bot ())
@@ -1172,7 +1173,7 @@ struct
     struct
       let context = context
       let scope = Node.find_fundec ctx.node
-      let find v = get_var ~ctx ask ctx.local v
+      let find v = get_var ~ctx ctx.local v
     end
     in
     let module I = ValueDomain.ValueInvariant (Arg) in
@@ -1250,7 +1251,7 @@ struct
         | Address jmp_buf ->
           if AD.mem Addr.UnknownPtr jmp_buf then
             M.warn ~category:Imprecise "Jump buffer %a may contain unknown pointers." d_exp e;
-          begin match get ~ctx ~top:(VD.bot ()) ask ctx.local jmp_buf None with
+          begin match get ~ctx ~top:(VD.bot ()) ctx.local jmp_buf None with
             | JmpBuf (x, copied) ->
               if copied then
                 M.warn ~category:(Behavior (Undefined Other)) "The jump buffer %a contains values that were copied here instead of being set by setjmp. This is Undefined Behavior." d_exp e;
@@ -1311,7 +1312,7 @@ struct
               else
                 a
             in
-            let r = get ~ctx ~full:true ask ctx.local a None in
+            let r = get ~ctx ~full:true ctx.local a None in
             (* ignore @@ printf "BlobSize %a = %a\n" d_plainexp e VD.pretty r; *)
             (match r with
              | Array a ->
@@ -1659,7 +1660,7 @@ struct
     let convert_offset = convert_offset
 
     let get_var = get_var
-    let get ~ctx a st addrs exp = get ~ctx a st addrs exp
+    let get ~ctx st addrs exp = get ~ctx st addrs exp
     let set a ~ctx gs st lval lval_type ?lval_raw value = set ~ctx ~invariant:true st lval lval_type ?lval_raw value
 
     let refine_entire_var = true
@@ -1906,7 +1907,7 @@ struct
     let ask = Analyses.ask_of_ctx ctx in
     let invalidate_address st a =
       let t = AD.type_of a in
-      let v = get ~ctx ask st a None in (* None here is ok, just causes us to be a bit less precise *)
+      let v = get ~ctx st a None in (* None here is ok, just causes us to be a bit less precise *)
       let nv =  VD.invalidate_value (Queries.to_value_domain_ask ask) t v in
       (a, t, nv)
     in
@@ -2257,7 +2258,7 @@ struct
         let lv_a, lv_typ = match lv with
           | Some lv_val -> eval_lv ~ctx lv_val, Cilfacade.typeOfLval lv_val
           | None -> s1_a, s1_typ in
-        begin match (get ~ctx (Analyses.ask_of_ctx ctx) st s1_a None), get ~ctx (Analyses.ask_of_ctx ctx) st s2_a None with
+        begin match (get ~ctx st s1_a None), get ~ctx st s2_a None with
           | Array array_s1, Array array_s2 -> set ~ctx ~blob_destructive:true st lv_a lv_typ (op_array array_s1 array_s2)
           | Array array_s1, _ when CilType.Typ.equal s2_typ charPtrType ->
             let s2_null_bytes = List.map CArrays.to_null_byte_domain (AD.to_string s2_a) in
@@ -2334,7 +2335,7 @@ struct
               Int (AD.to_string_length a)
               (* else compute strlen in array domain *)
             else
-              begin match get ~ctx (Analyses.ask_of_ctx ctx) st a None with
+              begin match get ~ctx st a None with
                 | Array array_s -> Int (CArrays.to_string_length array_s)
                 | _ -> VD.top_value (unrollType dest_typ)
               end in
@@ -2558,7 +2559,6 @@ struct
       check_invalid_mem_dealloc ctx f p;
       begin match lv with
         | Some lv ->
-          let ask = Analyses.ask_of_ctx ctx in
           let p_rv = eval_rv ~ctx p in
           let p_addr =
             match p_rv with
@@ -2569,7 +2569,7 @@ struct
             | _ -> AD.top_ptr (* TODO: why does this ever happen? *)
           in
           let p_addr' = AD.remove NullPtr p_addr in (* realloc with NULL is same as malloc, remove to avoid unknown value from NullPtr access *)
-          let p_addr_get = get ~ctx ask st p_addr' None in (* implicitly includes join of malloc value (VD.bot) *)
+          let p_addr_get = get ~ctx st p_addr' None in (* implicitly includes join of malloc value (VD.bot) *)
           let size_int = eval_int ~ctx size in
           let heap_val:value = Blob (p_addr_get, size_int, true) in (* copy old contents with new size *)
           let heap_addr = AD.of_var (heap_var false ctx) in
@@ -2649,7 +2649,6 @@ struct
     if get_bool "sem.noreturn.dead_code" && Cil.hasAttribute "noreturn" f.vattr then raise Deadcode else st
 
   let combine_st ctx (local_st : store) (fun_st : store) (tainted_lvs : AD.t) : store =
-    let ask = Analyses.ask_of_ctx ctx in
     AD.fold (fun addr (st: store) ->
         match addr with
         | Addr.Addr (v,o) ->
@@ -2665,7 +2664,7 @@ struct
             (* "get" returned "unknown" when applied to a void type, so special case void types. This caused problems with some sv-comps (e.g. regtest 64 11) *)
             | Some voidVal, TVoid _ -> {st with cpa = CPA.add v voidVal st.cpa}
             | _, _ -> begin
-                let new_val = get ~ctx ask fun_st address None in
+                let new_val = get ~ctx fun_st address None in
                 if M.tracing then M.trace "taintPC" "update val: %a\n\n" VD.pretty new_val;
                 let st' = set_savetop ~ctx st address lval_type new_val in
                 let partDep = Dep.find_opt v fun_st.deps in
@@ -2740,7 +2739,7 @@ struct
       let return_var = return_var () in
       let return_val =
         if CPA.mem (return_varinfo ()) fun_st.cpa
-        then get ~ctx (Analyses.ask_of_ctx ctx) fun_st return_var None
+        then get ~ctx fun_st return_var None
         else VD.top ()
       in
 
@@ -2860,7 +2859,7 @@ struct
 
           (* all updates happen in ctx with top values *)
           let get_var = get_var
-          let get ~ctx a st addrs exp = get ~ctx a st addrs exp
+          let get ~ctx st addrs exp = get ~ctx st addrs exp
           let set a ~ctx gs st lval lval_type ?lval_raw value = set ~ctx ~invariant:false st lval lval_type ?lval_raw value (* TODO: should have invariant false? doesn't work with empty cpa then, because meets *)
 
           let refine_entire_var = false

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -18,7 +18,7 @@ sig
   val eval_rv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> exp -> VD.t
   val eval_rv_address: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> exp -> VD.t
   val eval_lv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> lval -> AD.t
-  val convert_offset: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> offset -> ID.t Offset.t
+  val convert_offset: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> offset -> ID.t Offset.t
 
   val get_var: Queries.ask -> (V.t -> G.t) -> D.t -> varinfo -> VD.t
   val get: Queries.ask -> (V.t -> G.t) -> D.t -> AD.t -> exp option -> VD.t
@@ -98,7 +98,7 @@ struct
       (* For variables, this is done at to the level of entire variables to benefit e.g. from disjunctive struct domains *)
       let old_val = get_var a gs st var in
       let old_val = map_oldval old_val var.vtype in
-      let offs = convert_offset ~ctx a gs st o in
+      let offs = convert_offset ~ctx o in
       let new_val = VD.update_offset (Queries.to_value_domain_ask a) old_val offs c' (Some exp) x (var.vtype) in
       let v = apply_invariant ~old_val ~new_val in
       if is_some_bot v then contra st

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -21,7 +21,7 @@ sig
   val convert_offset: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> offset -> ID.t Offset.t
 
   val get_var: Queries.ask -> (V.t -> G.t) -> D.t -> varinfo -> VD.t
-  val get: Queries.ask -> (V.t -> G.t) -> D.t -> AD.t -> exp option -> VD.t
+  val get: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> AD.t -> exp option -> VD.t
   val set: Queries.ask -> ctx:(D.t, G.t, _, V.t) Analyses.ctx -> (V.t -> G.t) -> D.t -> AD.t -> typ -> ?lval_raw:lval -> VD.t -> D.t
 
   val refine_entire_var: bool
@@ -67,7 +67,7 @@ struct
     let addr = eval_lv ~ctx lval in
     if (AD.is_top addr) then st
     else
-      let old_val = get a gs st addr None in (* None is ok here, we could try to get more precise, but this is ok (reading at unknown position in array) *)
+      let old_val = get ~ctx a gs st addr None in (* None is ok here, we could try to get more precise, but this is ok (reading at unknown position in array) *)
       let t_lval = Cilfacade.typeOfLval lval in
       let old_val = map_oldval old_val t_lval in
       let old_val =
@@ -79,7 +79,7 @@ struct
           old_val
       in
       let state_with_excluded = set a gs st addr t_lval value ~ctx in
-      let value =  get a gs state_with_excluded addr None in
+      let value =  get ~ctx a gs state_with_excluded addr None in
       let new_val = apply_invariant ~old_val ~new_val:value in
       if M.tracing then M.traceu "invariant" "New value is %a\n" VD.pretty new_val;
       (* make that address meet the invariant, i.e exclusion sets will be joined *)

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -20,7 +20,7 @@ sig
   val eval_lv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> lval -> AD.t
   val convert_offset: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> offset -> ID.t Offset.t
 
-  val get_var: Queries.ask -> (V.t -> G.t) -> D.t -> varinfo -> VD.t
+  val get_var: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> varinfo -> VD.t
   val get: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> AD.t -> exp option -> VD.t
   val set: Queries.ask -> ctx:(D.t, G.t, _, V.t) Analyses.ctx -> (V.t -> G.t) -> D.t -> AD.t -> typ -> ?lval_raw:lval -> VD.t -> D.t
 
@@ -96,7 +96,7 @@ struct
     match x with
     | Var var, o when refine_entire_var ->
       (* For variables, this is done at to the level of entire variables to benefit e.g. from disjunctive struct domains *)
-      let old_val = get_var a gs st var in
+      let old_val = get_var ~ctx a gs st var in
       let old_val = map_oldval old_val var.vtype in
       let offs = convert_offset ~ctx o in
       let new_val = VD.update_offset (Queries.to_value_domain_ask a) old_val offs c' (Some exp) x (var.vtype) in

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -15,7 +15,7 @@ sig
   module V: Analyses.SpecSysVar
   module G: Lattice.S
 
-  val eval_rv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> D.t -> exp -> VD.t
+  val eval_rv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> exp -> VD.t
   val eval_rv_address: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> exp -> VD.t
   val eval_lv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> lval -> AD.t
   val convert_offset: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> offset -> ID.t Offset.t
@@ -211,12 +211,12 @@ struct
       let switchedOp = function Lt -> Gt | Gt -> Lt | Le -> Ge | Ge -> Le | x -> x in (* a op b <=> b (switchedOp op) b *)
       match exp with
       (* Since we handle not only equalities, the order is important *)
-      | BinOp(op, Lval x, rval, typ) -> helper op x (VD.cast (Cilfacade.typeOfLval x) (eval_rv ~ctx st rval)) tv
+      | BinOp(op, Lval x, rval, typ) -> helper op x (VD.cast (Cilfacade.typeOfLval x) (eval_rv ~ctx rval)) tv
       | BinOp(op, rval, Lval x, typ) -> derived_invariant (BinOp(switchedOp op, Lval x, rval, typ)) tv
       | BinOp(op, CastE (t1, c1), CastE (t2, c2), t) when (op = Eq || op = Ne) && typeSig t1 = typeSig t2 && VD.is_safe_cast t1 (Cilfacade.typeOf c1) && VD.is_safe_cast t2 (Cilfacade.typeOf c2)
         -> derived_invariant (BinOp (op, c1, c2, t)) tv
       | BinOp(op, CastE (TInt (ik, _) as t1, Lval x), rval, typ) ->
-        (match eval_rv ~ctx st (Lval x) with
+        (match eval_rv ~ctx (Lval x) with
          | Int v ->
            (* This is tricky: It it is not sufficient to check that ID.cast_to_ik v = v
              * If there is one domain that knows this to be true and the other does not, we
@@ -555,7 +555,7 @@ struct
           a, b
       with FloatDomain.ArithmeticOnFloatBot _ -> raise Analyses.Deadcode
     in
-    let eval e st = eval_rv ~ctx st e in
+    let eval e st = eval_rv ~ctx e in
     let eval_bool e st = match eval e st with Int i -> ID.to_bool i | _ -> None in
     let unroll_fk_of_exp e =
       match unrollType (Cilfacade.typeOf e) with

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -15,7 +15,7 @@ sig
   module V: Analyses.SpecSysVar
   module G: Lattice.S
 
-  val eval_rv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> exp -> VD.t
+  val eval_rv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> D.t -> exp -> VD.t
   val eval_rv_address: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> exp -> VD.t
   val eval_lv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> lval -> AD.t
   val convert_offset: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> offset -> ID.t Offset.t
@@ -26,7 +26,7 @@ sig
 
   val refine_entire_var: bool
   val map_oldval: VD.t -> typ -> VD.t
-  val eval_rv_lval_refine: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> exp -> lval -> VD.t
+  val eval_rv_lval_refine: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> D.t -> exp -> lval -> VD.t
 
   val id_meet_down: old:ID.t -> c:ID.t -> ID.t
   val fd_meet_down: old:FD.t -> c:FD.t -> FD.t
@@ -111,7 +111,7 @@ struct
     | Var _, _
     | Mem _, _ ->
       (* For accesses via pointers, not yet *)
-      let old_val = eval_rv_lval_refine ~ctx a gs st exp x in
+      let old_val = eval_rv_lval_refine ~ctx st exp x in
       let old_val = map_oldval old_val (Cilfacade.typeOfLval x) in
       let v = apply_invariant ~old_val ~new_val:c' in
       if is_some_bot v then contra st
@@ -211,12 +211,12 @@ struct
       let switchedOp = function Lt -> Gt | Gt -> Lt | Le -> Ge | Ge -> Le | x -> x in (* a op b <=> b (switchedOp op) b *)
       match exp with
       (* Since we handle not only equalities, the order is important *)
-      | BinOp(op, Lval x, rval, typ) -> helper op x (VD.cast (Cilfacade.typeOfLval x) (eval_rv ~ctx a gs st rval)) tv
+      | BinOp(op, Lval x, rval, typ) -> helper op x (VD.cast (Cilfacade.typeOfLval x) (eval_rv ~ctx st rval)) tv
       | BinOp(op, rval, Lval x, typ) -> derived_invariant (BinOp(switchedOp op, Lval x, rval, typ)) tv
       | BinOp(op, CastE (t1, c1), CastE (t2, c2), t) when (op = Eq || op = Ne) && typeSig t1 = typeSig t2 && VD.is_safe_cast t1 (Cilfacade.typeOf c1) && VD.is_safe_cast t2 (Cilfacade.typeOf c2)
         -> derived_invariant (BinOp (op, c1, c2, t)) tv
       | BinOp(op, CastE (TInt (ik, _) as t1, Lval x), rval, typ) ->
-        (match eval_rv ~ctx a gs st (Lval x) with
+        (match eval_rv ~ctx st (Lval x) with
          | Int v ->
            (* This is tricky: It it is not sufficient to check that ID.cast_to_ik v = v
              * If there is one domain that knows this to be true and the other does not, we
@@ -555,7 +555,7 @@ struct
           a, b
       with FloatDomain.ArithmeticOnFloatBot _ -> raise Analyses.Deadcode
     in
-    let eval e st = eval_rv ~ctx a gs st e in
+    let eval e st = eval_rv ~ctx st e in
     let eval_bool e st = match eval e st with Int i -> ID.to_bool i | _ -> None in
     let unroll_fk_of_exp e =
       match unrollType (Cilfacade.typeOf e) with

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -17,7 +17,7 @@ sig
 
   val eval_rv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> exp -> VD.t
   val eval_rv_address: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> exp -> VD.t
-  val eval_lv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> lval -> AD.t
+  val eval_lv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> lval -> AD.t
   val convert_offset: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> offset -> ID.t Offset.t
 
   val get_var: Queries.ask -> (V.t -> G.t) -> D.t -> varinfo -> VD.t
@@ -64,7 +64,7 @@ struct
 
   let refine_lv_fallback ctx a gs st lval value tv =
     if M.tracing then M.tracec "invariant" "Restricting %a with %a\n" d_lval lval VD.pretty value;
-    let addr = eval_lv ~ctx a gs st lval in
+    let addr = eval_lv ~ctx lval in
     if (AD.is_top addr) then st
     else
       let old_val = get a gs st addr None in (* None is ok here, we could try to get more precise, but this is ok (reading at unknown position in array) *)
@@ -92,7 +92,7 @@ struct
       else set a gs st addr t_lval new_val ~ctx (* no *_raw because this is not a real assignment *)
 
   let refine_lv ctx a gs st c x c' pretty exp =
-    let set' lval v st = set a gs st (eval_lv ~ctx a gs st lval) (Cilfacade.typeOfLval lval) ~lval_raw:lval v ~ctx in
+    let set' lval v st = set a gs st (eval_lv ~ctx lval) (Cilfacade.typeOfLval lval) ~lval_raw:lval v ~ctx in
     match x with
     | Var var, o when refine_entire_var ->
       (* For variables, this is done at to the level of entire variables to benefit e.g. from disjunctive struct domains *)

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -16,7 +16,7 @@ sig
   module G: Lattice.S
 
   val eval_rv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> exp -> VD.t
-  val eval_rv_address: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> exp -> VD.t
+  val eval_rv_address: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> exp -> VD.t
   val eval_lv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> lval -> AD.t
   val convert_offset: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> offset -> ID.t Offset.t
 
@@ -147,7 +147,7 @@ struct
             end
           | Address n -> begin
               if M.tracing then M.tracec "invariant" "Yes, %a is not %a\n" d_lval x AD.pretty n;
-              match eval_rv_address ~ctx a gs st (Lval x) with
+              match eval_rv_address ~ctx (Lval x) with
               | Address a when AD.is_definite n ->
                 Some (x, Address (AD.diff a n))
               | Top when AD.is_null n ->

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -15,10 +15,10 @@ sig
   module V: Analyses.SpecSysVar
   module G: Lattice.S
 
-  val eval_rv: Queries.ask -> (V.t -> G.t) -> D.t -> exp -> VD.t
-  val eval_rv_address: Queries.ask -> (V.t -> G.t) -> D.t -> exp -> VD.t
-  val eval_lv: Queries.ask -> (V.t -> G.t) -> D.t -> lval -> AD.t
-  val convert_offset: Queries.ask -> (V.t -> G.t) -> D.t -> offset -> ID.t Offset.t
+  val eval_rv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> exp -> VD.t
+  val eval_rv_address: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> exp -> VD.t
+  val eval_lv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> lval -> AD.t
+  val convert_offset: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> offset -> ID.t Offset.t
 
   val get_var: Queries.ask -> (V.t -> G.t) -> D.t -> varinfo -> VD.t
   val get: Queries.ask -> (V.t -> G.t) -> D.t -> AD.t -> exp option -> VD.t
@@ -26,7 +26,7 @@ sig
 
   val refine_entire_var: bool
   val map_oldval: VD.t -> typ -> VD.t
-  val eval_rv_lval_refine: Queries.ask -> (V.t -> G.t) -> D.t -> exp -> lval -> VD.t
+  val eval_rv_lval_refine: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> (V.t -> G.t) -> D.t -> exp -> lval -> VD.t
 
   val id_meet_down: old:ID.t -> c:ID.t -> ID.t
   val fd_meet_down: old:FD.t -> c:FD.t -> FD.t
@@ -64,7 +64,7 @@ struct
 
   let refine_lv_fallback ctx a gs st lval value tv =
     if M.tracing then M.tracec "invariant" "Restricting %a with %a\n" d_lval lval VD.pretty value;
-    let addr = eval_lv a gs st lval in
+    let addr = eval_lv ~ctx a gs st lval in
     if (AD.is_top addr) then st
     else
       let old_val = get a gs st addr None in (* None is ok here, we could try to get more precise, but this is ok (reading at unknown position in array) *)
@@ -92,13 +92,13 @@ struct
       else set a gs st addr t_lval new_val ~ctx (* no *_raw because this is not a real assignment *)
 
   let refine_lv ctx a gs st c x c' pretty exp =
-    let set' lval v st = set a gs st (eval_lv a gs st lval) (Cilfacade.typeOfLval lval) ~lval_raw:lval v ~ctx in
+    let set' lval v st = set a gs st (eval_lv ~ctx a gs st lval) (Cilfacade.typeOfLval lval) ~lval_raw:lval v ~ctx in
     match x with
     | Var var, o when refine_entire_var ->
       (* For variables, this is done at to the level of entire variables to benefit e.g. from disjunctive struct domains *)
       let old_val = get_var a gs st var in
       let old_val = map_oldval old_val var.vtype in
-      let offs = convert_offset a gs st o in
+      let offs = convert_offset ~ctx a gs st o in
       let new_val = VD.update_offset (Queries.to_value_domain_ask a) old_val offs c' (Some exp) x (var.vtype) in
       let v = apply_invariant ~old_val ~new_val in
       if is_some_bot v then contra st
@@ -111,7 +111,7 @@ struct
     | Var _, _
     | Mem _, _ ->
       (* For accesses via pointers, not yet *)
-      let old_val = eval_rv_lval_refine a gs st exp x in
+      let old_val = eval_rv_lval_refine ~ctx a gs st exp x in
       let old_val = map_oldval old_val (Cilfacade.typeOfLval x) in
       let v = apply_invariant ~old_val ~new_val:c' in
       if is_some_bot v then contra st
@@ -147,7 +147,7 @@ struct
             end
           | Address n -> begin
               if M.tracing then M.tracec "invariant" "Yes, %a is not %a\n" d_lval x AD.pretty n;
-              match eval_rv_address a gs st (Lval x) with
+              match eval_rv_address ~ctx a gs st (Lval x) with
               | Address a when AD.is_definite n ->
                 Some (x, Address (AD.diff a n))
               | Top when AD.is_null n ->
@@ -211,12 +211,12 @@ struct
       let switchedOp = function Lt -> Gt | Gt -> Lt | Le -> Ge | Ge -> Le | x -> x in (* a op b <=> b (switchedOp op) b *)
       match exp with
       (* Since we handle not only equalities, the order is important *)
-      | BinOp(op, Lval x, rval, typ) -> helper op x (VD.cast (Cilfacade.typeOfLval x) (eval_rv a gs st rval)) tv
+      | BinOp(op, Lval x, rval, typ) -> helper op x (VD.cast (Cilfacade.typeOfLval x) (eval_rv ~ctx a gs st rval)) tv
       | BinOp(op, rval, Lval x, typ) -> derived_invariant (BinOp(switchedOp op, Lval x, rval, typ)) tv
       | BinOp(op, CastE (t1, c1), CastE (t2, c2), t) when (op = Eq || op = Ne) && typeSig t1 = typeSig t2 && VD.is_safe_cast t1 (Cilfacade.typeOf c1) && VD.is_safe_cast t2 (Cilfacade.typeOf c2)
         -> derived_invariant (BinOp (op, c1, c2, t)) tv
       | BinOp(op, CastE (TInt (ik, _) as t1, Lval x), rval, typ) ->
-        (match eval_rv a gs st (Lval x) with
+        (match eval_rv ~ctx a gs st (Lval x) with
          | Int v ->
            (* This is tricky: It it is not sufficient to check that ID.cast_to_ik v = v
              * If there is one domain that knows this to be true and the other does not, we
@@ -555,7 +555,7 @@ struct
           a, b
       with FloatDomain.ArithmeticOnFloatBot _ -> raise Analyses.Deadcode
     in
-    let eval e st = eval_rv a gs st e in
+    let eval e st = eval_rv ~ctx a gs st e in
     let eval_bool e st = match eval e st with Int i -> ID.to_bool i | _ -> None in
     let unroll_fk_of_exp e =
       match unrollType (Cilfacade.typeOf e) with

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -20,8 +20,8 @@ sig
   val eval_lv: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> lval -> AD.t
   val convert_offset: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> offset -> ID.t Offset.t
 
-  val get_var: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> D.t -> varinfo -> VD.t
-  val get: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> Queries.ask -> D.t -> AD.t -> exp option -> VD.t
+  val get_var: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> D.t -> varinfo -> VD.t
+  val get: ctx:(D.t, G.t, _, V.t) Analyses.ctx -> D.t -> AD.t -> exp option -> VD.t
   val set: Queries.ask -> ctx:(D.t, G.t, _, V.t) Analyses.ctx -> (V.t -> G.t) -> D.t -> AD.t -> typ -> ?lval_raw:lval -> VD.t -> D.t
 
   val refine_entire_var: bool
@@ -67,7 +67,7 @@ struct
     let addr = eval_lv ~ctx lval in
     if (AD.is_top addr) then st
     else
-      let old_val = get ~ctx a st addr None in (* None is ok here, we could try to get more precise, but this is ok (reading at unknown position in array) *)
+      let old_val = get ~ctx st addr None in (* None is ok here, we could try to get more precise, but this is ok (reading at unknown position in array) *)
       let t_lval = Cilfacade.typeOfLval lval in
       let old_val = map_oldval old_val t_lval in
       let old_val =
@@ -79,7 +79,7 @@ struct
           old_val
       in
       let state_with_excluded = set a gs st addr t_lval value ~ctx in
-      let value =  get ~ctx a state_with_excluded addr None in
+      let value =  get ~ctx state_with_excluded addr None in
       let new_val = apply_invariant ~old_val ~new_val:value in
       if M.tracing then M.traceu "invariant" "New value is %a\n" VD.pretty new_val;
       (* make that address meet the invariant, i.e exclusion sets will be joined *)
@@ -96,7 +96,7 @@ struct
     match x with
     | Var var, o when refine_entire_var ->
       (* For variables, this is done at to the level of entire variables to benefit e.g. from disjunctive struct domains *)
-      let old_val = get_var ~ctx a st var in
+      let old_val = get_var ~ctx st var in
       let old_val = map_oldval old_val var.vtype in
       let offs = convert_offset ~ctx o in
       let new_val = VD.update_offset (Queries.to_value_domain_ask a) old_val offs c' (Some exp) x (var.vtype) in


### PR DESCRIPTION
Solves #1266 

### TODO
- [x] `reachable_from_value`
- [x] `reachable_from_address`
- [x] `reachable_vars`
- [x] Before and after sv-benchmarks run. @sim642 