### PR TITLE
Missing division by zero treatment in MaySignedOverflow

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1261,11 +1261,11 @@ struct
   *)
   (* TODO: deduplicate https://github.com/goblint/analyzer/pull/1297#discussion_r1477804502 *)
   let rec exp_may_signed_overflow ctx exp =
-    let binop = (GobOption.map2 Z.div )in
     let res = match Cilfacade.get_ikind_exp exp with
       | exception _ -> BoolDomain.MayBool.top ()
       | ik ->
         let checkDiv e1 e2 =
+          let binop = (GobOption.map2 Z.div )in
           match ctx.ask (EvalInt e1), ctx.ask (EvalInt e2) with
           | `Bot, _ -> false
           | _, `Bot -> false

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1317,7 +1317,7 @@ struct
               | PlusA|PlusPI|IndexPI -> checkBinop e1 e2 (GobOption.map2 Z.(+))
               | MinusA|MinusPI|MinusPP -> checkBinop e1 e2 (GobOption.map2 Z.(-))
               | Mult -> checkBinop e1 e2 (GobOption.map2 Z.mul)
-              | Div -> checkBinop e1 e2 (GobOption.map2 Z.div)
+              | Div -> (try checkBinop e1 e2 (GobOption.map2 Z.div) with Division_by_zero -> true)
               | Mod -> (* an overflow happens when the second operand is negative *)
                 checkPredicate e2 (fun interval_bound _ -> Z.gt interval_bound Z.zero)
               (* operations that do not result in overflow in C: *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1270,7 +1270,7 @@ struct
           | `Bot, _ -> false
           | _, `Bot -> false
           | `Lifted i1, `Lifted i2 ->
-            ( let divisor_contains_zero = (ID.meet i2 (ID.of_int ik Z.zero) = ID.of_int ik Z.zero)  in
+            ( let divisor_contains_zero = (ID.is_bot @@ ID.meet i2 (ID.of_int ik Z.zero))  in
               if divisor_contains_zero then true else 
                 ( let (min_ik, max_ik) = IntDomain.Size.range ik in
                   let (min_i1, max_i1) = (IntDomain.IntDomTuple.minimal i1, IntDomain.IntDomTuple.maximal i1) in

--- a/tests/regression/77-lin2vareq/32-divbzero-in-overflow.c
+++ b/tests/regression/77-lin2vareq/32-divbzero-in-overflow.c
@@ -2,17 +2,15 @@
 
 /**
  * This test shows an instance where MaySignedOverflow raised
- * an uncaught division by zero in the treatment of c's body
+ * an uncaught division by zero in the treatment of main's sole statement
  * 
  * Fixed in #1419
  */
 int a;
 char b;
-int c() { 0 == a && 1 / b; }
-void d(int (*func)()) { func(); }
 int main()
 {
-    d(c);
+     0 == a && 1 / b;
     __goblint_check(1); // (reachable)
     return 0;
 }

--- a/tests/regression/77-lin2vareq/32-divbzero-in-overflow.c
+++ b/tests/regression/77-lin2vareq/32-divbzero-in-overflow.c
@@ -1,0 +1,18 @@
+// SKIP PARAM: --set ana.activated[+] lin2vareq
+
+/**
+ * This test shows an instance where MaySignedOverflow raised
+ * an uncaught division by zero in the treatment of c's body
+ * 
+ * Fixed in #1419
+ */
+int a;
+char b;
+int c() { 0 == a && 1 / b; }
+void d(int (*func)()) { func(); }
+int main()
+{
+    d(c);
+    __goblint_check(1); // (reachable)
+    return 0;
+}


### PR DESCRIPTION
During the treatment of expressions within the MaySignedOverflow query treatment in base.ml, we compute possible value ranges for expressions. We do so for division expressions too, but do not catch a possible division by zero within this treatment.

The first solution proposal to this would is in the case of such an exception just do the safe thing and return true.