### PR TITLE
Investigate apron, apron2 and termination "Excellent: ignored check"-s

### DIFF
--- a/tests/regression/36-apron/21-traces-cluster-based.c
+++ b/tests/regression/36-apron/21-traces-cluster-based.c
@@ -1,6 +1,6 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --enable ana.sv-comp.functions
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --enable ana.sv-comp.functions --set ana.relation.privatization mutex-meet
 extern int __VERIFIER_nondet_int();
-
+// TODO: rename? this doesn't require clusters
 #include <pthread.h>
 #include <goblint.h>
 
@@ -45,7 +45,7 @@ void *t3_fun(void *arg) {
   y = h;
   pthread_mutex_unlock(&A);
   pthread_mutex_unlock(&B);
-  __goblint_check(y == x); // TODO (mutex-meet succeeds, protection unknown)
+  __goblint_check(y == x); // mutex-meet succeeds, protection unknown
   return NULL;
 }
 
@@ -63,9 +63,9 @@ int main(void) {
   x = g;
   y = h;
   pthread_mutex_lock(&B);
-  __goblint_check(y == x); // TODO (mutex-meet succeeds, protection unknown)
+  __goblint_check(y == x); // mutex-meet succeeds, protection unknown
   pthread_mutex_unlock(&B);
   pthread_mutex_unlock(&A);
-  __goblint_check(y == x); // TODO (mutex-meet succeeds, protection unknown)
+  __goblint_check(y == x); // mutex-meet succeeds, protection unknown
   return 0;
 }

--- a/tests/regression/36-apron/22-traces-write-centered-vs-meet-mutex.c
+++ b/tests/regression/36-apron/22-traces-write-centered-vs-meet-mutex.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --enable ana.sv-comp.functions
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --enable ana.sv-comp.functions --set ana.relation.privatization mutex-meet
 extern int __VERIFIER_nondet_int();
 
 #include <pthread.h>
@@ -22,11 +22,11 @@ void *t_fun(void *arg) {
     y = h;
     __goblint_check(y <= x);
     pthread_mutex_lock(&B);
-    __goblint_check(x == y); // TODO (mutex-meet succeeds, write unknown)
+    __goblint_check(x == y); // mutex-meet succeeds, (now-defunct) write unknown
     pthread_mutex_unlock(&B);
     i = x + 31;
     z = i;
-    __goblint_check(z >= x); // TODO (write succeeds, mutex-meet unknown)
+    __goblint_check(z >= x); // TODO ((now-defunct) write succeeds, mutex-meet unknown)
     pthread_mutex_unlock(&A);
     pthread_mutex_unlock(&C);
   }

