### PR TITLE
Avoid base invariant fallback not understood message on reflexive pointer literal equality

### DIFF
--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -237,7 +237,7 @@ struct
     | `Refine (lval, value) ->
       refine_lv_fallback ctx st lval value tv
     | `NothingToRefine ->
-      if M.tracing then M.traceu "invariant" "Doing to refine.\n";
+      if M.tracing then M.traceu "invariant" "Nothing to refine.\n";
       st
     | `NotUnderstood ->
       if M.tracing then M.traceu "invariant" "Doing nothing.\n";


### PR DESCRIPTION
Closes #1374.

The fix is uglier than I imagined it to be because address set refinement happens in `invariant_fallback`, not in the general `inv_exp`, so it doesn't simply fall into the existing
https://github.com/goblint/analyzer/blob/da91765f030b3583606e50ad21b0d0b336c52fc7/src/analyses/baseInvariant.ml#L775

A less ugly fix would be to make `inv_exp` also do addresses with HC4-revise, but that requires carefully porting all the ancient fallback logic with countless edge cases.