### PR TITLE
Add `context_to_yojson` in messages

### DIFF
--- a/src/common/util/messages.ml
+++ b/src/common/util/messages.ml
@@ -69,7 +69,7 @@ struct
 
   let text_with_context {text; context; _} =
     match context with
-    | Some context when GobConfig.get_bool "dbg.warn_with_context" -> text ^ " in context " ^ string_of_int (ControlSpecC.hash context) (* TODO: this is kind of useless *)
+    | Some context when GobConfig.get_bool "dbg.warn_with_context" -> text ^ " in context " ^ string_of_int (ControlSpecC.tag context) (* TODO: this is kind of useless *)
     | _ -> text
 end
 

--- a/src/common/util/messages.ml
+++ b/src/common/util/messages.ml
@@ -61,10 +61,12 @@ end
 
 module Piece =
 struct
+  let context_to_yojson context = `Assoc [("tag", `Int (ControlSpecC.tag context))]
+
   type t = {
     loc: Location.t option; (* only *_each warnings have this, used for deduplication *)
     text: string;
-    context: (ControlSpecC.t [@of_yojson fun x -> Result.Error "ControlSpecC"]) option;
+    context: (ControlSpecC.t [@to_yojson context_to_yojson] [@of_yojson fun x -> Result.Error "ControlSpecC"]) option;
   } [@@deriving eq, ord, hash, yojson]
 
   let text_with_context {text; context; _} =


### PR DESCRIPTION
so that the big `context` objects would not crowd the JSON and cause `java.lang.OutOfMemoryError: Java heap space`