### PR TITLE
Type-safe global query system

### DIFF
--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -48,9 +48,8 @@ struct
   module G = Arg.G (* help type checker using explicit constraint *)
 
   let global_query gctx (type a) (q: a Queries.t): a Queries.result =
-    match q with
-    | WarnGlobal ->
-      let g = Option.get gctx.var in
+    match gctx.var, q with
+    | Some g, WarnGlobal ->
       let module LH = Hashtbl.Make (Lock) in
       let module LS = Set.Make (Lock) in
       (* TODO: find all cycles/SCCs *)
@@ -109,7 +108,7 @@ struct
       in
 
       Timing.wrap ~args:[("lock", `String (Lock.show g))] "deadlock" (iter_lock LS.empty []) g
-    | _ -> Queries.Result.top q
+    | _, _ -> Queries.Result.top q
 end
 
 let _ =

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -49,7 +49,7 @@ struct
 
   let global_query gctx (type a) (q: a Queries.t): a Queries.result =
     match q with
-    | WarnGlobal _ ->
+    | WarnGlobal ->
       let g = Option.get gctx.var in
       let module LH = Hashtbl.Make (Lock) in
       let module LS = Set.Make (Lock) in

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -47,9 +47,10 @@ struct
 
   module G = Arg.G (* help type checker using explicit constraint *)
 
-  let global_query getg (type a) g (q: a Queries.t): a Queries.result =
+  let global_query gctx (type a) (q: a Queries.t): a Queries.result =
     match q with
     | WarnGlobal _ ->
+      let g = Option.get gctx.var in
       let module LH = Hashtbl.Make (Lock) in
       let module LS = Set.Make (Lock) in
       (* TODO: find all cycles/SCCs *)
@@ -103,7 +104,7 @@ struct
                   let new_path_visited_lock_event_pairs' = lock_event_pair :: path_visited_lock_event_pairs in
                   iter_lock new_path_visited_locks new_path_visited_lock_event_pairs' to_lock
                 ) lock_event_pairs
-            ) (getg lock)
+            ) (gctx.global lock)
         end
       in
 

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -47,11 +47,9 @@ struct
 
   module G = Arg.G (* help type checker using explicit constraint *)
 
-  let query ctx (type a) (q: a Queries.t): a Queries.result =
+  let global_query getg (type a) g (q: a Queries.t): a Queries.result =
     match q with
-    | WarnGlobal g ->
-      let g: V.t = Obj.obj g in
-
+    | WarnGlobal _ ->
       let module LH = Hashtbl.Make (Lock) in
       let module LS = Set.Make (Lock) in
       (* TODO: find all cycles/SCCs *)
@@ -105,7 +103,7 @@ struct
                   let new_path_visited_lock_event_pairs' = lock_event_pair :: path_visited_lock_event_pairs in
                   iter_lock new_path_visited_locks new_path_visited_lock_event_pairs' to_lock
                 ) lock_event_pairs
-            ) (ctx.global lock)
+            ) (getg lock)
         end
       in
 

--- a/src/analyses/loopTermination.ml
+++ b/src/analyses/loopTermination.ml
@@ -65,22 +65,16 @@ struct
 
   let global_query (gctx: _ gctx) (type a) (q: a Queries.t): a Queries.result =
     match q with
-    | Queries.MustTermLoop loop_statement ->
-      let multithreaded = gctx.ask Queries.IsEverMultiThreaded in
-      (not multithreaded)
-      && (match G.find_opt (`Lifted loop_statement) (gctx.global ()) with
-            Some b -> b
-          | None -> false)
-    | Queries.MustTermAllLoops ->
-      let multithreaded = gctx.ask Queries.IsEverMultiThreaded in
-      if multithreaded then (
-        M.warn ~category:Termination "The program might not terminate! (Multithreaded)";
-        false)
-      else
-        G.for_all (fun _ term_info -> term_info) (gctx.global ())
     | WarnGlobal ->
-      (* check result of loop analysis *)
-      if not (gctx.ask Queries.MustTermAllLoops) then
+      let must_term_all_loops =
+        let multithreaded = gctx.ask Queries.IsEverMultiThreaded in
+        if multithreaded then (
+          M.warn ~category:Termination "The program might not terminate! (Multithreaded)";
+          false)
+        else
+          G.for_all (fun _ term_info -> term_info) (gctx.global ())
+      in
+      if not must_term_all_loops then
         AnalysisState.svcomp_may_not_terminate := true;
     | _ -> Queries.Result.top q
 end

--- a/src/analyses/loopTermination.ml
+++ b/src/analyses/loopTermination.ml
@@ -63,23 +63,22 @@ struct
       | _ -> ()
     else ()
 
-  let query ctx (type a) (q: a Queries.t): a Queries.result =
+  let global_query (gctx: _ gctx) (type a) (q: a Queries.t): a Queries.result =
     match q with
     | Queries.MustTermLoop loop_statement ->
-      let multithreaded = ctx.ask Queries.IsEverMultiThreaded in
+      let multithreaded = gctx.ask Queries.IsEverMultiThreaded in
       (not multithreaded)
