### PR TITLE
Ego-Lane-Derived-Digests for Privatizations: `ProtectionBasedTIDPriv`

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1243,7 +1243,7 @@ struct
       (* TODO: account for single-threaded values without earlyglobs. *)
       match g with
       | `Left g' -> (* priv *)
-        Priv.invariant_global (priv_getg ctx.global) g'
+        Priv.invariant_global (Analyses.ask_of_ctx ctx) (priv_getg ctx.global) g'
       | `Right _ -> (* thread return *)
         Invariant.none
     )

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -662,17 +662,15 @@ end
 module type ProtectionBasedWrapper =
 sig
   module G: Lattice.S
-  module V: module type of (ProtectionBasedV.V)
 
-  val getg: Q.ask -> (V.t -> G.t)  -> V.t -> VD.t
-  val sideg: Q.ask -> (V.t -> G.t -> unit) -> V.t -> VD.t -> unit
+  val getg: Q.ask -> (ProtectionBasedV.V.t -> G.t) -> ProtectionBasedV.V.t -> VD.t
+  val sideg: Q.ask -> (ProtectionBasedV.V.t -> G.t -> unit) -> ProtectionBasedV.V.t -> VD.t -> unit
 end
 
 
 module NoWrapper: ProtectionBasedWrapper =
 struct
   module G = VD
-  module V = ProtectionBasedV.V
 
   let getg _ getg = getg
   let sideg _ sideg = sideg
@@ -680,7 +678,6 @@ end
 
 module DigestWrapper(Digest: Digest): ProtectionBasedWrapper = struct
   module G = MapDomain.MapBot_LiftTop (Digest) (VD)
-  module V = ProtectionBasedV.V
 
   let getg ask getg x =
     let vs = getg x in

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -1842,6 +1842,7 @@ let priv_module: (module S) Lazy.t =
         | "protection-tid" -> (module ProtectionBasedPrivWrapper (struct let check_read_unprotected = false let handle_atomic = false end)(DigestWrapper(ThreadNotStartedDigest)))
         | "protection-atomic" -> (module ProtectionBasedPrivWrapper (struct let check_read_unprotected = false let handle_atomic = true end)(NoWrapper)) (* experimental *)
         | "protection-read" -> (module ProtectionBasedPrivWrapper (struct let check_read_unprotected = true let handle_atomic = false end)(NoWrapper))
+        | "protection-read-tid" -> (module ProtectionBasedPrivWrapper (struct let check_read_unprotected = true let handle_atomic = false end)(DigestWrapper(ThreadNotStartedDigest)))
         | "protection-read-atomic" -> (module ProtectionBasedPrivWrapper (struct let check_read_unprotected = true let handle_atomic = true end)(NoWrapper)) (* experimental *)
         | "mine" -> (module MinePriv)
         | "mine-nothread" -> (module MineNoThreadPriv)

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -42,7 +42,7 @@ sig
   val thread_join: ?force:bool -> Q.ask -> (V.t -> G.t) -> Cil.exp -> BaseComponents (D).t -> BaseComponents (D).t
   val thread_return: Q.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> ThreadIdDomain.Thread.t -> BaseComponents (D).t -> BaseComponents (D).t
 
-  val invariant_global: (V.t -> G.t) -> V.t -> Invariant.t
+  val invariant_global: Q.ask -> (V.t -> G.t) -> V.t -> Invariant.t
   val invariant_vars: Q.ask -> (V.t -> G.t) -> BaseComponents (D).t -> varinfo list
 
   val init: unit -> unit
@@ -131,7 +131,7 @@ struct
   let thread_join ?(force=false) ask get e st = st
   let thread_return ask get set tid st = st
 
-  let invariant_global getg g =
+  let invariant_global ask getg g =
     ValueDomain.invariant_global getg g
 
   let invariant_vars ask getg st = []
@@ -211,7 +211,7 @@ struct
   let thread_join ?(force=false) ask get e st = st
   let thread_return ask get set tid st = st
 
