### PR TITLE
Exclude Goblint stubs from YAML witnesses

### DIFF
--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -201,9 +201,9 @@ struct
     let is_invariant_node (n : Node.t) =
       let loc = Node.location n in
       match n with
-      | Statement _ when not loc.synthetic && WitnessInvariant.is_invariant_node n ->
-        not (is_stub_node n)
-      | _ ->
+      | Statement _ ->
+        not loc.synthetic && WitnessInvariant.is_invariant_node n && not (is_stub_node n)
+      | FunctionEntry _ | Function _ ->
         (* avoid FunctionEntry/Function, because their locations are not inside the function where asserts could be inserted *)
         false
     in


### PR DESCRIPTION
This fixes the issue identified by Freiburg.

The other "issue" with `(unsigned long )_ == 0UL` or really any `(unsigned long )arg == 0UL` has no easy improvement in Goblint. I thought it came from relation analysis because of the cast, but apparently it comes from base. Passing `0` into an `void*` argument performs no cast and simply puts the integer abstraction into the state for the pointer variable. The outputted invariant comes from `IntDomain` instead, which correctly inserts the cast.

I thought about using `Cilfacade.makeBinOp` which hopefully would be smarter about inserting casts for binary operators, but actually it's worse and turns it into `(unsigned long )arg == (unsigned long )((void *)0)` because of https://github.com/goblint/cil/issues/162. If that is fixed, then we might have a neater way.