-      && (match G.find_opt (`Lifted loop_statement) (ctx.global ()) with
+      && (match G.find_opt (`Lifted loop_statement) (gctx.global ()) with
             Some b -> b
           | None -> false)
     | Queries.MustTermAllLoops ->
-      let multithreaded = ctx.ask Queries.IsEverMultiThreaded in
+      let multithreaded = gctx.ask Queries.IsEverMultiThreaded in
       if multithreaded then (
         M.warn ~category:Termination "The program might not terminate! (Multithreaded)";
         false)
       else
-        G.for_all (fun _ term_info -> term_info) (ctx.global ())
+        G.for_all (fun _ term_info -> term_info) (gctx.global ())
     | _ -> Queries.Result.top q
-
 end
 
 let () =

--- a/src/analyses/loopTermination.ml
+++ b/src/analyses/loopTermination.ml
@@ -78,6 +78,10 @@ struct
         false)
       else
         G.for_all (fun _ term_info -> term_info) (gctx.global ())
+    | WarnGlobal ->
+      (* check result of loop analysis *)
+      if not (gctx.ask Queries.MustTermAllLoops) then
+        AnalysisState.svcomp_may_not_terminate := true;
     | _ -> Queries.Result.top q
 end
 

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -599,6 +599,8 @@ struct
 
   let event (ctx:(D.t, G.t, C.t, V.t) ctx) e _ = do_emits ctx [e] ctx.local false
 
+  let global_query _ _ _ = failwith "TODO"
+
   (* Just to satisfy signature *)
   let paths_as_set ctx = [ctx.local]
 end

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -599,7 +599,10 @@ struct
 
   let event (ctx:(D.t, G.t, C.t, V.t) ctx) e _ = do_emits ctx [e] ctx.local false
 
-  let global_query _ _ _ = failwith "TODO"
+  let global_query getg (type a) ((n, g): V.t) (q: a Queries.t): a Queries.result =
+    (* TODO: cache? *)
+    let module S: MCPSpec = (val spec n: MCPSpec) in
+    S.global_query (fun v -> getg (v_of n v) |> g_to n |> obj) (Obj.obj g) q
 
   (* Just to satisfy signature *)
   let paths_as_set ctx = [ctx.local]

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -277,10 +277,6 @@ struct
             Result.meet a @@ res
           in
           match q with
-          | Queries.WarnGlobal g ->
-            (* WarnGlobal is special: it only goes to corresponding analysis and the argument variant is unlifted for it *)
-            let (n, g): V.t = Obj.obj g in
-            f ~q:(WarnGlobal (Obj.repr g)) (Result.top ()) (n, spec n, assoc n ctx.local)
           | Queries.InvariantGlobal g ->
             (* InvariantGlobal is special: it only goes to corresponding analysis and the argument variant is unlifted for it *)
             let (n, g): V.t = Obj.obj g in

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -249,9 +249,8 @@ struct
     | _ -> Queries.Result.top q
 
   let global_query gctx (type a) (q: a Queries.t): a Queries.result =
-    match q with
-    | WarnGlobal ->
-      let g = Option.get gctx.var in
+    match gctx.var, q with
+    | Some g, WarnGlobal ->
       begin match g with
         | `Left g' -> (* protecting *)
           if GobConfig.get_bool "dbg.print_protection" then (
@@ -269,7 +268,7 @@ struct
             M.info_noloc ~category:Race "Mutex %a read-write protects %d variable(s): %a" ValueDomain.Addr.pretty m s VarSet.pretty protected
           )
       end
-    | _ -> Queries.Result.top q
+    | _, _ -> Queries.Result.top q
 
   module A =
   struct

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -250,7 +250,7 @@ struct
 
   let global_query gctx (type a) (q: a Queries.t): a Queries.result =
     match q with
-    | WarnGlobal _ ->
+    | WarnGlobal ->
       let g = Option.get gctx.var in
       begin match g with
         | `Left g' -> (* protecting *)

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -248,19 +248,20 @@ struct
       f (Obj.repr (V.protecting g)) (* TODO: something about V.protected? *)
     | _ -> Queries.Result.top q
 
-  let global_query getg (type a) g (q: a Queries.t): a Queries.result =
+  let global_query gctx (type a) (q: a Queries.t): a Queries.result =
     match q with
     | WarnGlobal _ ->
