### PR TITLE
Fix `NullPtr` assignment crash in relation analysis

### DIFF
--- a/tests/regression/46-apron2/58-issue-1249.c
+++ b/tests/regression/46-apron2/58-issue-1249.c
@@ -1,0 +1,10 @@
+// SKIP PARAM: --set ana.activated[+] apron
+int *a;
+int b;
+void c(int d) {
+    // *a is a null pointer here, so we should warn but maybe not crash
+    *a = d;
+}
+int main() {
+    c(b);
+}


### PR DESCRIPTION
Closes #1249.

If assigning through a pointer which isn't unknown, but also doesn't have any known pointers (so is NULL or maybe some string), then previously `D.bot ()` was returned.
This has an empty environment which broke `combine` in the particular test because `combine` expects to find the `#arg` variables added by `enter`.

If there's such a crash in SV-COMP, then likely it has to be due to a NULL pointer as well.