### PR TITLE
Automatically add newline to trace output

### DIFF
--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -13,25 +13,25 @@ Goblint extensively uses [CIL's `Pretty`](https://people.eecs.berkeley.edu/~necu
 * Logging CIL values (e.g. an expression `exp`) using the corresponding pretty-printer `d_exp` from `Cil` module:
 
 ```ocaml
-Logs.debug "A CIL exp: %a\n" d_exp exp;
+Logs.debug "A CIL exp: %a" d_exp exp;
 ```
 
 * Logging Goblint's `Printable` values (e.g. a domain `D` element `d`) using the corresponding pretty-printer `D.pretty`:
 
 ```ocaml
-Logs.debug "A domain element: %a\n" D.pretty d;
+Logs.debug "A domain element: %a" D.pretty d;
 ```
 
 * Logging primitives (e.g. OCaml ints, strings, etc) using the standard [OCaml `Printf`](https://ocaml.org/api/Printf.html) specifiers:
 
 ```ocaml
-Logs.debug "An int and a string: %d %s\n" 42 "magic";
+Logs.debug "An int and a string: %d %s" 42 "magic";
 ```
 
 * Logging lists of pretty-printables (e.g. expressions list `exps`) using `d_list`:
 
 ```ocaml
-Logs.debug "Some expressions: %a\n" (d_list ", " d_exp) exps;
+Logs.debug "Some expressions: %a" (d_list ", " d_exp) exps;
 ```
 
 
@@ -42,7 +42,7 @@ Recompile with tracing enabled: `./scripts/trace_on.sh`.
 
 Instead of logging use a tracing function from the `Messages` module, which is often aliased to just `M` (and pick a relevant name instead of `mything`):
 ```ocaml
-if M.tracing then M.trace "mything" "A domain element: %a\n" D.pretty d;
+if M.tracing then M.trace "mything" "A domain element: %a" D.pretty d;
 ```
 
 Then run Goblint with the additional argument `--trace mything`.

--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -32,7 +32,7 @@ struct
     emit_single_threaded := List.mem (ModifiedSinceSetjmp.Spec.name ()) activated || List.mem (PoisonVariables.Spec.name ()) activated
 
   let do_access (ctx: (D.t, G.t, C.t, V.t) ctx) (kind:AccessKind.t) (reach:bool) (e:exp) =
-    if M.tracing then M.trace "access" "do_access %a %a %B\n" d_exp e AccessKind.pretty kind reach;
+    if M.tracing then M.trace "access" "do_access %a %a %B" d_exp e AccessKind.pretty kind reach;
     let reach_or_mpt: _ Queries.t = if reach then ReachableFrom e else MayPointTo e in
     let ad = ctx.ask reach_or_mpt in
     ctx.emit (Access {exp=e; ad; kind; reach})
@@ -42,15 +42,15 @@ struct
       + [deref=true], [reach=false] - Access [exp] by dereferencing once (may-point-to), used for lval writes and shallow special accesses.
       + [deref=true], [reach=true] - Access [exp] by dereferencing transitively (reachable), used for deep special accesses. *)
   let access_one_top ?(force=false) ?(deref=false) ctx (kind: AccessKind.t) reach exp =
-    if M.tracing then M.traceli "access" "access_one_top %a (kind = %a, reach = %B, deref = %B)\n" CilType.Exp.pretty exp AccessKind.pretty kind reach deref;
+    if M.tracing then M.traceli "access" "access_one_top %a (kind = %a, reach = %B, deref = %B)" CilType.Exp.pretty exp AccessKind.pretty kind reach deref;
     if force || !collect_local || !emit_single_threaded || ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx) then (
       if deref && Cil.isPointerType (Cilfacade.typeOf exp) then (* avoid dereferencing integers to unknown pointers, which cause many spurious type-based accesses *)
         do_access ctx kind reach exp;
-      if M.tracing then M.tracei "access" "distribute_access_exp\n";
+      if M.tracing then M.tracei "access" "distribute_access_exp";
       Access.distribute_access_exp (do_access ctx Read false) exp;
-      if M.tracing then M.traceu "access" "distribute_access_exp\n";
+      if M.tracing then M.traceu "access" "distribute_access_exp";
     );
-    if M.tracing then M.traceu "access" "access_one_top\n"
+    if M.tracing then M.traceu "access" "access_one_top"
 
   (** We just lift start state, global and dependency functions: *)
   let startstate v = ()

