### PR TITLE
Fix unsound join for `top` with empty environment in `ApronDomain`

### DIFF
--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -672,9 +672,9 @@ struct
 
   let join x y =
     (* just to optimize joining folds, which start with bot *)
-    if is_bot x then (* TODO: also for non-empty env *)
+    if is_bot_env x then (* TODO: also for non-empty env *)
       y
-    else if is_bot y then (* TODO: also for non-empty env *)
+    else if is_bot_env y then (* TODO: also for non-empty env *)
       x
     else (
       if M.tracing then M.traceli "apron" "join %a %a\n" pretty x pretty y;

--- a/tests/regression/46-apron2/61-context-insens.c
+++ b/tests/regression/46-apron2/61-context-insens.c
@@ -1,0 +1,46 @@
+// PARAM: --set ana.activated "['base', 'threadid', 'threadflag', 'threadreturn','mallocWrapper','mutexEvents','mutex','access','race','escape','expRelation','assert','var_eq','symb_locks','apron','memLeak']" --enable ana.int.interval_set --set ana.ctx_insens "['base', 'threadid', 'threadflag', 'threadreturn','mallocWrapper','mutexEvents','mutex','access','race','escape','expRelation','assert','var_eq','symb_locks','apron','memLeak']" --enable ana.autotune.enabled --set ana.autotune.activated "['octagon']" --set ana.specification "CHECK( init(main()), LTL(G valid-memcleanup) )" --set ana.path_sens "['mutex', 'malloc_null', 'uninit','expsplit','activeSetjmp','memLeak',      'threadflag']" --set ana.malloc.unique_address_count 5
+
+// Adapted from https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/blob/main/c/list-properties/list_search-1.c
+#include <stdlib.h>
+#include <assert.h>
+#include <goblint.h>
+
+typedef struct list {
+	int key;
+	struct list *next;
+} mlist;
+
+mlist *head;
+
+mlist* search(mlist *l, int k){
+  l = head;
+  while(l!=0 && l->key!=k) { // Used to detect dead code after loop head
+    l = l->next;
+  }
+  return l;
+}
+
+int insert(mlist *l, int k){
+  l = (mlist*)malloc(sizeof(mlist));
+  l->key = k;
+  if (head==0) {
+  } else {
+    l->key = k;
+    l->next = head;
+  }
+  head = l;
+  return 0;
+}
+
+int main(void){
+  int i;
+  mlist *mylist, *temp;
+  insert(mylist,2);
+  insert(mylist,5);
+
+  temp = search(head,2);
+
+  __goblint_check(1); // Should be reachable
+  return 0;
+}
+


### PR DESCRIPTION
The `join` in the `ApronDomain` behaves incorrectly when given the "Top" element for the empty environment: In that case, it returns the other element. This is because the `join` checks for `is_bot`, which checks for equality with `bot`, which is defined as the top element for the empty environment. 
Under specific circumstances in a context-insensitive analysis, such a Top-element in an empty environment would arise, leading to an unsound analysis. 

This PR changes the check in the `join` from `is_bot` to `is_bot_env`, which fixes the issue. However, 28 tests in the `apron` group and 6 tests in the `apron2` group now fail due to imprecision.