--- a/tests/regression/36-apron/34-large-bigint.c
+++ b/tests/regression/36-apron/34-large-bigint.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.activated[-] expRelation
 #include <goblint.h>
 
 void main() {
@@ -17,6 +17,7 @@ void main() {
       __goblint_check(18446744073709551614ull <= z); // TODO (unknown with D, success with MPQ)
       __goblint_check(z <= 18446744073709551615ull); // TODO (unknown with D, success with MPQ)
 
+      // disable expRelation to prevent base from simplifying x - x to 0
       __goblint_check(x >= x - x); // avoid base from answering to check if apron doesn't say x == -3
       __goblint_check(y >= y - y); // avoid base from answering to check if apron doesn't say y == -3
       __goblint_check(z >= z - z); // avoid base from answering to check if apron doesn't say z == -3

--- a/tests/regression/36-apron/34-large-bigint.c
+++ b/tests/regression/36-apron/34-large-bigint.c
@@ -9,13 +9,13 @@ void main() {
     __goblint_check(y < z);
     __goblint_check(x < z);
 
-    if (18446744073709551612ull <= x && z <= 18446744073709551615ull) {
-      __goblint_check(18446744073709551612ull <= x); // TODO (unknown with D, success with MPQ)
-      __goblint_check(x <= 18446744073709551613ull); // TODO (unknown with D, success with MPQ)
-      __goblint_check(18446744073709551613ull <= y); // TODO (unknown with D, success with MPQ)
-      __goblint_check(y <= 18446744073709551614ull); // TODO (unknown with D, success with MPQ)
-      __goblint_check(18446744073709551614ull <= z); // TODO (unknown with D, success with MPQ)
-      __goblint_check(z <= 18446744073709551615ull); // TODO (unknown with D, success with MPQ)
+    if (18446744073709551611ull <= x && z <= 18446744073709551614ull) {
+      __goblint_check(18446744073709551611ull <= x); // TODO (unknown with D, success with MPQ)
+      __goblint_check(x <= 18446744073709551612ull); // TODO (unknown with D, success with MPQ)
+      __goblint_check(18446744073709551612ull <= y); // TODO (unknown with D, success with MPQ)
+      __goblint_check(y <= 18446744073709551613ull); // TODO (unknown with D, success with MPQ)
+      __goblint_check(18446744073709551613ull <= z); // TODO (unknown with D, success with MPQ)
+      __goblint_check(z <= 18446744073709551614ull); // TODO (unknown with D, success with MPQ)
 
       // disable expRelation to prevent base from simplifying x - x to 0
       __goblint_check(x >= x - x); // avoid base from answering to check if apron doesn't say x == -3

--- a/tests/regression/36-apron/38-branch-global.c
+++ b/tests/regression/36-apron/38-branch-global.c
@@ -10,6 +10,6 @@ int main() {
         __goblint_check(count < ARR_SIZE);
         count++;
     }
-    __goblint_check(count == ARR_SIZE); // TODO (requires threshold)
+    __goblint_check(count == ARR_SIZE); // requires narrowing
     return 0 ;
 }

--- a/tests/regression/36-apron/42-threadenter-arg.c
+++ b/tests/regression/36-apron/42-threadenter-arg.c
@@ -2,8 +2,8 @@
 #include <pthread.h>
 #include <goblint.h>
 
-void *t_fun(int arg) {
-  __goblint_check(arg == 3); // TODO (cast through void*)
+void *t_fun(int arg) { // check that apron doesn't crash with tracked thread argument
+  __goblint_check(arg == 3); // cast through void*, passes by base
   return NULL;
 }
 

--- a/tests/regression/36-apron/90-mine14-5b.c
+++ b/tests/regression/36-apron/90-mine14-5b.c
@@ -46,6 +46,8 @@ int main(void) {
   pthread_create(&id2, NULL, t_fun2, NULL);
   pthread_mutex_lock(&mutex);
   __goblint_check(x==y);
+  __goblint_check(0 <= x);
+  __goblint_check(x <= 10);
   pthread_mutex_unlock(&mutex);
   return 0;
 }

--- a/tests/regression/36-apron/91-mine14-5b-no-threshhold.c
+++ b/tests/regression/36-apron/91-mine14-5b-no-threshhold.c
@@ -46,7 +46,9 @@ int main(void) {
   pthread_create(&id, NULL, t_fun, NULL);
   pthread_create(&id2, NULL, t_fun2, NULL);
   pthread_mutex_lock(&mutex);
-  __goblint_check(x==y); //TODO
+  __goblint_check(x==y);
+  __goblint_check(0 <= x);
+  __goblint_check(x <= 10); // TODO
   pthread_mutex_unlock(&mutex);
   return 0;
 }

--- a/tests/regression/46-apron2/75-mutex_with_ghosts.c
+++ b/tests/regression/46-apron2/75-mutex_with_ghosts.c
@@ -1,4 +1,4 @@
-// SKIP PARAM: --enable ana.sv-comp.functions --set ana.activated[+] apron --set ana.relation.privatization mutex-meet-atomic --set sem.int.signed_overflow assume_none
+// SKIP PARAM: --enable ana.sv-comp.functions --set ana.activated[+] apron --set ana.relation.privatization mutex-meet-atomic --set sem.int.signed_overflow assume_none --set ana.base.privatization protection-atomic
 /*-----------------------------------------------------------------------------
  * mutex_with_ghosts.c - Annotated concurrent program with ghost variables for
  *                       witness validation using locking to access a shared
@@ -53,6 +53,7 @@ int main()
   pthread_mutex_lock(&m);
   __VERIFIER_atomic_end();
 
+  // TODO: works with base protection privatization but not protection-atomic
   __goblint_check(used == 0); // TODO (read/refine? of used above makes used write-unprotected)
 
   __VERIFIER_atomic_begin();

--- a/tests/regression/78-termination/25-leave-loop-goto-terminating.c
+++ b/tests/regression/78-termination/25-leave-loop-goto-terminating.c
@@ -1,4 +1,4 @@
-// SKIP TODO TERM PARAM: --set "ana.activated[+]" termination --set ana.activated[+] apron --enable ana.int.interval --set ana.apron.domain polyhedra
+// SKIP TERM PARAM: --set "ana.activated[+]" termination --set ana.activated[+] apron --enable ana.int.interval --set ana.apron.domain polyhedra
 #include <stdio.h>
 
 int main()

--- a/tests/regression/78-termination/28-do-while-continue-terminating.c
+++ b/tests/regression/78-termination/28-do-while-continue-terminating.c
@@ -1,4 +1,4 @@
-// SKIP TODO TERM PARAM: --set "ana.activated[+]" termination --set ana.activated[+] apron --enable ana.int.interval --set ana.apron.domain polyhedra
+// SKIP TERM PARAM: --set "ana.activated[+]" termination --set ana.activated[+] apron --enable ana.int.interval --set ana.apron.domain polyhedra
 #include <stdio.h>
 
 int main()
@@ -22,7 +22,8 @@ int main()
 }
 
 /*
-NOTE:
+NOTE: The description below is probably outdated. This works since 5d291caf43da73d24f3093ec36cced018972cc30.
+
 Test 28: does not terminate but should terminate (test case
 "28-do-while-continue-terminating.c") Reason: upjumping goto
 


### PR DESCRIPTION
See #1425.

I went over all the apron, apron2 and termination instances from the issue and adapted the tests in one of the ways:
1. Remove TODO because we are soundly more precise now.
2. Remove TODO because we changed defaults to the passing one.
3. Adapt test to check originally intended aspect which we haven't solved but we became more precise due to orthogonal reasons.