### PR TITLE
Fix no function to call warnings on dead code

### DIFF
--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -758,7 +758,7 @@ struct
         None
     in
     let funs = List.filter_map one_function functions in
-    if [] = funs then begin
+    if [] = funs && not (S.D.is_bot ctx.local) then begin
       M.msg_final Warning ~category:Unsound ~tags:[Category Call] "No suitable function to call";
       M.warn ~category:Unsound ~tags:[Category Call] "No suitable function to be called at call site. Continuing with state before call.";
       d (* because LevelSliceLifter *)

--- a/tests/regression/00-sanity/38-evalfunvar-dead.c
+++ b/tests/regression/00-sanity/38-evalfunvar-dead.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+
+int main() {
+  int (*fp)() = &rand;
+  abort();
+  fp(); // NOWARN (No suitable function to call)
+  return 0;
+}


### PR DESCRIPTION
@karoliineh noticed odd "No suitable function to call" warnings from our stdlib stubs in their tests (e.g. 41-stdlib/02-bsearch) from cases where the call through a function pointer is dead code.

However, `FromSpec` does an `EvalFunvar` query even on dead code states (because it computes on everything). The dead-code-ness is handled deeper in `DeadcodeLifter`, which for dead code returns `Queries.Result.bot ()`, which for `EvalFunvar` is an empty-points to set. This is correct, but we shouldn't emit a warning in this case, especially because if the code were reachable, there would be a valid call target.