### PR TITLE
`eval_rv_base`: cast without `torg` when `typeOf` fails

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -878,10 +878,10 @@ struct
       | CastE (t, Const (CStr (x,e))) -> (* VD.top () *) eval_rv ~ctx st (Const (CStr (x,e))) (* TODO safe? *)
       | CastE  (t, exp) ->
         (let v = eval_rv ~ctx st exp in
-        try 
-          VD.cast ~torg:(Cilfacade.typeOf exp) t v
-        with Cilfacade.TypeOfError _  -> 
-          VD.cast t v)
+         try 
+           VD.cast ~torg:(Cilfacade.typeOf exp) t v
+         with Cilfacade.TypeOfError _  -> 
+           VD.cast t v)
       | SizeOf _
       | Real _
       | Imag _

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -877,8 +877,11 @@ struct
         Address (AD.map array_start (eval_lv ~ctx st lval))
       | CastE (t, Const (CStr (x,e))) -> (* VD.top () *) eval_rv ~ctx st (Const (CStr (x,e))) (* TODO safe? *)
       | CastE  (t, exp) ->
-        let v = eval_rv ~ctx st exp in
-        VD.cast ~torg:(Cilfacade.typeOf exp) t v
+        (let v = eval_rv ~ctx st exp in
+        try 
+          VD.cast ~torg:(Cilfacade.typeOf exp) t v
+        with Cilfacade.TypeOfError _  -> 
+          VD.cast t v)
       | SizeOf _
       | Real _
       | Imag _

--- a/tests/regression/46-apron2/60-issue-1338.c
+++ b/tests/regression/46-apron2/60-issue-1338.c
@@ -1,0 +1,11 @@
+// SKIP PARAM: --set ana.activated[+] apron
+#include <stdlib.h>
+int main()
+{
+    char *ptr = malloc(2);
+    char s = *(ptr+0)+0;
+
+    char *arr;
+    arr = malloc(8);
+    int tmp = (int)*(arr+0);
+}


### PR DESCRIPTION
This can apparently happen in the case of malloc'ed blocks.

Closes #1338 