+      let g = Option.get gctx.var in
       begin match g with
         | `Left g' -> (* protecting *)
           if GobConfig.get_bool "dbg.print_protection" then (
-            let protecting = GProtecting.get ~write:false Strong (G.protecting (getg g)) in (* readwrite protecting *)
+            let protecting = GProtecting.get ~write:false Strong (G.protecting (gctx.global g)) in (* readwrite protecting *)
             let s = Mutexes.cardinal protecting in
             M.info_noloc ~category:Race "Variable %a read-write protected by %d mutex(es): %a" CilType.Varinfo.pretty g' s Mutexes.pretty protecting
           )
         | `Right m -> (* protected *)
           if GobConfig.get_bool "dbg.print_protection" then (
-            let protected = GProtected.get ~write:false Strong (G.protected (getg g)) in (* readwrite protected *)
+            let protected = GProtected.get ~write:false Strong (G.protected (gctx.global g)) in (* readwrite protected *)
             let s = VarSet.cardinal protected in
             max_protected := max !max_protected s;
             sum_protected := !sum_protected + s;

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -264,9 +264,8 @@ struct
     | None -> Access.AS.empty ()
 
   let global_query gctx (type a) (q: a Queries.t): a Queries.result =
-    match q with
-    | WarnGlobal ->
-      let g = Option.get gctx.var in
+    match gctx.var, q with
+    | Some g, WarnGlobal ->
       begin match g with
         | `Left g' -> (* accesses *)
           (* Logs.debug "WarnGlobal %a" Access.MemoRoot.pretty g'; *)
@@ -296,7 +295,7 @@ struct
         | `Right _ -> (* vars *)
           ()
       end
-    | _ -> Queries.Result.top q
+    | _, _ -> Queries.Result.top q
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     match q with

--- a/src/analyses/raceAnalysis.ml
+++ b/src/analyses/raceAnalysis.ml
@@ -265,7 +265,7 @@ struct
 
   let global_query gctx (type a) (q: a Queries.t): a Queries.result =
     match q with
-    | WarnGlobal _ ->
+    | WarnGlobal ->
       let g = Option.get gctx.var in
       begin match g with
         | `Left g' -> (* accesses *)

--- a/src/analyses/threadFlag.ml
+++ b/src/analyses/threadFlag.ml
@@ -42,6 +42,11 @@ struct
     | _ ->
       ctx.local
 
+  let global_query (gctx: _ gctx) (type a) (x: a Queries.t): a Queries.result =
+    match x with
+    | Queries.IsEverMultiThreaded -> (gctx.global () : bool) (* requires annotation to compile *)
+    | _ -> Queries.Result.top x
+
   let query ctx (type a) (x: a Queries.t): a Queries.result =
     match x with
     | Queries.MustBeSingleThreaded _ -> not (Flag.is_multi ctx.local) (* If this analysis can tell, it is the case since the start *)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -121,8 +121,6 @@ type _ t =
   | MayAccessed: AccessDomain.EventSet.t t
   | MayBeTainted: AD.t t
   | MayBeModifiedSinceSetjmp: JmpBufDomain.BufferEntry.t -> VS.t t
-  | MustTermLoop: stmt -> MustBool.t t
-  | MustTermAllLoops: MustBool.t t
   | IsEverMultiThreaded: MayBool.t t
   | TmpSpecial:  Mval.Exp.t -> ML.t t
   | MaySignedOverflow: exp -> MayBool.t t
@@ -191,8 +189,6 @@ struct
     | MayAccessed -> (module AccessDomain.EventSet)
     | MayBeTainted -> (module AD)
     | MayBeModifiedSinceSetjmp _ -> (module VS)
-    | MustTermLoop _ -> (module MustBool)
-    | MustTermAllLoops -> (module MustBool)
     | IsEverMultiThreaded -> (module MayBool)
     | TmpSpecial _ -> (module ML)
     | MaySignedOverflow  _ -> (module MayBool)
@@ -260,8 +256,6 @@ struct
     | MayAccessed -> AccessDomain.EventSet.top ()
     | MayBeTainted -> AD.top ()
     | MayBeModifiedSinceSetjmp _ -> VS.top ()
-    | MustTermLoop _ -> MustBool.top ()
-    | MustTermAllLoops -> MustBool.top ()
     | IsEverMultiThreaded -> MayBool.top ()
     | TmpSpecial _ -> ML.top ()
     | MaySignedOverflow _ -> MayBool.top ()
@@ -325,8 +319,6 @@ struct
     | Any (EvalMutexAttr _ ) -> 50
     | Any ThreadCreateIndexedNode -> 51
     | Any ThreadsJoinedCleanly -> 52
-    | Any (MustTermLoop _) -> 53
-    | Any MustTermAllLoops -> 54
     | Any IsEverMultiThreaded -> 55
     | Any (TmpSpecial _) -> 56
     | Any (IsAllocVar _) -> 57
@@ -372,7 +364,6 @@ struct
       | Any (IsHeapVar v1), Any (IsHeapVar v2) -> CilType.Varinfo.compare v1 v2
       | Any (IsAllocVar v1), Any (IsAllocVar v2) -> CilType.Varinfo.compare v1 v2
       | Any (IsMultiple v1), Any (IsMultiple v2) -> CilType.Varinfo.compare v1 v2
-      | Any (MustTermLoop s1), Any (MustTermLoop s2) -> CilType.Stmt.compare s1 s2
       | Any (EvalThread e1), Any (EvalThread e2) -> CilType.Exp.compare e1 e2
       | Any (EvalJumpBuf e1), Any (EvalJumpBuf e2) -> CilType.Exp.compare e1 e2
       | Any (Invariant i1), Any (Invariant i2) -> compare_invariant_context i1 i2
@@ -412,7 +403,6 @@ struct
     | Any (IterVars i) -> 0
     | Any (PathQuery (i, q)) -> 31 * i + hash (Any q)
     | Any (IsHeapVar v) -> CilType.Varinfo.hash v
-    | Any (MustTermLoop s) -> CilType.Stmt.hash s
     | Any (IsAllocVar v) -> CilType.Varinfo.hash v
     | Any (IsMultiple v) -> CilType.Varinfo.hash v
     | Any (EvalThread e) -> CilType.Exp.hash e
@@ -483,8 +473,6 @@ struct
     | Any MayBeTainted -> Pretty.dprintf "MayBeTainted"
     | Any DYojson -> Pretty.dprintf "DYojson"
     | Any MayBeModifiedSinceSetjmp buf -> Pretty.dprintf "MayBeModifiedSinceSetjmp %a" JmpBufDomain.BufferEntry.pretty buf
-    | Any (MustTermLoop s) -> Pretty.dprintf "MustTermLoop %a" CilType.Stmt.pretty s
-    | Any MustTermAllLoops -> Pretty.dprintf "MustTermAllLoops"
     | Any IsEverMultiThreaded -> Pretty.dprintf "IsEverMultiThreaded"
     | Any (TmpSpecial lv) -> Pretty.dprintf "TmpSpecial %a" Mval.Exp.pretty lv
     | Any (MaySignedOverflow e) -> Pretty.dprintf "MaySignedOverflow %a" CilType.Exp.pretty e

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -116,7 +116,7 @@ type _ t =
   | MustProtectedVars: mustprotectedvars -> VS.t t
   | Invariant: invariant_context -> Invariant.t t
   | InvariantGlobal: Obj.t -> Invariant.t t (** Argument must be of corresponding [Spec.V.t]. *)
-  | WarnGlobal: Obj.t -> Unit.t t (** Argument must be of corresponding [Spec.V.t]. *)
+  | WarnGlobal: Unit.t t
   | IterSysVars: VarQuery.t * Obj.t VarQuery.f -> Unit.t t (** [iter_vars] for [Constraints.FromSpec]. [Obj.t] represents [Spec.V.t]. *)
   | MayAccessed: AccessDomain.EventSet.t t
   | MayBeTainted: AD.t t
@@ -186,7 +186,7 @@ struct
     | MustProtectedVars _ -> (module VS)
     | Invariant _ -> (module Invariant)
     | InvariantGlobal _ -> (module Invariant)
-    | WarnGlobal _ -> (module Unit)
+    | WarnGlobal -> (module Unit)
     | IterSysVars _ -> (module Unit)
     | MayAccessed -> (module AccessDomain.EventSet)
     | MayBeTainted -> (module AD)
@@ -255,7 +255,7 @@ struct
     | MustProtectedVars _ -> VS.top ()
     | Invariant _ -> Invariant.top ()
     | InvariantGlobal _ -> Invariant.top ()
-    | WarnGlobal _ -> Unit.top ()
+    | WarnGlobal -> Unit.top ()
     | IterSysVars _ -> Unit.top ()
     | MayAccessed -> AccessDomain.EventSet.top ()
     | MayBeTainted -> AD.top ()
@@ -307,7 +307,7 @@ struct
     | Any (EvalThread _) -> 32
     | Any CreatedThreads -> 33
     | Any MustJoinedThreads -> 34
-    | Any (WarnGlobal _) -> 35
+    | Any WarnGlobal -> 35
     | Any (Invariant _) -> 36
     | Any (IterSysVars _) -> 37
     | Any (InvariantGlobal _) -> 38
@@ -375,7 +375,6 @@ struct
       | Any (MustTermLoop s1), Any (MustTermLoop s2) -> CilType.Stmt.compare s1 s2
       | Any (EvalThread e1), Any (EvalThread e2) -> CilType.Exp.compare e1 e2
       | Any (EvalJumpBuf e1), Any (EvalJumpBuf e2) -> CilType.Exp.compare e1 e2
-      | Any (WarnGlobal vi1), Any (WarnGlobal vi2) -> Stdlib.compare (Hashtbl.hash vi1) (Hashtbl.hash vi2)
       | Any (Invariant i1), Any (Invariant i2) -> compare_invariant_context i1 i2
       | Any (InvariantGlobal vi1), Any (InvariantGlobal vi2) -> Stdlib.compare (Hashtbl.hash vi1) (Hashtbl.hash vi2)
       | Any (IterSysVars (vq1, vf1)), Any (IterSysVars (vq2, vf2)) -> VarQuery.compare vq1 vq2 (* not comparing fs *)
@@ -418,7 +417,6 @@ struct
     | Any (IsMultiple v) -> CilType.Varinfo.hash v
     | Any (EvalThread e) -> CilType.Exp.hash e
     | Any (EvalJumpBuf e) -> CilType.Exp.hash e
-    | Any (WarnGlobal vi) -> Hashtbl.hash vi
     | Any (Invariant i) -> hash_invariant_context i
     | Any (MutexType m) -> Mval.Unit.hash m
     | Any (InvariantGlobal vi) -> Hashtbl.hash vi
@@ -476,7 +474,7 @@ struct
     | Any ThreadsJoinedCleanly -> Pretty.dprintf "ThreadsJoinedCleanly"
     | Any (MustProtectedVars m) -> Pretty.dprintf "MustProtectedVars _"
     | Any (Invariant i) -> Pretty.dprintf "Invariant _"
-    | Any (WarnGlobal vi) -> Pretty.dprintf "WarnGlobal _"
+    | Any WarnGlobal -> Pretty.dprintf "WarnGlobal"
     | Any (IterSysVars _) -> Pretty.dprintf "IterSysVars _"
     | Any (InvariantGlobal i) -> Pretty.dprintf "InvariantGlobal _"
     | Any (MutexType (v,o)) ->  Pretty.dprintf "MutexType _"

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -151,6 +151,7 @@ end
 type ('v, 'g) gctx = {
   var: 'v option;
   global: 'v -> 'g;
+  ask: 'a. 'a Queries.t -> 'a Queries.result; (* Inlined Queries.ask *) (* TODO: add optional var argument? *)
 }
 
 (* Experiment to reduce the number of arguments on transfer functions and allow

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -210,6 +210,7 @@ sig
 
   val sync  : (D.t, G.t, C.t, V.t) ctx -> [`Normal | `Join | `Return] -> D.t
   val query : (D.t, G.t, C.t, V.t) ctx -> 'a Queries.t -> 'a Queries.result
