### PR TITLE
Float domain: Fix `eval_comparison_binop`

### DIFF
--- a/tests/regression/57-floats/05-invariant.c
+++ b/tests/regression/57-floats/05-invariant.c
@@ -1,6 +1,7 @@
 // PARAM: --enable ana.float.interval --enable ana.int.interval
 #include <goblint.h>
 #include <float.h>
+#include <math.h>
 
 int main()
 {
@@ -118,6 +119,21 @@ int main()
             return 1;
         }
     }
+
+    float max = INFINITY;
+    float min = -INFINITY;
+
+    int res = max <= max;
+    __goblint_check(res);
+
+    res = max <= min;
+    __goblint_check(res == 0);
+
+    res = max < max;
+    __goblint_check(res == 0);
+
+    res = max > max;
+    __goblint_check(res == 0);
 
     return 0;
 }


### PR DESCRIPTION
As remarked in #1333 the logic for comparison of float values was broken for cases in which the first argument is maximal w.r.t. the considered order. This PR 

- fixes this
- adds comments to `eval_comparison_binop`
- renames the parameter `sym` to `reflexive` which is the correct terminology
- adds some tests that would have caught the problem and pass now

Closes #1333.