### PR TITLE
Fix SV-COMP Apron unassume crash

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -76,6 +76,7 @@ struct
               VH.find v_ins v
             else
               let v_in = Cilfacade.create_var @@ makeVarinfo false (v.vname ^ "#in") v.vtype in (* temporary local g#in for global g *)
+              v_in.vattr <- v.vattr; (* preserve goblint_relation_track attribute *)
               VH.replace v_ins v v_in;
               v_in
           in
@@ -97,6 +98,7 @@ struct
     let v_ins_inv = VH.create (List.length vs) in
     List.iter (fun v ->
         let v_in = Cilfacade.create_var @@ makeVarinfo false (v.vname ^ "#in") v.vtype in (* temporary local g#in for global g *)
+        v_in.vattr <- v.vattr; (* preserve goblint_relation_track attribute *)
         VH.replace v_ins_inv v_in v;
       ) vs;
     let rel = RD.add_vars st.rel (List.map RV.local (VH.keys v_ins_inv |> List.of_enum)) in (* add temporary g#in-s *)

--- a/tests/regression/56-witness/45-apron-tracked-global-annot.c
+++ b/tests/regression/56-witness/45-apron-tracked-global-annot.c
@@ -1,0 +1,9 @@
+// PARAM: --set ana.activated[+] apron --enable annotation.goblint_relation_track --set ana.activated[+] unassume --set witness.yaml.unassume 45-apron-tracked-global-annot.yml
+#include <goblint.h>
+
+int g __attribute__((__goblint_relation_track__)) = 0;
+
+int main() {
+  __goblint_check(g == 0); // unassume should not crash here
+  return 0;
+}

--- a/tests/regression/56-witness/45-apron-tracked-global-annot.yml
+++ b/tests/regression/56-witness/45-apron-tracked-global-annot.yml
@@ -1,0 +1,25 @@
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: d834761a-d0d7-4fea-bf42-2ff2b9a19143
+    creation_time: 2024-04-23T10:59:25Z
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - 45-apron-tracked-global-annot.c
+      input_file_hashes:
+        45-apron-tracked-global-annot.c: 9c984e89a790b595d2b37ca8a05e5967a15130592cb2567fac2fae4aff668a4f
+      data_model: LP64
+      language: C
+  location:
+    file_name: 45-apron-tracked-global-annot.c
+    file_hash: 9c984e89a790b595d2b37ca8a05e5967a15130592cb2567fac2fae4aff668a4f
+    line: 7
+    column: 3
+    function: main
+  location_invariant:
+    string: g == 0
+    type: assertion
+    format: C


### PR DESCRIPTION
Our sv-benchmarks validation runs (at least) contain some crashes like
```
Fatal error: exception Failure("Environment.dim_of_var: unknown variable in the environment")
```

Since the autotuner uses `goblint_relation_track` attributes to specify which variables are tracked, these need to be preserved for copied globals. This is already done in `assign_to_global_wrapper`, but not `read_globals_to_locals`, which this fixes.