--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -87,7 +87,7 @@ struct
     let e' = visitCilExpr visitor e in
     let rel = RD.add_vars st.rel (List.map RV.local (VH.values v_ins |> List.of_enum)) in (* add temporary g#in-s *)
     let rel' = VH.fold (fun v v_in rel ->
-        if M.tracing then M.trace "relation" "read_global %a %a\n" CilType.Varinfo.pretty v CilType.Varinfo.pretty v_in;
+        if M.tracing then M.trace "relation" "read_global %a %a" CilType.Varinfo.pretty v CilType.Varinfo.pretty v_in;
         read_global ask getg {st with rel} v v_in (* g#in = g; *)
       ) v_ins rel
     in
@@ -121,7 +121,7 @@ struct
 
   let assign_from_globals_wrapper ask getg st e f =
     let (rel', e', v_ins) = read_globals_to_locals ask getg st e in
-    if M.tracing then M.trace "relation" "assign_from_globals_wrapper %a\n" d_exp e';
+    if M.tracing then M.trace "relation" "assign_from_globals_wrapper %a" d_exp e';
     let rel' = f rel' e' in (* x = e; *)
     let rel'' = RD.remove_vars rel' (List.map RV.local (VH.values v_ins |> List.of_enum)) in (* remove temporary g#in-s *)
     rel''
@@ -152,7 +152,7 @@ struct
         v_out.vattr <- v.vattr; (*copy the attributes because the tracking may depend on them. Otherwise an assertion fails *)
         let st = {st with rel = RD.add_vars st.rel [RV.local v_out]} in (* add temporary g#out *)
         let st' = {st with rel = f st v_out} in (* g#out = e; *)
-        if M.tracing then M.trace "relation" "write_global %a %a\n" CilType.Varinfo.pretty v CilType.Varinfo.pretty v_out;
+        if M.tracing then M.trace "relation" "write_global %a %a" CilType.Varinfo.pretty v CilType.Varinfo.pretty v_out;
         let st' = write_global ask getg sideg st' v v_out in (* g = g#out; *)
         let rel'' = RD.remove_vars st'.rel [RV.local v_out] in (* remove temporary g#out *)
         {st' with rel = rel''}
@@ -189,7 +189,7 @@ struct
 
   let no_overflow ctx exp = lazy (
     let res = no_overflow ctx exp in
-    if M.tracing then M.tracel "no_ov" "no_ov %b exp: %a\n" res d_exp exp;
+    if M.tracing then M.tracel "no_ov" "no_ov %b exp: %a" res d_exp exp;
     res
   )
 
@@ -250,19 +250,19 @@ struct
       st (* ignore extern inits because there's no body before assign, so env is empty... *)
     else (
       let simplified_e = replace_deref_exps ctx.ask e in
-      if M.tracing then M.traceli "relation" "assign %a = %a (simplified to %a)\n" d_lval lv  d_exp e d_exp simplified_e;
+      if M.tracing then M.traceli "relation" "assign %a = %a (simplified to %a)" d_lval lv  d_exp e d_exp simplified_e;
       let ask = Analyses.ask_of_ctx ctx in
       let r = assign_to_global_wrapper ask ctx.global ctx.sideg st lv (fun st v ->
           assign_from_globals_wrapper ask ctx.global st simplified_e (fun apr' e' ->
-              if M.tracing then M.traceli "relation" "assign inner %a = %a (%a)\n" CilType.Varinfo.pretty v d_exp e' d_plainexp e';
-              if M.tracing then M.trace "relation" "st: %a\n" RD.pretty apr';
+              if M.tracing then M.traceli "relation" "assign inner %a = %a (%a)" CilType.Varinfo.pretty v d_exp e' d_plainexp e';
+              if M.tracing then M.trace "relation" "st: %a" RD.pretty apr';
               let r = RD.assign_exp apr' (RV.local v) e' (no_overflow ask simplified_e) in
-              if M.tracing then M.traceu "relation" "-> %a\n" RD.pretty r;
+              if M.tracing then M.traceu "relation" "-> %a" RD.pretty r;
               r
             )
         )
       in
-      if M.tracing then M.traceu "relation" "-> %a\n" D.pretty r;
+      if M.tracing then M.traceu "relation" "-> %a" D.pretty r;
       r
     )
 
@@ -334,7 +334,7 @@ struct
         | Some (Arg _) when not (List.mem_cmp Apron.Var.compare var arg_vars) -> true (* remove caller args, but keep just added args *)
         | _ -> false (* keep everything else (just added args, globals, global privs) *)
       );
-    if M.tracing then M.tracel "combine" "relation enter newd: %a\n" RD.pretty new_rel;
+    if M.tracing then M.tracel "combine" "relation enter newd: %a" RD.pretty new_rel;
     new_rel
 
   let enter ctx r f args =
@@ -391,11 +391,11 @@ struct
     let st = ctx.local in
     let reachable_from_args = reachable_from_args ctx args in
     let fundec = Node.find_fundec ctx.node in
-    if M.tracing then M.tracel "combine" "relation f: %a\n" CilType.Varinfo.pretty f.svar;
-    if M.tracing then M.tracel "combine" "relation formals: %a\n" (d_list "," CilType.Varinfo.pretty) f.sformals;
-    if M.tracing then M.tracel "combine" "relation args: %a\n" (d_list "," d_exp) args;
-    if M.tracing then M.tracel "combine" "relation st: %a\n" D.pretty st;
-    if M.tracing then M.tracel "combine" "relation fun_st: %a\n" D.pretty fun_st;
+    if M.tracing then M.tracel "combine" "relation f: %a" CilType.Varinfo.pretty f.svar;
+    if M.tracing then M.tracel "combine" "relation formals: %a" (d_list "," CilType.Varinfo.pretty) f.sformals;
+    if M.tracing then M.tracel "combine" "relation args: %a" (d_list "," d_exp) args;
+    if M.tracing then M.tracel "combine" "relation st: %a" D.pretty st;
+    if M.tracing then M.tracel "combine" "relation fun_st: %a" D.pretty fun_st;
     let new_fun_rel = RD.add_vars fun_st.rel (RD.vars st.rel) in
     let arg_substitutes =
       let filter_actuals (x,e) =
@@ -419,7 +419,7 @@ struct
     in
     let any_local_reachable = any_local_reachable fundec reachable_from_args in
     let arg_vars = f.sformals |> List.filter (RD.Tracked.varinfo_tracked) |> List.map RV.arg in
-    if M.tracing then M.tracel "combine" "relation remove vars: %a\n" (docList (fun v -> Pretty.text (Apron.Var.to_string v))) arg_vars;
+    if M.tracing then M.tracel "combine" "relation remove vars: %a" (docList (fun v -> Pretty.text (Apron.Var.to_string v))) arg_vars;
     RD.remove_vars_with new_fun_rel arg_vars; (* fine to remove arg vars that also exist in caller because unify from new_rel adds them back with proper constraints *)
     let tainted = f_ask.f Queries.MayBeTainted in
     let tainted_vars = TaintPartialContexts.conv_varset tainted in
@@ -433,7 +433,7 @@ struct
       )
     in
     let unify_rel = RD.unify new_rel new_fun_rel in (* TODO: unify_with *)
-    if M.tracing then M.tracel "combine" "relation unifying %a %a = %a\n" RD.pretty new_rel RD.pretty new_fun_rel RD.pretty unify_rel;
+    if M.tracing then M.tracel "combine" "relation unifying %a %a = %a" RD.pretty new_rel RD.pretty new_fun_rel RD.pretty unify_rel;
     {fun_st with rel = unify_rel}
 
   let combine_assign ctx r fe f args fc fun_st (f_ask : Queries.ask) =
@@ -647,10 +647,10 @@ struct
     in
     match q with
     | EvalInt e ->
-      if M.tracing then M.traceli "evalint" "relation query %a (%a)\n" d_exp e d_plainexp e;
-      if M.tracing then M.trace "evalint" "relation st: %a\n" D.pretty ctx.local;
+      if M.tracing then M.traceli "evalint" "relation query %a (%a)" d_exp e d_plainexp e;
+      if M.tracing then M.trace "evalint" "relation st: %a" D.pretty ctx.local;
       let r = eval_int e (lazy(no_overflow ctx e)) in
-      if M.tracing then M.traceu "evalint" "relation query %a -> %a\n" d_exp e ID.pretty r;
+      if M.tracing then M.traceu "evalint" "relation query %a -> %a" d_exp e ID.pretty r;
       r
     | Queries.IterSysVars (vq, vf) ->
       let vf' x = vf (Obj.repr x) in

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -812,20 +812,20 @@ struct
 
   let lock_get_m oct local_m get_m =
     let joined = LRD.join local_m get_m in
-    if M.tracing then M.traceli "relationpriv" "lock_get_m:\n  get=%a\n  joined=%a\n" LRD.pretty get_m LRD.pretty joined;
+    if M.tracing then M.traceli "relationpriv" "lock_get_m:\n  get=%a\n  joined=%a" LRD.pretty get_m LRD.pretty joined;
     let r = LRD.fold (fun _ -> RD.meet) joined (RD.top ()) in
-    if M.tracing then M.trace "relationpriv" "meet=%a\n" RD.pretty r;
+    if M.tracing then M.trace "relationpriv" "meet=%a" RD.pretty r;
     let r = RD.meet oct r in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RD.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RD.pretty r;
     r
 
   let lock oct local_m get_m =
-    if M.tracing then M.traceli "relationpriv" "cluster lock: local=%a\n" LRD.pretty local_m;
+    if M.tracing then M.traceli "relationpriv" "cluster lock: local=%a" LRD.pretty local_m;
     let r = lock_get_m oct local_m get_m in
     (* is_bot check commented out because it's unnecessarily expensive *)
     (* if RD.is_bot_env r then
        failwith "DownwardClosedCluster.lock: not downward closed?"; *)
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RD.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RD.pretty r;
     r
 
   let unlock w oct_side =
@@ -903,7 +903,7 @@ struct
     (lad, lad_weak)
 
   let lock oct (local_m, _) (get_m, get_m') =
-    if M.tracing then M.traceli "relationpriv" "cluster lock: local=%a\n" LRD1.pretty local_m;
+    if M.tracing then M.traceli "relationpriv" "cluster lock: local=%a" LRD1.pretty local_m;
     let r =
       let locked = DCCluster.lock_get_m oct local_m get_m in
       if RD.is_bot_env locked then (
@@ -916,7 +916,7 @@ struct
       else
         locked
     in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RD.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RD.pretty r;
     r
 
   let unlock w oct_side =
@@ -954,17 +954,17 @@ struct
 
   let get_m_with_mutex_inits inits ask getg m =
     let get_m = get_relevant_writes ask m (G.mutex @@ getg (V.mutex m)) in
-    if M.tracing then M.traceli "relationpriv" "get_m_with_mutex_inits %a\n  get=%a\n" LockDomain.Addr.pretty m LRD.pretty get_m;
+    if M.tracing then M.traceli "relationpriv" "get_m_with_mutex_inits %a\n  get=%a" LockDomain.Addr.pretty m LRD.pretty get_m;
     let r =
       if not inits then
         get_m
       else
         let get_mutex_inits = merge_all @@ G.mutex @@ getg V.mutex_inits in
         let get_mutex_inits' = Cluster.keep_only_protected_globals ask m get_mutex_inits in
-        if M.tracing then M.trace "relationpriv" "inits=%a\n  inits'=%a\n" LRD.pretty get_mutex_inits LRD.pretty get_mutex_inits';
+        if M.tracing then M.trace "relationpriv" "inits=%a\n  inits'=%a" LRD.pretty get_mutex_inits LRD.pretty get_mutex_inits';
         LRD.join get_m get_mutex_inits'
     in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" LRD.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" LRD.pretty r;
     r
 
   let atomic_mutex = LockDomain.Addr.of_var LibraryFunctions.verifier_atomic_var
@@ -979,17 +979,17 @@ struct
       else
         get_relevant_writes_nofilter ask @@ G.mutex @@ getg (V.global g)
     in
-    if M.tracing then M.traceli "relationpriv" "get_mutex_global_g_with_mutex_inits %a\n  get=%a\n" CilType.Varinfo.pretty g LRD.pretty get_mutex_global_g;
+    if M.tracing then M.traceli "relationpriv" "get_mutex_global_g_with_mutex_inits %a\n  get=%a" CilType.Varinfo.pretty g LRD.pretty get_mutex_global_g;
     let r =
       if not inits then
         get_mutex_global_g
       else
         let get_mutex_inits = merge_all @@ G.mutex @@ getg V.mutex_inits in
         let get_mutex_inits' = Cluster.keep_global g get_mutex_inits in
-        if M.tracing then M.trace "relationpriv" "inits=%a\n  inits'=%a\n" LRD.pretty get_mutex_inits LRD.pretty get_mutex_inits';
+        if M.tracing then M.trace "relationpriv" "inits=%a\n  inits'=%a" LRD.pretty get_mutex_inits LRD.pretty get_mutex_inits';
         LRD.join get_mutex_global_g get_mutex_inits'
     in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" LRD.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" LRD.pretty r;
     r
 
   let get_mutex_global_g_with_mutex_inits_atomic inits ask getg =
@@ -1253,147 +1253,147 @@ struct
   module RelComponents = RelationDomain.RelComponents (RD) (D)
 
   let read_global ask getg st g x =
-    if M.tracing then M.traceli "relationpriv" "read_global %a %a\n" CilType.Varinfo.pretty g CilType.Varinfo.pretty x;
-    if M.tracing then M.trace "relationpriv" "st: %a\n" RelComponents.pretty st;
+    if M.tracing then M.traceli "relationpriv" "read_global %a %a" CilType.Varinfo.pretty g CilType.Varinfo.pretty x;
+    if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
-      if M.tracing then M.trace "relationpriv" "getg %a -> %a\n" V.pretty x G.pretty r;
+      if M.tracing then M.trace "relationpriv" "getg %a -> %a" V.pretty x G.pretty r;
       r
     in
     let r = Priv.read_global ask getg st g x in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RD.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RD.pretty r;
     r
 
   let write_global ?invariant ask getg sideg st g x =
-    if M.tracing then M.traceli "relationpriv" "write_global %a %a\n" CilType.Varinfo.pretty g CilType.Varinfo.pretty x;
-    if M.tracing then M.trace "relationpriv" "st: %a\n" RelComponents.pretty st;
+    if M.tracing then M.traceli "relationpriv" "write_global %a %a" CilType.Varinfo.pretty g CilType.Varinfo.pretty x;
+    if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
-      if M.tracing then M.trace "relationpriv" "getg %a -> %a\n" V.pretty x G.pretty r;
+      if M.tracing then M.trace "relationpriv" "getg %a -> %a" V.pretty x G.pretty r;
       r
     in
     let sideg x v =
-      if M.tracing then M.trace "relationpriv" "sideg %a %a\n" V.pretty x G.pretty v;
+      if M.tracing then M.trace "relationpriv" "sideg %a %a" V.pretty x G.pretty v;
       sideg x v
     in
     let r = write_global ?invariant ask getg sideg st g x in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RelComponents.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RelComponents.pretty r;
     r
 
   let lock ask getg st m =
-    if M.tracing then M.traceli "relationpriv" "lock %a\n" LockDomain.Addr.pretty m;
-    if M.tracing then M.trace "relationpriv" "st: %a\n" RelComponents.pretty st;
+    if M.tracing then M.traceli "relationpriv" "lock %a" LockDomain.Addr.pretty m;
+    if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
-      if M.tracing then M.trace "relationpriv" "getg %a -> %a\n" V.pretty x G.pretty r;
+      if M.tracing then M.trace "relationpriv" "getg %a -> %a" V.pretty x G.pretty r;
       r
     in
     let r = lock ask getg st m in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RelComponents.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RelComponents.pretty r;
     r
 
   let unlock ask getg sideg st m =
-    if M.tracing then M.traceli "relationpriv" "unlock %a\n" LockDomain.Addr.pretty m;
-    if M.tracing then M.trace "relationpriv" "st: %a\n" RelComponents.pretty st;
+    if M.tracing then M.traceli "relationpriv" "unlock %a" LockDomain.Addr.pretty m;
+    if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
-      if M.tracing then M.trace "relationpriv" "getg %a -> %a\n" V.pretty x G.pretty r;
+      if M.tracing then M.trace "relationpriv" "getg %a -> %a" V.pretty x G.pretty r;
       r
     in
     let sideg x v =
-      if M.tracing then M.trace "relationpriv" "sideg %a %a\n" V.pretty x G.pretty v;
+      if M.tracing then M.trace "relationpriv" "sideg %a %a" V.pretty x G.pretty v;
       sideg x v
     in
     let r = unlock ask getg sideg st m in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RelComponents.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RelComponents.pretty r;
     r
 
   let enter_multithreaded ask getg sideg st =
-    if M.tracing then M.traceli "relationpriv" "enter_multithreaded\n";
-    if M.tracing then M.trace "relationpriv" "st: %a\n" RelComponents.pretty st;
+    if M.tracing then M.traceli "relationpriv" "enter_multithreaded";
+    if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
-      if M.tracing then M.trace "relationpriv" "getg %a -> %a\n" V.pretty x G.pretty r;
+      if M.tracing then M.trace "relationpriv" "getg %a -> %a" V.pretty x G.pretty r;
       r
     in
     let sideg x v =
-      if M.tracing then M.trace "relationpriv" "sideg %a %a\n" V.pretty x G.pretty v;
+      if M.tracing then M.trace "relationpriv" "sideg %a %a" V.pretty x G.pretty v;
       sideg x v
     in
     let r = enter_multithreaded ask getg sideg st in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RelComponents.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RelComponents.pretty r;
     r
 
   let threadenter ask getg st =
-    if M.tracing then M.traceli "relationpriv" "threadenter\n";
-    if M.tracing then M.trace "relationpriv" "st: %a\n" RelComponents.pretty st;
+    if M.tracing then M.traceli "relationpriv" "threadenter";
+    if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
-      if M.tracing then M.trace "relationpriv" "getg %a -> %a\n" V.pretty x G.pretty r;
+      if M.tracing then M.trace "relationpriv" "getg %a -> %a" V.pretty x G.pretty r;
       r
     in
     let r = threadenter ask getg st in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RelComponents.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RelComponents.pretty r;
     r
 
   let sync ask getg sideg st reason =
-    if M.tracing then M.traceli "relationpriv" "sync\n";
-    if M.tracing then M.trace "relationpriv" "st: %a\n" RelComponents.pretty st;
+    if M.tracing then M.traceli "relationpriv" "sync";
+    if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
-      if M.tracing then M.trace "relationpriv" "getg %a -> %a\n" V.pretty x G.pretty r;
+      if M.tracing then M.trace "relationpriv" "getg %a -> %a" V.pretty x G.pretty r;
       r
     in
     let sideg x v =
-      if M.tracing then M.trace "relationpriv" "sideg %a %a\n" V.pretty x G.pretty v;
+      if M.tracing then M.trace "relationpriv" "sideg %a %a" V.pretty x G.pretty v;
       sideg x v
     in
     let r = sync ask getg sideg st reason in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RelComponents.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RelComponents.pretty r;
     r
 
   let escape node ask getg sideg st vs =
-    if M.tracing then M.traceli "relationpriv" "escape\n";
-    if M.tracing then M.trace "relationpriv" "st: %a\n" RelComponents.pretty st;
+    if M.tracing then M.traceli "relationpriv" "escape";
+    if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
-      if M.tracing then M.trace "relationpriv" "getg %a -> %a\n" V.pretty x G.pretty r;
+      if M.tracing then M.trace "relationpriv" "getg %a -> %a" V.pretty x G.pretty r;
       r
     in
     let sideg x v =
-      if M.tracing then M.trace "relationpriv" "sideg %a %a\n" V.pretty x G.pretty v;
+      if M.tracing then M.trace "relationpriv" "sideg %a %a" V.pretty x G.pretty v;
       sideg x v
     in
     let r = escape node ask getg sideg st vs in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RelComponents.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RelComponents.pretty r;
     r
 
   let thread_join ?force ask getg e st =
-    if M.tracing then M.traceli "relationpriv" "thread_join\n";
-    if M.tracing then M.trace "relationpriv" "st: %a\n" RelComponents.pretty st;
+    if M.tracing then M.traceli "relationpriv" "thread_join";
+    if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
-      if M.tracing then M.trace "relationpriv" "getg %a -> %a\n" V.pretty x G.pretty r;
+      if M.tracing then M.trace "relationpriv" "getg %a -> %a" V.pretty x G.pretty r;
       r
     in
     let r = thread_join ?force ask getg e st in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RelComponents.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RelComponents.pretty r;
     r
 
   let thread_return ask getg sideg tid st =
-    if M.tracing then M.traceli "relationpriv" "thread_return\n";
-    if M.tracing then M.trace "relationpriv" "st: %a\n" RelComponents.pretty st;
+    if M.tracing then M.traceli "relationpriv" "thread_return";
+    if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
-      if M.tracing then M.trace "relationpriv" "getg %a -> %a\n" V.pretty x G.pretty r;
+      if M.tracing then M.trace "relationpriv" "getg %a -> %a" V.pretty x G.pretty r;
       r
     in
     let sideg x v =
-      if M.tracing then M.trace "relationpriv" "sideg %a %a\n" V.pretty x G.pretty v;
+      if M.tracing then M.trace "relationpriv" "sideg %a %a" V.pretty x G.pretty v;
       sideg x v
     in
     let r = thread_return ask getg sideg tid st in
-    if M.tracing then M.traceu "relationpriv" "-> %a\n" RelComponents.pretty r;
+    if M.tracing then M.traceu "relationpriv" "-> %a" RelComponents.pretty r;
     r
 end
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -756,7 +756,7 @@ struct
       let te2 = Cilfacade.typeOf e2 in
       let both_arith_type = isArithmeticType te1 && isArithmeticType te2 in
       let is_safe = (extra_is_safe || VD.is_safe_cast t1 te1 && VD.is_safe_cast t2 te2) && not both_arith_type in
-      M.tracel "cast" "remove cast on both sides for %a? -> %b\n" d_exp exp is_safe;
+      if M.tracing then M.tracel "cast" "remove cast on both sides for %a? -> %b" d_exp exp is_safe;
       if is_safe then ( (* we can ignore the casts if the casts can't change the value *)
         let e1 = if isArithmeticType te1 then c1 else e1 in
         let e2 = if isArithmeticType te2 then c2 else e2 in
@@ -772,7 +772,7 @@ struct
       (* seems like constFold already converts CChr to CInt *)
       | Const (CChr x) -> eval_rv ~ctx st (Const (charConstToInt x)) (* char becomes int, see Cil doc/ISO C 6.4.4.4.10 *)
       | Const (CInt (num,ikind,str)) ->
-        (match str with Some x -> M.tracel "casto" "CInt (%s, %a, %s)\n" (Z.to_string num) d_ikind ikind x | None -> ());
+        (match str with Some x -> if M.tracing then M.tracel "casto" "CInt (%s, %a, %s)" (Z.to_string num) d_ikind ikind x | None -> ());
         Int (ID.cast_to ikind (IntDomain.of_const (num,ikind,str)))
       | Const (CReal (_,fkind, Some str)) when not (Cilfacade.isComplexFKind fkind) -> Float (FD.of_string fkind str) (* prefer parsing from string due to higher precision *)
       | Const (CReal (num, fkind, None)) when not (Cilfacade.isComplexFKind fkind) && num = 0.0 -> Float (FD.of_const fkind num) (* constant 0 is ok, CIL creates these for zero-initializers; it is safe across float types *)
@@ -918,7 +918,7 @@ struct
     | (Var v, ofs) -> get ~ctx st (eval_lv ~ctx st (Var v, ofs)) (Some exp)
     (* | Lval (Mem e, ofs) -> get ~ctx st (eval_lv ~ctx (Mem e, ofs)) *)
     | (Mem e, ofs) ->
-      (*M.tracel "cast" "Deref: lval: %a\n" d_plainlval lv;*)
+      (*if M.tracing then M.tracel "cast" "Deref: lval: %a" d_plainlval lv;*)
       let rec contains_vla (t:typ) = match t with
         | TPtr (t, _) -> contains_vla t
         | TArray(t, None, args) -> true
@@ -1935,7 +1935,7 @@ struct
     if M.tracing && exps <> [] then (
       let addrs = List.map (Tuple3.first) invalids' in
       let vs = List.map (Tuple3.third) invalids' in
-      M.tracel "invalidate" "Setting addresses [%a] to values [%a]\n" (d_list ", " AD.pretty) addrs (d_list ", " VD.pretty) vs
+      if M.tracing then M.tracel "invalidate" "Setting addresses [%a] to values [%a]" (d_list ", " AD.pretty) addrs (d_list ", " VD.pretty) vs
     );
     set_many ~ctx st invalids'
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -244,7 +244,7 @@ struct
 
   (* Evaluate binop for two abstract values: *)
   let evalbinop_base ~ctx (op: binop) (t1:typ) (a1:value) (t2:typ) (a2:value) (t:typ) :value =
-    if M.tracing then M.tracel "eval" "evalbinop %a %a %a\n" d_binop op VD.pretty a1 VD.pretty a2;
+    if M.tracing then M.tracel "eval" "evalbinop %a %a %a" d_binop op VD.pretty a1 VD.pretty a2;
     (* We define a conversion function for the easy cases when we can just use
      * the integer domain operations. *)
     let bool_top ik = ID.(join (of_int ik Z.zero) (of_int ik Z.one)) in
@@ -358,7 +358,7 @@ struct
             let ay = AD.choose y in
             let handle_address_is_multiple addr = begin match Addr.to_var addr with
               | Some v when ctx.ask (Q.IsMultiple v) ->
-                if M.tracing then M.tracel "addr" "IsMultiple %a\n" CilType.Varinfo.pretty v;
+                if M.tracing then M.tracel "addr" "IsMultiple %a" CilType.Varinfo.pretty v;
                 None
               | _ ->
                 Some true
@@ -366,7 +366,7 @@ struct
             in
             match Addr.semantic_equal ax ay with
             | Some true ->
-              if M.tracing then M.tracel "addr" "semantic_equal %a %a\n" AD.pretty x AD.pretty y;
+              if M.tracing then M.tracel "addr" "semantic_equal %a %a" AD.pretty x AD.pretty y;
               handle_address_is_multiple ax
             | Some false -> Some false
             | None -> None
@@ -441,7 +441,7 @@ struct
       | _ ->
         ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx)
     in
-    if M.tracing then M.tracel "sync" "sync multi=%B earlyglobs=%B\n" multi !earlyglobs;
+    if M.tracing then M.tracel "sync" "sync multi=%B earlyglobs=%B" multi !earlyglobs;
     if !earlyglobs || multi then
       WideningTokens.with_local_side_tokens (fun () ->
           Priv.sync (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) (priv_sideg ctx.sideg) ctx.local reason
@@ -459,7 +459,7 @@ struct
     if (!earlyglobs || ThreadFlag.has_ever_been_multi ask) && is_global ask x then
       Priv.read_global ask (priv_getg ctx.global) st x
     else begin
-      if M.tracing then M.tracec "get" "Singlethreaded mode.\n";
+      if M.tracing then M.tracec "get" "Singlethreaded mode.";
       CPA.find x st.cpa
     end
 
@@ -470,14 +470,14 @@ struct
   let rec get ~ctx ?(top=VD.top ()) ?(full=false) (st: store) (addrs:address) (exp:exp option): value =
     let at = AD.type_of addrs in
     let firstvar = if M.tracing then match AD.to_var_may addrs with [] -> "" | x :: _ -> x.vname else "" in
-    if M.tracing then M.traceli "get" ~var:firstvar "Address: %a\nState: %a\n" AD.pretty addrs CPA.pretty st.cpa;
+    if M.tracing then M.traceli "get" ~var:firstvar "Address: %a\nState: %a" AD.pretty addrs CPA.pretty st.cpa;
     (* Finding a single varinfo*offset pair *)
     let res =
       let f_addr (x, offs) =
         (* get hold of the variable value, either from local or global state *)
         let var = get_var ~ctx st x in
         let v = VD.eval_offset (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) (fun x -> get ~ctx st x exp) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
-        if M.tracing then M.tracec "get" "var = %a, %a = %a\n" VD.pretty var AD.pretty (AD.of_mval (x, offs)) VD.pretty v;
+        if M.tracing then M.tracec "get" "var = %a, %a = %a" VD.pretty var AD.pretty (AD.of_mval (x, offs)) VD.pretty v;
         if full then var else match v with
           | Blob (c,s,_) -> c
           | x -> x
@@ -501,7 +501,7 @@ struct
       let f x a = VD.join (c @@ f x) a in      (* Finally we join over all the addresses in the set. *)
       AD.fold f addrs (VD.bot ())
     in
-    if M.tracing then M.traceu "get" "Result: %a\n" VD.pretty res;
+    if M.tracing then M.traceu "get" "Result: %a" VD.pretty res;
     res
 
 
@@ -526,7 +526,7 @@ struct
 
   let rec reachable_from_value ask (value: value) (t: typ) (description: string)  =
     let empty = AD.empty () in
-    if M.tracing then M.trace "reachability" "Checking value %a\n" VD.pretty value;
+    if M.tracing then M.trace "reachability" "Checking value %a" VD.pretty value;
     match value with
     | Top ->
       if not (VD.is_immediate_type t) then M.info ~category:Unsound "Unknown value in %s could be an escaped pointer address!" description; empty
@@ -553,9 +553,9 @@ struct
    * all pointers within a structure should be considered, but we don't follow
    * pointers. We return a flattend representation, thus simply an address (set). *)
   let reachable_from_address ~ctx st (adr: address): address =
-    if M.tracing then M.tracei "reachability" "Checking for %a\n" AD.pretty adr;
+    if M.tracing then M.tracei "reachability" "Checking for %a" AD.pretty adr;
     let res = reachable_from_value (Analyses.ask_of_ctx ctx) (get ~ctx st adr None) (AD.type_of adr) (AD.show adr) in
-    if M.tracing then M.traceu "reachability" "Reachable addresses: %a\n" AD.pretty res;
+    if M.tracing then M.traceu "reachability" "Reachable addresses: %a" AD.pretty res;
     res
 
   (* The code for getting the variables reachable from the list of parameters.
@@ -563,7 +563,7 @@ struct
    * addresses, as both AD elements abstracting individual (ambiguous) addresses
    * and the workset of visited addresses. *)
   let reachable_vars ~ctx (st: store) (args: address list): address list =
-    if M.tracing then M.traceli "reachability" "Checking reachable arguments from [%a]!\n" (d_list ", " AD.pretty) args;
+    if M.tracing then M.traceli "reachability" "Checking reachable arguments from [%a]!" (d_list ", " AD.pretty) args;
     let empty = AD.empty () in
     (* We begin looking at the parameters: *)
     let argset = List.fold_right (AD.join) args empty in
@@ -581,7 +581,7 @@ struct
       workset := AD.diff collected !visited
     done;
     (* Return the list of elements that have been visited. *)
-    if M.tracing then M.traceu "reachability" "All reachable vars: %a\n" AD.pretty !visited;
+    if M.tracing then M.traceu "reachability" "All reachable vars: %a" AD.pretty !visited;
     List.map AD.singleton (AD.elements !visited)
 
   let reachable_vars ~ctx st args = Timing.wrap "reachability" (reachable_vars ~ctx st) args
@@ -692,7 +692,7 @@ struct
 
   (* The evaluation function as mutually recursive eval_lv & eval_rv *)
   let rec eval_rv ~(ctx: _ ctx) (st: store) (exp:exp): value =
-    if M.tracing then M.traceli "evalint" "base eval_rv %a\n" d_exp exp;
+    if M.tracing then M.traceli "evalint" "base eval_rv %a" d_exp exp;
     let r =
       (* we have a special expression that should evaluate to top ... *)
       if exp = MyCFG.unknown_exp then
@@ -700,7 +700,7 @@ struct
       else
         eval_rv_ask_evalint ~ctx st exp
     in
-    if M.tracing then M.traceu "evalint" "base eval_rv %a -> %a\n" d_exp exp VD.pretty r;
+    if M.tracing then M.traceu "evalint" "base eval_rv %a -> %a" d_exp exp VD.pretty r;
     r
 
   (** Evaluate expression using EvalInt query.
@@ -709,13 +709,13 @@ struct
       Non-integer expression just delegate to next eval_rv function. *)
   and eval_rv_ask_evalint ~ctx st exp =
     let eval_next () = eval_rv_no_ask_evalint ~ctx st exp in
-    if M.tracing then M.traceli "evalint" "base eval_rv_ask_evalint %a\n" d_exp exp;
+    if M.tracing then M.traceli "evalint" "base eval_rv_ask_evalint %a" d_exp exp;
     let r:value =
       match Cilfacade.typeOf exp with
       | typ when Cil.isIntegralType typ && not (Cil.isConstant exp) -> (* don't EvalInt integer constants, base can do them precisely itself *)
-        if M.tracing then M.traceli "evalint" "base ask EvalInt %a\n" d_exp exp;
+        if M.tracing then M.traceli "evalint" "base ask EvalInt %a" d_exp exp;
         let a = ctx.ask (Q.EvalInt exp) in (* through queries includes eval_next, so no (exponential) branching is necessary *)
-        if M.tracing then M.traceu "evalint" "base ask EvalInt %a -> %a\n" d_exp exp Queries.ID.pretty a;
+        if M.tracing then M.traceu "evalint" "base ask EvalInt %a -> %a" d_exp exp Queries.ID.pretty a;
         begin match a with
           | `Bot -> eval_next () (* Base EvalInt returns bot on incorrect type (e.g. pthread_t); ignore and continue. *)
           (* | x -> Some (Int x) *)
@@ -725,7 +725,7 @@ struct
       | exception Cilfacade.TypeOfError _ (* Bug: typeOffset: Field on a non-compound *)
       | _ -> eval_next ()
     in
-    if M.tracing then M.traceu "evalint" "base eval_rv_ask_evalint %a -> %a\n" d_exp exp VD.pretty r;
+    if M.tracing then M.traceu "evalint" "base eval_rv_ask_evalint %a -> %a" d_exp exp VD.pretty r;
     r
 
   (** Evaluate expression without EvalInt query on outermost expression.
@@ -750,7 +750,7 @@ struct
       Subexpressions delegate to [eval_rv], which may use queries on them. *)
   and eval_rv_base ~ctx (st: store) (exp:exp): value =
     let eval_rv = eval_rv_back_up in
-    if M.tracing then M.traceli "evalint" "base eval_rv_base %a\n" d_exp exp;
+    if M.tracing then M.traceli "evalint" "base eval_rv_base %a" d_exp exp;
     let binop_remove_same_casts ~extra_is_safe ~e1 ~e2 ~t1 ~t2 ~c1 ~c2 =
       let te1 = Cilfacade.typeOf e1 in
       let te2 = Cilfacade.typeOf e2 in
@@ -910,7 +910,7 @@ struct
       | AddrOfLabel _ ->
         VD.top ()
     in
-    if M.tracing then M.traceu "evalint" "base eval_rv_base %a -> %a\n" d_exp exp VD.pretty r;
+    if M.tracing then M.traceu "evalint" "base eval_rv_base %a -> %a" d_exp exp VD.pretty r;
     r
 
   and eval_rv_base_lval ~eval_lv ~ctx (st: store) (exp: exp) (lv: lval): value =
@@ -937,7 +937,7 @@ struct
         | Addr (x, o) ->
           begin
             let at = Addr.Mval.type_of (x, o) in
-            if M.tracing then M.tracel "evalint" "cast_ok %a %a %a\n" Addr.pretty (Addr (x, o)) CilType.Typ.pretty (Cil.unrollType x.vtype) CilType.Typ.pretty at;
+            if M.tracing then M.tracel "evalint" "cast_ok %a %a %a" Addr.pretty (Addr (x, o)) CilType.Typ.pretty (Cil.unrollType x.vtype) CilType.Typ.pretty at;
             if at = TVoid [] then (* HACK: cast from alloc variable is always fine *)
               true
             else
@@ -965,7 +965,7 @@ struct
             VD.top () (* upcasts not! *)
         in
         let v' = VD.cast t v in (* cast to the expected type (the abstract type might be something other than t since we don't change addresses upon casts!) *)
-        if M.tracing then M.tracel "cast" "Ptr-Deref: cast %a to %a = %a!\n" VD.pretty v d_type t VD.pretty v';
+        if M.tracing then M.tracel "cast" "Ptr-Deref: cast %a to %a = %a!" VD.pretty v d_type t VD.pretty v';
         let v' = VD.eval_offset (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) (fun x -> get ~ctx st x (Some exp)) v' (convert_offset ~ctx st ofs) (Some exp) None t in (* handle offset *)
         v'
       in
@@ -989,7 +989,7 @@ struct
         (* Fallback to MustBeEqual query, could get extra precision from exprelation/var_eq. *)
         let must_be_equal () =
           let r = Q.must_be_equal (Analyses.ask_of_ctx ctx) e1 e2 in
-          if M.tracing then M.tracel "query" "MustBeEqual (%a, %a) = %b\n" d_exp e1 d_exp e2 r;
+          if M.tracing then M.tracel "query" "MustBeEqual (%a, %a) = %b" d_exp e1 d_exp e2 r;
           r
         in
         match op with
@@ -1093,13 +1093,13 @@ struct
   let eval_rv ~ctx (st: store) (exp:exp): value =
     try
       let r = eval_rv ~ctx st exp in
-      if M.tracing then M.tracel "eval" "eval_rv %a = %a\n" d_exp exp VD.pretty r;
+      if M.tracing then M.tracel "eval" "eval_rv %a = %a" d_exp exp VD.pretty r;
       if VD.is_bot r then VD.top_value (Cilfacade.typeOf exp) else r
     with IntDomain.ArithmeticOnIntegerBot _ ->
       ValueDomain.Compound.top_value (Cilfacade.typeOf exp)
 
   let query_evalint ~ctx st e =
-    if M.tracing then M.traceli "evalint" "base query_evalint %a\n" d_exp e;
+    if M.tracing then M.traceli "evalint" "base query_evalint %a" d_exp e;
     let r = match eval_rv_no_ask_evalint ~ctx st e with
       | Int i -> `Lifted i (* cast should be unnecessary, eval_rv should guarantee right ikind already *)
       | Bot   -> Queries.ID.top () (* out-of-scope variables cause bot, but query result should then be unknown *)
@@ -1107,7 +1107,7 @@ struct
       | v      -> M.debug ~category:Analyzer "Base EvalInt %a query answering bot instead of %a" d_exp e VD.pretty v; Queries.ID.bot ()
       | exception (IntDomain.ArithmeticOnIntegerBot _) when not !AnalysisState.should_warn -> Queries.ID.top () (* for some privatizations, values can intermediately be bot because side-effects have not happened yet *)
     in
-    if M.tracing then M.traceu "evalint" "base query_evalint %a -> %a\n" d_exp e Queries.ID.pretty r;
+    if M.tracing then M.traceu "evalint" "base query_evalint %a -> %a" d_exp e Queries.ID.pretty r;
     r
 
   (* Evaluate an expression containing only locals. This is needed for smart joining the partitioned arrays where ctx is not accessible. *)
@@ -1447,14 +1447,14 @@ struct
    * precise information about arrays. *)
   let set ~(ctx: _ ctx) ?(invariant=false) ?(blob_destructive=false) ?lval_raw ?rval_raw ?t_override (st: store) (lval: AD.t) (lval_type: Cil.typ) (value: value) : store =
     let update_variable x t y z =
-      if M.tracing then M.tracel "set" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a\n\n" x.vname VD.pretty y CPA.pretty z;
+      if M.tracing then M.tracel "set" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a\n" x.vname VD.pretty y CPA.pretty z;
       let r = update_variable x t y z in (* refers to defintion that is outside of set *)
-      if M.tracing then M.tracel "set" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a\nresults in\n%a\n" x.vname VD.pretty y CPA.pretty z CPA.pretty r;
+      if M.tracing then M.tracel "set" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a\nresults in\n%a" x.vname VD.pretty y CPA.pretty z CPA.pretty r;
       r
     in
     let firstvar = if M.tracing then match AD.to_var_may lval with [] -> "" | x :: _ -> x.vname else "" in
     let lval_raw = (Option.map (fun x -> Lval x) lval_raw) in
-    if M.tracing then M.tracel "set" ~var:firstvar "lval: %a\nvalue: %a\nstate: %a\n" AD.pretty lval VD.pretty value CPA.pretty st.cpa;
+    if M.tracing then M.tracel "set" ~var:firstvar "lval: %a\nvalue: %a\nstate: %a" AD.pretty lval VD.pretty value CPA.pretty st.cpa;
     (* Updating a single varinfo*offset pair. NB! This function's type does
      * not include the flag. *)
     let update_one_addr (x, offs) (st: store): store =
@@ -1492,19 +1492,19 @@ struct
         else
           new_value
       in
-      if M.tracing then M.tracel "set" ~var:firstvar "update_one_addr: start with '%a' (type '%a') \nstate:%a\n\n" AD.pretty (AD.of_mval (x,offs)) d_type x.vtype D.pretty st;
+      if M.tracing then M.tracel "set" ~var:firstvar "update_one_addr: start with '%a' (type '%a') \nstate:%a\n" AD.pretty (AD.of_mval (x,offs)) d_type x.vtype D.pretty st;
       if isFunctionType x.vtype then begin
-        if M.tracing then M.tracel "set" ~var:firstvar "update_one_addr: returning: '%a' is a function type \n" d_type x.vtype;
+        if M.tracing then M.tracel "set" ~var:firstvar "update_one_addr: returning: '%a' is a function type " d_type x.vtype;
         st
       end else
       if get_bool "exp.globs_are_top" then begin
-        if M.tracing then M.tracel "set" ~var:firstvar "update_one_addr: BAD? exp.globs_are_top is set \n";
+        if M.tracing then M.tracel "set" ~var:firstvar "update_one_addr: BAD? exp.globs_are_top is set ";
         { st with cpa = CPA.add x Top st.cpa }
       end else
         (* Check if we need to side-effect this one. We no longer generate
          * side-effects here, but the code still distinguishes these cases. *)
       if (!earlyglobs || ThreadFlag.has_ever_been_multi ask) && is_global ask x then begin
-        if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: update a global var '%s' ...\n" x.vname;
+        if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: update a global var '%s' ..." x.vname;
         let priv_getg = priv_getg ctx.global in
         (* Optimization to avoid evaluating integer values when setting them.
            The case when invariant = true requires the old_value to be sound for the meet.
@@ -1515,12 +1515,12 @@ struct
             Priv.read_global ask priv_getg st x
         in
         let new_value = update_offset old_value in
-        if M.tracing then M.tracel "set" "update_offset %a -> %a\n" VD.pretty old_value VD.pretty new_value;
+        if M.tracing then M.tracel "set" "update_offset %a -> %a" VD.pretty old_value VD.pretty new_value;
         let r = Priv.write_global ~invariant ask priv_getg (priv_sideg ctx.sideg) st x new_value in
-        if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: updated a global var '%s' \nstate:%a\n\n" x.vname D.pretty r;
+        if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: updated a global var '%s' \nstate:%a\n" x.vname D.pretty r;
         r
       end else begin
-        if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: update a local var '%s' ...\n" x.vname;
+        if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: update a local var '%s' ..." x.vname;
         (* Normal update of the local state *)
         let new_value = update_offset (CPA.find x st.cpa) in
         (* what effect does changing this local variable have on arrays -
@@ -1604,16 +1604,16 @@ struct
       (* We start from the current state and an empty list of global deltas,
        * and we assign to all the the different possible places: *)
       let nst = AD.fold update_one lval st in
-      (* if M.tracing then M.tracel "set" ~var:firstvar "new state1 %a\n" CPA.pretty nst; *)
+      (* if M.tracing then M.tracel "set" ~var:firstvar "new state1 %a" CPA.pretty nst; *)
       (* If the address was definite, then we just return it. If the address
        * was ambiguous, we have to join it with the initial state. *)
       let nst = if AD.cardinal lval > 1 then { nst with cpa = CPA.join st.cpa nst.cpa } else nst in
-      (* if M.tracing then M.tracel "set" ~var:firstvar "new state2 %a\n" CPA.pretty nst; *)
+      (* if M.tracing then M.tracel "set" ~var:firstvar "new state2 %a" CPA.pretty nst; *)
       nst
     with
     (* If any of the addresses are unknown, we ignore it!?! *)
     | SetDomain.Unsupported x ->
-      (* if M.tracing then M.tracel "set" ~var:firstvar "set got an exception '%s'\n" x; *)
+      (* if M.tracing then M.tracel "set" ~var:firstvar "set got an exception '%s'" x; *)
       M.info ~category:Unsound "Assignment to unknown address, assuming no write happened."; st
 
   let set_many ~ctx (st: store) lval_value_list: store =
@@ -1690,7 +1690,7 @@ struct
 
 
   let set_savetop ~ctx ?lval_raw ?rval_raw st adr lval_t v : store =
-    if M.tracing then M.tracel "set" "savetop %a %a %a\n" AD.pretty adr d_type lval_t VD.pretty v;
+    if M.tracing then M.tracel "set" "savetop %a %a %a" AD.pretty adr d_type lval_t VD.pretty v;
     match v with
     | Top -> set ~ctx st adr lval_t (VD.top_value (AD.type_of adr)) ?lval_raw ?rval_raw
     | v -> set ~ctx st adr lval_t v ?lval_raw ?rval_raw
@@ -1778,7 +1778,7 @@ struct
             | Some (x,offs) ->
               let t = v.vtype in
               let iv = VD.bot_value ~varAttr:v.vattr t in (* correct bottom value for top level variable *)
-              if M.tracing then M.tracel "set" "init bot value: %a\n" VD.pretty iv;
+              if M.tracing then M.tracel "set" "init bot value: %a" VD.pretty iv;
               let nv = VD.update_offset (Queries.to_value_domain_ask (Analyses.ask_of_ctx ctx)) iv offs rval_val (Some  (Lval lval)) lval t in (* do desired update to value *)
               set_savetop ~ctx  ctx.local (AD.of_var v) lval_t nv ~lval_raw:lval ~rval_raw:rval (* set top-level variable to updated value *)
             | None ->
@@ -1795,28 +1795,28 @@ struct
     let valu = eval_rv ~ctx ctx.local exp in
     let refine () =
       let res = invariant ctx ctx.local exp tv in
-      if M.tracing then M.tracec "branch" "EqualSet result for expression %a is %a\n" d_exp exp Queries.ES.pretty (ctx.ask (Queries.EqualSet exp));
-      if M.tracing then M.tracec "branch" "CondVars result for expression %a is %a\n" d_exp exp Queries.ES.pretty (ctx.ask (Queries.CondVars exp));
-      if M.tracing then M.traceu "branch" "Invariant enforced!\n";
+      if M.tracing then M.tracec "branch" "EqualSet result for expression %a is %a" d_exp exp Queries.ES.pretty (ctx.ask (Queries.EqualSet exp));
+      if M.tracing then M.tracec "branch" "CondVars result for expression %a is %a" d_exp exp Queries.ES.pretty (ctx.ask (Queries.CondVars exp));
+      if M.tracing then M.traceu "branch" "Invariant enforced!";
       match ctx.ask (Queries.CondVars exp) with
       | s when Queries.ES.cardinal s = 1 ->
         let e = Queries.ES.choose s in
         invariant ctx res e tv
       | _ -> res
     in
-    if M.tracing then M.traceli "branch" ~subsys:["invariant"] "Evaluating branch for expression %a with value %a\n" d_exp exp VD.pretty valu;
+    if M.tracing then M.traceli "branch" ~subsys:["invariant"] "Evaluating branch for expression %a with value %a" d_exp exp VD.pretty valu;
     (* First we want to see, if we can determine a dead branch: *)
     match valu with
     (* For a boolean value: *)
     | Int value ->
-      if M.tracing then M.traceu "branch" "Expression %a evaluated to %a\n" d_exp exp ID.pretty value;
+      if M.tracing then M.traceu "branch" "Expression %a evaluated to %a" d_exp exp ID.pretty value;
       begin match ID.to_bool value with
         | Some v ->
           (* Eliminate the dead branch and just propagate to the true branch *)
           if v = tv then
             refine ()
           else (
-            if M.tracing then M.tracel "branch" "A The branch %B is dead!\n" tv;
+            if M.tracing then M.tracel "branch" "A The branch %B is dead!" tv;
             raise Deadcode
           )
         | None ->
@@ -1828,7 +1828,7 @@ struct
     | Address ad when not tv && AD.is_not_null ad ->
       raise Deadcode
     | Bot ->
-      if M.tracing then M.traceu "branch" "The branch %B is dead!\n" tv;
+      if M.tracing then M.traceu "branch" "The branch %B is dead!" tv;
       raise Deadcode
     (* Otherwise we try to impose an invariant: *)
     | _ ->
@@ -1850,7 +1850,7 @@ struct
     let st: store = ctx.local in
     match fundec.svar.vname with
     | "__goblint_dummy_init" ->
-      if M.tracing then M.trace "init" "dummy init: %a\n" D.pretty st;
+      if M.tracing then M.trace "init" "dummy init: %a" D.pretty st;
       publish_all ctx `Init;
       (* otherfun uses __goblint_dummy_init, where we can properly side effect global initialization *)
       (* TODO: move into sync `Init *)
@@ -1911,7 +1911,7 @@ struct
     )
 
   let invalidate ?(deep=true) ~ctx (st:store) (exps: exp list): store =
-    if M.tracing && exps <> [] then M.tracel "invalidate" "Will invalidate expressions [%a]\n" (d_list ", " d_plainexp) exps;
+    if M.tracing && exps <> [] then M.tracel "invalidate" "Will invalidate expressions [%a]" (d_list ", " d_plainexp) exps;
     if exps <> [] then M.info ~category:Imprecise "Invalidating expressions: %a" (d_list ", " d_exp) exps;
     (* To invalidate a single address, we create a pair with its corresponding
      * top value. *)
@@ -2166,7 +2166,7 @@ struct
   let special ctx (lv:lval option) (f: varinfo) (args: exp list) =
     let invalidate_ret_lv st = match lv with
       | Some lv ->
-        if M.tracing then M.tracel "invalidate" "Invalidating lhs %a for function call %s\n" d_plainlval lv f.vname;
+        if M.tracing then M.tracel "invalidate" "Invalidating lhs %a for function call %s" d_plainlval lv f.vname;
         invalidate ~deep:false ~ctx st [Cil.mkAddrOrStartOf lv]
       | None -> st
     in
@@ -2176,7 +2176,7 @@ struct
       (addr, AD.type_of addr)
     in
     let forks = forkfun ctx lv f args in
-    if M.tracing then if not (List.is_empty forks) then M.tracel "spawn" "Base.special %s: spawning functions %a\n" f.vname (d_list "," CilType.Varinfo.pretty) (List.map BatTuple.Tuple4.second forks);
+    if M.tracing then if not (List.is_empty forks) then M.tracel "spawn" "Base.special %s: spawning functions %a" f.vname (d_list "," CilType.Varinfo.pretty) (List.map BatTuple.Tuple4.second forks);
     List.iter (fun (lval, f, args, multiple) -> ctx.spawn ~multiple lval f args) forks;
     let st: store = ctx.local in
     let desc = LF.find f in
@@ -2408,7 +2408,7 @@ struct
           begin
             match ID.to_int x with
             | Some z ->
-              if M.tracing then M.tracel "attr" "setting\n";
+              if M.tracing then M.tracel "attr" "setting";
               set ~ctx st dest_a dest_typ (MutexAttr (ValueDomain.MutexAttr.of_int z))
             | None -> set ~ctx st dest_a dest_typ (MutexAttr (ValueDomain.MutexAttr.top ()))
           end
@@ -2607,7 +2607,7 @@ struct
         | Address jmp_buf ->
           let value = VD.JmpBuf (ValueDomain.JmpBufs.Bufs.singleton (Target (ctx.prev_node, ctx.control_context ())), false) in
           let r = set ~ctx st jmp_buf (Cilfacade.typeOf env) value in
-          if M.tracing then M.tracel "setjmp" "setting setjmp %a on %a -> %a\n" d_exp env D.pretty st D.pretty r;
+          if M.tracing then M.tracel "setjmp" "setting setjmp %a on %a -> %a" d_exp env D.pretty st D.pretty r;
           r
         | _ -> failwith "problem?!"
       in
@@ -2664,7 +2664,7 @@ struct
         | Addr.Addr (v,o) when CPA.mem v fun_st.cpa ->
           begin
             let lval_type = Addr.type_of addr in
-            if M.tracing then M.trace "taintPC" "updating %a; type: %a\n" Addr.Mval.pretty (v,o) d_type lval_type;
+            if M.tracing then M.trace "taintPC" "updating %a; type: %a" Addr.Mval.pretty (v,o) d_type lval_type;
             match CPA.find_opt v (fun_st.cpa) with
             | None -> st
             (* partitioned arrays cannot be copied by individual lvalues, so if tainted just copy the whole callee value for the array variable *)
@@ -2675,7 +2675,7 @@ struct
               begin
                 let address = AD.singleton addr in
                 let new_val = get ~ctx fun_st address None in
-                if M.tracing then M.trace "taintPC" "update val: %a\n\n" VD.pretty new_val;
+                if M.tracing then M.trace "taintPC" "update val: %a\n" VD.pretty new_val;
                 let st' = set_savetop ~ctx st address lval_type new_val in
                 match Dep.find_opt v fun_st.deps with
                 | None -> st'
@@ -2691,7 +2691,7 @@ struct
 
   let combine_env ctx lval fexp f args fc au (f_ask: Queries.ask) =
     let combine_one (st: D.t) (fun_st: D.t) =
-      if M.tracing then M.tracel "combine" "%a\n%a\n" CPA.pretty st.cpa CPA.pretty fun_st.cpa;
+      if M.tracing then M.tracel "combine" "%a\n%a" CPA.pretty st.cpa CPA.pretty fun_st.cpa;
       (* This function does miscellaneous things, but the main task was to give the
        * handle to the global state to the state return from the function, but now
        * the function tries to add all the context variables back to the callee.
@@ -2702,29 +2702,29 @@ struct
         let cpa_noreturn = CPA.remove (return_varinfo ()) fun_st.cpa in
         let ask = Analyses.ask_of_ctx ctx in
         let tainted = f_ask.f Q.MayBeTainted in
-        if M.tracing then M.trace "taintPC" "combine for %s in base: tainted: %a\n" f.svar.vname AD.pretty tainted;
-        if M.tracing then M.trace "taintPC" "combine base:\ncaller: %a\ncallee: %a\n" CPA.pretty st.cpa CPA.pretty fun_st.cpa;
+        if M.tracing then M.trace "taintPC" "combine for %s in base: tainted: %a" f.svar.vname AD.pretty tainted;
+        if M.tracing then M.trace "taintPC" "combine base:\ncaller: %a\ncallee: %a" CPA.pretty st.cpa CPA.pretty fun_st.cpa;
         if AD.is_top tainted then
           let cpa_local = CPA.filter (fun x _ -> not (is_global ask x)) st.cpa in
           let cpa' = CPA.fold CPA.add cpa_noreturn cpa_local in (* add cpa_noreturn to cpa_local *)
-          if M.tracing then M.trace "taintPC" "combined: %a\n" CPA.pretty cpa';
+          if M.tracing then M.trace "taintPC" "combined: %a" CPA.pretty cpa';
           { fun_st with cpa = cpa' }
         else
           (* remove variables from caller cpa, that are global and not in the callee cpa *)
           let cpa_caller = CPA.filter (fun x _ -> (not (is_global ask x)) || CPA.mem x fun_st.cpa) st.cpa in
-          if M.tracing then M.trace "taintPC" "cpa_caller: %a\n" CPA.pretty cpa_caller;
+          if M.tracing then M.trace "taintPC" "cpa_caller: %a" CPA.pretty cpa_caller;
           (* add variables from callee that are not in caller yet *)
           let cpa_new = CPA.filter (fun x _ -> not (CPA.mem x cpa_caller)) cpa_noreturn in
-          if M.tracing then M.trace "taintPC" "cpa_new: %a\n" CPA.pretty cpa_new;
+          if M.tracing then M.trace "taintPC" "cpa_new: %a" CPA.pretty cpa_new;
           let cpa_caller' = CPA.fold CPA.add cpa_new cpa_caller in
-          if M.tracing then M.trace "taintPC" "cpa_caller': %a\n" CPA.pretty cpa_caller';
+          if M.tracing then M.trace "taintPC" "cpa_caller': %a" CPA.pretty cpa_caller';
           (* remove lvals from the tainted set that correspond to variables for which we just added a new mapping from the callee*)
           let tainted = AD.filter (function
               | Addr.Addr (v,_) -> not (CPA.mem v cpa_new)
               | _ -> false
             ) tainted in
           let st_combined = combine_st ctx {st with cpa = cpa_caller'} fun_st tainted in
-          if M.tracing then M.trace "taintPC" "combined: %a\n" CPA.pretty st_combined.cpa;
+          if M.tracing then M.trace "taintPC" "combined: %a" CPA.pretty st_combined.cpa;
           { fun_st with cpa = st_combined.cpa }
       in
       let nst = add_globals st fun_st in
@@ -2896,7 +2896,7 @@ struct
         with Deadcode -> (* contradiction in unassume *)
           D.bot ()
       in
-      if M.tracing then M.traceli "unassume" "base unassuming\n";
+      if M.tracing then M.traceli "unassume" "base unassuming";
       let r =
         match get_string "ana.base.invariant.unassume" with
         | "once" ->
@@ -2907,7 +2907,7 @@ struct
         | _ ->
           assert false
       in
-      if M.tracing then M.traceu "unassume" "base unassumed\n";
+      if M.tracing then M.traceu "unassume" "base unassumed";
       r
     in
     M.info ~category:Witness "base unassumed invariant: %a" d_exp e;
@@ -2929,7 +2929,7 @@ struct
     let st: store = ctx.local in
     match e with
     | Events.Lock (addr, _) when ThreadFlag.has_ever_been_multi ask -> (* TODO: is this condition sound? *)
-      if M.tracing then M.tracel "priv" "LOCK EVENT %a\n" LockDomain.Addr.pretty addr;
+      if M.tracing then M.tracel "priv" "LOCK EVENT %a" LockDomain.Addr.pretty addr;
       Priv.lock ask (priv_getg ctx.global) st addr
     | Events.Unlock addr when ThreadFlag.has_ever_been_multi ask -> (* TODO: is this condition sound? *)
       if addr = UnknownPtr then

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1935,7 +1935,7 @@ struct
     if M.tracing && exps <> [] then (
       let addrs = List.map (Tuple3.first) invalids' in
       let vs = List.map (Tuple3.third) invalids' in
-      if M.tracing then M.tracel "invalidate" "Setting addresses [%a] to values [%a]" (d_list ", " AD.pretty) addrs (d_list ", " VD.pretty) vs
+      M.tracel "invalidate" "Setting addresses [%a] to values [%a]" (d_list ", " AD.pretty) addrs (d_list ", " VD.pretty) vs
     );
     set_many ~ctx st invalids'
 

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1447,7 +1447,7 @@ struct
    * precise information about arrays. *)
   let set ~(ctx: _ ctx) ?(invariant=false) ?(blob_destructive=false) ?lval_raw ?rval_raw ?t_override (st: store) (lval: AD.t) (lval_type: Cil.typ) (value: value) : store =
     let update_variable x t y z =
-      if M.tracing then M.tracel "set" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a\n" x.vname VD.pretty y CPA.pretty z;
+      if M.tracing then M.tracel "set" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a" x.vname VD.pretty y CPA.pretty z;
       let r = update_variable x t y z in (* refers to defintion that is outside of set *)
       if M.tracing then M.tracel "set" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a\nresults in\n%a" x.vname VD.pretty y CPA.pretty z CPA.pretty r;
       r
@@ -1492,7 +1492,7 @@ struct
         else
           new_value
       in
-      if M.tracing then M.tracel "set" ~var:firstvar "update_one_addr: start with '%a' (type '%a') \nstate:%a\n" AD.pretty (AD.of_mval (x,offs)) d_type x.vtype D.pretty st;
+      if M.tracing then M.tracel "set" ~var:firstvar "update_one_addr: start with '%a' (type '%a') \nstate:%a" AD.pretty (AD.of_mval (x,offs)) d_type x.vtype D.pretty st;
       if isFunctionType x.vtype then begin
         if M.tracing then M.tracel "set" ~var:firstvar "update_one_addr: returning: '%a' is a function type " d_type x.vtype;
         st
@@ -1517,7 +1517,7 @@ struct
         let new_value = update_offset old_value in
         if M.tracing then M.tracel "set" "update_offset %a -> %a" VD.pretty old_value VD.pretty new_value;
         let r = Priv.write_global ~invariant ask priv_getg (priv_sideg ctx.sideg) st x new_value in
-        if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: updated a global var '%s' \nstate:%a\n" x.vname D.pretty r;
+        if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: updated a global var '%s' \nstate:%a" x.vname D.pretty r;
         r
       end else begin
         if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: update a local var '%s' ..." x.vname;
@@ -2675,7 +2675,7 @@ struct
               begin
                 let address = AD.singleton addr in
                 let new_val = get ~ctx fun_st address None in
-                if M.tracing then M.trace "taintPC" "update val: %a\n" VD.pretty new_val;
+                if M.tracing then M.trace "taintPC" "update val: %a" VD.pretty new_val;
                 let st' = set_savetop ~ctx st address lval_type new_val in
                 match Dep.find_opt v fun_st.deps with
                 | None -> st'

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -165,7 +165,7 @@ struct
               let limit_from = if tv then ID.maximal else ID.minimal in
               match limit_from n with
               | Some n ->
-                if M.tracing then M.tracec "invariant" "Yes, success! %a is not %a\n" d_lval x GobZ.pretty n;
+                if M.tracing then M.tracec "invariant" "Yes, success! %a is not %a" d_lval x GobZ.pretty n;
                 Some (x, Int (range_from n))
               | None -> None
             end
@@ -180,7 +180,7 @@ struct
               let limit_from = if tv then ID.maximal else ID.minimal in
               match limit_from n with
               | Some n ->
-                if M.tracing then M.tracec "invariant" "Yes, success! %a is not %a\n" d_lval x GobZ.pretty n;
+                if M.tracing then M.tracec "invariant" "Yes, success! %a is not %a" d_lval x GobZ.pretty n;
                 Some (x, Int (range_from n))
               | None -> None
             end
@@ -189,7 +189,7 @@ struct
       | Gt, x, value, _ -> helper Le x value (not tv)
       | Ge, x, value, _ -> helper Lt x value (not tv)
       | _ ->
-        if M.tracing then M.trace "invariant" "Failed! (operation not supported)\n";
+        if M.tracing then M.trace "invariant" "Failed! (operation not supported)";
         None
     in
     if M.tracing then M.traceli "invariant" "assume expression %a is %B" d_exp exp tv;
@@ -227,7 +227,7 @@ struct
         helper Ne x (null_val (Cilfacade.typeOf exp)) tv
       | UnOp (LNot,uexp,typ) -> derived_invariant uexp (not tv)
       | _ ->
-        if M.tracing then M.tracec "invariant" "Failed! (expression %a not understood)\n" d_plainexp exp;
+        if M.tracing then M.tracec "invariant" "Failed! (expression %a not understood)" d_plainexp exp;
         None
     in
     match derived_invariant exp tv with
@@ -513,7 +513,7 @@ struct
                 else
                   b
               | _ -> b) in
-          if M.tracing then M.trace "inv_float" "Div: (%a,%a) = %a   yields (%a,%a) \n" FD.pretty a FD.pretty b FD.pretty c FD.pretty a' FD.pretty b';
+          if M.tracing then M.trace "inv_float" "Div: (%a,%a) = %a   yields (%a,%a)" FD.pretty a FD.pretty b FD.pretty c FD.pretty a' FD.pretty b';
           meet_bin a' b'
         | Eq | Ne as op ->
           let both x = x, x in

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -55,7 +55,7 @@ struct
     with Lattice.Uncomparable -> old_val
 
   let refine_lv_fallback ctx st lval value tv =
-    if M.tracing then M.tracec "invariant" "Restricting %a with %a\n" d_lval lval VD.pretty value;
+    if M.tracing then M.tracec "invariant" "Restricting %a with %a" d_lval lval VD.pretty value;
     let addr = eval_lv ~ctx st lval in
     if (AD.is_top addr) then st
     else
@@ -73,10 +73,10 @@ struct
       let state_with_excluded = set st addr t_lval value ~ctx in
       let value =  get ~ctx state_with_excluded addr None in
       let new_val = apply_invariant ~old_val ~new_val:value in
-      if M.tracing then M.traceu "invariant" "New value is %a\n" VD.pretty new_val;
+      if M.tracing then M.traceu "invariant" "New value is %a" VD.pretty new_val;
       (* make that address meet the invariant, i.e exclusion sets will be joined *)
       if is_some_bot new_val then (
-        if M.tracing then M.tracel "branch" "C The branch %B is dead!\n" tv;
+        if M.tracing then M.tracel "branch" "C The branch %B is dead!" tv;
         contra st
       )
       else if VD.is_bot new_val
@@ -95,9 +95,9 @@ struct
       let v = apply_invariant ~old_val ~new_val in
       if is_some_bot v then contra st
       else (
-        if M.tracing then M.tracel "inv" "improve variable %a from %a to %a (c = %a, c' = %a)\n" CilType.Varinfo.pretty var VD.pretty old_val VD.pretty v pretty c VD.pretty c';
+        if M.tracing then M.tracel "inv" "improve variable %a from %a to %a (c = %a, c' = %a)" CilType.Varinfo.pretty var VD.pretty old_val VD.pretty v pretty c VD.pretty c';
         let r = set' (Var var,NoOffset) v st in
-        if M.tracing then M.tracel "inv" "st from %a to %a\n" D.pretty st D.pretty r;
+        if M.tracing then M.tracel "inv" "st from %a to %a" D.pretty st D.pretty r;
         r
       )
     | Var _, _
@@ -108,7 +108,7 @@ struct
       let v = apply_invariant ~old_val ~new_val:c' in
       if is_some_bot v then contra st
       else (
-        if M.tracing then M.tracel "inv" "improve lval %a from %a to %a (c = %a, c' = %a)\n" d_lval x VD.pretty old_val VD.pretty v pretty c VD.pretty c';
+        if M.tracing then M.tracel "inv" "improve lval %a from %a to %a (c = %a, c' = %a)" d_lval x VD.pretty old_val VD.pretty v pretty c VD.pretty c';
         set' x v st
       )
 
@@ -119,7 +119,7 @@ struct
       match (op, lval, value, tv) with
       (* The true-branch where x == value: *)
       | Eq, x, value, true ->
-        if M.tracing then M.tracec "invariant" "Yes, %a equals %a\n" d_lval x VD.pretty value;
+        if M.tracing then M.tracec "invariant" "Yes, %a equals %a" d_lval x VD.pretty value;
         (match value with
          | Int n ->
            let ikind = Cilfacade.get_ikind_exp (Lval lval) in
@@ -132,27 +132,27 @@ struct
               match ID.to_int n with
               | Some n ->
                 (* When x != n, we can return a singleton exclusion set *)
-                if M.tracing then M.tracec "invariant" "Yes, %a is not %a\n" d_lval x GobZ.pretty n;
+                if M.tracing then M.tracec "invariant" "Yes, %a is not %a" d_lval x GobZ.pretty n;
                 let ikind = Cilfacade.get_ikind_exp (Lval lval) in
                 Some (x, Int (ID.of_excl_list ikind [n]))
               | None -> None
             end
           | Address n -> begin
-              if M.tracing then M.tracec "invariant" "Yes, %a is not %a\n" d_lval x AD.pretty n;
+              if M.tracing then M.tracec "invariant" "Yes, %a is not %a" d_lval x AD.pretty n;
               match eval_rv_address ~ctx st (Lval x) with
               | Address a when AD.is_definite n ->
                 Some (x, Address (AD.diff a n))
               | Top when AD.is_null n ->
                 Some (x, Address AD.not_null)
               | v ->
-                if M.tracing then M.tracec "invariant" "No address invariant for: %a != %a\n" VD.pretty v AD.pretty n;
+                if M.tracing then M.tracec "invariant" "No address invariant for: %a != %a" VD.pretty v AD.pretty n;
                 None
             end
           (* | Address a -> Some (x, value) *)
           | _ ->
             (* We can't say anything else, exclusion sets are finite, so not
              * being in one means an infinite number of values *)
-            if M.tracing then M.tracec "invariant" "Failed! (not a definite value)\n";
+            if M.tracing then M.tracec "invariant" "Failed! (not a definite value)";
             None
         end
       | Ne, x, value, _ -> helper Eq x value (not tv)
@@ -165,7 +165,7 @@ struct
               let limit_from = if tv then ID.maximal else ID.minimal in
               match limit_from n with
               | Some n ->
-                if M.tracing then M.tracec "invariant" "Yes, success! %a is not %a\n\n" d_lval x GobZ.pretty n;
+                if M.tracing then M.tracec "invariant" "Yes, success! %a is not %a\n" d_lval x GobZ.pretty n;
                 Some (x, Int (range_from n))
               | None -> None
             end
@@ -180,7 +180,7 @@ struct
               let limit_from = if tv then ID.maximal else ID.minimal in
               match limit_from n with
               | Some n ->
-                if M.tracing then M.tracec "invariant" "Yes, success! %a is not %a\n\n" d_lval x GobZ.pretty n;
+                if M.tracing then M.tracec "invariant" "Yes, success! %a is not %a\n" d_lval x GobZ.pretty n;
                 Some (x, Int (range_from n))
               | None -> None
             end
@@ -189,10 +189,10 @@ struct
       | Gt, x, value, _ -> helper Le x value (not tv)
       | Ge, x, value, _ -> helper Lt x value (not tv)
       | _ ->
-        if M.tracing then M.trace "invariant" "Failed! (operation not supported)\n\n";
+        if M.tracing then M.trace "invariant" "Failed! (operation not supported)\n";
         None
     in
-    if M.tracing then M.traceli "invariant" "assume expression %a is %B\n" d_exp exp tv;
+    if M.tracing then M.traceli "invariant" "assume expression %a is %B" d_exp exp tv;
     let null_val (typ:typ):VD.t =
       match Cil.unrollType typ with
       | TPtr _                    -> Address AD.null_ptr
@@ -227,20 +227,20 @@ struct
         helper Ne x (null_val (Cilfacade.typeOf exp)) tv
       | UnOp (LNot,uexp,typ) -> derived_invariant uexp (not tv)
       | _ ->
-        if M.tracing then M.tracec "invariant" "Failed! (expression %a not understood)\n\n" d_plainexp exp;
+        if M.tracing then M.tracec "invariant" "Failed! (expression %a not understood)\n" d_plainexp exp;
         None
     in
     match derived_invariant exp tv with
     | Some (lval, value) ->
       refine_lv_fallback ctx st lval value tv
     | None ->
-      if M.tracing then M.traceu "invariant" "Doing nothing.\n";
+      if M.tracing then M.traceu "invariant" "Doing nothing.";
       M.debug ~category:Analyzer "Invariant failed: expression \"%a\" not understood." d_exp exp;
       st
 
   let invariant ctx st exp tv: D.t =
     let fallback reason st =
-      if M.tracing then M.tracel "inv" "Can't handle %a.\n%t\n" d_plainexp exp reason;
+      if M.tracing then M.tracel "inv" "Can't handle %a.\n%t" d_plainexp exp reason;
       invariant_fallback ctx st exp tv
     in
     (* inverse values for binary operation a `op` b == c *)
@@ -368,14 +368,14 @@ struct
             in
             let a' = excl b a in
             let b' = excl a b in
-            if M.tracing then M.tracel "inv" "inv_bin_int: unequal: %a and %a; ikind: %a; a': %a, b': %a\n" ID.pretty a ID.pretty b d_ikind ikind ID.pretty a' ID.pretty b';
+            if M.tracing then M.tracel "inv" "inv_bin_int: unequal: %a and %a; ikind: %a; a': %a, b': %a" ID.pretty a ID.pretty b d_ikind ikind ID.pretty a' ID.pretty b';
             meet_bin a' b'
           | _, _ -> a, b
         end
       | Lt | Le | Ge | Gt as op ->
         (match ID.minimal a, ID.maximal a, ID.minimal b, ID.maximal b with
          | Some l1, Some u1, Some l2, Some u2 ->
-           (* if M.tracing then M.tracel "inv" "Op: %s, l1: %Ld, u1: %Ld, l2: %Ld, u2: %Ld\n" (show_binop op) l1 u1 l2 u2; *)
+           (* if M.tracing then M.tracel "inv" "Op: %s, l1: %Ld, u1: %Ld, l2: %Ld, u2: %Ld" (show_binop op) l1 u1 l2 u2; *)
            (* TODO: This causes inconsistent results:
               def_exc and interval in conflict:
                 binop m < 0 with (Not {-1}([-31,31]),[-1,0]) < (0,[0,0]) == (1,[1,1])
@@ -392,7 +392,7 @@ struct
             | _, _ -> a, b)
          | _ -> a, b)
       | BOr | BXor as op->
-        if M.tracing then M.tracel "inv" "Unhandled operator %a\n" d_binop op;
+        if M.tracing then M.tracel "inv" "Unhandled operator %a" d_binop op;
         (* Be careful: inv_exp performs a meet on both arguments of the BOr / BXor. *)
         a, b
       | LAnd ->
@@ -408,12 +408,12 @@ struct
             (match ID.to_bool c with
              | Some true -> ID.meet a (ID.of_congruence ikind (Z.one, Z.of_int 2))
              | Some false -> ID.meet a (ID.of_congruence ikind (Z.zero, Z.of_int 2))
-             | None -> if M.tracing then M.tracel "inv" "Unhandled case for operator x %a 1 = %a\n" d_binop op ID.pretty c; a)
-          | _ -> if M.tracing then M.tracel "inv" "Unhandled case for operator x %a %a = %a\n" d_binop op ID.pretty b ID.pretty c; a
+             | None -> if M.tracing then M.tracel "inv" "Unhandled case for operator x %a 1 = %a" d_binop op ID.pretty c; a)
+          | _ -> if M.tracing then M.tracel "inv" "Unhandled case for operator x %a %a = %a" d_binop op ID.pretty b ID.pretty c; a
         in
         a, b
       | op ->
-        if M.tracing then M.tracel "inv" "Unhandled operator %a\n" d_binop op;
+        if M.tracing then M.tracel "inv" "Unhandled operator %a" d_binop op;
         a, b
     in
     let inv_bin_float (a, b) c op =
@@ -513,7 +513,7 @@ struct
                 else
                   b
               | _ -> b) in
-          if M.tracing then M.trace "inv_float" "Div: (%a,%a) = %a   yields (%a,%a) \n\n" FD.pretty a FD.pretty b FD.pretty c FD.pretty a' FD.pretty b';
+          if M.tracing then M.trace "inv_float" "Div: (%a,%a) = %a   yields (%a,%a) \n" FD.pretty a FD.pretty b FD.pretty c FD.pretty a' FD.pretty b';
           meet_bin a' b'
         | Eq | Ne as op ->
           let both x = x, x in
@@ -541,7 +541,7 @@ struct
               | _, _ -> a, b)
            | _ -> a, b)
         | op ->
-          if M.tracing then M.tracel "inv" "Unhandled operator %a\n" d_binop op;
+          if M.tracing then M.tracel "inv" "Unhandled operator %a" d_binop op;
           a, b
       with FloatDomain.ArithmeticOnFloatBot _ -> raise Analyses.Deadcode
     in
@@ -672,20 +672,20 @@ struct
         | (BinOp (op, e1, e2, _) as e, Float _)
         | (BinOp (op, e1, e2, _) as e, Int _) ->
           let invert_binary_op c pretty c_int c_float =
-            if M.tracing then M.tracel "inv" "binop %a with %a %a %a == %a\n" d_exp e VD.pretty (eval e1 st) d_binop op VD.pretty (eval e2 st) pretty c;
+            if M.tracing then M.tracel "inv" "binop %a with %a %a %a == %a" d_exp e VD.pretty (eval e1 st) d_binop op VD.pretty (eval e2 st) pretty c;
             (match eval e1 st, eval e2 st with
              | Int a, Int b ->
                let ikind = Cilfacade.get_ikind_exp e1 in (* both operands have the same type (except for Shiftlt, Shiftrt)! *)
                let ikres = Cilfacade.get_ikind_exp e in (* might be different from argument types, e.g. for LT, GT, EQ, ... *)
                let a', b' = inv_bin_int (a, b) ikind (c_int ikres) op in
-               if M.tracing then M.tracel "inv" "binop: %a, c: %a, a': %a, b': %a\n" d_exp e ID.pretty (c_int ikind) ID.pretty a' ID.pretty b';
+               if M.tracing then M.tracel "inv" "binop: %a, c: %a, a': %a, b': %a" d_exp e ID.pretty (c_int ikind) ID.pretty a' ID.pretty b';
                let st' = inv_exp (Int a') e1 st in
                let st'' = inv_exp (Int b') e2 st' in
                st''
              | Float a, Float b ->
                let fkind = Cilfacade.get_fkind_exp e1 in (* both operands have the same type *)
                let a', b' = inv_bin_float (a, b) (c_float fkind) op in
-               if M.tracing then M.tracel "inv" "binop: %a, c: %a, a': %a, b': %a\n" d_exp e FD.pretty (c_float fkind) FD.pretty a' FD.pretty b';
+               if M.tracing then M.tracel "inv" "binop: %a, c: %a, a': %a, b': %a" d_exp e FD.pretty (c_float fkind) FD.pretty a' FD.pretty b';
                let st' = inv_exp (Float a') e1 st in
                let st'' = inv_exp (Float b') e2 st' in
                st''
@@ -701,7 +701,7 @@ struct
         | Lval x, (Int _ | Float _ | Address _) -> (* meet x with c *)
           let update_lval c x c' pretty = refine_lv ctx st c x c' pretty exp in
           let t = Cil.unrollType (Cilfacade.typeOfLval x) in  (* unroll type to deal with TNamed *)
-          if M.tracing then M.trace "invSpecial" "invariant with Lval %a, c_typed %a, type %a\n" d_lval x VD.pretty c_typed d_type t;
+          if M.tracing then M.trace "invSpecial" "invariant with Lval %a, c_typed %a, type %a" d_lval x VD.pretty c_typed d_type t;
           begin match c_typed with
             | Int c ->
               let c' = match t with
@@ -715,7 +715,7 @@ struct
               begin match x, t with
                 | (Var v, offs), TInt (ik, _) ->
                   let tmpSpecial = ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) in
-                  if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty tmpSpecial;
+                  if M.tracing then M.trace "invSpecial" "qry Result: %a" Queries.ML.pretty tmpSpecial;
                   begin match tmpSpecial with
                     | `Lifted (Abs (ik, xInt)) ->
                       let c' = ID.cast_to ik c in (* different ik! *)
@@ -753,7 +753,7 @@ struct
               begin match x, t with
                 | (Var v, offs), TFloat (fk, _) ->
                   let tmpSpecial = ctx.ask (Queries.TmpSpecial (v, Offset.Exp.of_cil offs)) in
-                  if M.tracing then M.trace "invSpecial" "qry Result: %a\n" Queries.ML.pretty tmpSpecial;
+                  if M.tracing then M.trace "invSpecial" "qry Result: %a" Queries.ML.pretty tmpSpecial;
                   begin match tmpSpecial with
                     | `Lifted (Ceil (ret_fk, xFloat)) -> inv_exp (Float (FD.inv_ceil (FD.cast_to ret_fk c))) xFloat st
                     | `Lifted (Floor (ret_fk, xFloat)) -> inv_exp (Float (FD.inv_floor (FD.cast_to ret_fk c))) xFloat st
@@ -792,7 +792,7 @@ struct
                | TEnum ({ekind = ik_e; _ }, _) ->
                  (* let c' = ID.cast_to ik_e c in *)
                  let c' = ID.cast_to ik_e (ID.meet c (ID.cast_to ik (ID.top_of ik_e))) in (* TODO: cast without overflow, is this right for normal invariant? *)
-                 if M.tracing then M.tracel "inv" "cast: %a from %a to %a: i = %a; cast c = %a to %a = %a\n" d_exp e d_ikind ik_e d_ikind ik ID.pretty i ID.pretty c d_ikind ik_e ID.pretty c';
+                 if M.tracing then M.tracel "inv" "cast: %a from %a to %a: i = %a; cast c = %a to %a = %a" d_exp e d_ikind ik_e d_ikind ik ID.pretty i ID.pretty c d_ikind ik_e ID.pretty c';
                  inv_exp (Int c') e st
                | x -> fallback (fun () -> Pretty.dprintf "CastE: e did evaluate to Int, but the type did not match %a" CilType.Typ.pretty t) st
              else

--- a/src/analyses/condVars.ml
+++ b/src/analyses/condVars.ml
@@ -108,7 +108,7 @@ struct
     let save_expr lval expr =
       match mustPointTo ctx (AddrOf lval) with
       | Some clval ->
-        if M.tracing then M.tracel "condvars" "CondVars: saving %a = %a\n" Mval.Exp.pretty clval d_exp expr;
+        if M.tracing then M.tracel "condvars" "CondVars: saving %a = %a" Mval.Exp.pretty clval d_exp expr;
         D.add clval (D.V.singleton expr) d (* if lval must point to clval, add expr *)
       | None -> d
     in

--- a/src/analyses/loopTermination.ml
+++ b/src/analyses/loopTermination.ml
@@ -74,7 +74,7 @@ struct
     | Queries.MustTermAllLoops ->
       let multithreaded = ctx.ask Queries.IsEverMultiThreaded in
       if multithreaded then (
-        M.warn ~category:Termination "The program might not terminate! (Multithreaded)\n";
+        M.warn ~category:Termination "The program might not terminate! (Multithreaded)";
         false)
       else
         G.for_all (fun _ term_info -> term_info) (ctx.global ())

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -206,16 +206,16 @@ struct
           let octx' : (S.D.t, S.G.t, S.C.t, S.V.t) ctx = inner_ctx "do_emits" ~splits ~post_all octx'' n od in
           n, repr @@ S.event ctx' e octx'
         in
-        if M.tracing then M.traceli "event" "%a\n  before: %a\n" Events.pretty e D.pretty ctx.local;
+        if M.tracing then M.traceli "event" "%a\n  before: %a" Events.pretty e D.pretty ctx.local;
         let d, q = map_deadcode f @@ spec_list2 ctx.local octx.local in
-        if M.tracing then M.traceu "event" "%a\n  after:%a\n" Events.pretty e D.pretty d;
+        if M.tracing then M.traceu "event" "%a\n  after:%a" Events.pretty e D.pretty d;
         do_sideg ctx !sides;
         do_spawns ctx !spawns;
         do_splits ctx d !splits !emits;
         let d = do_emits ctx !emits d q in
         if q then raise Deadcode else ctx_with_local ctx d
     in
-    if M.tracing then M.traceli "event" "do_emits:\n";
+    if M.tracing then M.traceli "event" "do_emits:";
     let emits =
       if dead then
         List.filter Events.emit_on_deadcode emits
@@ -224,7 +224,7 @@ struct
     in
     (* [emits] is in reverse order. *)
     let ctx' = List.fold_left do_emit (ctx_with_local ctx xs) (List.rev emits) in
-    if M.tracing then M.traceu "event" "\n";
+    if M.tracing then M.traceu "event" "";
     ctx'.local
 
   and branch (ctx:(D.t, G.t, C.t, V.t) ctx) (e:exp) (tv:bool) =
@@ -247,15 +247,15 @@ struct
   (* Explicitly polymorphic type required here for recursive GADT call in ask. *)
   and query': type a. querycache:Obj.t Queries.Hashtbl.t -> Queries.Set.t -> (D.t, G.t, C.t, V.t) ctx -> a Queries.t -> a Queries.result = fun ~querycache asked ctx q ->
     let anyq = Queries.Any q in
-    if M.tracing then M.traceli "query" "query %a\n" Queries.Any.pretty anyq;
+    if M.tracing then M.traceli "query" "query %a" Queries.Any.pretty anyq;
     let r = match Queries.Hashtbl.find_option querycache anyq with
       | Some r ->
-        if M.tracing then M.trace "query" "cached\n";
+        if M.tracing then M.trace "query" "cached";
         Obj.obj r
       | None ->
         let module Result = (val Queries.Result.lattice q) in
         if Queries.Set.mem anyq asked then (
-          if M.tracing then M.trace "query" "cycle\n";
+          if M.tracing then M.trace "query" "cycle";
           Result.top () (* query cycle *)
         )
         else

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -306,7 +306,7 @@ struct
     in
     if M.tracing then (
       let module Result = (val Queries.Result.lattice q) in
-      M.traceu "query" "-> %a\n" Result.pretty r
+      M.traceu "query" "-> %a" Result.pretty r
     );
     r
 

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -58,7 +58,7 @@ struct
       let y = find_id yn in
       if not (exists (fun (y',_) -> y=y') xs) then begin
         let xn = find_spec_name x in
-        Logs.error "Activated analysis '%s' depends on '%s' and '%s' is not activated.\n" xn yn yn;
+        Logs.error "Activated analysis '%s' depends on '%s' and '%s' is not activated." xn yn yn;
         raise Stdlib.Exit
       end
     in

--- a/src/analyses/memLeak.ml
+++ b/src/analyses/memLeak.ml
@@ -169,7 +169,7 @@ struct
       let allocated_and_unreachable_mem = D.diff allocated_mem reachable_mem in
       if not (D.is_empty allocated_and_unreachable_mem) then (
         set_mem_safety_flag InvalidMemTrack;
-        M.warn ~category:(Behavior (Undefined MemoryLeak)) ~tags:[CWE 401] "There is unreachable allocated heap memory at program exit. A memory leak might occur for the alloc vars %a\n" (Pretty.d_list ", " CilType.Varinfo.pretty) (D.elements allocated_and_unreachable_mem)
+        M.warn ~category:(Behavior (Undefined MemoryLeak)) ~tags:[CWE 401] "There is unreachable allocated heap memory at program exit. A memory leak might occur for the alloc vars %a" (Pretty.d_list ", " CilType.Varinfo.pretty) (D.elements allocated_and_unreachable_mem)
       );
       (* Check and warn if some of the allocated memory is not deallocated at program exit *)
       match assert_exp_imprecise, exp with

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -65,11 +65,11 @@ struct
       | a when not (Queries.ES.is_bot a) -> Queries.ES.add e a
       | _ -> Queries.ES.singleton e
     in
-    if M.tracing then M.tracel "symb_locks" "get_all_locks exps %a = %a\n" d_plainexp e Queries.ES.pretty exps;
-    if M.tracing then M.tracel "symb_locks" "get_all_locks st = %a\n" D.pretty st;
+    if M.tracing then M.tracel "symb_locks" "get_all_locks exps %a = %a" d_plainexp e Queries.ES.pretty exps;
+    if M.tracing then M.tracel "symb_locks" "get_all_locks st = %a" D.pretty st;
     let add_locks x xs = PS.union (get_locks x st) xs in
     let r = Queries.ES.fold add_locks exps (PS.empty ()) in
-    if M.tracing then M.tracel "symb_locks" "get_all_locks %a = %a\n" d_plainexp e PS.pretty r;
+    if M.tracing then M.tracel "symb_locks" "get_all_locks %a = %a" d_plainexp e PS.pretty r;
     r
 
   let same_unknown_index (ask: Queries.ask) exp slocks =
@@ -138,7 +138,7 @@ struct
     *)
     let one_perelem (e,a,l) xs =
       (* ignore (printf "one_perelem (%a,%a,%a)\n" Exp.pretty e Exp.pretty a Exp.pretty l); *)
-      if M.tracing then M.tracel "symb_locks" "one_perelem (%a,%a,%a)\n" Exp.pretty e Exp.pretty a Exp.pretty l;
+      if M.tracing then M.tracel "symb_locks" "one_perelem (%a,%a,%a)" Exp.pretty e Exp.pretty a Exp.pretty l;
       match Exp.fold_offs (Exp.replace_base (dummyFunDec.svar,`NoOffset) e l) with
       | Some (v, o) ->
         (* ignore (printf "adding lock %s\n" l); *)

--- a/src/analyses/taintPartialContexts.ml
+++ b/src/analyses/taintPartialContexts.ml
@@ -40,7 +40,7 @@ struct
             | _ -> false
           ) d
     in
-    if M.tracing then M.trace "taintPC" "returning from %s: tainted vars: %a\n without locals: %a\n" f.svar.vname D.pretty d D.pretty d_return;
+    if M.tracing then M.trace "taintPC" "returning from %s: tainted vars: %a\n without locals: %a" f.svar.vname D.pretty d D.pretty d_return;
     d_return
 
 
@@ -49,7 +49,7 @@ struct
     [ctx.local, (D.bot ())]
 
   let combine_env ctx lval fexp f args fc au f_ask =
-    if M.tracing then M.trace "taintPC" "combine for %s in TaintPC: tainted: in function: %a before call: %a\n" f.svar.vname D.pretty au D.pretty ctx.local;
+    if M.tracing then M.trace "taintPC" "combine for %s in TaintPC: tainted: in function: %a before call: %a" f.svar.vname D.pretty au D.pretty ctx.local;
     D.union ctx.local au
 
   let combine_assign ctx (lvalOpt:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -36,7 +36,7 @@ struct
       Queries.AD.fold to_extra ad (D.empty ())
     (* Ignore soundness warnings, as invalidation proper will raise them. *)
     | ad ->
-      if M.tracing then M.tracel "escape" "reachable %a: %a\n" d_exp e Queries.AD.pretty ad;
+      if M.tracing then M.tracel "escape" "reachable %a: %a" d_exp e Queries.AD.pretty ad;
       D.empty ()
 
   let mpt (ask: Queries.ask) e: D.t =
@@ -50,7 +50,7 @@ struct
       AD.fold to_extra (AD.remove UnknownPtr ad) (D.empty ())
     (* Ignore soundness warnings, as invalidation proper will raise them. *)
     | ad ->
-      if M.tracing then M.tracel "escape" "mpt %a: %a\n" d_exp e AD.pretty ad;
+      if M.tracing then M.tracel "escape" "mpt %a: %a" d_exp e AD.pretty ad;
       D.empty ()
 
   let thread_id ctx =
@@ -171,7 +171,7 @@ struct
       (* not reusing fctx.local to avoid unnecessarily early join of extra *)
       let escaped = reachable (Analyses.ask_of_ctx ctx) ptc_arg in
       let escaped = D.filter (fun v -> not v.vglob) escaped in
-      if M.tracing then M.tracel "escape" "%a: %a\n" d_exp ptc_arg D.pretty escaped;
+      if M.tracing then M.tracel "escape" "%a: %a" d_exp ptc_arg D.pretty escaped;
       let thread_id = thread_id ctx in
       emit_escape_event ctx escaped;
       side_effect_escape ctx escaped thread_id;

--- a/src/analyses/tmpSpecial.ml
+++ b/src/analyses/tmpSpecial.ml
@@ -76,7 +76,7 @@ struct
 
     in
 
-    if M.tracing then M.tracel "tmpSpecial" "Result: %a\n" D.pretty d;
+    if M.tracing then M.tracel "tmpSpecial" "Result: %a" D.pretty d;
     d
 
 

--- a/src/analyses/tmpSpecial.ml
+++ b/src/analyses/tmpSpecial.ml
@@ -25,7 +25,7 @@ struct
 
   (* transfer functions *)
   let assign ctx (lval:lval) (rval:exp) : D.t =
-    if M.tracing then M.tracel "tmpSpecial" "assignment of %a\n" d_lval lval;
+    if M.tracing then M.tracel "tmpSpecial" "assignment of %a" d_lval lval;
     (* Invalidate all entrys from the map that are possibly written by the assignment *)
     invalidate (Analyses.ask_of_ctx ctx) (mkAddrOf lval) ctx.local
 
@@ -44,8 +44,8 @@ struct
     (* Just dbg prints *)
     (if M.tracing then
        match lval with
-       | Some lv -> if M.tracing then M.tracel "tmpSpecial" "Special: %s with lval %a\n" f.vname d_lval lv
-       | _ -> if M.tracing then M.tracel "tmpSpecial" "Special: %s\n" f.vname);
+       | Some lv -> if M.tracing then M.tracel "tmpSpecial" "Special: %s with lval %a" f.vname d_lval lv
+       | _ -> if M.tracing then M.tracel "tmpSpecial" "Special: %s" f.vname);
 
 
     let desc = LibraryFunctions.find f in
@@ -76,7 +76,7 @@ struct
 
     in
 
-    if M.tracing then M.tracel "tmpSpecial" "Result: %a\n\n" D.pretty d;
+    if M.tracing then M.tracel "tmpSpecial" "Result: %a\n" D.pretty d;
     d
 
 

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -307,7 +307,7 @@ struct
           else (Messages.warn ~category:Analyzer ~msg:("Keep " ^sprint 80 (Exp.pretty () a)^" because of "^sprint 80 (Exp.pretty () b)) (); r)
           Messages.warn ~category:Analyzer ~msg:(sprint 80 (Exp.pretty () b) ^" changed lvalues: "^sprint 80 (Queries.LS.pretty () bls)) ();
     *)
-    if M.tracing then M.tracel "var_eq" "may_change %a %a = %B\n" CilType.Exp.pretty b CilType.Exp.pretty a r;
+    if M.tracing then M.tracel "var_eq" "may_change %a %a = %B" CilType.Exp.pretty b CilType.Exp.pretty a r;
     r
 
   (* Remove elements, that would change if the given lval would change.*)
@@ -459,7 +459,7 @@ struct
 
   let remove_reachable ~deep ask es st =
     let rs = reachables ~deep ask es in
-    if M.tracing then M.tracel "var_eq" "remove_reachable %a: %a\n" (Pretty.d_list ", " d_exp) es AD.pretty rs;
+    if M.tracing then M.tracel "var_eq" "remove_reachable %a: %a" (Pretty.d_list ", " d_exp) es AD.pretty rs;
     (* Prior to https://github.com/goblint/analyzer/pull/694 checks were done "in the other direction":
        each expression in st was checked for reachability from es/rs using very conservative but also unsound reachable_from.
        It is unknown, why that was necessary. *)
@@ -516,7 +516,7 @@ struct
       D.B.fold add es (Queries.ES.empty ())
 
   let rec eq_set_clos e s =
-    if M.tracing then M.traceli "var_eq" "eq_set_clos %a\n" d_plainexp e;
+    if M.tracing then M.traceli "var_eq" "eq_set_clos %a" d_plainexp e;
     let r = match e with
       | AddrOf (Mem (BinOp (IndexPI, a, i, _)), os) ->
         (* convert IndexPI to Index offset *)
@@ -552,7 +552,7 @@ struct
       | CastE (t,e) ->
         Queries.ES.map (fun e -> CastE (t,e)) (eq_set_clos e s)
     in
-    if M.tracing then M.traceu "var_eq" "eq_set_clos %a = %a\n" d_plainexp e Queries.ES.pretty r;
+    if M.tracing then M.traceu "var_eq" "eq_set_clos %a = %a" d_plainexp e Queries.ES.pretty r;
     r
 
 
@@ -562,7 +562,7 @@ struct
       Queries.ID.of_bool (Cilfacade.get_ikind t) true
     | Queries.EqualSet e ->
       let r = eq_set_clos e ctx.local in
-      if M.tracing then M.tracel "var_eq" "equalset %a = %a\n" d_plainexp e Queries.ES.pretty r;
+      if M.tracing then M.tracel "var_eq" "equalset %a = %a" d_plainexp e Queries.ES.pretty r;
       r
     | Queries.Invariant context when GobConfig.get_bool "witness.invariant.exact" -> (* only exact equalities here *)
       let scope = Node.find_fundec ctx.node in

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -362,10 +362,10 @@ struct
   let add_eq ask (lv:lval) (rv:Exp.t) st =
     let lvt = unrollType @@ Cilfacade.typeOfLval lv in
     if M.tracing then (
-      M.tracel "var_eq" "add_eq is_global_var %a = %B\n" d_plainlval lv (is_global_var ask (Lval lv) = Some false);
-      M.tracel "var_eq" "add_eq interesting %a = %B\n" d_plainexp rv (interesting rv);
-      M.tracel "var_eq" "add_eq is_global_var %a = %B\n" d_plainexp rv (is_global_var ask rv = Some false);
-      M.tracel "var_eq" "add_eq type %a = %B\n" d_plainlval lv (isIntegralType lvt || isPointerType lvt);
+      M.tracel "var_eq" "add_eq is_global_var %a = %B" d_plainlval lv (is_global_var ask (Lval lv) = Some false);
+      M.tracel "var_eq" "add_eq interesting %a = %B" d_plainexp rv (interesting rv);
+      M.tracel "var_eq" "add_eq is_global_var %a = %B" d_plainexp rv (is_global_var ask rv = Some false);
+      M.tracel "var_eq" "add_eq type %a = %B" d_plainlval lv (isIntegralType lvt || isPointerType lvt);
     );
     if is_global_var ask (Lval lv) = Some false
     && interesting rv

--- a/src/cdomain/value/cdomains/addressDomain.ml
+++ b/src/cdomain/value/cdomains/addressDomain.ml
@@ -194,19 +194,19 @@ struct
   let equal x y = x == y || equal x y
 
   let widen x y =
-    if M.tracing then M.traceli "ad" "widen %a %a\n" pretty x pretty y;
+    if M.tracing then M.traceli "ad" "widen %a %a" pretty x pretty y;
     let r = widen x y in
-    if M.tracing then M.traceu "ad" "-> %a\n" pretty r;
+    if M.tracing then M.traceu "ad" "-> %a" pretty r;
     r
   let join x y =
-    if M.tracing then M.traceli "ad" "join %a %a\n" pretty x pretty y;
+    if M.tracing then M.traceli "ad" "join %a %a" pretty x pretty y;
     let r = join x y in
-    if M.tracing then M.traceu "ad" "-> %a\n" pretty r;
+    if M.tracing then M.traceu "ad" "-> %a" pretty r;
     r
   let leq x y =
-    if M.tracing then M.traceli "ad" "leq %a %a\n" pretty x pretty y;
+    if M.tracing then M.traceli "ad" "leq %a %a" pretty x pretty y;
     let r = x == y || leq x y in (* short-circuit with physical equality, not benchmarked *)
-    if M.tracing then M.traceu "ad" "-> %B\n" r;
+    if M.tracing then M.traceu "ad" "-> %B" r;
     r
 
   let null_ptr       = singleton Addr.NullPtr
@@ -383,15 +383,15 @@ struct
   let narrow x y = merge (fun x y -> widen x (join x y)) narrow x y
 
   let meet x y =
-    if M.tracing then M.traceli "ad" "meet %a %a\n" pretty x pretty y;
+    if M.tracing then M.traceli "ad" "meet %a %a" pretty x pretty y;
     let r = meet x y in
-    if M.tracing then M.traceu "ad" "-> %a\n" pretty r;
+    if M.tracing then M.traceu "ad" "-> %a" pretty r;
     r
 
   let narrow x y =
-    if M.tracing then M.traceli "ad" "narrow %a %a\n" pretty x pretty y;
+    if M.tracing then M.traceli "ad" "narrow %a %a" pretty x pretty y;
     let r = narrow x y in
-    if M.tracing then M.traceu "ad" "-> %a\n" pretty r;
+    if M.tracing then M.traceu "ad" "-> %a" pretty r;
     r
 
   let filter f ad = fold (fun addr ad -> if f addr then add addr ad else ad) ad (empty ())

--- a/src/cdomain/value/cdomains/arrayDomain.ml
+++ b/src/cdomain/value/cdomains/arrayDomain.ml
@@ -532,7 +532,7 @@ struct
   let move_if_affected ?replace_with_const = move_if_affected_with_length ?replace_with_const None
 
   let set_with_length length (ask:VDQ.t) x (i,_) a =
-    if M.tracing then M.trace "update_offset" "part array set_with_length %a %s %a\n" pretty x (BatOption.map_default Basetype.CilExp.show "None" i) Val.pretty a;
+    if M.tracing then M.trace "update_offset" "part array set_with_length %a %s %a" pretty x (BatOption.map_default Basetype.CilExp.show "None" i) Val.pretty a;
     match i with
     | Some ie when CilType.Exp.equal ie (Lazy.force Offset.Index.Exp.all) ->
       (* TODO: Doesn't seem to work for unassume. *)

--- a/src/cdomain/value/cdomains/floatDomain.ml
+++ b/src/cdomain/value/cdomains/floatDomain.ml
@@ -374,9 +374,9 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
       | NaN, _ | _, NaN -> (0,0) (* comparisons involving NaN always return false *)
       | Top, _ | _, Top -> (0,1) (* comparisons with Top yield top *)
       (* neither of the arguments below is Top/Bot/NaN *)
-      | v1, v2 when v1 = min -> 
-        (* v1 is the minimal element w.r.t. the order *)  
-        if v2 <> min || reflexive then 
+      | v1, v2 when v1 = min ->
+        (* v1 is the minimal element w.r.t. the order *)
+        if v2 <> min || reflexive then
           (* v2 is different, i.e., greater or the relation is reflexive *)
           (1,1)
         else
@@ -389,7 +389,7 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
         if v2 = max && reflexive then
           (* v2 is also maximal and the relation is reflexive *)
           (1,1)
-        else 
+        else
           (0,0)
       | _, v2 when v2 = max -> (1,1) (* first argument cannot be max *)
       | _ -> (0, 1)
@@ -652,7 +652,7 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
   (** returns the min of the given mfun once computed with rounding mode Up and once with rounding mode down*)
   let safe_mathfun_down mfun f = min (mfun Down f) (mfun Up f)
 
-  (** This function does two things: 
+  (** This function does two things:
    ** 1. projects l and h onto the interval [0, k*pi] (for k = 2 this is the phase length of sin/cos, for k = 1 it is the phase length of tan)
    ** 2. compresses/transforms the interval [0, k*pi] to the interval [0, 1] to ease further computations
    ** i.e. the function computes dist = distance, l'' = (l/(k*pi)) - floor(l/(k*pi)), h'' = (h/(k*pi)) - floor(h/(k*pi))*)
@@ -684,7 +684,7 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
 
   let eval_cos_cfun l h =
     let (dist, l'', h'') = project_and_compress l h 2. in
-    if Messages.tracing then Messages.trace "CstubsTrig" "cos: dist %s; l'' %s; h'' %s\n" (Float_t.to_string dist) (Float_t.to_string l'') (Float_t.to_string h'');
+    if Messages.tracing then Messages.trace "CstubsTrig" "cos: dist %s; l'' %s; h'' %s" (Float_t.to_string dist) (Float_t.to_string l'') (Float_t.to_string h'');
     if (dist <= Float_t.of_float Down 0.5) && (h'' <= Float_t.of_float Down 0.5) && (l'' <= h'') then
       (* case: monotonic decreasing interval*)
       Interval (safe_mathfun_down Float_t.cos h, safe_mathfun_up Float_t.cos l)
@@ -707,7 +707,7 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
 
   let eval_tan_cfun l h =
     let (dist, l'', h'') = project_and_compress l h 1. in
-    if Messages.tracing then Messages.trace "CstubsTrig" "tan: dist %s; l'' %s; h'' %s\n" (Float_t.to_string dist) (Float_t.to_string l'') (Float_t.to_string h'');
+    if Messages.tracing then Messages.trace "CstubsTrig" "tan: dist %s; l'' %s; h'' %s" (Float_t.to_string dist) (Float_t.to_string l'') (Float_t.to_string h'');
     if (dist <= Float_t.of_float Down 1.) && (Bool.not ((l'' <= Float_t.of_float Up 0.5) && (h'' >= Float_t.of_float Up 0.5))) then
       (* case: monotonic increasing interval*)
       Interval (safe_mathfun_down Float_t.tan l, safe_mathfun_up Float_t.tan h)

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -427,7 +427,7 @@ module Size = struct (* size in bits as int, range as int64 *)
   let is_cast_injective ~from_type ~to_type =
     let (from_min, from_max) = range (Cilfacade.get_ikind from_type) in
     let (to_min, to_max) = range (Cilfacade.get_ikind to_type) in
-    if M.tracing then M.trace "int" "is_cast_injective %a (%a, %a) -> %a (%a, %a)\n" CilType.Typ.pretty from_type GobZ.pretty from_min GobZ.pretty from_max CilType.Typ.pretty to_type GobZ.pretty to_min GobZ.pretty to_max;
+    if M.tracing then M.trace "int" "is_cast_injective %a (%a, %a) -> %a (%a, %a)" CilType.Typ.pretty from_type GobZ.pretty from_min GobZ.pretty from_max CilType.Typ.pretty to_type GobZ.pretty to_min GobZ.pretty to_max;
     Z.compare to_min from_min <= 0 && Z.compare from_max to_max <= 0
 
   let cast t x = (* TODO: overflow is implementation-dependent! *)
@@ -442,7 +442,7 @@ module Size = struct (* size in bits as int, range as int64 *)
         else if Z.lt y a then Z.add y c
         else y
       in
-      if M.tracing then M.tracel "cast" "Cast %a to range [%a, %a] (%a) = %a (%s in int64)\n" GobZ.pretty x GobZ.pretty a GobZ.pretty b GobZ.pretty c GobZ.pretty y (if is_int64_big_int y then "fits" else "does not fit");
+      if M.tracing then M.tracel "cast" "Cast %a to range [%a, %a] (%a) = %a (%s in int64)" GobZ.pretty x GobZ.pretty a GobZ.pretty b GobZ.pretty c GobZ.pretty y (if is_int64_big_int y then "fits" else "does not fit");
       y
 
   let min_range_sign_agnostic x =
@@ -683,7 +683,7 @@ struct
       norm ik @@ Some (l2,u2) |> fst
   let widen ik x y =
     let r = widen ik x y in
-    if M.tracing && not (equal x y) then M.tracel "int" "interval widen %a %a -> %a\n" pretty x pretty y pretty r;
+    if M.tracing && not (equal x y) then M.tracel "int" "interval widen %a %a -> %a" pretty x pretty y pretty r;
     assert (leq x y); (* TODO: remove for performance reasons? *)
     r
 
@@ -950,7 +950,7 @@ struct
 
   let refine_with_congruence ik x y =
     let refn = refine_with_congruence ik x y in
-    if M.tracing then M.trace "refine" "int_refine_with_congruence %a %a -> %a\n" pretty x pretty y pretty refn;
+    if M.tracing then M.trace "refine" "int_refine_with_congruence %a %a -> %a" pretty x pretty y pretty refn;
     refn
 
   let refine_with_interval ik a b = meet ik a b
@@ -2822,7 +2822,7 @@ struct
 
   let leq x y =
     let res = leq x y in
-    if M.tracing then M.trace "congruence" "leq %a %a -> %a \n" pretty x pretty y pretty (Some (Z.of_int (Bool.to_int res), Z.zero)) ;
+    if M.tracing then M.trace "congruence" "leq %a %a -> %a " pretty x pretty y pretty (Some (Z.of_int (Bool.to_int res), Z.zero)) ;
     res
 
   let join ik (x:t) y =
@@ -2834,7 +2834,7 @@ struct
 
   let join ik (x:t) y =
     let res = join ik x y in
-    if M.tracing then M.trace "congruence" "join %a %a -> %a\n" pretty x pretty y pretty res;
+    if M.tracing then M.trace "congruence" "join %a %a -> %a" pretty x pretty y pretty res;
     res
 
 
@@ -2861,7 +2861,7 @@ struct
 
   let meet ik x y =
     let res = meet ik x y in
-    if M.tracing then M.trace "congruence" "meet %a %a -> %a\n" pretty x pretty y pretty res;
+    if M.tracing then M.trace "congruence" "meet %a %a -> %a" pretty x pretty y pretty res;
     res
 
   let to_int = function Some (c, m) when m =: Z.zero -> Some c | _ -> None
@@ -2919,14 +2919,14 @@ struct
   let cast_to ?torg ?no_ov (t : Cil.ikind) x =
     let pretty_bool _ x = Pretty.text (string_of_bool x) in
     let res = cast_to ?torg ?no_ov t x in
-    if M.tracing then M.trace "cong-cast" "Cast %a to %a (no_ov: %a) = %a\n" pretty x Cil.d_ikind t (Pretty.docOpt (pretty_bool ())) no_ov pretty res;
+    if M.tracing then M.trace "cong-cast" "Cast %a to %a (no_ov: %a) = %a" pretty x Cil.d_ikind t (Pretty.docOpt (pretty_bool ())) no_ov pretty res;
     res
 
   let widen = join
 
   let widen ik x y =
     let res = widen ik x y in
-    if M.tracing then M.trace "congruence" "widen %a %a -> %a\n" pretty x pretty y pretty res;
+    if M.tracing then M.trace "congruence" "widen %a %a -> %a" pretty x pretty y pretty res;
     res
 
   let narrow = meet
@@ -2958,7 +2958,7 @@ struct
 
   let shift_right ik x y =
     let res = shift_right ik x y in
-    if M.tracing then  M.trace "congruence" "shift_right : %a %a becomes %a \n" pretty x pretty y pretty res;
+    if M.tracing then  M.trace "congruence" "shift_right : %a %a becomes %a " pretty x pretty y pretty res;
     res
 
   let shift_left ik x y =
@@ -2989,7 +2989,7 @@ struct
 
   let shift_left ik x y =
     let res = shift_left ik x y in
-    if M.tracing then  M.trace "congruence" "shift_left : %a %a becomes %a \n" pretty x pretty y pretty res;
+    if M.tracing then  M.trace "congruence" "shift_left : %a %a becomes %a " pretty x pretty y pretty res;
     res
 
   (* Handle unsigned overflows.
@@ -3030,7 +3030,7 @@ struct
 
   let mul ?no_ov ik x y =
     let res = mul ?no_ov ik x y in
-    if M.tracing then  M.trace "congruence" "mul : %a %a -> %a \n" pretty x pretty y pretty res;
+    if M.tracing then  M.trace "congruence" "mul : %a %a -> %a " pretty x pretty y pretty res;
     res
 
   let neg ?(no_ov=false) ik x =
@@ -3124,7 +3124,7 @@ struct
         normalize ik (Some (c1, Z.gcd m1 (Z.gcd c2 m2)))
 
   let rem ik x y = let res = rem ik x y in
-    if M.tracing then  M.trace "congruence" "rem : %a %a -> %a \n" pretty x pretty y pretty res;
+    if M.tracing then  M.trace "congruence" "rem : %a %a -> %a " pretty x pretty y pretty res;
     res
 
   let div ?(no_ov=false) ik x y =
@@ -3166,14 +3166,14 @@ struct
 
   let ge ik x y =
     let res = ge ik x y in
-    if M.tracing then  M.trace "congruence" "greater or equal : %a %a -> %a \n" pretty x pretty y pretty res;
+    if M.tracing then  M.trace "congruence" "greater or equal : %a %a -> %a " pretty x pretty y pretty res;
     res
 
   let le ik x y = comparison ik (<=:) x y
 
   let le ik x y =
     let res = le ik x y in
-    if M.tracing then  M.trace "congruence" "less or equal : %a %a -> %a \n" pretty x pretty y pretty res;
+    if M.tracing then  M.trace "congruence" "less or equal : %a %a -> %a " pretty x pretty y pretty res;
     res
 
   let gt ik x y = comparison ik (>:) x y
@@ -3181,14 +3181,14 @@ struct
 
   let gt ik x y =
     let res = gt ik x y in
-    if M.tracing then  M.trace "congruence" "greater than : %a %a -> %a \n" pretty x pretty y pretty res;
+    if M.tracing then  M.trace "congruence" "greater than : %a %a -> %a " pretty x pretty y pretty res;
     res
 
   let lt ik x y = comparison ik (<:) x y
 
   let lt ik x y =
     let res = lt ik x y in
-    if M.tracing then  M.trace "congruence" "less than : %a %a -> %a \n" pretty x pretty y pretty res;
+    if M.tracing then  M.trace "congruence" "less than : %a %a -> %a " pretty x pretty y pretty res;
     res
 
   let invariant_ikind e ik x =
@@ -3232,7 +3232,7 @@ struct
       | Some (l, u) -> Pretty.dprintf "[%a,%a]" GobZ.pretty l GobZ.pretty u
       | _ -> Pretty.text ("Display Error") in
     let refn = refine_with_interval ik cong intv in
-    if M.tracing then M.trace "refine" "cong_refine_with_interval %a %a -> %a\n" pretty cong pretty_intv intv pretty refn;
+    if M.tracing then M.trace "refine" "cong_refine_with_interval %a %a -> %a" pretty cong pretty_intv intv pretty refn;
     refn
 
   let refine_with_congruence ik a b = meet ik a b
@@ -3533,7 +3533,7 @@ module IntDomTupleImpl = struct
          List.iter (fun f -> dt := f !dt) (refine_functions ik);
          quit_loop := equal old_dt !dt;
          if is_bot !dt then dt := bot_of ik; quit_loop := true;
-         if M.tracing then M.trace "cong-refine-loop" "old: %a, new: %a\n" pretty old_dt pretty !dt;
+         if M.tracing then M.trace "cong-refine-loop" "old: %a, new: %a" pretty old_dt pretty !dt;
        done;
      | _ -> ()
     ); !dt

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -3059,7 +3059,7 @@ struct
   let add ?no_ov ik x y =
     let res = add ?no_ov ik x y in
     if M.tracing then
-      M.trace "congruence" "add : %a %a -> %a \n" pretty x pretty y
+      M.trace "congruence" "add : %a %a -> %a" pretty x pretty y
         pretty res ;
     res
 
@@ -3069,7 +3069,7 @@ struct
   let sub ?no_ov ik x y =
     let res = sub ?no_ov ik x y in
     if M.tracing then
-      M.trace "congruence" "sub : %a %a -> %a \n" pretty x pretty y
+      M.trace "congruence" "sub : %a %a -> %a" pretty x pretty y
         pretty res ;
     res
 
@@ -3141,7 +3141,7 @@ struct
   let div ?no_ov ik x y =
     let res = div ?no_ov ik x y in
     if M.tracing then
-      M.trace "congruence" "div : %a %a -> %a \n" pretty x pretty y pretty
+      M.trace "congruence" "div : %a %a -> %a" pretty x pretty y pretty
         res ;
     res
 

--- a/src/cdomain/value/cdomains/offset.ml
+++ b/src/cdomain/value/cdomains/offset.ml
@@ -217,7 +217,7 @@ struct
   let semantic_equal ~typ1 xoffs ~typ2 yoffs =
     let x_index = to_index ~typ:typ1 xoffs in
     let y_index = to_index ~typ:typ2 yoffs in
-    if M.tracing then M.tracel "addr" "xoffs=%a typ1=%a xindex=%a yoffs=%a typ2=%a yindex=%a\n" pretty xoffs d_plaintype typ1 Idx.pretty x_index pretty yoffs d_plaintype typ2 Idx.pretty y_index;
+    if M.tracing then M.tracel "addr" "xoffs=%a typ1=%a xindex=%a yoffs=%a typ2=%a yindex=%a" pretty xoffs d_plaintype typ1 Idx.pretty x_index pretty yoffs d_plaintype typ2 Idx.pretty y_index;
     Idx.to_bool (Idx.eq x_index y_index)
 
   include Lattice.NoBotTop

--- a/src/cdomain/value/cdomains/structDomain.ml
+++ b/src/cdomain/value/cdomains/structDomain.ml
@@ -150,7 +150,7 @@ struct
   let create = hs_create
 
   let replace s field value =
-    if Messages.tracing then Messages.tracel "simplesets" "Normalize top Replace - s:\n%a\nfield:%a\nvalue: %a\n---------\n" HS.pretty s Basetype.CilField.pretty field Val.pretty value;
+    if Messages.tracing then Messages.tracel "simplesets" "Normalize top Replace - s:\n%a\nfield:%a\nvalue: %a\n---------" HS.pretty s Basetype.CilField.pretty field Val.pretty value;
     HS.map (fun s -> SS.replace s field value) s
 
   let get = hs_get
@@ -209,7 +209,7 @@ struct
 
   let join_with_fct f x y =
     let appended = List.append (HS.elements x) (HS.elements y) in
-    if Messages.tracing then Messages.tracel "simplesets-fct" "Join-fct start!\nx: %a\ny: %a\n" pretty x pretty y;
+    if Messages.tracing then Messages.tracel "simplesets-fct" "Join-fct start!\nx: %a\ny: %a" pretty x pretty y;
     let reduce_list_with_fct join_f xs s =
       let rec aux unique remaining =
         match remaining with
@@ -218,14 +218,14 @@ struct
           let (overlapping, rem_uniq) = List.partition (fun ss -> SS.leq h ss || SS.leq ss h ) unique in
           let joined = List.fold_left (fun el acc ->
               let res = join_f acc el in
-              if Messages.tracing then Messages.tracel "simplesets-fct" "Join-fct joining others!\nacc: %a\nel: %a\nres: %a\n" SS.pretty acc SS.pretty el SS.pretty res;
+              if Messages.tracing then Messages.tracel "simplesets-fct" "Join-fct joining others!\nacc: %a\nel: %a\nres: %a" SS.pretty acc SS.pretty el SS.pretty res;
               res
             ) h overlapping in
           aux (joined::rem_uniq) t
       in aux [] xs
     in
     let res = reduce_list_with_fct (SS.join_with_fct f) appended x in
-    if Messages.tracing then Messages.tracel "simplesets-fct" "Join-fct result!\nx: %a\ny: %a\nconverted: %a\nres: %a\n" pretty x pretty y pretty (HS.of_list appended) pretty res;
+    if Messages.tracing then Messages.tracel "simplesets-fct" "Join-fct result!\nx: %a\ny: %a\nconverted: %a\nres: %a" pretty x pretty y pretty (HS.of_list appended) pretty res;
     res
 
   let join = join_with_fct Val.join
@@ -313,14 +313,14 @@ struct
             aux (joined::rem_uniq) t
         in
         let res = aux [] (HS.elements s) in
-        if Messages.tracing then Messages.tracel "reduce-key" "Reduced - s:\n%a\nto:\n%a\n---------\n" HS.pretty s HS.pretty res;
+        if Messages.tracing then Messages.tracel "reduce-key" "Reduced - s:\n%a\nto:\n%a\n---------" HS.pretty s HS.pretty res;
         (res, Some key)
 
   let reduce_key (x: t): t = reduce_key_with_fct (SS.join) x
 
   let replace (s,k) field value : t =
     let join_set s =if HS.is_bot s then s else HS.singleton (join_ss s) in
-    if Messages.tracing then Messages.tracel "keyedsets" "Replace - s:\n%a\nfield:%a\nvalue: %a\n---------\n" HS.pretty s Basetype.CilField.pretty field Val.pretty value ;
+    if Messages.tracing then Messages.tracel "keyedsets" "Replace - s:\n%a\nfield:%a\nvalue: %a\n---------" HS.pretty s Basetype.CilField.pretty field Val.pretty value ;
     let replaced = HS.map (fun s -> SS.replace s field value) s in
     let result_key =
       match find_key_field (s,k) with
@@ -412,7 +412,7 @@ struct
 
   let join_with_fct f (x, k) (y, _) =
     let appended = List.append (HS.elements x) (HS.elements y) in
-    if Messages.tracing then Messages.tracel "bettersets" "Join-fct start!\nx: %a\ny: %a\n" HS.pretty x HS.pretty y;
+    if Messages.tracing then Messages.tracel "bettersets" "Join-fct start!\nx: %a\ny: %a" HS.pretty x HS.pretty y;
     let reduce_list_key_with_fct join_f (xs: variant list) (x: t) =
       match find_key_field x with
       | None -> x
@@ -428,14 +428,14 @@ struct
               ) unique in
             let joined = List.fold_left (fun el acc ->
                 let res = join_f acc el in
-                if Messages.tracing then Messages.tracel "bettersets" "Join-fct joining others!\nacc: %a\nel: %a\nres: %a\n" SS.pretty acc SS.pretty el SS.pretty res;
+                if Messages.tracing then Messages.tracel "bettersets" "Join-fct joining others!\nacc: %a\nel: %a\nres: %a" SS.pretty acc SS.pretty el SS.pretty res;
                 res
               ) h overlapping in
             aux (joined::rem_uniq) t
         in (aux [] xs, Some key)
     in
     let res = reduce_list_key_with_fct (SS.join_with_fct f) appended (x,k) in
-    if Messages.tracing then Messages.tracel "bettersets" "Join-fct result!\nx: %a\ny: %a\nconverted: %a\nres: %a\n" HS.pretty x HS.pretty y HS.pretty (HS.of_list appended) pretty res;
+    if Messages.tracing then Messages.tracel "bettersets" "Join-fct result!\nx: %a\ny: %a\nconverted: %a\nres: %a" HS.pretty x HS.pretty y HS.pretty (HS.of_list appended) pretty res;
     res
 
   let join = join_with_fct Val.join

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -373,32 +373,32 @@ struct
     let rec adjust_offs v o d =
       let ta = try Addr.Offs.type_of ~base:v.vtype o with Offset.Type_of_error (t,s) -> raise (CastError s) in
       let info = GobPretty.sprintf "Ptr-Cast %a from %a to %a" Addr.pretty (Addr.Addr (v,o)) d_type ta d_type t in
-      M.tracel "casta" "%s\n" info;
+      if M.tracing then M.tracel "casta" "%s" info; (* TODO: inline info? *)
       let err s = raise (CastError (s ^ " (" ^ info ^ ")")) in
       match Stdlib.compare (bitsSizeOf (stripVarLenArr t)) (bitsSizeOf (stripVarLenArr ta)) with (* TODO is it enough to compare the size? -> yes? *)
       | 0 ->
-        M.tracel "casta" "same size\n";
+        if M.tracing then M.tracel "casta" "same size";
         if not (typ_eq t ta) then err "Cast to different type of same size."
-        else (M.tracel "casta" "SUCCESS!\n"; o)
+        else (if M.tracing then M.tracel "casta" "SUCCESS!"; o)
       | c when c > 0 -> (* cast to bigger/outer type *)
-        M.tracel "casta" "cast to bigger size\n";
+        if M.tracing then M.tracel "casta" "cast to bigger size";
         if d = Some false then err "Ptr-cast to type of incompatible size!" else
         if o = `NoOffset then err "Ptr-cast to outer type, but no offset to remove."
         else if Addr.Offs.cmp_zero_offset o = `MustZero then adjust_offs v (Addr.Offs.remove_offset o) (Some true)
         else err "Ptr-cast to outer type, but possibly from non-zero offset."
       | _ -> (* cast to smaller/inner type *)
-        M.tracel "casta" "cast to smaller size\n";
+        if M.tracing then M.tracel "casta" "cast to smaller size";
         if d = Some true then err "Ptr-cast to type of incompatible size!" else
           begin match ta, t with
             (* struct to its first field *)
             | TComp ({cfields = fi::_; _}, _), _ ->
-              M.tracel "casta" "cast struct to its first field\n";
+              if M.tracing then M.tracel "casta" "cast struct to its first field";
               adjust_offs v (Addr.Offs.add_offset o (`Field (fi, `NoOffset))) (Some false)
             (* array of the same type but different length, e.g. assign array (with length) to array-ptr (no length) *)
             | TArray (t1, _, _), TArray (t2, _, _) when typ_eq t1 t2 -> o
             (* array to its first element *)
             | TArray _, _ ->
-              M.tracel "casta" "cast array to its first element\n";
+              if M.tracing then M.tracel "casta" "cast array to its first element";
               adjust_offs v (Addr.Offs.add_offset o (`Index (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ()) Z.zero, `NoOffset))) (Some false)
             | _ -> err @@ Format.sprintf "Cast to neither array index nor struct field. is_zero_offset: %b" (Addr.Offs.cmp_zero_offset o = `MustZero)
           end
@@ -415,7 +415,7 @@ struct
           begin try Addr (v, (adjust_offs v o None)) (* cast of one address by adjusting the abstract offset *)
             with
             | CastError s -> (* don't know how to handle this cast :( *)
-              M.tracel "caste" "%s\n" s;
+              if M.tracing then M.tracel "caste" "%s" s;
               a (* probably garbage, but this is deref's problem *)
             (*raise (CastError s)*)
             | SizeOfError (s,t) ->
@@ -425,7 +425,8 @@ struct
         | x -> x (* TODO we should also keep track of the type here *)
     in
     let a' = AD.map one_addr a in
-    M.tracel "cast" "cast_addr %a to %a is %a!\n" AD.pretty a d_type t AD.pretty a'; a'
+    if M.tracing then M.tracel "cast" "cast_addr %a to %a is %a!" AD.pretty a d_type t AD.pretty a';
+    a'
 
   (* this is called for:
    * 1. normal casts
@@ -441,7 +442,7 @@ struct
     | JmpBuf _ ->
       v
     | _ ->
-      let log_top (_,l,_,_) = Messages.tracel "cast" "log_top at %d: %a to %a is top!\n" l pretty v d_type t in
+      let log_top (_,l,_,_) = if Messages.tracing then Messages.tracel "cast" "log_top at %d: %a to %a is top!" l pretty v d_type t in
       let t = unrollType t in
       let v' = match t with
         | TInt (ik,_) ->
@@ -519,7 +520,8 @@ struct
         | _ -> log_top __POS__; assert false
       in
       let s_torg = match torg with Some t -> CilType.Typ.show t | None -> "?" in
-      Messages.tracel "cast" "cast %a from %s to %a is %a!\n" pretty v s_torg d_type t pretty v'; v'
+      if Messages.tracing then Messages.tracel "cast" "cast %a from %s to %a is %a!" pretty v s_torg d_type t pretty v';
+      v'
 
 
   let warn_type op x y =

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -857,7 +857,7 @@ struct
   (* Funny, this does not compile without the final type annotation! *)
   let rec eval_offset (ask: VDQ.t) f (x: t) (offs:offs) (exp:exp option) (v:lval option) (t:typ): t =
     let rec do_eval_offset (ask:VDQ.t) f (x:t) (offs:offs) (exp:exp option) (l:lval option) (o:offset option) (v:lval option) (t:typ): t =
-      if M.tracing then M.traceli "eval_offset" "do_eval_offset %a %a (%a)\n" pretty x Offs.pretty offs (Pretty.docOpt (CilType.Exp.pretty ())) exp;
+      if M.tracing then M.traceli "eval_offset" "do_eval_offset %a %a (%a)" pretty x Offs.pretty offs (Pretty.docOpt (CilType.Exp.pretty ())) exp;
       let r =
         match x, offs with
         | Blob((va, _, orig) as c), `Index (_, ox) ->
@@ -922,7 +922,7 @@ struct
               | _ -> M.warn ~category:Imprecise ~tags:[Category Program] "Trying to read an index, but was not given an array (%a)" pretty x; top ()
             end
       in
-      if M.tracing then M.traceu "eval_offset" "do_eval_offset -> %a\n" pretty r;
+      if M.tracing then M.traceu "eval_offset" "do_eval_offset -> %a" pretty r;
       r
     in
     let l, o = match exp with
@@ -933,7 +933,7 @@ struct
 
   let update_offset ?(blob_destructive=false) (ask: VDQ.t) (x:t) (offs:offs) (value:t) (exp:exp option) (v:lval) (t:typ): t =
     let rec do_update_offset (ask:VDQ.t) (x:t) (offs:offs) (value:t) (exp:exp option) (l:lval option) (o:offset option) (v:lval) (t:typ):t =
-      if M.tracing then M.traceli "update_offset" "do_update_offset %a %a (%a) %a\n" pretty x Offs.pretty offs (Pretty.docOpt (CilType.Exp.pretty ())) exp pretty value;
+      if M.tracing then M.traceli "update_offset" "do_update_offset %a %a (%a) %a" pretty x Offs.pretty offs (Pretty.docOpt (CilType.Exp.pretty ())) exp pretty value;
       let mu = function Blob (Blob (y, s', orig), s, orig2) -> Blob (y, ID.join s s',orig) | x -> x in
       let r =
         match x, offs with
@@ -1108,7 +1108,7 @@ struct
               end
           in mu result
       in
-      if M.tracing then M.traceu "update_offset" "do_update_offset -> %a\n" pretty r;
+      if M.tracing then M.traceu "update_offset" "do_update_offset -> %a" pretty r;
       r
     in
     let l, o = match exp with

--- a/src/cdomains/apron/affineEqualityDomain.apron.ml
+++ b/src/cdomains/apron/affineEqualityDomain.apron.ml
@@ -333,7 +333,7 @@ struct
 
   let meet t1 t2 =
     let res = meet t1 t2 in
-    if M.tracing then M.tracel "meet" "meet a: %s b: %s -> %s \n" (show t1) (show t2) (show res) ;
+    if M.tracing then M.tracel "meet" "meet a: %s b: %s -> %s " (show t1) (show t2) (show res) ;
     res
 
   let meet t1 t2 = timing_wrap "meet" (meet t1) t2
@@ -359,7 +359,7 @@ struct
 
   let leq t1 t2 =
     let res = leq t1 t2 in
-    if M.tracing then M.tracel "leq" "leq a: %s b: %s -> %b \n" (show t1) (show t2) res ;
+    if M.tracing then M.tracel "leq" "leq a: %s b: %s -> %b " (show t1) (show t2) res ;
     res
 
   let join a b =
@@ -428,7 +428,7 @@ struct
 
   let join a b =
     let res = join a b in
-    if M.tracing then M.tracel "join" "join a: %s b: %s -> %s \n" (show a) (show b) (show res) ;
+    if M.tracing then M.tracel "join" "join a: %s b: %s -> %s " (show a) (show b) (show res) ;
     res
 
   let widen a b =
@@ -461,7 +461,7 @@ struct
 
   let forget_vars t vars =
     let res = forget_vars t vars in
-    if M.tracing then M.tracel "ops" "forget_vars %s -> %s\n" (show t) (show res);
+    if M.tracing then M.tracel "ops" "forget_vars %s -> %s" (show t) (show res);
     res
 
   let forget_vars t vars = timing_wrap "forget_vars" (forget_vars t) vars
@@ -512,7 +512,7 @@ struct
 
   let assign_exp t var exp no_ov =
     let res = assign_exp t var exp no_ov in
-    if M.tracing then M.tracel "ops" "assign_exp t:\n %s \n var: %s \n exp: %a\n no_ov: %b -> \n %s\n"
+    if M.tracing then M.tracel "ops" "assign_exp t:\n %s \n var: %s \n exp: %a\n no_ov: %b -> \n %s"
         (show t) (Var.to_string var) d_exp exp (Lazy.force no_ov) (show res) ;
     res
 
@@ -523,7 +523,7 @@ struct
 
   let assign_var t v v' =
     let res = assign_var t v v' in
-    if M.tracing then M.tracel "ops" "assign_var t:\n %s \n v: %s \n v': %s\n -> %s\n" (show t) (Var.to_string v) (Var.to_string v') (show res) ;
+    if M.tracing then M.tracel "ops" "assign_var t:\n %s \n v: %s \n v': %s\n -> %s" (show t) (Var.to_string v) (Var.to_string v') (show res) ;
     res
 
   let assign_var_parallel t vv's =
@@ -551,7 +551,7 @@ struct
 
   let assign_var_parallel t vv's =
     let res = assign_var_parallel t vv's in
-    if M.tracing then M.tracel "ops" "assign_var parallel: %s -> %s \n" (show t) (show res);
+    if M.tracing then M.tracel "ops" "assign_var parallel: %s -> %s " (show t) (show res);
     res
 
   let assign_var_parallel t vv's = timing_wrap "var_parallel" (assign_var_parallel t) vv's
@@ -562,7 +562,7 @@ struct
     t.env <- t'.env
 
   let assign_var_parallel_with t vv's =
-    if M.tracing then M.tracel "var_parallel" "assign_var parallel'\n";
+    if M.tracing then M.tracel "var_parallel" "assign_var parallel'";
     assign_var_parallel_with t vv's
 
   let assign_var_parallel' t vs1 vs2 =
@@ -571,7 +571,7 @@ struct
 
   let assign_var_parallel' t vv's =
     let res = assign_var_parallel' t vv's in
-    if M.tracing then M.tracel "ops" "assign_var parallel'\n";
+    if M.tracing then M.tracel "ops" "assign_var parallel'";
     res
 
   let substitute_exp t var exp no_ov =
@@ -581,7 +581,7 @@ struct
 
   let substitute_exp t var exp ov =
     let res = substitute_exp t var exp ov in
-    if M.tracing then M.tracel "ops" "Substitute_expr t: \n %s \n var: %s \n exp: %a \n -> \n %s\n" (show t) (Var.to_string var) d_exp exp (show res);
+    if M.tracing then M.tracel "ops" "Substitute_expr t: \n %s \n var: %s \n exp: %a \n -> \n %s" (show t) (Var.to_string var) d_exp exp (show res);
     res
 
   let substitute_exp t var exp ov = timing_wrap "substitution" (substitute_exp t var exp) ov
@@ -662,7 +662,7 @@ struct
 
   let unify a b =
     let res = unify a b  in
-    if M.tracing then M.tracel "ops" "unify: %s %s -> %s\n" (show a) (show b) (show res);
+    if M.tracing then M.tracel "ops" "unify: %s %s -> %s" (show a) (show b) (show res);
     res
 
   let assert_cons d e negate no_ov =

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -279,10 +279,10 @@ struct
   let assign_exp_with nd v e no_ov =
     match Convert.texpr1_of_cil_exp nd (A.env nd) e (Lazy.force no_ov) with
     | texpr1 ->
-      if M.tracing then M.trace "apron" "assign_exp converted: %s\n" (Format.asprintf "%a" Texpr1.print texpr1);
+      if M.tracing then M.trace "apron" "assign_exp converted: %s" (Format.asprintf "%a" Texpr1.print texpr1);
       A.assign_texpr_with Man.mgr nd v texpr1 None
     | exception Convert.Unsupported_CilExp _ ->
-      if M.tracing then M.trace "apron" "assign_exp unsupported\n";
+      if M.tracing then M.trace "apron" "assign_exp unsupported";
       forget_vars_with nd [v]
 
   let assign_exp_parallel_with nd ves no_ov =
@@ -548,13 +548,13 @@ struct
     | _ ->
       begin match Convert.tcons1_of_cil_exp d (A.env d) e negate no_ov with
         | tcons1 ->
-          if M.tracing then M.trace "apron" "assert_cons %a %s\n" d_exp e (Format.asprintf "%a" Tcons1.print tcons1);
-          if M.tracing then M.trace "apron" "assert_cons st: %a\n" D.pretty d;
+          if M.tracing then M.trace "apron" "assert_cons %a %s" d_exp e (Format.asprintf "%a" Tcons1.print tcons1);
+          if M.tracing then M.trace "apron" "assert_cons st: %a" D.pretty d;
           let r = meet_tcons d tcons1 e in
-          if M.tracing then M.trace "apron" "assert_cons r: %a\n" D.pretty r;
+          if M.tracing then M.trace "apron" "assert_cons r: %a" D.pretty r;
           r
         | exception Convert.Unsupported_CilExp reason ->
-          if M.tracing then M.trace "apron" "assert_cons %a unsupported: %s\n" d_exp e (SharedFunctions.show_unsupported_cilExp reason);
+          if M.tracing then M.trace "apron" "assert_cons %a unsupported: %s" d_exp e (SharedFunctions.show_unsupported_cilExp reason);
           d
       end
 
@@ -603,7 +603,7 @@ struct
 
   let strengthening j x y =
     (* TODO: optimize strengthening *)
-    if M.tracing then M.traceli "apron" "strengthening %a\n" pretty j;
+    if M.tracing then M.traceli "apron" "strengthening %a" pretty j;
     let x_env = A.env x in
     let y_env = A.env y in
     let j_env = A.env j in
@@ -612,21 +612,21 @@ struct
     let x_cons = A.to_lincons_array Man.mgr x_j in
     let y_cons = A.to_lincons_array Man.mgr y_j in
     let try_add_con j con1 =
-      if M.tracing then M.tracei "apron" "try_add_con %s\n" (Format.asprintf "%a" (Lincons1.print: Format.formatter -> Lincons1.t -> unit) con1);
+      if M.tracing then M.tracei "apron" "try_add_con %s" (Format.asprintf "%a" (Lincons1.print: Format.formatter -> Lincons1.t -> unit) con1);
       let t = meet_lincons j con1 in
       let t_x = A.change_environment Man.mgr t x_env false in
       let t_y = A.change_environment Man.mgr t y_env false in
       let leq_x = A.is_leq Man.mgr x t_x in
       let leq_y = A.is_leq Man.mgr y t_y in
-      if M.tracing then M.trace "apron" "t: %a\n" pretty t;
-      if M.tracing then M.trace "apron" "t_x (leq x %B): %a\n" leq_x pretty t_x;
-      if M.tracing then M.trace "apron" "t_y (leq y %B): %a\n" leq_y pretty t_y;
+      if M.tracing then M.trace "apron" "t: %a" pretty t;
+      if M.tracing then M.trace "apron" "t_x (leq x %B): %a" leq_x pretty t_x;
+      if M.tracing then M.trace "apron" "t_y (leq y %B): %a" leq_y pretty t_y;
       if leq_x && leq_y then (
-        if M.tracing then M.traceu "apron" "added\n";
+        if M.tracing then M.traceu "apron" "added";
         t
       )
       else (
-        if M.tracing then M.traceu "apron" "not added\n";
+        if M.tracing then M.traceu "apron" "not added";
         j
       )
     in
@@ -654,7 +654,7 @@ struct
       Array.concat [x_cons1_only_x; y_cons1_only_y; x_cons1_some_y; y_cons1_some_x]
     in
     let j = Array.fold_left try_add_con j cons1 in
-    if M.tracing then M.traceu "apron" "-> %a\n" pretty j;
+    if M.tracing then M.traceu "apron" "-> %a" pretty j;
     j
 
   let empty_env = Environment.make [||] [||]
@@ -678,16 +678,16 @@ struct
     else if is_bot y then (* TODO: also for non-empty env *)
       x
     else (
-      if M.tracing then M.traceli "apron" "join %a %a\n" pretty x pretty y;
+      if M.tracing then M.traceli "apron" "join %a %a" pretty x pretty y;
       let j = join x y in
-      if M.tracing then M.trace "apron" "j = %a\n" pretty j;
+      if M.tracing then M.trace "apron" "j = %a" pretty j;
       let j =
         if strengthening_enabled then (* TODO: skip if same envs? *)
           strengthening j x y
         else
           j
       in
-      if M.tracing then M.traceu "apron" "-> %a\n" pretty j;
+      if M.tracing then M.traceu "apron" "-> %a" pretty j;
       j
     )
 
@@ -750,10 +750,10 @@ struct
       y (* env increased, just use joined value in y, assuming env doesn't increase infinitely *)
 
   let widen x y =
-    if M.tracing then M.traceli "apron" "widen %a %a\n" pretty x pretty y;
+    if M.tracing then M.traceli "apron" "widen %a %a" pretty x pretty y;
     let w = widen x y in
-    if M.tracing then M.trace "apron" "widen same %B\n" (equal y w);
-    if M.tracing then M.traceu "apron" "-> %a\n" pretty w;
+    if M.tracing then M.trace "apron" "widen same %B" (equal y w);
+    if M.tracing then M.traceu "apron" "-> %a" pretty w;
     w
 
   let narrow x y =

--- a/src/cdomains/apron/sharedFunctions.apron.ml
+++ b/src/cdomains/apron/sharedFunctions.apron.ml
@@ -129,7 +129,7 @@ struct
             match Bounds.bound_texpr d texpr1 with
             | Some min, Some max when Z.compare type_min min <= 0 && Z.compare max type_max <= 0 -> ()
             | min_opt, max_opt ->
-              if M.tracing then M.trace "apron" "may overflow: %a (%a, %a)\n" CilType.Exp.pretty exp (Pretty.docOpt (IntOps.BigIntOps.pretty ())) min_opt (Pretty.docOpt (IntOps.BigIntOps.pretty ())) max_opt;
+              if M.tracing then M.trace "apron" "may overflow: %a (%a, %a)" CilType.Exp.pretty exp (Pretty.docOpt (IntOps.BigIntOps.pretty ())) min_opt (Pretty.docOpt (IntOps.BigIntOps.pretty ())) max_opt;
               raise (Unsupported_CilExp Overflow)
           );
           expr
@@ -335,7 +335,7 @@ struct
     | exception Invalid_argument _ ->
       ID.top () (* real top, not a top of any ikind because we don't even know the ikind *)
     | ik ->
-      if M.tracing then M.trace "relation" "eval_int: exp_is_cons %a = %B\n" d_plainexp e (exp_is_cons e);
+      if M.tracing then M.trace "relation" "eval_int: exp_is_cons %a = %B" d_plainexp e (exp_is_cons e);
       if exp_is_cons e then
         match check_assert d e no_ov with
         | `True -> ID.of_bool ik true

--- a/src/cdomains/symbLocksDomain.ml
+++ b/src/cdomains/symbLocksDomain.ml
@@ -237,7 +237,7 @@ struct
     | _            ,             _ -> raise (Invalid_argument "")
 
   let from_exps a l : t option =
-    if M.tracing then M.tracel "symb_locks" "from_exps %a (%s) %a (%s)\n" d_plainexp a (ees_to_str (toEl a)) d_plainexp l (ees_to_str (toEl l));
+    if M.tracing then M.tracel "symb_locks" "from_exps %a (%s) %a (%s)" d_plainexp a (ees_to_str (toEl a)) d_plainexp l (ees_to_str (toEl l));
     let a, l = toEl a, toEl l in
     (* ignore (printf "from_exps:\n %s\n %s\n" (ees_to_str a) (ees_to_str l)); *)
     (*let rec fold_left2 f a xs ys =

--- a/src/common/framework/cfgTools.ml
+++ b/src/common/framework/cfgTools.ml
@@ -79,7 +79,7 @@ let computeSCCs (module Cfg: CfgBidir) nodes =
             dfs_inner prev_node scc
           else if not (NH.mem scc.nodes prev_node) then (
             (* prev_node has been visited, but not in current SCC, therefore is backwards edge to predecessor scc *)
-            if Messages.tracing then Messages.trace "cfg" "SCC edge: %s -> %s\n" (Node.show_id prev_node) (Node.show_id node);
+            if Messages.tracing then Messages.trace "cfg" "SCC edge: %s -> %s" (Node.show_id prev_node) (Node.show_id node);
             NH.modify_def [] node (List.cons (edges, prev_node)) scc.prev;
             NH.modify_def [] prev_node (List.cons (edges, node)) (NH.find node_scc prev_node).next;
           )
@@ -148,7 +148,7 @@ let createCFG (file: file) =
      which do not otherwise appear in the control flow graph. *)
   let skippedByEdge = CfgEdgeH.create 113 in
 
-  if Messages.tracing then Messages.trace "cfg" "Starting to build the cfg.\n\n";
+  if Messages.tracing then Messages.trace "cfg" "Starting to build the cfg.\n";
 
   let fd_nodes = NH.create 113 in
 
@@ -163,7 +163,7 @@ let createCFG (file: file) =
     H.modify_def [] toNode (List.cons (edges,fromNode)) cfgB;
     H.modify_def [] fromNode (List.cons (edges,toNode)) cfgF;
     CfgEdgeH.replace skippedByEdge (fromNode, edges, toNode) skippedStatements;
-    if Messages.tracing then Messages.trace "cfg" "done\n\n"
+    if Messages.tracing then Messages.trace "cfg" "done\n"
   in
   let addEdge ?skippedStatements fromNode edge toNode =
     addEdges ?skippedStatements fromNode [edge] toNode
@@ -181,7 +181,7 @@ let createCFG (file: file) =
      If not_found is true, then a stmt without succs will raise Not_found
      instead of returning that stmt. *)
   let find_real_stmt ?parent ?(not_found=false) stmt =
-    if Messages.tracing then Messages.tracei "cfg" "find_real_stmt not_found=%B stmt=%d\n" not_found stmt.sid;
+    if Messages.tracing then Messages.tracei "cfg" "find_real_stmt not_found=%B stmt=%d" not_found stmt.sid;
     let rec find visited_stmts stmt =
       if Messages.tracing then
         Messages.trace "cfg" "find_real_stmt visited=[%a] stmt=%d: %a\n"
@@ -227,10 +227,10 @@ let createCFG (file: file) =
     try
       (* rev_path is the stack of all visited statements, excluding the final statement *)
       let final_stmt, rev_path = find [] stmt in
-      if Messages.tracing then Messages.traceu "cfg" "-> %d\n" final_stmt.sid;
+      if Messages.tracing then Messages.traceu "cfg" "-> %d" final_stmt.sid;
       final_stmt, List.rev rev_path
     with Not_found ->
-      if Messages.tracing then Messages.traceu "cfg" "-> Not_found\n";
+      if Messages.tracing then Messages.traceu "cfg" "-> Not_found";
       raise Not_found
   in
   addEdge_fromLoc (FunctionEntry dummy_func) (Ret (None, dummy_func)) (Function dummy_func);
@@ -238,7 +238,7 @@ let createCFG (file: file) =
   iterGlobals file (fun glob ->
       match glob with
       | GFun (fd, fd_loc) ->
-        if Messages.tracing then Messages.trace "cfg" "Looking at the function %s.\n" fd.svar.vname;
+        if Messages.tracing then Messages.trace "cfg" "Looking at the function %s." fd.svar.vname;
 
         if get_bool "dbg.cilcfgdot" then
           Cfg.printCfgFilename ("cilcfg." ^ fd.svar.vname ^ ".dot") fd;
@@ -252,7 +252,7 @@ let createCFG (file: file) =
         (* Return node to be used for infinite loop connection to end of function
          * lazy, so it's only added when actually needed *)
         let pseudo_return = lazy (
-          if Messages.tracing then Messages.trace "cfg" "adding pseudo-return to the function %s.\n" fd.svar.vname;
+          if Messages.tracing then Messages.trace "cfg" "adding pseudo-return to the function %s." fd.svar.vname;
           let fd_end_loc = {fd_loc with line = fd_loc.endLine; byte = fd_loc.endByte; column = fd_loc.endColumn} in
           let newst = mkStmt (Return (None, fd_end_loc)) in
           newst.sid <- Cilfacade.get_pseudo_return_id fd;
@@ -266,7 +266,7 @@ let createCFG (file: file) =
         let loop_head_neg1 = NH.create 3 in
         (* So for each statement in the function body, we do the following: *)
         let handle stmt =
-          if Messages.tracing then Messages.trace "cfg" "Statement %d at %a.\n" stmt.sid d_loc (Cilfacade.get_stmtLoc stmt);
+          if Messages.tracing then Messages.trace "cfg" "Statement %d at %a." stmt.sid d_loc (Cilfacade.get_stmtLoc stmt);
 
           let real_succs () = List.map (find_real_stmt ~parent:stmt) stmt.succs in
 
@@ -321,7 +321,7 @@ let createCFG (file: file) =
             (* CIL eliminates the constant true If corresponding to constant true Loop.
                Then there is no Goto to after the loop and the CFG is unconnected (to Function node).
                An extra Neg(1) edge is added in such case. *)
-            if Messages.tracing then Messages.trace "cfg" "loop %d cont=%d brk=%d\n" stmt.sid cont.sid brk.sid;
+            if Messages.tracing then Messages.trace "cfg" "loop %d cont=%d brk=%d" stmt.sid cont.sid brk.sid;
             begin match find_real_stmt ~not_found:true brk with (* don't specify stmt as parent because if find_real_stmt finds cycle, it should not return the Loop statement *)
               | break_stmt, _ ->
                 (* break statement is what follows the (constant true) Loop *)
@@ -384,7 +384,7 @@ let createCFG (file: file) =
         in
         Timing.wrap ~args:[("function", `String fd.svar.vname)] "handle" (List.iter handle) fd.sallstmts;
 
-        if Messages.tracing then Messages.trace "cfg" "Over\n";
+        if Messages.tracing then Messages.trace "cfg" "Over";
 
         (* Connect remaining infinite loops (e.g made using goto) to end of function
          * via pseudo return node for demand driven solvers *)
@@ -468,7 +468,7 @@ let createCFG (file: file) =
           raise (Not_connect fd)
       | _ -> ()
     );
-  if Messages.tracing then Messages.trace "cfg" "CFG building finished.\n\n";
+  if Messages.tracing then Messages.trace "cfg" "CFG building finished.\n";
   Logs.debug "cfgF (%a), cfgB (%a)" GobHashtbl.pretty_statistics (NH.stats cfgF) GobHashtbl.pretty_statistics (NH.stats cfgB);
   cfgF, cfgB, skippedByEdge
 

--- a/src/common/framework/cfgTools.ml
+++ b/src/common/framework/cfgTools.ml
@@ -107,9 +107,9 @@ let computeSCCs (module Cfg: CfgBidir) nodes =
   if Messages.tracing then (
     List.iter (fun scc ->
         let nodes = scc.nodes |> NH.keys |> BatList.of_enum in
-        Messages.trace "cfg" "SCC: %a\n" (d_list " " (fun () node -> text (Node.show_id node))) nodes;
+        Messages.trace "cfg" "SCC: %a" (d_list " " (fun () node -> text (Node.show_id node))) nodes;
         NH.iter (fun node _ ->
-            Messages.trace "cfg" "SCC entry: %s\n" (Node.show_id node)
+            Messages.trace "cfg" "SCC entry: %s" (Node.show_id node)
           ) scc.prev
       ) sccs
   );
@@ -148,7 +148,7 @@ let createCFG (file: file) =
      which do not otherwise appear in the control flow graph. *)
   let skippedByEdge = CfgEdgeH.create 113 in
 
-  if Messages.tracing then Messages.trace "cfg" "Starting to build the cfg.\n";
+  if Messages.tracing then Messages.trace "cfg" "Starting to build the cfg.";
 
   let fd_nodes = NH.create 113 in
 
@@ -163,7 +163,7 @@ let createCFG (file: file) =
     H.modify_def [] toNode (List.cons (edges,fromNode)) cfgB;
     H.modify_def [] fromNode (List.cons (edges,toNode)) cfgF;
     CfgEdgeH.replace skippedByEdge (fromNode, edges, toNode) skippedStatements;
-    if Messages.tracing then Messages.trace "cfg" "done\n"
+    if Messages.tracing then Messages.trace "cfg" "done"
   in
   let addEdge ?skippedStatements fromNode edge toNode =
     addEdges ?skippedStatements fromNode [edge] toNode
@@ -184,7 +184,7 @@ let createCFG (file: file) =
     if Messages.tracing then Messages.tracei "cfg" "find_real_stmt not_found=%B stmt=%d" not_found stmt.sid;
     let rec find visited_stmts stmt =
       if Messages.tracing then
-        Messages.trace "cfg" "find_real_stmt visited=[%a] stmt=%d: %a\n"
+        Messages.trace "cfg" "find_real_stmt visited=[%a] stmt=%d: %a"
           (d_list "; " (fun () x -> Pretty.text (string_of_int x)))
           (List.map (fun s -> s.sid) visited_stmts) stmt.sid dn_stmt stmt;
       if
@@ -468,7 +468,7 @@ let createCFG (file: file) =
           raise (Not_connect fd)
       | _ -> ()
     );
