### PR TITLE
Use ppx_deriving_hash 0.1.2

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -30,7 +30,7 @@
     (yojson (>= 2.0.0))
     (qcheck-core (>= 0.19))
     ppx_deriving
-    ppx_deriving_hash
+    (ppx_deriving_hash (>= 0.1.2))
     (ppx_deriving_yojson (>= 3.7.0))
     (ounit2 :with-test)
     (qcheck-ounit :with-test)

--- a/goblint.opam
+++ b/goblint.opam
@@ -28,7 +28,7 @@ depends: [
   "yojson" {>= "2.0.0"}
   "qcheck-core" {>= "0.19"}
   "ppx_deriving"
-  "ppx_deriving_hash"
+  "ppx_deriving_hash" {>= "0.1.2"}
   "ppx_deriving_yojson" {>= "3.7.0"}
   "ounit2" {with-test}
   "qcheck-ounit" {with-test}

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -82,7 +82,7 @@ depends: [
   "pp" {= "1.1.2"}
   "ppx_derivers" {= "1.2.1"}
   "ppx_deriving" {= "5.2.1"}
-  "ppx_deriving_hash" {= "0.1.1"}
+  "ppx_deriving_hash" {= "0.1.2"}
   "ppx_deriving_yojson" {= "3.7.0"}
   "ppxlib" {= "0.28.0"}
   "qcheck-core" {= "0.20"}

--- a/src/cdomains/vectorMatrix.ml
+++ b/src/cdomains/vectorMatrix.ml
@@ -209,8 +209,7 @@ module ArrayVector: AbstractVector =
   struct
     include ConvenienceOps (A)
     include Array
-    type t = A.t array [@@deriving eq, ord]
-    let hash = Array.fold_left (fun acc a -> 31 * acc + A.hash a) 0 (* TODO: array in ppx_deriving_hash *)
+    type t = A.t array [@@deriving eq, ord, hash]
 
     let show t =
       let t = Array.to_list t in

--- a/src/cdomains/vectorMatrix.ml
+++ b/src/cdomains/vectorMatrix.ml
@@ -287,9 +287,7 @@ module ArrayMatrix: AbstractMatrix =
     include ConvenienceOps(A)
     module V = V(A)
 
-    type t = A.t array array [@@deriving eq, ord]
-
-    let hash = Array.fold_left (Array.fold_left (fun acc a -> 31 * acc + A.hash a)) 0
+    type t = A.t array array [@@deriving eq, ord, hash]
 
     let show x =
       Array.fold_left (^) "" (Array.map (fun v -> V.show @@ V.of_array v) x)

--- a/src/common/cdomains/floatOps/floatOps.ml
+++ b/src/common/cdomains/floatOps/floatOps.ml
@@ -49,7 +49,7 @@ let big_int_of_float f =
     (Z.pow (Z.of_int 2) (n - shift))
 
 module CDouble = struct
-  type t = float [@@deriving eq, ord, to_yojson]
+  type t = float [@@deriving eq, ord, hash, to_yojson]
 
   let name = "double"
   let zero = Float.zero
@@ -65,7 +65,6 @@ module CDouble = struct
   let pred = Float.pred
   let succ = Float.succ
 
-  let hash = Hashtbl.hash
   let to_string = Float.to_string
 
   let neg = Float.neg
@@ -82,7 +81,7 @@ module CDouble = struct
 end
 
 module CFloat = struct
-  type t = float [@@deriving eq, ord, to_yojson]
+  type t = float [@@deriving eq, ord, hash, to_yojson]
 
   let name = "float"
   let zero = Float.zero
@@ -99,7 +98,6 @@ module CFloat = struct
 
   let is_finite x = Float.is_finite x && x >= lower_bound && x <= upper_bound
 
-  let hash = Hashtbl.hash
   let to_string = Float.to_string
 
   let neg = Float.neg

--- a/src/common/util/cilType.ml
+++ b/src/common/util/cilType.ml
@@ -13,9 +13,6 @@ struct
   include Printable.StdLeaf
 end
 
-let hash_float = Hashtbl.hash (* TODO: float hash in ppx_deriving_hash *)
-let hash_ref hash r = hash !r (* TODO: ref in ppx_deriving_hash *)
-
 
 module Location:
 sig

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -52,11 +52,10 @@ type maybepublic = {global: CilType.Varinfo.t; write: bool; protection: Protecti
 type maybepublicwithout = {global: CilType.Varinfo.t; write: bool; without_mutex: PreValueDomain.Addr.t; protection: Protection.t} [@@deriving ord, hash]
 type mustbeprotectedby = {mutex: PreValueDomain.Addr.t; global: CilType.Varinfo.t; write: bool; protection: Protection.t} [@@deriving ord, hash]
 type mustprotectedvars = {mutex: PreValueDomain.Addr.t; write: bool} [@@deriving ord, hash]
-type memory_access = {exp: CilType.Exp.t; var_opt: CilType.Varinfo.t option; kind: AccessKind.t} [@@deriving ord, hash]
 type access =
-  | Memory of memory_access (** Memory location access (race). *)
+  | Memory of {exp: CilType.Exp.t; var_opt: CilType.Varinfo.t option; kind: AccessKind.t} (** Memory location access (race). *)
   | Point (** Program point and state access (MHP), independent of memory location. *)
-[@@deriving ord, hash] (* TODO: fix ppx_deriving_hash on variant with inline record *)
+[@@deriving ord, hash]
 type invariant_context = Invariant.context = {
   path: int option;
   lvals: Lval.Set.t;


### PR DESCRIPTION
This gets rid of some ppx_deriving_hash related TODOs by using a version of it which includes their support.