+  val global_query : (V.t -> G.t) -> V.t -> 'a Queries.t -> 'a Queries.result
 
   (** A transfer function which handles the assignment of a rval to a lval, i.e.,
       it handles program points of the form "lval = rval;" *)
@@ -365,6 +366,9 @@ struct
   let skip x = x.local (* Just ignore. *)
 
   let query _ (type a) (q: a Queries.t) = Queries.Result.top q
+  (* Don't know anything --- most will want to redefine this. *)
+
+  let global_query _ _ (type a) (q: a Queries.t) = Queries.Result.top q
   (* Don't know anything --- most will want to redefine this. *)
 
   let event ctx _ _ = ctx.local

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -84,6 +84,10 @@ struct
   let is_write_only = function
     | `Left x -> V.is_write_only x
     | `Right _ -> true
+
+  let get_spec = function
+    | `Left x -> x
+    | `Right _ -> failwith "GVarFC.get_spec"
 end
 
 module GVarG (G: Lattice.S) (C: Printable.S) =
@@ -143,6 +147,11 @@ struct
     | `Lifted x -> LD.printXml f x
 end
 
+
+type ('v, 'g) gctx = {
+  var: 'v option;
+  global: 'v -> 'g;
+}
 
 (* Experiment to reduce the number of arguments on transfer functions and allow
    sub-analyses. The list sub contains the current local states of analyses in
@@ -210,7 +219,7 @@ sig
 
   val sync  : (D.t, G.t, C.t, V.t) ctx -> [`Normal | `Join | `Return] -> D.t
   val query : (D.t, G.t, C.t, V.t) ctx -> 'a Queries.t -> 'a Queries.result
-  val global_query : (V.t -> G.t) -> V.t -> 'a Queries.t -> 'a Queries.result
+  val global_query : (V.t, G.t) gctx -> 'a Queries.t -> 'a Queries.result
 
   (** A transfer function which handles the assignment of a rval to a lval, i.e.,
       it handles program points of the form "lval = rval;" *)
@@ -368,7 +377,7 @@ struct
   let query _ (type a) (q: a Queries.t) = Queries.Result.top q
   (* Don't know anything --- most will want to redefine this. *)
 
-  let global_query _ _ (type a) (q: a Queries.t) = Queries.Result.top q
+  let global_query _ (type a) (q: a Queries.t) = Queries.Result.top q
   (* Don't know anything --- most will want to redefine this. *)
 
   let event ctx _ _ = ctx.local

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1264,14 +1264,6 @@ struct
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     match q with
-    | WarnGlobal g -> (* TODO: remove *)
-      let g: V.t = Obj.obj g in
-      begin match g with
-        | `Left g ->
-          S.query (conv ctx) (WarnGlobal (Obj.repr g))
-        | `Right g ->
-          Queries.Result.top q
-      end
     | InvariantGlobal g ->
       let g: V.t = Obj.obj g in
       begin match g with
@@ -1388,14 +1380,6 @@ struct
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     match q with
-    | WarnGlobal g ->
-      let g: V.t = Obj.obj g in
-      begin match g with
-        | `Left g ->
-          S.query (conv ctx) (WarnGlobal (Obj.repr g))
-        | _ ->
-          Queries.Result.top q
-      end
     | InvariantGlobal g ->
       let g: V.t = Obj.obj g in
       begin match g with
@@ -1698,16 +1682,6 @@ struct
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     match q with
-    | WarnGlobal v -> (* TODO: remove *)
-      (* check result of loop analysis *)
-      if not (ctx.ask Queries.MustTermAllLoops) then
-        AnalysisState.svcomp_may_not_terminate := true;
-      let v: V.t = Obj.obj v in
-      begin match v with
-        | `Left v' ->
-          S.query (conv ctx) (WarnGlobal (Obj.repr v'))
-        | `Right call -> cycleDetection ctx.global call (* Note: to make it more efficient, one could only execute the cycle detection in case the loop analysis returns true, because otherwise the program will probably not terminate anyway*)
-      end
     | InvariantGlobal v ->
       let v: V.t = Obj.obj v in
       begin match v with

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1228,29 +1228,32 @@ struct
       sideg = (fun v g -> ctx.sideg (V.s v) (G.create_s g));
     }
 
+
+  let global_query getg (type a) g (q: a Queries.t): a Queries.result =
+    match g with
+    | `Left g ->
+      S.global_query (fun v -> G.s (getg (V.s v))) g q
+    | `Right g ->
+      match q with
+      | WarnGlobal _ ->
+        let em = G.node (getg (V.node g)) in
+        EM.iter (fun exp tv ->
+            match tv with
+            | `Lifted tv ->
+              let loc = Node.location g in (* TODO: looking up location now doesn't work nicely with incremental *)
+              let cilinserted = if loc.synthetic then "(possibly inserted by CIL) " else "" in
+              M.warn ~loc:(Node g) ~tags:[CWE (if tv then 571 else 570)] ~category:Deadcode "condition '%a' %sis always %B" d_exp exp cilinserted tv
+            | `Bot when not (CilType.Exp.equal exp one) -> (* all branches dead *)
+              M.msg_final Error ~category:Analyzer ~tags:[Category Unsound] "Both branches dead";
+              M.error ~loc:(Node g) ~category:Analyzer ~tags:[Category Unsound] "both branches over condition '%a' are dead" d_exp exp
+            | `Bot (* all branches dead, fine at our inserted Neg(1)-s because no Pos(1) *)
+            | `Top -> (* may be both true and false *)
+              ()
+          ) em
+      | _ -> Queries.Result.top q
+
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     match q with
-    | WarnGlobal g ->
-      let g: V.t = Obj.obj g in
-      begin match g with
-        | `Left g ->
-          S.query (conv ctx) (WarnGlobal (Obj.repr g))
-        | `Right g ->
-          let em = G.node (ctx.global (V.node g)) in
-          EM.iter (fun exp tv ->
-              match tv with
-              | `Lifted tv ->
-                let loc = Node.location g in (* TODO: looking up location now doesn't work nicely with incremental *)
-                let cilinserted = if loc.synthetic then "(possibly inserted by CIL) " else "" in
-                M.warn ~loc:(Node g) ~tags:[CWE (if tv then 571 else 570)] ~category:Deadcode "condition '%a' %sis always %B" d_exp exp cilinserted tv
-              | `Bot when not (CilType.Exp.equal exp one) -> (* all branches dead *)
-                M.msg_final Error ~category:Analyzer ~tags:[Category Unsound] "Both branches dead";
-                M.error ~loc:(Node g) ~category:Analyzer ~tags:[Category Unsound] "both branches over condition '%a' are dead" d_exp exp
-              | `Bot (* all branches dead, fine at our inserted Neg(1)-s because no Pos(1) *)
-              | `Top -> (* may be both true and false *)
-                ()
-            ) em;
-      end
     | InvariantGlobal g ->
       let g: V.t = Obj.obj g in
       begin match g with
@@ -1273,13 +1276,6 @@ struct
       end
     | _ ->
       S.query (conv ctx) q
-
-  let global_query getg (type a) g (q: a Queries.t): a Queries.result =
-    match g with
-    | `Left g ->
-      S.global_query (fun v -> G.s (getg (V.s v))) g q
-    | `Right g ->
-      Queries.Result.top q
 
   let branch ctx = S.branch (conv ctx)
 

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1264,6 +1264,14 @@ struct
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     match q with
+    | WarnGlobal g -> (* TODO: remove *)
+      let g: V.t = Obj.obj g in
+      begin match g with
+        | `Left g ->
+          S.query (conv ctx) (WarnGlobal (Obj.repr g))
+        | `Right g ->
+          Queries.Result.top q
+      end
     | InvariantGlobal g ->
       let g: V.t = Obj.obj g in
       begin match g with

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1674,9 +1674,6 @@ struct
     | Some (`Right call) ->
       match q with
       | WarnGlobal ->
-        (* check result of loop analysis *)
-        if not (gctx.ask Queries.MustTermAllLoops) then
-          AnalysisState.svcomp_may_not_terminate := true;
         cycleDetection gctx.global call (* Note: to make it more efficient, one could only execute the cycle detection in case the loop analysis returns true, because otherwise the program will probably not terminate anyway*)
       | _ -> Queries.Result.top q
 

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1233,7 +1233,7 @@ struct
     }
 
   let global_conv (gctx: (V.t, G.t) gctx): (S.V.t, S.G.t) gctx =
-    {
+    { gctx with
       var = Option.map V.get_s gctx.var;
       global = (fun v -> G.s (gctx.global (V.s v)));
     }
@@ -1381,7 +1381,7 @@ struct
     }
 
   let global_conv (gctx: (V.t, G.t) gctx): (S.V.t, S.G.t) gctx =
-    {
+    { gctx with
       var = Option.map V.get_s gctx.var;
       global = (fun v -> G.s (gctx.global (V.s v)));
     }
@@ -1652,7 +1652,7 @@ struct
     }
 
   let global_conv (gctx: (V.t, G.t) gctx): (S.V.t, S.G.t) gctx =
-    {
+    { gctx with
       var = Option.map V.get_spec gctx.var;
       global = (fun v -> G.spec (gctx.global (V.spec v)));
     }

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -1245,7 +1245,7 @@ struct
       S.global_query (global_conv gctx) q
     | Some (`Right g) ->
       match q with
-      | WarnGlobal _ ->
+      | WarnGlobal ->
         let em = G.node (gctx.global (V.node g)) in
         EM.iter (fun exp tv ->
             match tv with
@@ -1673,7 +1673,7 @@ struct
       S.global_query (global_conv gctx) q
     | Some (`Right call) ->
       match q with
-      | WarnGlobal v ->
+      | WarnGlobal ->
         (* check result of loop analysis *)
         if not (gctx.ask Queries.MustTermAllLoops) then
           AnalysisState.svcomp_may_not_terminate := true;

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -738,11 +738,12 @@ struct
       (* Logs.debug "warn_global %a %a" EQSys.GVar.pretty_trace g EQSys.G.pretty v; *)
       match g with
       | `Left g -> (* Spec global *)
-        R.ask_global' g WarnGlobal
+        R.ask_global' (Some g) WarnGlobal
       | `Right _ -> (* contexts global *)
         ()
     in
     Timing.wrap "warn_global" (GHT.iter warn_global) gh;
+    Timing.wrap "warn_global" (R.ask_global' None) WarnGlobal;
 
     if get_bool "exp.arg" then (
       let module ArgTool = ArgTools.Make (R) in

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -738,7 +738,6 @@ struct
       (* Logs.debug "warn_global %a %a" EQSys.GVar.pretty_trace g EQSys.G.pretty v; *)
       match g with
       | `Left g -> (* Spec global *)
-        R.ask_global (WarnGlobal (Obj.repr g));
         R.ask_global' g (WarnGlobal (Obj.repr g))
       | `Right _ -> (* contexts global *)
         ()

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -738,7 +738,8 @@ struct
       (* Logs.debug "warn_global %a %a" EQSys.GVar.pretty_trace g EQSys.G.pretty v; *)
       match g with
       | `Left g -> (* Spec global *)
-        R.ask_global (WarnGlobal (Obj.repr g))
+        R.ask_global (WarnGlobal (Obj.repr g));
+        R.ask_global' g (WarnGlobal (Obj.repr g))
       | `Right _ -> (* contexts global *)
         ()
     in

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -738,7 +738,7 @@ struct
       (* Logs.debug "warn_global %a %a" EQSys.GVar.pretty_trace g EQSys.G.pretty v; *)
       match g with
       | `Left g -> (* Spec global *)
-        R.ask_global' g (WarnGlobal (Obj.repr g))
+        R.ask_global' g WarnGlobal
       | `Right _ -> (* contexts global *)
         ()
     in

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -64,7 +64,13 @@ struct
     in
     Spec.query ctx
 
-  let ask_global' (gh: EQSys.G.t GHT.t) (type a) g (q: a Queries.t): a Queries.result = Spec.global_query (fun v -> EQSys.G.spec (try GHT.find gh (EQSys.GVar.spec v) with Not_found -> EQSys.G.bot ())) g q (* TODO: how can be missing? *)
+  let ask_global' (gh: EQSys.G.t GHT.t) g =
+    let rec gctx = {
+      var = Some g;
+      global = (fun v -> EQSys.G.spec (try GHT.find gh (EQSys.GVar.spec v) with Not_found -> EQSys.G.bot ())) (* TODO: how can be missing? *)
+    }
+    in
+    Spec.global_query gctx
 end
 
 

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -66,7 +66,7 @@ struct
 
   let ask_global' (gh: EQSys.G.t GHT.t) g =
     let rec gctx = {
-      var = Some g;
+      var = g;
       global = (fun v -> EQSys.G.spec (try GHT.find gh (EQSys.GVar.spec v) with Not_found -> EQSys.G.bot ())); (* TODO: how can be missing? *)
       ask = (fun (type a) (q: a Queries.t) -> Spec.global_query gctx q);
     }
@@ -90,7 +90,7 @@ sig
   val ask_local: EQSys.LVar.t -> ?local:Spec.D.t -> 'a Queries.t -> 'a Queries.result
   val ask_local_node: Node.t -> ?local:Spec.D.t -> 'a Queries.t -> 'a Queries.result
   val ask_global: 'a Queries.t -> 'a Queries.result
-  val ask_global': Spec.V.t -> 'a Queries.t -> 'a Queries.result
+  val ask_global': Spec.V.t option -> 'a Queries.t -> 'a Queries.result
 end
 
 module Make (FileCfg: MyCFG.FileCfg) (SpecSysSol: SpecSysSol): SpecSysSol2 with module SpecSys = SpecSysSol.SpecSys =

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -63,6 +63,8 @@ struct
       }
     in
     Spec.query ctx
+
+  let ask_global' (gh: EQSys.G.t GHT.t) (type a) g (q: a Queries.t): a Queries.result = Spec.global_query (fun v -> EQSys.G.spec (try GHT.find gh (EQSys.GVar.spec v) with Not_found -> EQSys.G.bot ())) g q (* TODO: how can be missing? *)
 end
 
 
@@ -81,6 +83,7 @@ sig
   val ask_local: EQSys.LVar.t -> ?local:Spec.D.t -> 'a Queries.t -> 'a Queries.result
   val ask_local_node: Node.t -> ?local:Spec.D.t -> 'a Queries.t -> 'a Queries.result
   val ask_global: 'a Queries.t -> 'a Queries.result
+  val ask_global': Spec.V.t -> 'a Queries.t -> 'a Queries.result
 end
 
 module Make (FileCfg: MyCFG.FileCfg) (SpecSysSol: SpecSysSol): SpecSysSol2 with module SpecSys = SpecSysSol.SpecSys =
@@ -113,4 +116,5 @@ struct
     in
     Query.ask_local_node gh node local q
   let ask_global q = Query.ask_global gh q
+  let ask_global' v q = Query.ask_global' gh v q
 end

--- a/src/framework/resultQuery.ml
+++ b/src/framework/resultQuery.ml
@@ -67,7 +67,8 @@ struct
   let ask_global' (gh: EQSys.G.t GHT.t) g =
     let rec gctx = {
       var = Some g;
-      global = (fun v -> EQSys.G.spec (try GHT.find gh (EQSys.GVar.spec v) with Not_found -> EQSys.G.bot ())) (* TODO: how can be missing? *)
+      global = (fun v -> EQSys.G.spec (try GHT.find gh (EQSys.GVar.spec v) with Not_found -> EQSys.G.bot ())); (* TODO: how can be missing? *)
+      ask = (fun (type a) (q: a Queries.t) -> Spec.global_query gctx q);
     }
     in
     Spec.global_query gctx

--- a/src/util/wideningTokens.ml
+++ b/src/util/wideningTokens.ml
@@ -168,6 +168,8 @@ struct
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     lift_fun ctx Fun.const S.query (fun (x) -> x q)
+  let global_query getg (type a) g (q: a Queries.t): a Queries.result =
+    S.global_query (fun g -> G.unlift (getg g)) g q
   let assign ctx lv e = lift_fun ctx lift'   S.assign ((|>) e % (|>) lv)
   let vdecl ctx v     = lift_fun ctx lift'   S.vdecl  ((|>) v)
   let branch ctx e tv = lift_fun ctx lift'   S.branch ((|>) tv % (|>) e)

--- a/src/util/wideningTokens.ml
+++ b/src/util/wideningTokens.ml
@@ -135,6 +135,9 @@ struct
              ; sideg = (fun v g -> ctx.sideg v (g, !side_tokens)) (* Using side_tokens for side effect. *)
     }
 
+  let global_conv (gctx: (V.t, G.t) gctx): (S.V.t, S.G.t) gctx =
+    { gctx with global = (fun g -> G.unlift (gctx.global g)) }
+
   let lift_fun ctx f g h =
     let new_tokens = ref (snd ctx.local) in (* New tokens not yet used during this transfer function, such that it is deterministic. *)
     let old_add = !add_ref in
@@ -168,8 +171,8 @@ struct
 
   let query ctx (type a) (q: a Queries.t): a Queries.result =
     lift_fun ctx Fun.const S.query (fun (x) -> x q)
-  let global_query getg (type a) g (q: a Queries.t): a Queries.result =
-    S.global_query (fun g -> G.unlift (getg g)) g q
+  let global_query gctx (type a) (q: a Queries.t): a Queries.result =
+    S.global_query (global_conv gctx) q
   let assign ctx lv e = lift_fun ctx lift'   S.assign ((|>) e % (|>) lv)
   let vdecl ctx v     = lift_fun ctx lift'   S.vdecl  ((|>) v)
   let branch ctx e tv = lift_fun ctx lift'   S.branch ((|>) tv % (|>) e)

--- a/src/witness/witnessConstraints.ml
+++ b/src/witness/witnessConstraints.ml
@@ -261,6 +261,8 @@ struct
       let module Result = (val Queries.Result.lattice q) in
       fold' ctx Spec.query identity (fun x _ f -> Result.join x (f q)) (Result.bot ())
 
+  let global_query = Spec.global_query
+
   let should_inline f =
     (* (* inline __VERIFIER_error because Control requires the corresponding FunctionEntry node *)
     not (Svcomp.is_special_function f) || Svcomp.is_error_function f *)


### PR DESCRIPTION
Queries like `WarnGlobal` and `InvariantGlobal` are only used globally in dummy `ctx`. Moreover, they have `Obj.t` arguments which are unsafe.
Every analysis lifter which adds its own global unknowns must have special cases for converting such arguments for `WarnGlobal` and `InvariantGlobal`. If that is forgotten, then Goblint simply segfaults.

This PR introduces **global queries** using a separate `global_query` "transfer" function and `gctx` global "context" for the queries, which doesn't require all the dummy data.

### TODO
- [ ] Convert `InvariantGlobal` query.
- [ ] Use this for #1394.