-  if Messages.tracing then Messages.trace "cfg" "CFG building finished.\n";
+  if Messages.tracing then Messages.trace "cfg" "CFG building finished.";
   Logs.debug "cfgF (%a), cfgB (%a)" GobHashtbl.pretty_statistics (NH.stats cfgF) GobHashtbl.pretty_statistics (NH.stats cfgB);
   cfgF, cfgB, skippedByEdge
 

--- a/src/config/gobConfig.ml
+++ b/src/config/gobConfig.ml
@@ -331,7 +331,7 @@ struct
 
   let wrap_get f x =
     (* self-observe options, which Spec construction depends on *)
-    if !building_spec && Goblint_tracing.tracing then Goblint_tracing.trace "config" "get during building_spec: %s\n" x;
+    if !building_spec && Goblint_tracing.tracing then Goblint_tracing.trace "config" "get during building_spec: %s" x;
     (* TODO: blacklist such building_spec option from server mode modification since it will have no effect (spec is already built) *)
     f x
 

--- a/src/config/gobConfig.ml
+++ b/src/config/gobConfig.ml
@@ -299,7 +299,7 @@ struct
     try
       let st = String.trim st in
       let x = get_value !json_conf (parse_path st) in
-      if Goblint_tracing.tracing then Goblint_tracing.trace "conf-reads" "Reading '%s', it is %a.\n" st GobYojson.pretty x;
+      if Goblint_tracing.tracing then Goblint_tracing.trace "conf-reads" "Reading '%s', it is %a." st GobYojson.pretty x;
       try f x
       with Yojson.Safe.Util.Type_error (s, _) ->
         Logs.error "The value for '%s' has the wrong type: %s" st s;