-  let invariant_global getg = function
+  let invariant_global ask getg = function
     | `Right g' -> (* global *)
       ValueDomain.invariant_global (read_unprotected_global getg) g'
     | _ -> (* mutex *)
@@ -621,7 +621,7 @@ struct
     let get_mutex_inits' = CPA.find x get_mutex_inits in
     VD.join get_mutex_global_x' get_mutex_inits'
 
-  let invariant_global getg = function
+  let invariant_global ask getg = function
     | `Middle  g -> (* global *)
       ValueDomain.invariant_global (read_unprotected_global getg) g
     | `Left _
@@ -825,12 +825,13 @@ struct
       vf (V.protected g);
     | _ -> ()
 
-  let invariant_global getg g = Invariant.none
-  (* match g with
-     | `Left g' -> (* unprotected *)
-     ValueDomain.invariant_global (fun g -> getg (V.unprotected g)) g'
-     | `Right g -> (* protected *)
-     Invariant.none *)
+  let invariant_global ask getg g =
+    let getg = Wrapper.getg ask getg in
+    match g with
+    | `Left g' -> (* unprotected *)
+      ValueDomain.invariant_global (fun g -> getg (V.unprotected g)) g'
+    | `Right g -> (* protected *)
+      Invariant.none
 
   let invariant_vars ask getg st = protected_vars ask
 end
@@ -889,7 +890,7 @@ struct
 
   open Locksets
 
-  let invariant_global getg = function
+  let invariant_global ask getg = function
     | `Right g' -> (* global *)
       ValueDomain.invariant_global (fun x ->
           GWeak.fold (fun s' tm acc ->
@@ -1681,7 +1682,7 @@ struct
   let threadenter ask st = time "threadenter" (Priv.threadenter ask) st
   let threadspawn ask get set st = time "threadspawn" (Priv.threadspawn ask get set) st
   let iter_sys_vars getg vq vf = time "iter_sys_vars" (Priv.iter_sys_vars getg vq) vf
-  let invariant_global getg v = time "invariant_global" (Priv.invariant_global getg) v
+  let invariant_global ask getg v = time "invariant_global" (Priv.invariant_global ask getg) v
   let invariant_vars ask getg st = time "invariant_vars" (Priv.invariant_vars ask getg) st
 
   let thread_join ?(force=false) ask get e st = time "thread_join" (Priv.thread_join ~force ask get e) st

--- a/src/analyses/basePriv.mli
+++ b/src/analyses/basePriv.mli
@@ -31,7 +31,7 @@ sig
   val thread_join: ?force:bool -> Queries.ask -> (V.t -> G.t) -> Cil.exp -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t
   val thread_return: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> ThreadIdDomain.Thread.t -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t
 
-  val invariant_global: (V.t -> G.t) -> V.t -> Invariant.t
+  val invariant_global: Queries.ask -> (V.t -> G.t) -> V.t -> Invariant.t
   (** Provides [Queries.InvariantGlobal] result for base.
 
       Should account for all unprotected/weak values of global variables. *)

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -174,6 +174,9 @@ sig
   val accounted_for: Q.ask -> current:t -> other:t -> bool
 end
 
+(** Digest to be be used for analyses that account for all join-local contributions in some locally tracked datastructure, akin to the L component from the analyses in
+    @see <https://doi.org/10.1007/978-3-031-30044-8_2> Schwarz, M., Saan, S., Seidl, H., Erhard, J., Vojdani, V. Clustered Relational Thread-Modular Abstract Interpretation with Local Traces.
+*)
 module ThreadDigest: Digest =
 struct
   include ThreadIdDomain.ThreadLifted
@@ -197,6 +200,9 @@ struct
     | _ -> false
 end
 
+(** Ego-Lane Derived digest based on whether given threads have been started yet, can be used to refine any analysis
+    @see PhD thesis of M. Schwarz once it is published ;)
+*)
 module ThreadNotStartedDigest:Digest =
 struct
   include ThreadIdDomain.ThreadLifted

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -209,11 +209,7 @@ struct
   let accounted_for (ask: Q.ask) ~(current: t) ~(other: t) =
     match current, other with
     | `Lifted current, `Lifted other ->
-      if TID.is_unique current && TID.equal current other then
-        (* workaround `definitely_not_started` answers false when passing the same argument twice, TID.is_must_parent [main] [main] says true  *)
-        false
-      else
-        MHP.definitely_not_started (current, ask.f Q.CreatedThreads) other
+      MHP.definitely_not_started (current, ask.f Q.CreatedThreads) other
     | _ -> false
 end
 

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -174,7 +174,7 @@ sig
   val accounted_for: Q.ask -> current:t -> other:t -> bool
 end
 
-(** Digest to be be used for analyses that account for all join-local contributions in some locally tracked datastructure, akin to the L component from the analyses in
+(** Digest to be used for analyses that account for all join-local contributions in some locally tracked datastructure, akin to the L component from the analyses in
     @see <https://doi.org/10.1007/978-3-031-30044-8_2> Schwarz, M., Saan, S., Seidl, H., Erhard, J., Vojdani, V. Clustered Relational Thread-Modular Abstract Interpretation with Local Traces.
 *)
 module ThreadDigest: Digest =

--- a/src/analyses/useAfterFree.ml
+++ b/src/analyses/useAfterFree.ml
@@ -40,8 +40,11 @@ struct
     (* If we're single-threaded or there are no threads freeing the memory, we have nothing to WARN about *)
     if ctx.ask (Queries.MustBeSingleThreaded { since_start = true }) || G.is_empty freeing_threads then ()
     else begin
-      let possibly_started current tid joined_threads =
+      let other_possibly_started current tid joined_threads =
         match tid with
+        | `Lifted tid when (ThreadId.Thread.equal current tid && ThreadId.Thread.is_unique current) ->
+          (* if our own (unique) thread is started here, that is not a problem *)
+          false
         | `Lifted tid ->
           let created_threads = ctx.ask Queries.CreatedThreads in
           let not_started = MHP.definitely_not_started (current, created_threads) tid in
@@ -62,7 +65,7 @@ struct
       let bug_name = if is_double_free then "Double Free" else "Use After Free" in
       match get_current_threadid ctx with
       | `Lifted current ->
-        let possibly_started = G.exists (possibly_started current) freeing_threads in
+        let possibly_started = G.exists (other_possibly_started current) freeing_threads in
         if possibly_started then begin
           if is_double_free then set_mem_safety_flag InvalidFree else set_mem_safety_flag InvalidDeref;
           M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "There's a thread that's been started in parallel with the memory-freeing threads for heap variable %a. %s might occur" CilType.Varinfo.pretty heap_var bug_name

--- a/src/cdomain/value/cdomains/threadIdDomain.ml
+++ b/src/cdomain/value/cdomains/threadIdDomain.ml
@@ -141,9 +141,9 @@ struct
     S.is_empty s
 
   let is_must_parent (p,s) (p',s') =
-    if (not (S.is_empty s)) then
+    if not (S.is_empty s) then
       false
-    else if (P.equal p' p && S.equal s s') then
+    else if P.equal p' p && S.is_empty s' then (* s is already empty *)
       (* We do not consider a thread its own parent *)
       false
     else

--- a/src/cdomain/value/cdomains/threadIdDomain.ml
+++ b/src/cdomain/value/cdomains/threadIdDomain.ml
@@ -55,7 +55,7 @@ struct
             (struct let name = "no index" end)))
         (struct let name = "no node" end))
 
-  let show (f, ni_opt) = 
+  let show (f, ni_opt) =
     let vname = f.vname in
     match ni_opt with
     | None -> vname
@@ -141,7 +141,10 @@ struct
     S.is_empty s
 
   let is_must_parent (p,s) (p',s') =
-    if not (S.is_empty s) then
+    if (not (S.is_empty s)) then
+      false
+    else if (P.equal p' p && S.equal s s') then
+      (* We do not consider a thread its own parent *)
       false
     else
       let cdef_ancestor = P.common_suffix p p' in

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -754,7 +754,7 @@
               "description":
                 "Which privatization to use? none/mutex-oplus/mutex-meet/mutex-meet-tid/protection/protection-read/mine/mine-nothread/mine-W/mine-W-noinit/lock/write/write+lock",
               "type": "string",
-              "enum": ["none", "mutex-oplus", "mutex-meet", "protection", "protection-atomic", "protection-read", "protection-read-atomic", "mine", "mine-nothread", "mine-W", "mine-W-noinit", "lock", "write", "write+lock","mutex-meet-tid"],
+              "enum": ["none", "mutex-oplus", "mutex-meet", "protection", "protection-tid", "protection-atomic", "protection-read", "protection-read-atomic", "mine", "mine-nothread", "mine-W", "mine-W-noinit", "lock", "write", "write+lock","mutex-meet-tid"],
               "default": "protection-read"
             },
             "priv": {

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -754,7 +754,7 @@
               "description":
                 "Which privatization to use? none/mutex-oplus/mutex-meet/mutex-meet-tid/protection/protection-read/mine/mine-nothread/mine-W/mine-W-noinit/lock/write/write+lock",
               "type": "string",
-              "enum": ["none", "mutex-oplus", "mutex-meet", "protection", "protection-tid", "protection-atomic", "protection-read", "protection-read-atomic", "mine", "mine-nothread", "mine-W", "mine-W-noinit", "lock", "write", "write+lock","mutex-meet-tid"],
+              "enum": ["none", "mutex-oplus", "mutex-meet", "protection", "protection-tid", "protection-atomic", "protection-read", "protection-read-tid", "protection-read-atomic", "mine", "mine-nothread", "mine-W", "mine-W-noinit", "lock", "write", "write+lock","mutex-meet-tid"],
               "default": "protection-read"
             },
             "priv": {

--- a/tests/regression/02-base/01-thread_creation.c
+++ b/tests/regression/02-base/01-thread_creation.c
@@ -21,7 +21,7 @@ int main() {
   glob1 = 7;
   __goblint_check(glob1 == 7);
 
-  // Creat the thread
+  // Create the thread
   pthread_create(&id, NULL, t_fun, NULL);
 
   // The values should remain the same

--- a/tests/regression/13-privatized/75-protection-tid.c
+++ b/tests/regression/13-privatized/75-protection-tid.c
@@ -1,0 +1,42 @@
+// PARAM: --set ana.base.privatization protection-tid
+#include <pthread.h>
+#include <goblint.h>
+
+int g;
+pthread_mutex_t m;
+
+void* spoiler() {
+  int x;
+  pthread_mutex_lock(&m);
+  x=g;
+  pthread_mutex_unlock(&m);
+}
+
+void* producer()
+{
+  pthread_mutex_lock(&m);
+  g = 8;
+  pthread_mutex_unlock(&m);
+  return 0;
+}
+
+int main()
+{
+  pthread_t tid1;
+  pthread_t tid2;
+
+  pthread_create(&tid1, 0, spoiler, 0);
+
+  pthread_mutex_lock(&m);
+  __goblint_check(g == 0);
+  pthread_mutex_unlock(&m);
+
+  pthread_create(&tid2, 0, producer, 0);
+
+
+  pthread_mutex_lock(&m);
+  __goblint_check(g == 0); //UNKNOWN!
+  pthread_mutex_unlock(&m);
+
+  return 0;
+}

--- a/tests/regression/13-privatized/76-protection-tid2.c
+++ b/tests/regression/13-privatized/76-protection-tid2.c
@@ -1,0 +1,56 @@
+// PARAM: --set ana.base.privatization protection-tid --enable ana.int.interval
+#include <pthread.h>
+#include <goblint.h>
+
+int g;
+pthread_mutex_t m;
+
+void* spoiler() {
+  pthread_mutex_lock(&m);
+  g = 4;
+  pthread_mutex_unlock(&m);
+}
+
+void* otherproducer() {
+  pthread_mutex_lock(&m);
+  g = 9;
+  pthread_mutex_unlock(&m);
+}
+
+void* producer()
+{
+  pthread_t tid1;
+  pthread_mutex_lock(&m);
+  g = 8;
+  pthread_mutex_unlock(&m);
+
+  pthread_mutex_lock(&m);
+  __goblint_check(g < 9);
+  pthread_mutex_unlock(&m);
+
+  pthread_create(&tid1, 0, otherproducer, 0);
+
+  return 0;
+}
+
+int main()
+{
+  pthread_t tid1;
+  pthread_t tid2;
+
+  pthread_create(&tid1, 0, spoiler, 0);
+
+  pthread_mutex_lock(&m);
+  __goblint_check(g < 5);
+  pthread_mutex_unlock(&m);
+
+  pthread_create(&tid2, 0, producer, 0);
+
+
+  pthread_mutex_lock(&m);
+  __goblint_check(g < 5); //UNKNOWN!
+  __goblint_check(g < 10);
+  pthread_mutex_unlock(&m);
+
+  return 0;
+}


### PR DESCRIPTION
Introduces one of the new privatizations which will need to be evaluated for my thesis. This might actually be a lightweight interesting instance that might be worth evaluating it in practice.

This takes the protection based analysis and replaces `[g]` and `[g]'` by `[g,A]` and `[g,A]'` respectively, where `A` is an ego-lane derived digest.

Implementation-wise we once more use the Reduced-Cardinal-Powerset construction and change types of unknowns from `ValD` to partial maps `Digest -> ValD` with default value `bot`.

TODO:

- [x] Add new interesting tests
- [x] Modify `TID.is_must_parent`. Currently, this is reflexive, which is against intuition (I rarely think of myself as my own father)