### PR TITLE
Handle `LNot` for float in forward evaluation and refinement on guards

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1645,6 +1645,9 @@ struct
     module V = V
     module G = G
 
+    let unop_ID = unop_ID
+    let unop_FD = unop_FD
+
     let eval_rv = eval_rv
     let eval_rv_address = eval_rv_address
     let eval_lv = eval_lv
@@ -2841,6 +2844,9 @@ struct
           module G = G
 
           let ost = octx.local
+
+          let unop_ID = unop_ID
+          let unop_FD = unop_FD
 
           (* all evals happen in octx with non-top values *)
           let eval_rv ~ctx st e = eval_rv ~ctx:octx ost e

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -179,8 +179,8 @@ struct
   let unop_FD = function
     | Neg  -> (fun v -> (Float (FD.neg v):value))
     | LNot -> (fun c -> Int (FD.eq c (FD.of_const (FD.get_fkind c) 0.)))
-    (* other unary operators are not implemented on float values *)
-    | _ -> (fun c -> Float (FD.top_of (FD.get_fkind c)))
+    | BNot -> failwith "BNot on a value of type float!"
+
 
   (* Evaluating Cil's unary operators. *)
   let evalunop op typ: value -> value = function

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -178,14 +178,15 @@ struct
     | LNot -> ID.lognot
 
   let unop_FD = function
-    | Neg  -> FD.neg
+    | Neg  -> (fun v -> (Float (FD.neg v):value))
+    | LNot -> (fun c -> Int (FD.eq c (FD.of_const (FD.get_fkind c) 0.)))
     (* other unary operators are not implemented on float values *)
-    | _ -> (fun c -> FD.top_of (FD.get_fkind c))
+    | _ -> (fun c -> Float (FD.top_of (FD.get_fkind c)))
 
   (* Evaluating Cil's unary operators. *)
   let evalunop op typ: value -> value = function
     | Int v1 -> Int (ID.cast_to (Cilfacade.get_ikind typ) (unop_ID op v1))
-    | Float v -> Float (unop_FD op v)
+    | Float v -> unop_FD op v
     | Address a when op = LNot ->
       if AD.is_null a then
         Int (ID.of_bool (Cilfacade.get_ikind typ) true)

--- a/tests/regression/57-floats/22-lnot.c
+++ b/tests/regression/57-floats/22-lnot.c
@@ -1,0 +1,26 @@
+//PARAM: --enable ana.float.interval
+#include<goblint.h>
+int main() {
+  float x = 0.0f;
+  int z = !x; 
+
+  int reach;
+
+  if(z) {
+    __goblint_check(1); //Reachable
+    reach = 1;
+  } else {
+    reach = 0;
+  }
+
+  __goblint_check(reach == 1);
+
+  float y;
+  if (!y) {
+    __goblint_check(y == 0.0f);
+  } else {
+    __goblint_check(1); //Reachable
+  }
+  
+  return 0;
+}


### PR DESCRIPTION
Fixes the issues identified by @sim642 where 
- the type of the abstract values for expressions involving `LNot` was wrong
- having `!x` for float variables `x` in a guard lead to crashes

Closes #1211.