@@ -351,7 +351,7 @@ struct
 
   (** Helper function for writing values. Handles the tracing. *)
   let set_path_string st v =
-    if Goblint_tracing.tracing then Goblint_tracing.trace "conf" "Setting '%s' to %a.\n" st GobYojson.pretty v;
+    if Goblint_tracing.tracing then Goblint_tracing.trace "conf" "Setting '%s' to %a." st GobYojson.pretty v;
     set_value v json_conf (parse_path st)
 
   let set_json st j =
@@ -401,7 +401,7 @@ struct
     | Some fn ->
       let v = Yojson.Safe.from_channel % BatIO.to_input_channel |> File.with_file_in (Fpath.to_string fn) in
       merge v;
-      if Goblint_tracing.tracing then Goblint_tracing.trace "conf" "Merging with '%a', resulting\n%a.\n" GobFpath.pretty fn GobYojson.pretty !json_conf
+      if Goblint_tracing.tracing then Goblint_tracing.trace "conf" "Merging with '%a', resulting\n%a." GobFpath.pretty fn GobYojson.pretty !json_conf
     | None -> raise (Sys_error (Printf.sprintf "%s: No such file or diretory" (Fpath.to_string fn)))
 end
 

--- a/src/domains/access.ml
+++ b/src/domains/access.ml
@@ -273,7 +273,7 @@ let get_val_type e: acc_typ =
 (** Add access to {!Memo} after distributing. *)
 let add_one ~side memo: unit =
   let ignorable = is_ignorable_memo memo in
-  if M.tracing then M.trace "access" "add_one %a (ignorable = %B)\n" Memo.pretty memo ignorable;
+  if M.tracing then M.trace "access" "add_one %a (ignorable = %B)" Memo.pretty memo ignorable;
   if not ignorable then
     side memo
 
@@ -281,7 +281,7 @@ let add_one ~side memo: unit =
     Empty access sets are needed for prefix-type_suffix race checking. *)
 let rec add_distribute_outer ~side ~side_empty (ts: typsig) (o: Offset.Unit.t) =
   let memo = (`Type ts, o) in
-  if M.tracing then M.tracei "access" "add_distribute_outer %a\n" Memo.pretty memo;
+  if M.tracing then M.tracei "access" "add_distribute_outer %a" Memo.pretty memo;
   add_one ~side memo; (* Add actual access for non-recursive call, or empty access for recursive call when side is side_empty. *)
 
   (* distribute to variables of the type *)
@@ -298,17 +298,17 @@ let rec add_distribute_outer ~side ~side_empty (ts: typsig) (o: Offset.Unit.t) =
       add_distribute_outer ~side:side_empty ~side_empty (TSComp (f.fcomp.cstruct, f.fcomp.cname, [])) (`Field (f, o)) (* Switch to side_empty. *)
     ) fields;
 
-  if M.tracing then M.traceu "access" "add_distribute_outer\n"
+  if M.tracing then M.traceu "access" "add_distribute_outer"
 
 (** Add access to known variable with offsets or unknown variable from expression. *)
 let add ~side ~side_empty e voffs =
   begin match voffs with
     | Some (v, o) -> (* known variable *)
-      if M.tracing then M.traceli "access" "add var %a%a\n" CilType.Varinfo.pretty v CilType.Offset.pretty o;
+      if M.tracing then M.traceli "access" "add var %a%a" CilType.Varinfo.pretty v CilType.Offset.pretty o;
       let memo = (`Var v, Offset.Unit.of_cil o) in
       add_one ~side memo
     | None -> (* unknown variable *)
-      if M.tracing then M.traceli "access" "add type %a\n" CilType.Exp.pretty e;
+      if M.tracing then M.traceli "access" "add type %a" CilType.Exp.pretty e;
       let ty = get_val_type e in (* extract old acc_typ from expression *)
       let (t, o) = match ty with (* convert acc_typ to type-based Memo (components) *)
         | `Struct (c, o) -> (TComp (c, []), o)
@@ -318,7 +318,7 @@ let add ~side ~side_empty e voffs =
       | `NoOffset when not !collect_direct_arithmetic && isArithmeticType t -> ()
       | _ -> add_distribute_outer ~side ~side_empty (Cil.typeSig t) o (* distribute to variables and outer offsets *)
   end;
-  if M.tracing then M.traceu "access" "add\n"
+  if M.tracing then M.traceu "access" "add"
 
 
 (** Distribute to {!AddrOf} of all read lvals in subexpressions. *)
@@ -482,7 +482,7 @@ struct
 end
 
 let group_may_race (warn_accs:WarnAccs.t) =
-  if M.tracing then M.tracei "access" "group_may_race %a\n" WarnAccs.pretty warn_accs;
+  if M.tracing then M.tracei "access" "group_may_race %a" WarnAccs.pretty warn_accs;
   (* BFS to traverse one component with may_race edges *)
   let rec bfs' warn_accs ~todo ~visited =
     let todo_all = WarnAccs.union_all todo in
@@ -539,7 +539,7 @@ let group_may_race (warn_accs:WarnAccs.t) =
     )
   in
   let (comps, warn_accs) = components [] warn_accs in
-  if M.tracing then M.trace "access" "components %a\n" WarnAccs.pretty warn_accs;
+  if M.tracing then M.trace "access" "components %a" WarnAccs.pretty warn_accs;
   (* repeat BFS to find all prefix-type_suffix-only components starting from prefix accesses (symmetric) *)
   let rec components_cross comps ~prefix ~type_suffix =
     if AS.is_empty prefix then
@@ -547,7 +547,7 @@ let group_may_race (warn_accs:WarnAccs.t) =
     else (
       let prefix_acc = AS.choose prefix in
       let (warn_accs', comp) = bfs {(WarnAccs.empty ()) with prefix; type_suffix} {(WarnAccs.empty ()) with prefix=AS.singleton prefix_acc} in
-      if M.tracing then M.trace "access" "components_cross %a\n" WarnAccs.pretty warn_accs';
+      if M.tracing then M.trace "access" "components_cross %a" WarnAccs.pretty warn_accs';
       let comps' =
         if AS.cardinal comp > 1 then
           comp :: comps
@@ -558,7 +558,7 @@ let group_may_race (warn_accs:WarnAccs.t) =
     )
   in
   let components_cross = components_cross comps ~prefix:warn_accs.prefix ~type_suffix:warn_accs.type_suffix in
-  if M.tracing then M.traceu "access" "group_may_race\n";
+  if M.tracing then M.traceu "access" "group_may_race";
   components_cross
 
 let race_conf accs =

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -33,7 +33,7 @@ struct
   let getLocation (n,d) = Node.location n
 
   let pretty_trace () ((n,c) as x) =
-    if get_bool "dbg.trace.context" then dprintf "(%a, %a) on %a \n" Node.pretty_trace n LD.pretty c CilType.Location.pretty (getLocation x)
+    if get_bool "dbg.trace.context" then dprintf "(%a, %a) on %a" Node.pretty_trace n LD.pretty c CilType.Location.pretty (getLocation x)
     (* if get_bool "dbg.trace.context" then dprintf "(%a, %d) on %a" Node.pretty_trace n (LD.tag c) CilType.Location.pretty (getLocation x) *)
     else dprintf "%a on %a" Node.pretty_trace n CilType.Location.pretty (getLocation x)
 

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -409,7 +409,7 @@ struct
       if ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.context.widen" ~keepAttr:"widen" ~removeAttr:"no-widen" f then (
         let v_old = M.find f.svar m in (* S.D.bot () if not found *)
         let v_new = S.D.widen v_old (S.D.join v_old v_cur) in
-        Messages.(if tracing && not (S.D.equal v_old v_new) then tracel "widen-context" "enter results in new context for function %s\n" f.svar.vname);
+        Messages.(if tracing && not (S.D.equal v_old v_new) then tracel "widen-context" "enter results in new context for function %s" f.svar.vname);
         v_new, M.add f.svar v_new m
       )
       else

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -652,8 +652,8 @@ struct
 
   let tf_normal_call ctx lv e (f:fundec) args getl sidel getg sideg =
     let combine (cd, fc, fd) =
-      if M.tracing then M.traceli "combine" "local: %a\n" S.D.pretty cd;
-      if M.tracing then M.trace "combine" "function: %a\n" S.D.pretty fd;
+      if M.tracing then M.traceli "combine" "local: %a" S.D.pretty cd;
+      if M.tracing then M.trace "combine" "function: %a" S.D.pretty fd;
       let rec cd_ctx =
         { ctx with
           ask = (fun (type a) (q: a Queries.t) -> S.query cd_ctx q);
@@ -700,7 +700,7 @@ struct
           S.D.join acc (S.combine_assign combine_assign_ctx lv e f args fc fd1_ctx.local (Analyses.ask_of_ctx fd1_ctx))
         ) (S.D.bot ()) (S.paths_as_set fd_ctx)
       in
-      if M.tracing then M.traceu "combine" "combined local: %a\n" S.D.pretty r;
+      if M.tracing then M.traceu "combine" "combined local: %a" S.D.pretty r;
       r
     in
     let paths = S.enter ctx lv f args in
@@ -710,10 +710,10 @@ struct
     (* Don't filter bot paths, otherwise LongjmpLifter is not called. *)
     (* let paths = List.filter (fun (c,fc,v) -> not (D.is_bot v)) paths in *)
     let paths = List.map (Tuple3.map2 Option.some) paths in
-    if M.tracing then M.traceli "combine" "combining\n";
+    if M.tracing then M.traceli "combine" "combining";
     let paths = List.map combine paths in
     let r = List.fold_left D.join (D.bot ()) paths in
-    if M.tracing then M.traceu "combine" "combined: %a\n" S.D.pretty r;
+    if M.tracing then M.traceu "combine" "combined: %a" S.D.pretty r;
     r
 
   let tf_special_call ctx lv f args = S.special ctx lv f args
@@ -1135,13 +1135,13 @@ struct
     assert (D.cardinal ctx.local = 1);
     let cd = D.choose ctx.local in
     let k x y =
-      if M.tracing then M.traceli "combine" "function: %a\n" Spec.D.pretty x;
+      if M.tracing then M.traceli "combine" "function: %a" Spec.D.pretty x;
       try
         let r = Spec.combine_env (conv ctx cd) l fe f a fc x f_ask in
-        if M.tracing then M.traceu "combine" "combined function: %a\n" Spec.D.pretty r;
+        if M.tracing then M.traceu "combine" "combined function: %a" Spec.D.pretty r;
         D.add r y
       with Deadcode ->
-        if M.tracing then M.traceu "combine" "combined function: dead\n";
+        if M.tracing then M.traceu "combine" "combined function: dead";
         y
     in
     let d = D.fold k d (D.bot ()) in
@@ -1151,13 +1151,13 @@ struct
     assert (D.cardinal ctx.local = 1);
     let cd = D.choose ctx.local in
     let k x y =
-      if M.tracing then M.traceli "combine" "function: %a\n" Spec.D.pretty x;
+      if M.tracing then M.traceli "combine" "function: %a" Spec.D.pretty x;
       try
         let r = Spec.combine_assign (conv ctx cd) l fe f a fc x f_ask in
-        if M.tracing then M.traceu "combine" "combined function: %a\n" Spec.D.pretty r;
+        if M.tracing then M.traceu "combine" "combined function: %a" Spec.D.pretty r;
         D.add r y
       with Deadcode ->
-        if M.tracing then M.traceu "combine" "combined function: dead\n";
+        if M.tracing then M.traceu "combine" "combined function: dead";
         y
     in
     let d = D.fold k d (D.bot ()) in
@@ -1436,7 +1436,7 @@ struct
         | Target (target_node, target_context) ->
           let target_fundec = Node.find_fundec target_node in
           if CilType.Fundec.equal target_fundec current_fundec && ControlSpecC.equal target_context (ctx.control_context ()) then (
-            if M.tracing then Messages.tracel "longjmp" "Fun: Potentially from same context, side-effect to %a\n" Node.pretty target_node;
+            if M.tracing then Messages.tracel "longjmp" "Fun: Potentially from same context, side-effect to %a" Node.pretty target_node;
             ctx.sideg (V.longjmpto (target_node, ctx.context ())) (G.create_local (Lazy.force combined))
             (* No need to propagate this outwards here, the set of valid longjumps is part of the context, we can never have the same context setting the longjmp multiple times *)
           )
@@ -1450,9 +1450,9 @@ struct
       in
       JmpBufDomain.JmpBufSet.iter handle_target active_targets
     in
-    if M.tracing then M.tracel "longjmp" "longfd getg %a\n" CilType.Fundec.pretty f;
+    if M.tracing then M.tracel "longjmp" "longfd getg %a" CilType.Fundec.pretty f;
     let longfd = G.local (ctx.global (V.longjmpret (f, Option.get fc))) in
-    if M.tracing then M.tracel "longjmp" "longfd %a\n" D.pretty longfd;
+    if M.tracing then M.tracel "longjmp" "longfd %a" D.pretty longfd;
     if not (D.is_bot longfd) then
       handle_longjmp (ctx.local, fc, longfd);
     S.combine_env (conv_ctx) lv e f args fc fd f_ask
@@ -1505,7 +1505,7 @@ struct
         (* Eval `env` again to avoid having to construct bespoke ctx to ask *)
         let targets = path_ctx.ask (EvalJumpBuf env) in
         let valid_targets = path_ctx.ask ValidLongJmp in
-        if M.tracing then Messages.tracel "longjmp" "Jumping to %a\n" JmpBufDomain.JmpBufSet.pretty targets;
+        if M.tracing then Messages.tracel "longjmp" "Jumping to %a" JmpBufDomain.JmpBufSet.pretty targets;
         let handle_target target = match target with
           | JmpBufDomain.BufferEntryOrTop.AllTargets ->
             M.warn ~category:Imprecise "Longjmp to potentially invalid target, as contents of buffer %a may be unknown! (imprecision due to heap?)" d_exp env;
@@ -1513,11 +1513,11 @@ struct
           | Target (target_node, target_context) ->
             let target_fundec = Node.find_fundec target_node in
             if CilType.Fundec.equal target_fundec current_fundec && ControlSpecC.equal target_context (ctx.control_context ()) then (
-              if M.tracing then Messages.tracel "longjmp" "Potentially from same context, side-effect to %a\n" Node.pretty target_node;
+              if M.tracing then Messages.tracel "longjmp" "Potentially from same context, side-effect to %a" Node.pretty target_node;
               ctx.sideg (V.longjmpto (target_node, ctx.context ())) (G.create_local (Lazy.force specialed))
             )
             else if JmpBufDomain.JmpBufSet.mem target valid_targets then (
-              if M.tracing then Messages.tracel "longjmp" "Longjmp to somewhere else, side-effect to %i\n" (S.C.hash (ctx.context ()));
+              if M.tracing then Messages.tracel "longjmp" "Longjmp to somewhere else, side-effect to %i" (S.C.hash (ctx.context ()));
               ctx.sideg (V.longjmpret (current_fundec, ctx.context ())) (G.create_local (Lazy.force returned))
             )
             else

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -282,7 +282,7 @@ struct
     let gh = GHT.create 13 in
     let getg v = GHT.find_default gh v (EQSys.G.bot ()) in
     let sideg v d =
-      if M.tracing then M.trace "global_inits" "sideg %a = %a\n" EQSys.GVar.pretty v EQSys.G.pretty d;
+      if M.tracing then M.trace "global_inits" "sideg %a = %a" EQSys.GVar.pretty v EQSys.G.pretty d;
       GHT.replace gh v (EQSys.G.join (getg v) d)
     in
     (* Old-style global function for context.
@@ -311,16 +311,16 @@ struct
       let funs = ref [] in
       (*let count = ref 0 in*)
       let transfer_func (st : Spec.D.t) (loc, edge) : Spec.D.t =
-        if M.tracing then M.trace "con" "Initializer %a\n" CilType.Location.pretty loc;
+        if M.tracing then M.trace "con" "Initializer %a" CilType.Location.pretty loc;
         (*incr count;
           if (get_bool "dbg.verbose")&& (!count mod 1000 = 0)  then Printf.printf "%d %!" !count;    *)
         Goblint_tracing.current_loc := loc;
         match edge with
         | MyCFG.Entry func        ->
-          if M.tracing then M.trace "global_inits" "Entry %a\n" d_lval (var func.svar);
+          if M.tracing then M.trace "global_inits" "Entry %a" d_lval (var func.svar);
           Spec.body {ctx with local = st} func
         | MyCFG.Assign (lval,exp) ->
-          if M.tracing then M.trace "global_inits" "Assign %a = %a\n" d_lval lval d_exp exp;
+          if M.tracing then M.trace "global_inits" "Assign %a = %a" d_lval lval d_exp exp;
           (match lval, exp with
             | (Var v,o), (AddrOf (Var f,NoOffset))
               when v.vstorage <> Static && isFunctionType f.vtype ->
@@ -330,7 +330,7 @@ struct
           let res = Spec.assign {ctx with local = st} lval exp in
           (* Needed for privatizations (e.g. None) that do not side immediately *)
           let res' = Spec.sync {ctx with local = res} `Normal in
-          if M.tracing then M.trace "global_inits" "\t\t -> state:%a\n" Spec.D.pretty res;
+          if M.tracing then M.trace "global_inits" "\t\t -> state:%a" Spec.D.pretty res;
           res'
         | _                       -> failwith "Unsupported global initializer edge"
       in
@@ -339,7 +339,7 @@ struct
       let old_loc = !Goblint_tracing.current_loc in
       let result : Spec.D.t = List.fold_left transfer_func with_externs edges in
       Goblint_tracing.current_loc := old_loc;
-      if M.tracing then M.trace "global_inits" "startstate: %a\n" Spec.D.pretty result;
+      if M.tracing then M.trace "global_inits" "startstate: %a" Spec.D.pretty result;
       result, !funs
     in
 

--- a/src/incremental/compareAST.ml
+++ b/src/incremental/compareAST.ml
@@ -129,7 +129,7 @@ and eq_typ_acc ?(fun_parameter_name_comparison_enabled: bool = true) (a: typ) (b
     a, b, c, (updatedCompinfoRenames, updatedEnumRenames)
   in
 
-  if Messages.tracing then Messages.tracei "compareast" "eq_typ_acc %a vs %a (%a, %a)\n" d_type a d_type b pretty_length acc pretty_length !global_typ_acc; (* %a makes List.length calls lazy if compareast isn't being traced *)
+  if Messages.tracing then Messages.tracei "compareast" "eq_typ_acc %a vs %a (%a, %a)" d_type a d_type b pretty_length acc pretty_length !global_typ_acc; (* %a makes List.length calls lazy if compareast isn't being traced *)
   let r, updated_rename_mapping = match a, b with
     | TPtr (typ1, attr1), TPtr (typ2, attr2) -> eq_typ_acc typ1 typ2 ~rename_mapping ~acc &&>> forward_list_equal (eq_attribute ~acc) attr1 attr2
     | TArray (typ1, (Some lenExp1), attr1), TArray (typ2, (Some lenExp2), attr2) -> eq_typ_acc typ1 typ2 ~rename_mapping ~acc &&>> eq_exp lenExp1 lenExp2 ~acc &&>>  forward_list_equal (eq_attribute ~acc) attr1 attr2
@@ -150,7 +150,7 @@ and eq_typ_acc ?(fun_parameter_name_comparison_enabled: bool = true) (a: typ) (b
     (* The following two lines are a hack to ensure that anonymous types get the same name and thus, the same typsig *)
     | TComp (compinfo1, attr1), TComp (compinfo2, attr2) ->
       if mem_typ_acc a b acc || mem_typ_acc a b !global_typ_acc then (
-        if Messages.tracing then Messages.trace "compareast" "in acc\n";
+        if Messages.tracing then Messages.trace "compareast" "in acc";
         true, rename_mapping
       )
       else (
@@ -175,7 +175,7 @@ and eq_typ_acc ?(fun_parameter_name_comparison_enabled: bool = true) (a: typ) (b
     | TFloat (fk1, attr1), TFloat (fk2, attr2) -> (fk1 = fk2, rename_mapping) &&>> forward_list_equal (eq_attribute ~acc) attr1 attr2
     | _, _ -> false, rename_mapping
   in
-  if Messages.tracing then Messages.traceu "compareast" "eq_typ_acc %a vs %a\n" d_type a d_type b;
+  if Messages.tracing then Messages.traceu "compareast" "eq_typ_acc %a vs %a" d_type a d_type b;
   (r, updated_rename_mapping)
 
 and eq_eitems (a: string * exp * location) (b: string * exp * location) ~(rename_mapping: rename_mapping) ~(acc: (typ * typ) list) = match a, b with
@@ -272,11 +272,11 @@ and eq_compinfo (a: compinfo) (b: compinfo) (acc: (typ * typ) list) (rename_mapp
   (a.cdefined = b.cdefined) (* Ignore ckey, and ignore creferenced *)
 
 and eq_fieldinfo (a: fieldinfo) (b: fieldinfo) ~(acc: (typ * typ) list) ~(rename_mapping: rename_mapping) =
-  if Messages.tracing then Messages.tracei "compareast" "fieldinfo %s vs %s\n" a.fname b.fname;
+  if Messages.tracing then Messages.tracei "compareast" "fieldinfo %s vs %s" a.fname b.fname;
   let (r, rm) = (a.fname = b.fname, rename_mapping) &&>>
                 eq_typ_acc a.ftype b.ftype ~acc &&> (a.fbitfield = b.fbitfield) &&>>
                 forward_list_equal (eq_attribute ~acc) a.fattr b.fattr in
-  if Messages.tracing then Messages.traceu "compareast" "fieldinfo %s vs %s\n" a.fname b.fname;
+  if Messages.tracing then Messages.traceu "compareast" "fieldinfo %s vs %s" a.fname b.fname;
   (r, rm)
 
 and eq_offset (a: offset) (b: offset) ~(rename_mapping: rename_mapping) ~(acc: (typ * typ) list) : bool * rename_mapping = match a, b with

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -135,7 +135,7 @@ let check_arguments () =
     failwith "Option error"
   in
   let warn m = Logs.warn "%s" m in
-  if get_bool "allfuns" && not (get_bool "exp.earlyglobs") then (set_bool "exp.earlyglobs" true; warn "allfuns enables exp.earlyglobs.\n");
+  if get_bool "allfuns" && not (get_bool "exp.earlyglobs") then (set_bool "exp.earlyglobs" true; warn "allfuns enables exp.earlyglobs.");
   if not @@ List.mem "escape" @@ get_string_list "ana.activated" then warn "Without thread escape analysis, every local variable whose address is taken is considered escaped, i.e., global!";
   if List.mem "malloc_null" @@ get_string_list "ana.activated" && not @@ get_bool "sem.malloc.fail" then (set_bool "sem.malloc.fail" true; warn "The malloc_null analysis enables sem.malloc.fail.");
   if List.mem "memOutOfBounds" @@ get_string_list "ana.activated" && not @@ get_bool "cil.addNestedScopeAttr" then (set_bool "cil.addNestedScopeAttr" true; warn "The memOutOfBounds analysis enables cil.addNestedScopeAttr.");

--- a/src/solver/generic.ml
+++ b/src/solver/generic.ml
@@ -45,7 +45,7 @@ struct
   let increase (v:Var.t) =
     let set v c =
       if not full_trace && (c > start_c && c > !max_c && (Option.is_none !max_var || not (Var.equal (Option.get !max_var) v))) then begin
-        if tracing then trace "sol" "Switched tracing to %a\n" Var.pretty_trace v;
+        if tracing then trace "sol" "Switched tracing to %a" Var.pretty_trace v;
         max_c := c;
         max_var := Some v
       end
@@ -63,21 +63,21 @@ struct
 
   let new_var_event x =
     incr SolverStats.vars;
-    if tracing then trace "sol" "New %a\n" Var.pretty_trace x
+    if tracing then trace "sol" "New %a" Var.pretty_trace x
 
   let get_var_event x =
-    if full_trace then trace "sol" "Querying %a\n" Var.pretty_trace x
+    if full_trace then trace "sol" "Querying %a" Var.pretty_trace x
 
   let eval_rhs_event x =
-    if full_trace then trace "sol" "(Re-)evaluating %a\n" Var.pretty_trace x;
+    if full_trace then trace "sol" "(Re-)evaluating %a" Var.pretty_trace x;
     incr SolverStats.evals;
     if (get_bool "dbg.solver-progress") then (incr stack_d; Logs.debug "%d" !stack_d)
 
   let update_var_event x o n =
     if tracing then increase x;
     if full_trace || ((not (Dom.is_bot o)) && Option.is_some !max_var && Var.equal (Option.get !max_var) x) then begin
-      if tracing then tracei "sol_max" "(%d) Update to %a.\n" !max_c Var.pretty_trace x;
-      if tracing then traceu "sol_max" "%a\n\n" Dom.pretty_diff (n, o)
+      if tracing then tracei "sol_max" "(%d) Update to %a" !max_c Var.pretty_trace x;
+      if tracing then traceu "sol_max" "%a" Dom.pretty_diff (n, o)
     end
 
   (* solvers can assign this to print solver specific statistics using their data structures *)
@@ -296,7 +296,7 @@ module SoundBoxSolverImpl =
           H.remove infl x;
           H.replace infl x [x];
           if full_trace
-          then Messages.trace "sol" "Need to review %d deps.\n" (List.length deps); (* nosemgrep: trace-not-in-tracing *)
+          then Messages.trace "sol" "Need to review %d deps." (List.length deps); (* nosemgrep: trace-not-in-tracing *)
           (* solve all dependencies *)
           solve_all deps
         end

--- a/src/solver/generic.ml
+++ b/src/solver/generic.ml
@@ -66,10 +66,10 @@ struct
     if tracing then trace "sol" "New %a" Var.pretty_trace x
 
   let get_var_event x =
-    if full_trace then trace "sol" "Querying %a" Var.pretty_trace x
+    if tracing && full_trace then trace "sol" "Querying %a" Var.pretty_trace x
 
   let eval_rhs_event x =
-    if full_trace then trace "sol" "(Re-)evaluating %a" Var.pretty_trace x;
+    if tracing && full_trace then trace "sol" "(Re-)evaluating %a" Var.pretty_trace x;
     incr SolverStats.evals;
     if (get_bool "dbg.solver-progress") then (incr stack_d; Logs.debug "%d" !stack_d)
 
@@ -295,7 +295,7 @@ module SoundBoxSolverImpl =
           (* remove old influences of [x] -- they will be re-generated if still needed *)
           H.remove infl x;
           H.replace infl x [x];
-          if full_trace
+          if Messages.tracing && full_trace
           then Messages.trace "sol" "Need to review %d deps." (List.length deps); (* nosemgrep: trace-not-in-tracing *)
           (* solve all dependencies *)
           solve_all deps

--- a/src/solver/postSolver.ml
+++ b/src/solver/postSolver.ml
@@ -190,7 +190,7 @@ struct
 
     let reachable = PS.init_reachable ~vh in
     let rec one_var x =
-      if M.tracing then M.trace "postsolver" "one_var %a reachable=%B system=%B\n" S.Var.pretty_trace x (VH.mem reachable x) (Option.is_some (S.system x));
+      if M.tracing then M.trace "postsolver" "one_var %a reachable=%B system=%B" S.Var.pretty_trace x (VH.mem reachable x) (Option.is_some (S.system x));
       if not (VH.mem reachable x) then (
         VH.replace reachable x ();
         Option.may (one_constraint x) (S.system x)
@@ -201,13 +201,13 @@ struct
         try VH.find vh y with Not_found -> S.Dom.bot ()
       in
       let set y d =
-        if M.tracing then M.trace "postsolver" "one_side %a %a %a\n" S.Var.pretty_trace x S.Var.pretty_trace y S.Dom.pretty d;
+        if M.tracing then M.trace "postsolver" "one_side %a %a %a" S.Var.pretty_trace x S.Var.pretty_trace y S.Dom.pretty d;
         PS.one_side ~vh ~x ~y ~d;
         (* check before recursing *)
         one_var y
       in
       let rhs = f get set in
-      if M.tracing then M.trace "postsolver" "one_constraint %a %a\n" S.Var.pretty_trace x S.Dom.pretty rhs;
+      if M.tracing then M.trace "postsolver" "one_constraint %a %a" S.Var.pretty_trace x S.Dom.pretty rhs;
       PS.one_constraint ~vh ~x ~rhs
     in
     (Timing.wrap "postsolver_iter" (List.iter one_var)) vs;

--- a/src/solver/sLR.ml
+++ b/src/solver/sLR.ml
@@ -62,8 +62,8 @@ module SLR3 =
           let old = HM.find rho x in
           let tmp = eq x (eval x) (side x) in
           let tmp = S.Dom.join tmp (sides x) in
-          if tracing then trace "sol" "Var: %a\n" S.Var.pretty_trace x ;
-          if tracing then trace "sol" "Contrib:%a\n" S.Dom.pretty tmp;
+          if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
+          if tracing then trace "sol" "Contrib:%a" S.Dom.pretty tmp;
           let tmp =
             if wpx then
               if HM.mem globals x then S.Dom.widen old tmp
@@ -72,7 +72,7 @@ module SLR3 =
           in
           if not (S.Dom.equal old tmp) then begin
             update_var_event x old tmp;
-            if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty tmp;
+            if tracing then trace "sol" "New Value:%a" S.Dom.pretty tmp;
             HM.replace rho x tmp;
             let w = try HM.find infl x with Not_found -> VS.empty in
             let w = if wpx then VS.add x w else w in
@@ -401,11 +401,11 @@ module Make0 =
           let use_box = (not (V.ver>1)) || HM.mem wpoint x in
           let restart_mode_x = h_find_default restart_mode x (2*GobConfig.get_int "solvers.slr4.restart_count") in
           let rstrt = use_box && (V.ver>3) && D.leq tmp old && restart_mode_x <> 0 in
-          if tracing then trace "sol" "Var: %a\n" S.Var.pretty_trace x ;
-          if tracing then trace "sol" "Contrib:%a\n" S.Dom.pretty tmp;
+          if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
+          if tracing then trace "sol" "Contrib:%a" S.Dom.pretty tmp;
           let tmp = if use_box then box old tmp else tmp in
           if not (D.eq tmp old) then begin
-            if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty tmp;
+            if tracing then trace "sol" "New Value:%a" S.Dom.pretty tmp;
             let _ = X.set_value x tmp in
             if V.ver>3 && restart_mode_x mod 2 = 1 && not (D.leq tmp old) then
               HM.replace restart_mode x (restart_mode_x - 1);

--- a/src/solver/sLRphased.ml
+++ b/src/solver/sLRphased.ml
@@ -72,7 +72,7 @@ module Make =
         let effects = ref Set.empty in
         let side y d =
           assert (not (S.Dom.is_bot d));
-          if tracing then trace "sol" "SIDE: Var: %a\nVal: %a\n" S.Var.pretty_trace y S.Dom.pretty d;
+          if tracing then trace "sol" "SIDE: Var: %a\nVal: %a" S.Var.pretty_trace y S.Dom.pretty d;
           let first = not (Set.mem y !effects) in
           effects := Set.add y !effects;
           if first then (
@@ -83,7 +83,7 @@ module Make =
             if not (HM.mem rho y) then (
               if b then solve1 (HM.find key x - 1) ~side:true y else solve0 ~side:true y
             ) else (
-              (* trace "sol" "SIDE: Var: %a already exists with Prio: %i and Val: %a\n" S.Var.pretty_trace y (HM.find key y) S.Dom.pretty d; *)
+              (* trace "sol" "SIDE: Var: %a already exists with Prio: %i and Val: %a" S.Var.pretty_trace y (HM.find key y) S.Dom.pretty d; *)
               if HM.find key y < 0 then HM.replace key y (Ref.post_decr count_side)
             );
             q := H.add y !q
@@ -101,28 +101,28 @@ module Make =
         let tmp = eq x eval side in
         let tmp = S.Dom.join tmp (sides x) in
         (* if (b && not (S.Dom.leq old tmp)) then ( *)
-        (*   trace "sol" "Var: %a\nOld: %a\nTmp: %a\n" S.Var.pretty_trace x S.Dom.pretty old S.Dom.pretty tmp; *)
+        (*   trace "sol" "Var: %a\nOld: %a\nTmp: %a" S.Var.pretty_trace x S.Dom.pretty old S.Dom.pretty tmp; *)
         (*   assert false *)
         (* ); *)
         let val_new =
           if wpx then
             if b then
               let nar = narrow old tmp in
-              if tracing then trace "sol" "NARROW: Var: %a\nOld: %a\nNew: %a\nWiden: %a\n" S.Var.pretty_trace x S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty nar;
+              if tracing then trace "sol" "NARROW: Var: %a\nOld: %a\nNew: %a\nWiden: %a" S.Var.pretty_trace x S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty nar;
               nar
             else
               let wid = S.Dom.widen old (S.Dom.join old tmp) in
-              if tracing then trace "sol" "WIDEN: Var: %a\nOld: %a\nNew: %a\nWiden: %a\n" S.Var.pretty_trace x S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty wid;
+              if tracing then trace "sol" "WIDEN: Var: %a\nOld: %a\nNew: %a\nWiden: %a" S.Var.pretty_trace x S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty wid;
               wid
           else
             tmp
         in
-        if tracing then trace "sol" "Var: %a\n" S.Var.pretty_trace x ;
-        if tracing then trace "sol" "Contrib:%a\n" S.Dom.pretty val_new;
+        if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
+        if tracing then trace "sol" "Contrib:%a" S.Dom.pretty val_new;
         if S.Dom.equal old val_new then ()
         else begin
           update_var_event x old val_new;
-          if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty val_new;
+          if tracing then trace "sol" "New Value:%a" S.Dom.pretty val_new;
           HM.replace rho x val_new;
           let w = try HM.find infl x with Not_found -> VS.empty in
           (* let w = if wpx then VS.add x w else w in *)
@@ -162,7 +162,7 @@ module Make =
       and sides x =
         let w = try HM.find set x with Not_found -> VS.empty in
         let v = Enum.fold (fun d z -> try S.Dom.join d (HPM.find rho' (z,x)) with Not_found -> d) (S.Dom.bot ()) (VS.enum w)
-        in if tracing then trace "sol" "SIDES: Var: %a\nVal: %a\n" S.Var.pretty_trace x S.Dom.pretty v; v
+        in if tracing then trace "sol" "SIDES: Var: %a\nVal: %a" S.Var.pretty_trace x S.Dom.pretty v; v
       and eq x get set =
         eval_rhs_event x;
         match S.system x with

--- a/src/solver/sLRterm.ml
+++ b/src/solver/sLRterm.ml
@@ -63,14 +63,14 @@ module SLR3term =
           HM.replace rho  x (S.Dom.bot ());
           HM.replace infl x (VS.add x VS.empty);
           let c = if side then count_side else count in
-          if tracing then trace "sol" "INIT: Var: %a with prio %d\n" S.Var.pretty_trace x !c;
+          if tracing then trace "sol" "INIT: Var: %a with prio %d" S.Var.pretty_trace x !c;
           HM.replace key x !c; decr c
         end
       in
       let sides x =
         let w = try HM.find set x with Not_found -> VS.empty in
         let v = Enum.fold (fun d z -> try S.Dom.join d (HPM.find rho' (z,x)) with Not_found -> d) (S.Dom.bot ()) (VS.enum w) in
-        if tracing then trace "sol" "SIDES: Var: %a\nVal: %a\n" S.Var.pretty_trace x S.Dom.pretty v; v
+        if tracing then trace "sol" "SIDES: Var: %a\nVal: %a" S.Var.pretty_trace x S.Dom.pretty v; v
       in
       let rec iterate b_old prio =
         if H.size !q = 0 || min_key q > prio then ()
@@ -121,7 +121,7 @@ module SLR3term =
           )
           *)
           (* if S.Dom.is_bot d then print_endline "BOT" else *)
-          if tracing then trace "sol" "SIDE: Var: %a\nVal: %a\n" S.Var.pretty_trace y S.Dom.pretty d;
+          if tracing then trace "sol" "SIDE: Var: %a\nVal: %a" S.Var.pretty_trace y S.Dom.pretty d;
           let first = not (Set.mem y !effects) in
           effects := Set.add y !effects;
           if first then (
@@ -132,7 +132,7 @@ module SLR3term =
               ignore @@ do_var false y
               (* solve ~side:true y *)
             ) else (
-              (* trace "sol" "SIDE: Var: %a already exists with Prio: %i and Val: %a\n" S.Var.pretty_trace y (HM.find key y) S.Dom.pretty d; *)
+              (* trace "sol" "SIDE: Var: %a already exists with Prio: %i and Val: %a" S.Var.pretty_trace y (HM.find key y) S.Dom.pretty d; *)
               if HM.find key y < 0 then (
                 HM.replace key y (Ref.post_decr count_side);
                 q := rebuild !q
@@ -171,12 +171,12 @@ module SLR3term =
           else
             tmp, b_old
         in
-        if tracing then trace "sol" "Var: %a\n" S.Var.pretty_trace x ;
-        if tracing then trace "sol" "Contrib:%a\n" S.Dom.pretty val_new;
+        if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
+        if tracing then trace "sol" "Contrib:%a" S.Dom.pretty val_new;
         if S.Dom.equal old val_new then ()
         else begin
           update_var_event x old val_new;
-          if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty val_new;
+          if tracing then trace "sol" "New Value:%a" S.Dom.pretty val_new;
           HM.replace rho x val_new;
           let w = try HM.find infl x with Not_found -> VS.empty in
           (* let w = if wpx then VS.add x w else w in *)

--- a/src/solver/td3.ml
+++ b/src/solver/td3.ml
@@ -410,9 +410,9 @@ module Base =
         init y;
         (match x with None -> () | Some x -> if side_widen = "unstable_self" then add_infl x y);
         let widen a b =
-          if M.tracing then M.traceli "sol2" "side widen %a %a\n" S.Dom.pretty a S.Dom.pretty b;
+          if M.tracing then M.traceli "sol2" "side widen %a %a" S.Dom.pretty a S.Dom.pretty b;
           let r = S.Dom.widen a (S.Dom.join a b) in
-          if M.tracing then M.traceu "sol2" "-> %a\n" S.Dom.pretty r;
+          if M.tracing then M.traceu "sol2" "-> %a" S.Dom.pretty r;
           r
         in
         let old_sides = HM.find_default sides y VS.empty in
@@ -1120,7 +1120,7 @@ module DepVals: GenericEqIncrSolver =
             in
             match all_deps_unchanged with
             | Some oldv ->
-              if M.tracing then M.trace "sol2" "All deps unchanged for %a, not evaluating RHS\n" S.Var.pretty_trace x;
+              if M.tracing then M.trace "sol2" "All deps unchanged for %a, not evaluating RHS" S.Var.pretty_trace x;
               oldv
             | None ->
               (* This needs to be done here as a local wrapper around get to avoid polluting dep_vals during earlier checks *)

--- a/src/solver/topDown.ml
+++ b/src/solver/topDown.ml
@@ -32,7 +32,7 @@ module WP =
       let wpoint = HM.create  10 in
 
       let add_infl y x =
-        if tracing then trace "sol2" "add_infl %a %a\n" S.Var.pretty_trace y S.Var.pretty_trace x;
+        if tracing then trace "sol2" "add_infl %a %a" S.Var.pretty_trace y S.Var.pretty_trace x;
         HM.replace infl y (VS.add x (try HM.find infl y with Not_found -> VS.empty))
       in
       let add_set x y d =
@@ -42,15 +42,15 @@ module WP =
       in
       let is_side x = HM.mem set x in
       let rec destabilize x =
-        (* if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace x; *)
+        (* if tracing then trace "sol2" "destabilize %a" S.Var.pretty_trace x; *)
         let w = HM.find_default infl x VS.empty in
         HM.replace infl x VS.empty;
         VS.iter (fun y ->
           HM.remove stable y;
-          if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace y;
+          if tracing then trace "sol2" "destabilize %a" S.Var.pretty_trace y;
           if not (HM.mem called y) then destabilize y) w
       and solve x =
-        if tracing then trace "sol2" "solve %a, called: %b, stable: %b\n" S.Var.pretty_trace x (HM.mem called x) (HM.mem stable x);
+        if tracing then trace "sol2" "solve %a, called: %b, stable: %b" S.Var.pretty_trace x (HM.mem called x) (HM.mem stable x);
         if not (HM.mem called x || HM.mem stable x) then (
           HM.replace stable x ();
           HM.replace called x ();
@@ -59,22 +59,22 @@ module WP =
           let old = HM.find rho x in
           let tmp' = eq x (eval x) (side x) in
           let tmp = S.Dom.join tmp' (sides x) in
-          if tracing then trace "sol" "Var: %a\n" S.Var.pretty_trace x ;
-          if tracing then trace "sol" "Contrib:%a\n" S.Dom.pretty tmp;
+          if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
+          if tracing then trace "sol" "Contrib:%a" S.Dom.pretty tmp;
           let tmp = if is_side x then S.Dom.widen old (S.Dom.join old tmp) else if wpx then box old tmp else tmp in
           HM.remove called x;
           if not (S.Dom.equal old tmp) then (
-            if tracing then if is_side x then trace "sol2" "solve side: old = %a, tmp = %a, widen = %a\n" S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty (S.Dom.widen old (S.Dom.join old tmp));
+            if tracing then if is_side x then trace "sol2" "solve side: old = %a, tmp = %a, widen = %a" S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty (S.Dom.widen old (S.Dom.join old tmp));
             update_var_event x old tmp;
-            if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty tmp;
-            if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) is %a. Old value was %a\n" S.Var.pretty_trace x (HM.mem rho x) (is_side x) S.Dom.pretty tmp S.Dom.pretty old;
+            if tracing then trace "sol" "New Value:%a" S.Dom.pretty tmp;
+            if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) is %a. Old value was %a" S.Var.pretty_trace x (HM.mem rho x) (is_side x) S.Dom.pretty tmp S.Dom.pretty old;
             HM.replace rho x tmp;
             destabilize x;
           );
           (solve[@tailcall]) x
         )
       and eq x get set =
-        if tracing then trace "sol2" "eq %a\n" S.Var.pretty_trace x;
+        if tracing then trace "sol2" "eq %a" S.Var.pretty_trace x;
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
@@ -89,7 +89,7 @@ module WP =
           in
           f get sidef
       and eval x y =
-        if tracing then trace "sol2" "eval %a ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y;
+        if tracing then trace "sol2" "eval %a ## %a" S.Var.pretty_trace x S.Var.pretty_trace y;
         get_var_event y;
         if HM.mem called y || S.system y = None then HM.replace wpoint y ();
         solve y;
@@ -97,11 +97,11 @@ module WP =
         HM.find rho y
       and sides x =
         let w = try HM.find set x with Not_found -> VS.empty in
-        let d = Enum.fold (fun d y -> let r = try S.Dom.join d (HPM.find rho' (y,x)) with Not_found -> d in if tracing then trace "sol2" "sides: side %a from %a: %a\n" S.Var.pretty_trace x S.Var.pretty_trace y S.Dom.pretty r; r) (S.Dom.bot ()) (VS.enum w) in
-        if tracing then trace "sol2" "sides %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
+        let d = Enum.fold (fun d y -> let r = try S.Dom.join d (HPM.find rho' (y,x)) with Not_found -> d in if tracing then trace "sol2" "sides: side %a from %a: %a" S.Var.pretty_trace x S.Var.pretty_trace y S.Dom.pretty r; r) (S.Dom.bot ()) (VS.enum w) in
+        if tracing then trace "sol2" "sides %a ## %a" S.Var.pretty_trace x S.Dom.pretty d;
         d
       and side x y d =
-        if tracing then trace "sol2" "side %a ## %a (wpx: %b) ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y (HM.mem rho y) S.Dom.pretty d;
+        if tracing then trace "sol2" "side %a ## %a (wpx: %b) ## %a" S.Var.pretty_trace x S.Var.pretty_trace y (HM.mem rho y) S.Dom.pretty d;
         let old = try HPM.find rho' (x,y) with Not_found -> S.Dom.bot () in
         if not (S.Dom.equal old d) then (
           add_set x y (S.Dom.join old d);
@@ -109,7 +109,7 @@ module WP =
           solve y;
         )
       and init x =
-        if tracing then trace "sol2" "init %a\n" S.Var.pretty_trace x;
+        if tracing then trace "sol2" "init %a" S.Var.pretty_trace x;
         if not (HM.mem rho x) then (
           new_var_event x;
           HM.replace rho  x (S.Dom.bot ())
@@ -117,7 +117,7 @@ module WP =
       in
 
       let set_start (x,d) =
-        if tracing then trace "sol2" "set_start %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
+        if tracing then trace "sol2" "set_start %a ## %a" S.Var.pretty_trace x S.Dom.pretty d;
         init x;
         add_set x x d;
         solve x
@@ -134,7 +134,7 @@ module WP =
         let gs = keys sidevs in
         HM.clear sidevs;
         if gs <> [] then (
-          if tracing then trace "sol2" "Round %d: %d side-effected variables to solve\n" !n (List.length gs);
+          if tracing then trace "sol2" "Round %d: %d side-effected variables to solve" !n (List.length gs);
           incr n;
           List.iter solve gs;
           List.iter solve vs;

--- a/src/solver/topDown_deprecated.ml
+++ b/src/solver/topDown_deprecated.ml
@@ -38,16 +38,16 @@ module TD3 =
       let add_set x y d = HM.replace set y (VS.add x (try HM.find set y with Not_found -> VS.empty)); HPM.add rho' (x,y) d; HM.add sidevs y () in
       let is_side x = HM.mem set x in
       let make_wpoint x =
-        if tracing then trace "sol2" "make_wpoint %a\n" S.Var.pretty_trace x;
+        if tracing then trace "sol2" "make_wpoint %a" S.Var.pretty_trace x;
         HM.replace wpoint x ()
       in
       let rec destabilize x =
-        if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace x;
+        if tracing then trace "sol2" "destabilize %a" S.Var.pretty_trace x;
         let t = HM.find_default infl x VS.empty in
         HM.replace infl x VS.empty;
         VS.iter (fun y -> HM.remove stable y; if not (HM.mem called y) then destabilize y) t
       and solve x =
-        if tracing then trace "sol2" "solve %a, called: %b, stable: %b\n" S.Var.pretty_trace x (HM.mem called x) (HM.mem stable x);
+        if tracing then trace "sol2" "solve %a, called: %b, stable: %b" S.Var.pretty_trace x (HM.mem called x) (HM.mem stable x);
         if not (HM.mem called x || HM.mem stable x) then begin
           HM.replace called x ();
           let wpx = HM.mem wpoint x in
@@ -56,21 +56,21 @@ module TD3 =
           let old = HM.find rho x in
           let tmp = eq x (eval x) (side x) in
           let tmp = S.Dom.join tmp (sides x) in
-          if tracing then trace "sol" "Var: %a\n" S.Var.pretty_trace x ;
-          if tracing then trace "sol" "Contrib:%a\n" S.Dom.pretty tmp;
+          if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
+          if tracing then trace "sol" "Contrib:%a" S.Dom.pretty tmp;
           let tmp = if is_side x then S.Dom.widen old (S.Dom.join old tmp) else if wpx then box old tmp else tmp in
           HM.remove called x;
           if not (S.Dom.equal old tmp) then begin
             update_var_event x old tmp;
-            if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty tmp;
-            if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) is %a. Old value was %a\n" S.Var.pretty_trace x wpx (is_side x) S.Dom.pretty tmp S.Dom.pretty old;
+            if tracing then trace "sol" "New Value:%a" S.Dom.pretty tmp;
+            if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) is %a. Old value was %a" S.Var.pretty_trace x wpx (is_side x) S.Dom.pretty tmp S.Dom.pretty old;
             HM.replace rho x tmp;
             destabilize x;
             (solve[@tailcall]) x;
           end;
         end;
       and eq x get set =
-        if tracing then trace "sol2" "eq %a\n" S.Var.pretty_trace x;
+        if tracing then trace "sol2" "eq %a" S.Var.pretty_trace x;
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
@@ -85,7 +85,7 @@ module TD3 =
           in
           f get sidef
       and eval x y =
-        if tracing then trace "sol2" "eval %a ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y;
+        if tracing then trace "sol2" "eval %a ## %a" S.Var.pretty_trace x S.Var.pretty_trace y;
         get_var_event y;
         if not (HM.mem rho y) then init y;
         if HM.mem called y then make_wpoint y else if neg is_side y then solve y;
@@ -94,11 +94,11 @@ module TD3 =
       and sides x =
         let w = try HM.find set x with Not_found -> VS.empty in
         let d = Enum.fold (fun d z -> try S.Dom.join d (HPM.find rho' (z,x)) with Not_found -> d) (S.Dom.bot ()) (VS.enum w) in
-        if tracing then trace "sol2" "sides %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
+        if tracing then trace "sol2" "sides %a ## %a" S.Var.pretty_trace x S.Dom.pretty d;
         d
       and side x y d =
         if S.Dom.is_bot d then () else
-        if tracing then trace "sol2" "side %a ## %a (wpx: %b) ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y (HM.mem wpoint y) S.Dom.pretty d;
+        if tracing then trace "sol2" "side %a ## %a (wpx: %b) ## %a" S.Var.pretty_trace x S.Var.pretty_trace y (HM.mem wpoint y) S.Dom.pretty d;
         if not (HM.mem rho y) then begin
           init y;
           add_set x y d;
@@ -115,7 +115,7 @@ module TD3 =
           end
         end
       and init x =
-        if tracing then trace "sol2" "init %a\n" S.Var.pretty_trace x;
+        if tracing then trace "sol2" "init %a" S.Var.pretty_trace x;
         if not (HM.mem rho x) then begin
           new_var_event x;
           HM.replace rho  x (S.Dom.bot ());
@@ -124,7 +124,7 @@ module TD3 =
       in
 
       let set_start (x,d) =
-        if tracing then trace "sol2" "set_start %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
+        if tracing then trace "sol2" "set_start %a ## %a" S.Var.pretty_trace x S.Dom.pretty d;
         init x;
         add_set x x d;
         solve x

--- a/src/solver/topDown_term.ml
+++ b/src/solver/topDown_term.ml
@@ -29,19 +29,19 @@ module WP =
       let wpoint = HM.create  10 in
 
       let add_infl y x =
-        if tracing then trace "sol2" "add_infl %a %a\n" S.Var.pretty_trace y S.Var.pretty_trace x;
+        if tracing then trace "sol2" "add_infl %a %a" S.Var.pretty_trace y S.Var.pretty_trace x;
         HM.replace infl y (VS.add x (try HM.find infl y with Not_found -> VS.empty))
       in
       let rec destabilize x =
-        if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace x;
+        if tracing then trace "sol2" "destabilize %a" S.Var.pretty_trace x;
         let w = HM.find_default infl x VS.empty in
         HM.replace infl x VS.empty;
         VS.iter (fun y ->
           HM.remove stable y;
-          (* if tracing then trace "sol2" "destabilize %a\n" S.Var.pretty_trace y; *)
+          (* if tracing then trace "sol2" "destabilize %a" S.Var.pretty_trace y; *)
           if not (HM.mem called y) then destabilize y) w
       and solve x phase =
-        if tracing then trace "sol2" "solve %a, called: %b, stable: %b\n" S.Var.pretty_trace x (HM.mem called x) (HM.mem stable x);
+        if tracing then trace "sol2" "solve %a, called: %b, stable: %b" S.Var.pretty_trace x (HM.mem called x) (HM.mem stable x);
         if not (HM.mem called x || HM.mem stable x) then (
           HM.replace stable x ();
           HM.replace called x ();
@@ -50,15 +50,15 @@ module WP =
           let old = HM.find rho x in
           let tmp = eq x (eval x) side in
           let tmp = S.Dom.join tmp (try HM.find rho' x with Not_found -> S.Dom.bot ()) in
-          if tracing then trace "sol" "Var: %a\n" S.Var.pretty_trace x ;
-          if tracing then trace "sol" "Contrib:%a\n" S.Dom.pretty tmp;
+          if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
+          if tracing then trace "sol" "Contrib:%a" S.Dom.pretty tmp;
           HM.remove called x;
           let tmp = if wpx then match phase with Widen -> S.Dom.widen old (S.Dom.join old tmp) | Narrow -> S.Dom.narrow old tmp else tmp in
           if not (S.Dom.equal old tmp) then (
-            (* if tracing then if is_side x then trace "sol2" "solve side: old = %a, tmp = %a, widen = %a\n" S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty (S.Dom.widen old (S.Dom.join old tmp)); *)
+            (* if tracing then if is_side x then trace "sol2" "solve side: old = %a, tmp = %a, widen = %a" S.Dom.pretty old S.Dom.pretty tmp S.Dom.pretty (S.Dom.widen old (S.Dom.join old tmp)); *)
             update_var_event x old tmp;
-            if tracing then trace "sol" "New Value:%a\n\n" S.Dom.pretty tmp;
-            (* if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) is %a. Old value was %a\n" S.Var.pretty_trace x (HM.mem rho x) (is_side x) S.Dom.pretty tmp S.Dom.pretty old; *)
+            if tracing then trace "sol" "New Value:%a" S.Dom.pretty tmp;
+            (* if tracing then trace "sol2" "new value for %a (wpx: %b, is_side: %b) is %a. Old value was %a" S.Var.pretty_trace x (HM.mem rho x) (is_side x) S.Dom.pretty tmp S.Dom.pretty old; *)
             HM.replace rho x tmp;
             destabilize x;
             (solve[@tailcall]) x phase;
@@ -70,13 +70,13 @@ module WP =
           );
         )
       and eq x get set =
-        if tracing then trace "sol2" "eq %a\n" S.Var.pretty_trace x;
+        if tracing then trace "sol2" "eq %a" S.Var.pretty_trace x;
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
         | Some f -> f get set
       and eval x y =
-        if tracing then trace "sol2" "eval %a ## %a\n" S.Var.pretty_trace x S.Var.pretty_trace y;
+        if tracing then trace "sol2" "eval %a ## %a" S.Var.pretty_trace x S.Var.pretty_trace y;
         get_var_event y;
         if HM.mem called y then HM.replace wpoint y ();
         solve y Widen;
@@ -91,7 +91,7 @@ module WP =
           solve y Widen;
         )
       and init x =
-        if tracing then trace "sol2" "init %a\n" S.Var.pretty_trace x;
+        if tracing then trace "sol2" "init %a" S.Var.pretty_trace x;
         if not (HM.mem rho x) then (
           new_var_event x;
           HM.replace rho  x (S.Dom.bot ())
@@ -99,7 +99,7 @@ module WP =
       in
 
       let set_start (x,d) =
-        if tracing then trace "sol2" "set_start %a ## %a\n" S.Var.pretty_trace x S.Dom.pretty d;
+        if tracing then trace "sol2" "set_start %a ## %a" S.Var.pretty_trace x S.Dom.pretty d;
         init x;
         HM.replace rho x d;
         solve x Widen

--- a/src/util/tracing/goblint_tracing.ml
+++ b/src/util/tracing/goblint_tracing.ml
@@ -39,7 +39,7 @@ let traceTag (sys : string) : Pretty.doc =
   (text ((ind !indent_level) ^ "%%% " ^ sys ^ ": "))
 
 let printtrace sys d: unit =
-  fprint stderr ~width:max_int ((traceTag sys) ++ d);
+  fprint stderr ~width:max_int ((traceTag sys) ++ d ++ line);
   flush stderr
 
 let gtrace always f sys var ?loc do_subsys fmt =

--- a/src/witness/argTools.ml
+++ b/src/witness/argTools.ml
@@ -124,7 +124,7 @@ struct
               (* Exclude accumulated prevs, which were pruned *)
               if NHT.mem vars prev_lvar then (
                 let lvar' = (fst lvar, snd lvar, i) in
-                if M.tracing then M.trace "witness" "%s -( %a )-> %s\n" (Node.to_string prev_lvar) MyARG.pretty_inline_edge edge (Node.to_string lvar');
+                if M.tracing then M.trace "witness" "%s -( %a )-> %s" (Node.to_string prev_lvar) MyARG.pretty_inline_edge edge (Node.to_string lvar');
                 NHT.modify_def [] lvar' (fun prevs -> (edge, prev_lvar) :: prevs) prev;
                 NHT.modify_def [] prev_lvar (fun nexts -> (edge, lvar') :: nexts) next
               )

--- a/src/witness/witness.ml
+++ b/src/witness/witness.ml
@@ -229,7 +229,7 @@ let write_file filename (module Task:Task) (module TaskResult:WitnessTaskResult)
       NH.add itered_nodes node ();
       write_node node;
       let is_sink = TaskResult.is_violation node || TaskResult.is_sink node in
-      if M.tracing then M.tracei "witness" "iter_node %s\n" (N.to_string node);
+      if M.tracing then M.tracei "witness" "iter_node %s" (N.to_string node);
       if not is_sink then begin
         let edge_to_nodes =
           Arg.next node
@@ -250,17 +250,17 @@ let write_file filename (module Task:Task) (module TaskResult:WitnessTaskResult)
           |> BatList.unique_cmp ~cmp:[%ord: MyARG.inline_edge * N.t]
         in
         List.iter (fun (edge, to_node) ->
-            if M.tracing then M.tracec "witness" "edge %a to_node %s\n" MyARG.pretty_inline_edge edge (N.to_string to_node);
+            if M.tracing then M.tracec "witness" "edge %a to_node %s" MyARG.pretty_inline_edge edge (N.to_string to_node);
             write_node to_node;
             write_edge node edge to_node
           ) edge_to_nodes;
-        if M.tracing then M.traceu "witness" "iter_node %s\n" (N.to_string node);
+        if M.tracing then M.traceu "witness" "iter_node %s" (N.to_string node);
         List.iter (fun (edge, to_node) ->
             iter_node to_node
           ) edge_to_nodes
       end
       else
-      if M.tracing then M.traceu "witness" "iter_node %s\n" (N.to_string node);
+      if M.tracing then M.traceu "witness" "iter_node %s" (N.to_string node);
     end
   in
 

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -230,7 +230,7 @@ struct
               if M.tracing then M.tracec "witness" "j = %a" Spec.D.pretty j;
               f (I.to_int x) (n, Obj.repr c, I.to_int j) e
             ) r;
-          if M.tracing then M.traceu "witness" ""
+          if M.tracing then M.traceu "witness" "" (* unindent! *)
         ) (fst ctx.local);
       (* check that sync mappings don't leak into solution (except Function) *)
       (* TODO: disabled because we now use and leave Sync for every tf,

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -221,16 +221,16 @@ struct
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     match q with
     | Queries.IterPrevVars f ->
-      if M.tracing then M.tracei "witness" "IterPrevVars\n";
+      if M.tracing then M.tracei "witness" "IterPrevVars";
       Dom.iter (fun x r ->
-          if M.tracing then M.tracei "witness" "x = %a\n" Spec.D.pretty x;
+          if M.tracing then M.tracei "witness" "x = %a" Spec.D.pretty x;
           R.iter (function ((n, c, j), e) ->
-              if M.tracing then M.tracec "witness" "n = %a\n" Node.pretty_plain n;
-              if M.tracing then M.tracec "witness" "c = %a\n" Spec.C.pretty c;
-              if M.tracing then M.tracec "witness" "j = %a\n" Spec.D.pretty j;
+              if M.tracing then M.tracec "witness" "n = %a" Node.pretty_plain n;
+              if M.tracing then M.tracec "witness" "c = %a" Spec.C.pretty c;
+              if M.tracing then M.tracec "witness" "j = %a" Spec.D.pretty j;
               f (I.to_int x) (n, Obj.repr c, I.to_int j) e
             ) r;
-          if M.tracing then M.traceu "witness" "\n"
+          if M.tracing then M.traceu "witness" ""
         ) (fst ctx.local);
       (* check that sync mappings don't leak into solution (except Function) *)
       (* TODO: disabled because we now use and leave Sync for every tf,
@@ -239,7 +239,7 @@ struct
            | Function _ -> () (* returns post-sync in FromSpec *)
            | _ -> assert (Sync.is_bot (snd ctx.local));
          end; *)
-      if M.tracing then M.traceu "witness" "\n";
+      if M.tracing then M.traceu "witness" "";
       ()
     | Queries.IterVars f ->
       Dom.iter (fun x r ->


### PR DESCRIPTION
It has always been annoying that every trace call must include a trailing newline in its format string. Otherwise trace output becomes unusable because multiple steps are printed on the same line.
We can just have the tracing module itself add the newline, just like how it adds the `%%%` prefix with indentation.

While adapting all trace calls, I found a couple in central parts of base analysis which weren't guarded by `if M.tracing then`.

### TODO
- [x] Update documentation