### PR TITLE
Refactor must-locksets to use definite mvals instead of addresses

### DIFF
--- a/.github/workflows/locked.yml
+++ b/.github/workflows/locked.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13
         ocaml-compiler:
           - ocaml-variants.4.14.0+options,ocaml-option-flambda # matches opam lock file
           # don't add any other because they won't be used

--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13
         ocaml-compiler:
           - 5.0.x
           - ocaml-variants.4.14.0+options,ocaml-option-flambda
@@ -91,7 +91,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13
         ocaml-compiler:
           - ocaml-variants.4.14.0+options,ocaml-option-flambda # matches opam lock file, downgrade deps step
 
@@ -189,7 +189,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13
         ocaml-compiler:
           - ocaml-variants.4.14.0+options,ocaml-option-flambda # matches opam lock file
 

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -74,7 +74,7 @@ struct
 
   let protected_vars (ask: Q.ask): varinfo list =
     LockDomain.MustLockset.fold (fun ml acc ->
-        Q.VS.join (ask.f (Q.MustProtectedVars {mutex = Addr (LockDomain.MustLock.to_mval ml); write = true})) acc (* TODO: avoid Addr conversion *)
+        Q.VS.join (ask.f (Q.MustProtectedVars {mutex = ml; write = true})) acc
       ) (ask.f Q.MustLockset) (Q.VS.empty ())
     |> Q.VS.elements
 end

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -73,8 +73,8 @@ struct
     ask.f (Q.MustBeProtectedBy {mutex=m; global=x; write=true; protection})
 
   let protected_vars (ask: Q.ask): varinfo list =
-    Q.AD.fold (fun m acc ->
-        Q.VS.join (ask.f (Q.MustProtectedVars {mutex = m; write = true})) acc
+    LockDomain.MustLockset.fold (fun ml acc ->
+        Q.VS.join (ask.f (Q.MustProtectedVars {mutex = Addr (LockDomain.MustLock.to_mval ml); write = true})) acc (* TODO: avoid Addr conversion *)
       ) (ask.f Q.MustLockset) (Q.VS.empty ())
     |> Q.VS.elements
 end
@@ -136,8 +136,8 @@ struct
     if !AnalysisState.global_initialization then
       Lockset.empty ()
     else
-      let ad = ask.f Queries.MustLockset in
-      Q.AD.fold (fun mls acc -> Lockset.add mls acc) ad (Lockset.empty ()) (* TODO: use AD as Lockset *)
+      let mls = ask.f Queries.MustLockset in
+      LockDomain.MustLockset.fold (fun ml acc -> Lockset.add (Addr (LockDomain.MustLock.to_mval ml)) acc) mls (Lockset.empty ()) (* TODO: use MustLockset as Lockset *)
 
   (* TODO: reversed SetDomain.Hoare *)
   module MinLocksets = HoareDomain.Set_LiftTop (MustLockset) (struct let topname = "All locksets" end) (* reverse Lockset because Hoare keeps maximal, but we need minimal *)

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -30,7 +30,7 @@ struct
     let part_access ctx: MCPAccess.A.t =
       Obj.obj (ctx.ask (PartAccess Point))
 
-    let add ctx ((l, _): LockDomain.Lockset.Lock.t) =
+    let add ctx ((l, _): LockDomain.Lock.t) =
       let after: LockEvent.t = (l, ctx.prev_node, part_access ctx) in (* use octx for access to use locksets before event *)
       D.iter (fun before ->
           side_lock_event_pair ctx before after

--- a/src/analyses/deadlock.ml
+++ b/src/analyses/deadlock.ml
@@ -30,7 +30,7 @@ struct
     let part_access ctx: MCPAccess.A.t =
       Obj.obj (ctx.ask (PartAccess Point))
 
-    let add ctx ((l, _): LockDomain.Lock.t) =
+    let add ctx ((l, _): LockDomain.AddrRW.t) =
       let after: LockEvent.t = (l, ctx.prev_node, part_access ctx) in (* use octx for access to use locksets before event *)
       D.iter (fun before ->
           side_lock_event_pair ctx before after

--- a/src/analyses/locksetAnalysis.ml
+++ b/src/analyses/locksetAnalysis.ml
@@ -29,7 +29,7 @@ sig
   module G: Lattice.S
   module V: SpecSysVar
 
-  val add: (D.t, G.t, D.t, V.t) ctx -> LockDomain.Lockset.Lock.t -> D.t
+  val add: (D.t, G.t, D.t, V.t) ctx -> LockDomain.Lock.t -> D.t
   val remove: (D.t, G.t, D.t, V.t) ctx -> ValueDomain.Addr.t -> D.t
 end
 

--- a/src/analyses/locksetAnalysis.ml
+++ b/src/analyses/locksetAnalysis.ml
@@ -29,7 +29,7 @@ sig
   module G: Lattice.S
   module V: SpecSysVar
 
-  val add: (D.t, G.t, D.t, V.t) ctx -> LockDomain.Lock.t -> D.t
+  val add: (D.t, G.t, D.t, V.t) ctx -> LockDomain.AddrRW.t -> D.t
   val remove: (D.t, G.t, D.t, V.t) ctx -> ValueDomain.Addr.t -> D.t
 end
 

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -188,7 +188,6 @@ struct
     let ls, m = ctx.local in
     (* get the set of mutexes protecting the variable v in the given mode *)
     let protecting ~write mode v = GProtecting.get ~write mode (G.protecting (ctx.global (V.protecting v))) in
-    let non_overlapping locks1 locks2 = MustLockset.is_empty @@ MustLockset.inter locks1 locks2 in
     match q with
     | Queries.MayBePublic _ when MustLocksetRW.is_all ls -> false
     | Queries.MayBePublic {global=v; write; protection} ->
@@ -198,7 +197,7 @@ struct
       (* if Mutexes.mem verifier_atomic (Lockset.export_locks ctx.local) then
         false
       else *)
-      non_overlapping held_locks protecting
+      MustLockset.disjoint held_locks protecting
     | Queries.MayBePublicWithout _ when MustLocksetRW.is_all ls -> false
     | Queries.MayBePublicWithout {global=v; write; without_mutex; protection} ->
       let held_locks = MustLocksetRW.export_locks @@ fst @@ Arg.remove' ctx ~warn:false without_mutex in
@@ -207,7 +206,7 @@ struct
       (* if Mutexes.mem verifier_atomic (Lockset.export_locks (Lockset.remove (without_mutex, true) ctx.local)) then
         false
       else *)
-      non_overlapping held_locks protecting
+      MustLockset.disjoint held_locks protecting
     | Queries.MustBeProtectedBy {mutex = Addr mutex; global=v; write; protection} -> (* TODO: non-Addr? *)
       let mutex_lockset = MustLocksetRW.export_locks @@ MustLocksetRW.singleton (LockDomain.MustLock.of_mval mutex, true) in (* TODO: what if non-definite? *)
       let protecting = protecting ~write protection v in

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -221,8 +221,8 @@ struct
     | Queries.MustBeAtomic ->
       let held_locks = MustLocksetRW.to_must_lockset (MustLocksetRW.filter snd ls) in
       MustLockset.mem (LF.verifier_atomic_var, `NoOffset) held_locks (* TODO: Mval.of_var *)
-    | Queries.MustProtectedVars {mutex = Addr mutex_mv; write} -> (* TODO: non-Addr? *)
-      let protected = GProtected.get ~write Strong (G.protected (ctx.global (V.protected (LockDomain.MustLock.of_mval mutex_mv)))) in (* TODO: what if non-definite? *)
+    | Queries.MustProtectedVars {mutex; write} ->
+      let protected = GProtected.get ~write Strong (G.protected (ctx.global (V.protected mutex))) in
       VarSet.fold (fun v acc ->
           Queries.VS.add v acc
         ) protected (Queries.VS.empty ())

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -208,13 +208,13 @@ struct
       else *)
       MustLockset.disjoint held_locks protecting
     | Queries.MustBeProtectedBy {mutex = Addr mutex_mv; global=v; write; protection} -> (* TODO: non-Addr? *)
-      let mutex_lockset = MustLocksetRW.to_must_lockset @@ MustLocksetRW.singleton (LockDomain.MustLock.of_mval mutex_mv, true) in (* TODO: what if non-definite? *)
+      let ml = LockDomain.MustLock.of_mval mutex_mv in (* TODO: what if non-definite? *)
       let protecting = protecting ~write protection v in
       (* TODO: unsound in 29/24, why did we do this before? *)
       (* if LockDomain.Addr.equal mutex (LockDomain.Addr.of_var LF.verifier_atomic_var) then
         true
       else *)
-      MustLockset.subset mutex_lockset protecting (* TODO: some mem? *)
+      MustLockset.mem ml protecting
     | Queries.MustLockset ->
       let held_locks = MustLocksetRW.to_must_lockset (MustLocksetRW.filter snd ls) in
       MustLockset.fold (fun addr ls -> Queries.AD.add (Addr (LockDomain.MustLock.to_mval addr)) ls) held_locks (Queries.AD.empty ()) (* TODO: Z indices for Queries.MustLockset result? *)

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -4,6 +4,7 @@ module M = Messages
 module Addr = ValueDomain.Addr
 module Lock = LockDomain.Lock
 module Lockset = LockDomain.Lockset
+module Multiplicity = LockDomain.Multiplicity
 module Simple = LockDomain.Simple
 module Mutexes = LockDomain.Mutexes
 module LF = LibraryFunctions
@@ -17,59 +18,6 @@ module Spec =
 struct
   module Arg =
   struct
-    module Multiplicity = struct
-      (* the maximum multiplicity which we keep track of precisely *)
-      let max_count () = 4
-
-      module Count = Lattice.Reverse (
-          Lattice.Chain (
-          struct
-            let n () = max_count () + 1
-            let names x = if x = max_count () then Format.asprintf ">= %d" x else Format.asprintf "%d" x
-          end
-          )
-        )
-
-      include MapDomain.MapTop_LiftBot (LockDomain.Mval) (Count)
-
-      let name () = "multiplicity"
-
-      let increment v x =
-        let current = find v x in
-        if current = max_count () then
-          x
-        else
-          add v (current + 1) x
-
-      let increment mv m =
-        if Addr.Mval.is_definite mv then
-          increment (LockDomain.Mval.of_mval mv) m
-        else
-          m
-
-      let decrement v x =
-        let current = find v x in
-        if current = 0 then
-          (x, true)
-        else
-          (add v (current - 1) x, current - 1 = 0) (* TODO: remove if 0? *)
-
-      let decrement mv m =
-        if Addr.Mval.is_definite mv then
-          decrement (LockDomain.Mval.of_mval mv) m
-        else
-          (* TODO: non-definite should also decrement (to 0)? *)
-          fold (fun mv' _ (m, rmed) ->
-              (* TODO: avoid conversion: semantic_equal between ValueDomain.Mval and Mval *)
-              if ValueDomain.Mval.semantic_equal mv (LockDomain.Mval.to_mval mv') = Some false then
-                (m, rmed)
-              else (
-                let (m', rmed') = decrement mv' m in
-                (m', rmed || rmed')
-              )
-            ) m (m, false)
-    end
-
     module D = struct include Lattice.Prod(Lockset)(Multiplicity)
       let empty () = (Lockset.empty (), Multiplicity.empty ())
     end

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -3,6 +3,7 @@
 module M = Messages
 module Addr = ValueDomain.Addr
 module Lockset = LockDomain.Lockset
+module MLockset = LockDomain.MLockset
 module Mutexes = LockDomain.Mutexes
 module LF = LibraryFunctions
 open GoblintCil
@@ -47,8 +48,8 @@ struct
           (add v (current - 1) x, current - 1 = 0)
     end
 
-    module D = struct include Lattice.Prod(Lockset)(Multiplicity)
-      let empty () = (Lockset.empty (), Multiplicity.empty ())
+    module D = struct include Lattice.Prod(MLockset)(Multiplicity)
+      let empty () = (MLockset.empty (), Multiplicity.empty ())
     end
 
 
@@ -146,36 +147,43 @@ struct
       let create_protected protected = `Lifted2 protected
     end
 
-    let add ctx (l:Mutexes.elt*bool) =
+    let add ctx (l:Mutexes.elt*bool): D.t =
       let s,m = ctx.local in
-      let s' = Lockset.add l s in
       match Addr.to_mval (fst l) with
       | Some mval when MutexTypeAnalysis.must_be_recursive ctx mval ->
+        let s' = MLockset.add (mval, snd l) s in
         (s', Multiplicity.increment (fst l) m)
-      | _ -> (s', m)
+      | Some mval ->
+        let s' = MLockset.add (mval, snd l) s in
+        (s', m)
+      | _ -> (s, m)
 
-    let remove' ctx ~warn l =
-      let s, m = ctx.local in
-      let rm s = Lockset.remove (l, true) (Lockset.remove (l, false) s) in
-      if warn &&  (not (Lockset.mem (l,true) s || Lockset.mem (l,false) s)) then M.warn "unlocking mutex (%a) which may not be held" Addr.pretty l;
+    let remove' ctx ~warn l: D.t =
       match Addr.to_mval l with
-      | Some mval when MutexTypeAnalysis.must_be_recursive ctx mval ->
-        let m',rmed = Multiplicity.decrement l m in
-        if rmed then
-          (rm s, m')
+      | None -> ctx.local
+      | Some l ->
+        let s, m = ctx.local in
+        let rm s = MLockset.remove (l, true) (MLockset.remove (l, false) s) in
+        if warn &&  (not (MLockset.mem (l,true) s || MLockset.mem (l,false) s)) then M.warn "unlocking mutex (%a) which may not be held" LockDomain.Mval.pretty l;
+        if MutexTypeAnalysis.must_be_recursive ctx l then (
+          let m',rmed = Multiplicity.decrement (Addr l) m in
+          if rmed then
+            (rm s, m')
+          else
+            (s, m')
+        )
         else
-          (s, m')
-      | _ -> (rm s, m)
+          (rm s, m)
 
     let remove = remove' ~warn:true
 
-    let remove_all ctx =
+    let remove_all ctx: D.t =
       (* Mutexes.iter (fun m ->
            ctx.emit (MustUnlock m)
          ) (D.export_locks ctx.local); *)
       (* TODO: used to have remove_nonspecial, which kept v.vname.[0] = '{' variables *)
       M.warn "unlocking unknown mutex which may not be held";
-      (Lockset.empty (), Multiplicity.empty ())
+      (MLockset.empty (), Multiplicity.empty ())
 
     let empty () = (Lockset.empty (), Multiplicity.empty ())
   end
@@ -201,24 +209,24 @@ struct
     num_mutexes := 0;
     sum_protected := 0
 
-  let query ctx (type a) (q: a Queries.t): a Queries.result =
+  let query (ctx: (D.t, _, _, _) ctx) (type a) (q: a Queries.t): a Queries.result =
     let ls, m = ctx.local in
     (* get the set of mutexes protecting the variable v in the given mode *)
     let protecting ~write mode v = GProtecting.get ~write mode (G.protecting (ctx.global (V.protecting v))) in
     let non_overlapping locks1 locks2 = Mutexes.is_empty @@ Mutexes.inter locks1 locks2 in
     match q with
-    | Queries.MayBePublic _ when Lockset.is_bot ls -> false
+    | Queries.MayBePublic _ when MLockset.is_bot ls -> false
     | Queries.MayBePublic {global=v; write; protection} ->
-      let held_locks = Lockset.export_locks (Lockset.filter snd ls) in
+      let held_locks = MLockset.export_locks (MLockset.filter snd ls) in
       let protecting = protecting ~write protection v in
       (* TODO: unsound in 29/24, why did we do this before? *)
       (* if Mutexes.mem verifier_atomic (Lockset.export_locks ctx.local) then
         false
       else *)
       non_overlapping held_locks protecting
-    | Queries.MayBePublicWithout _ when Lockset.is_bot ls -> false
+    | Queries.MayBePublicWithout _ when MLockset.is_bot ls -> false
     | Queries.MayBePublicWithout {global=v; write; without_mutex; protection} ->
-      let held_locks = Lockset.export_locks @@ fst @@ Arg.remove' ctx ~warn:false without_mutex in
+      let held_locks = MLockset.export_locks @@ fst @@ Arg.remove' ctx ~warn:false without_mutex in
       let protecting = protecting ~write protection v in
       (* TODO: unsound in 29/24, why did we do this before? *)
       (* if Mutexes.mem verifier_atomic (Lockset.export_locks (Lockset.remove (without_mutex, true) ctx.local)) then
@@ -234,10 +242,10 @@ struct
       else *)
       Mutexes.leq mutex_lockset protecting
     | Queries.MustLockset ->
-      let held_locks = Lockset.export_locks (Lockset.filter snd ls) in
+      let held_locks = MLockset.export_locks (MLockset.filter snd ls) in
       Mutexes.fold (fun addr ls -> Queries.AD.add addr ls) held_locks (Queries.AD.empty ())
     | Queries.MustBeAtomic ->
-      let held_locks = Lockset.export_locks (Lockset.filter snd ls) in
+      let held_locks = MLockset.export_locks (MLockset.filter snd ls) in
       Mutexes.mem (LockDomain.Addr.of_var LF.verifier_atomic_var) held_locks
     | Queries.MustProtectedVars {mutex = m; write} ->
       let protected = GProtected.get ~write Strong (G.protected (ctx.global (V.protected m))) in
@@ -269,7 +277,7 @@ struct
 
   module A =
   struct
-    include Lockset
+    include MLockset
     let name () = "lock"
     let may_race ls1 ls2 =
       (* not mutually exclusive *)
@@ -287,7 +295,7 @@ struct
   let access ctx (a: Queries.access) =
     fst ctx.local
 
-  let event ctx e octx =
+  let event (ctx: (D.t, _, _, _) ctx) e (octx: (D.t, _, _, _) ctx) =
     match e with
     | Events.Access {exp; ad; kind; _} when ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx) -> (* threadflag query in post-threadspawn ctx *)
       let is_recovered_to_st = not (ThreadFlag.is_currently_multi (Analyses.ask_of_ctx ctx)) in
@@ -297,8 +305,8 @@ struct
         (*privatization*)
         match var_opt with
         | Some v ->
-          if not (Lockset.is_bot (fst octx.local)) then
-            let locks = Lockset.export_locks (Lockset.filter snd (fst octx.local)) in
+          if not (MLockset.is_bot (fst octx.local)) then
+            let locks = MLockset.export_locks (MLockset.filter snd (fst octx.local)) in
             let write = match kind with
               | Write | Free -> true
               | Read -> false

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -7,7 +7,6 @@ module AddrRW = LockDomain.AddrRW
 module MustLockset = LockDomain.MustLockset
 module MustLocksetRW = LockDomain.MustLocksetRW
 module MustMultiplicity = LockDomain.MustMultiplicity
-module Mutexes = LockDomain.Mutexes
 module LF = LibraryFunctions
 open GoblintCil
 open Analyses

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -1,6 +1,7 @@
 (** Must lockset and protecting lockset analysis ([mutex]). *)
 
 module M = Messages
+module Mval = ValueDomain.Mval
 module Addr = ValueDomain.Addr
 module Lock = LockDomain.Lock
 module MustLockset = LockDomain.MustLockset
@@ -139,7 +140,7 @@ struct
       | Some mv ->
         let (s, m) = ctx.local in
         if warn && not (MustLocksetRW.mem_rw mv s) then
-          M.warn "unlocking mutex (%a) which may not be held" ValueDomain.Mval.pretty mv;
+          M.warn "unlocking mutex (%a) which may not be held" Mval.pretty mv;
         if MutexTypeAnalysis.must_be_recursive ctx mv then (
           let (m', rmed) = MustMultiplicity.decrement mv m in
           if rmed then

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -29,7 +29,7 @@ struct
           )
         )
 
-      include MapDomain.MapTop_LiftBot (ValueDomain.Addr) (Count)
+      include MapDomain.MapTop_LiftBot (LockDomain.Mval) (Count)
 
       let name () = "multiplicity"
 
@@ -154,7 +154,7 @@ struct
         let s' = Lockset.add (mv, rw) s in
         let m' =
           if MutexTypeAnalysis.must_be_recursive ctx mv then
-            Multiplicity.increment addr m
+            Multiplicity.increment mv m
           else
             m
         in
@@ -170,7 +170,7 @@ struct
           M.warn "unlocking mutex (%a) which may not be held" LockDomain.Mval.pretty mv;
         let rm s = Lockset.remove (mv, true) (Lockset.remove (mv, false) s) in
         if MutexTypeAnalysis.must_be_recursive ctx mv then (
-          let (m', rmed) = Multiplicity.decrement (Addr mv) m in
+          let (m', rmed) = Multiplicity.decrement mv m in
           if rmed then
             (rm s, m')
           else

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -217,7 +217,7 @@ struct
       MustLockset.mem ml protecting
     | Queries.MustLockset ->
       let held_locks = MustLocksetRW.to_must_lockset (MustLocksetRW.filter snd ls) in
-      MustLockset.fold (fun addr ls -> Queries.AD.add (Addr (LockDomain.MustLock.to_mval addr)) ls) held_locks (Queries.AD.empty ()) (* TODO: Z indices for Queries.MustLockset result? *)
+      held_locks
     | Queries.MustBeAtomic ->
       let held_locks = MustLocksetRW.to_must_lockset (MustLocksetRW.filter snd ls) in
       MustLockset.mem (LF.verifier_atomic_var, `NoOffset) held_locks (* TODO: Mval.of_var *)

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -207,8 +207,8 @@ struct
         false
       else *)
       MustLockset.disjoint held_locks protecting
-    | Queries.MustBeProtectedBy {mutex = Addr mutex_mv; global=v; write; protection} -> (* TODO: non-Addr? *)
-      let ml = LockDomain.MustLock.of_mval mutex_mv in (* TODO: what if non-definite? *)
+    | Queries.MustBeProtectedBy {mutex = Addr mutex_mv; global=v; write; protection} when Mval.is_definite mutex_mv -> (* only definite Addrs can be in must-locksets to begin with, anything else cannot protect anything *)
+      let ml = LockDomain.MustLock.of_mval mutex_mv in
       let protecting = protecting ~write protection v in
       (* TODO: unsound in 29/24, why did we do this before? *)
       (* if LockDomain.Addr.equal mutex (LockDomain.Addr.of_var LF.verifier_atomic_var) then

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -3,7 +3,7 @@
 module M = Messages
 module Mval = ValueDomain.Mval
 module Addr = ValueDomain.Addr
-module Lock = LockDomain.Lock
+module AddrRW = LockDomain.AddrRW
 module MustLockset = LockDomain.MustLockset
 module MustLocksetRW = LockDomain.MustLocksetRW
 module MustMultiplicity = LockDomain.MustMultiplicity
@@ -120,7 +120,7 @@ struct
       let create_protected protected = `Lifted2 protected
     end
 
-    let add ctx ((addr, rw): Lock.t): D.t =
+    let add ctx ((addr, rw): AddrRW.t): D.t =
       match Addr.to_mval addr with
       | Some mv ->
         let (s, m) = ctx.local in

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -154,8 +154,8 @@ struct
         let (s, m) = ctx.local in
         let s' = Lockset.add (mv, rw) s in
         let m' =
-          if MutexTypeAnalysis.must_be_recursive ctx mv then
-            Multiplicity.increment (LockDomain.Mval.of_mval mv) m (* TODO: no definite check? *)
+          if ValueDomain.Mval.is_definite mv && MutexTypeAnalysis.must_be_recursive ctx mv then
+            Multiplicity.increment (LockDomain.Mval.of_mval mv) m
           else
             m
         in
@@ -169,8 +169,8 @@ struct
         let (s, m) = ctx.local in
         if warn && not (Lockset.mem_rw mv s) then
           M.warn "unlocking mutex (%a) which may not be held" ValueDomain.Mval.pretty mv;
-        if MutexTypeAnalysis.must_be_recursive ctx mv then (
-          let (m', rmed) = Multiplicity.decrement (LockDomain.Mval.of_mval mv) m in (* TODO: no definite check? *)
+        if ValueDomain.Mval.is_definite mv && MutexTypeAnalysis.must_be_recursive ctx mv then (
+          let (m', rmed) = Multiplicity.decrement (LockDomain.Mval.of_mval mv) m in (* TODO: non-definite should also decrement (to 0)? *)
           if rmed then
             (Lockset.remove_rw mv s, m')
           else

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -167,18 +167,17 @@ struct
       | None -> ctx.local
       | Some mv ->
         let (s, m) = ctx.local in
-        if warn && (not (Lockset.mem (mv, true) s || Lockset.mem (mv, false) s)) then
+        if warn && not (Lockset.mem_rw mv s) then
           M.warn "unlocking mutex (%a) which may not be held" LockDomain.Mval.pretty mv;
-        let rm s = Lockset.remove (mv, true) (Lockset.remove (mv, false) s) in
         if MutexTypeAnalysis.must_be_recursive ctx mv then (
           let (m', rmed) = Multiplicity.decrement mv m in
           if rmed then
-            (rm s, m')
+            (Lockset.remove_rw mv s, m')
           else
             (s, m')
         )
         else
-          (rm s, m)
+          (Lockset.remove_rw mv s, m)
 
     let remove = remove' ~warn:true
 

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -159,7 +159,7 @@ struct
             (s, m')
         )
         else
-          (MustLocksetRW.remove_mval mv s, m) (* TODO: should decrement something if may be recursive? *)
+          (MustLocksetRW.remove_mval mv s, m) (* Should decrement something if may be recursive? No: https://github.com/goblint/analyzer/pull/1430#discussion_r1615266081. *)
 
     let remove = remove' ~warn:true
 

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -4,7 +4,7 @@ module M = Messages
 module Addr = ValueDomain.Addr
 module Lock = LockDomain.Lock
 module MustLocksetRW = LockDomain.MustLocksetRW
-module Multiplicity = LockDomain.Multiplicity
+module MustMultiplicity = LockDomain.MustMultiplicity
 module Simple = LockDomain.Simple
 module Mutexes = LockDomain.Mutexes
 module LF = LibraryFunctions
@@ -20,8 +20,8 @@ struct
   struct
     module D =
     struct
-      include Lattice.Prod (MustLocksetRW) (Multiplicity)
-      let empty () = (MustLocksetRW.empty (), Multiplicity.empty ())
+      include Lattice.Prod (MustLocksetRW) (MustMultiplicity)
+      let empty () = (MustLocksetRW.empty (), MustMultiplicity.empty ())
     end
 
 
@@ -126,7 +126,7 @@ struct
         let s' = MustLocksetRW.add (mv, rw) s in
         let m' =
           if MutexTypeAnalysis.must_be_recursive ctx mv then
-            Multiplicity.increment mv m
+            MustMultiplicity.increment mv m
           else
             m
         in
@@ -141,7 +141,7 @@ struct
         if warn && not (MustLocksetRW.mem_rw mv s) then
           M.warn "unlocking mutex (%a) which may not be held" ValueDomain.Mval.pretty mv;
         if MutexTypeAnalysis.must_be_recursive ctx mv then (
-          let (m', rmed) = Multiplicity.decrement mv m in
+          let (m', rmed) = MustMultiplicity.decrement mv m in
           if rmed then
             (* TODO: don't repeat the same semantic_equal checks *)
             (* TODO: rmed per lockset element, not aggregated *)

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -184,8 +184,6 @@ struct
       (* TODO: used to have remove_nonspecial, which kept v.vname.[0] = '{' variables *)
       M.warn "unlocking unknown mutex which may not be held";
       (MLockset.empty (), Multiplicity.empty ())
-
-    let empty () = (Lockset.empty (), Multiplicity.empty ())
   end
   include LocksetAnalysis.MakeMust (Arg)
   let name () = "mutex"
@@ -233,8 +231,8 @@ struct
         false
       else *)
       non_overlapping held_locks protecting
-    | Queries.MustBeProtectedBy {mutex; global=v; write; protection} ->
-      let mutex_lockset = Lockset.export_locks @@ Lockset.singleton (mutex, true) in
+    | Queries.MustBeProtectedBy {mutex = Addr mutex; global=v; write; protection} ->
+      let mutex_lockset = MLockset.export_locks @@ MLockset.singleton (mutex, true) in
       let protecting = protecting ~write protection v in
       (* TODO: unsound in 29/24, why did we do this before? *)
       (* if LockDomain.Addr.equal mutex (LockDomain.Addr.of_var LF.verifier_atomic_var) then

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -120,8 +120,8 @@ struct
     end
 
     let add ctx ((addr, rw): AddrRW.t): D.t =
-      match Addr.to_mval addr with
-      | Some mv ->
+      match addr with
+      | Addr mv ->
         let (s, m) = ctx.local in
         let s' = MustLocksetRW.add_mval_rw (mv, rw) s in
         let m' =
@@ -131,7 +131,11 @@ struct
             m
         in
         (s', m')
-      | None -> ctx.local
+      | NullPtr ->
+        M.warn "locking NULL mutex";
+        ctx.local
+      | StrPtr _
+      | UnknownPtr -> ctx.local
 
     let remove' ctx ~warn (addr: Addr.t): D.t =
       match addr with

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -2,7 +2,6 @@
 
 module M = Messages
 module Addr = ValueDomain.Addr
-module Lockset = LockDomain.Lockset
 module MLockset = LockDomain.MLockset
 module Mutexes = LockDomain.Mutexes
 module LF = LibraryFunctions

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -134,9 +134,14 @@ struct
       | None -> ctx.local
 
     let remove' ctx ~warn (addr: Addr.t): D.t =
-      match Addr.to_mval addr with
-      | None -> ctx.local
-      | Some mv ->
+      match addr with
+      | StrPtr _
+      | UnknownPtr -> ctx.local
+      | NullPtr ->
+        if warn then
+          M.warn "unlocking NULL mutex";
+        ctx.local
+      | Addr mv ->
         let (s, m) = ctx.local in
         if warn && not (MustLocksetRW.mem_mval mv s) then
           M.warn "unlocking mutex (%a) which may not be held" Mval.pretty mv;

--- a/src/analyses/mutexEventsAnalysis.ml
+++ b/src/analyses/mutexEventsAnalysis.ml
@@ -4,7 +4,6 @@
 
 module M = Messages
 module Addr = ValueDomain.Addr
-module Lockset = LockDomain.Lockset
 module Mutexes = LockDomain.Mutexes
 module LF = LibraryFunctions
 open Batteries

--- a/src/analyses/mutexEventsAnalysis.ml
+++ b/src/analyses/mutexEventsAnalysis.ml
@@ -4,7 +4,6 @@
 
 module M = Messages
 module Addr = ValueDomain.Addr
-module Mutexes = LockDomain.Mutexes
 module LF = LibraryFunctions
 open Batteries
 open GoblintCil
@@ -20,7 +19,7 @@ struct
   let eval_exp_addr (a: Queries.ask) exp = a.f (Queries.MayPointTo exp)
 
   let lock ctx rw may_fail nonzero_return_when_aquired a lv_opt arg =
-    let compute_refine_split (e:Mutexes.elt) = match e with
+    let compute_refine_split (e: Addr.t) = match e with
       | Addr a ->
         let e' = BinOp(Eq, arg, AddrOf ((PreValueDomain.Mval.to_cil a)), intType) in
         [Events.SplitBranch  (e',true)]

--- a/src/analyses/symbLocks.ml
+++ b/src/analyses/symbLocks.ml
@@ -23,8 +23,8 @@ struct
 
   exception Top
 
-  module D = LockDomain.Symbolic
-  module C = LockDomain.Symbolic
+  module D = SymbLocksDomain.Symbolic
+  module C = SymbLocksDomain.Symbolic
 
   let name () = "symb_locks"
 

--- a/src/cdomain/value/cdomains/mval.ml
+++ b/src/cdomain/value/cdomains/mval.ml
@@ -72,3 +72,4 @@ end
 
 module Unit = MakePrintable (Offset.Unit)
 module Exp = MakePrintable (Offset.Exp)
+module Z = MakePrintable (Offset.Z)

--- a/src/cdomain/value/cdomains/mval.ml
+++ b/src/cdomain/value/cdomains/mval.ml
@@ -36,12 +36,13 @@ struct
   let to_cil_exp lv = Lval (to_cil lv)
 
   let is_definite (_, o) = Offs.is_definite o
-  let top_indices (x, o) = (x, Offs.top_indices o)
 end
 
 module MakeLattice (Offs: Offset.Lattice): Lattice with type idx = Offs.idx =
 struct
   include MakePrintable (Offs)
+  
+  let top_indices (x, o) = (x, Offs.top_indices o)
 
   let semantic_equal (x, xoffs) (y, yoffs) =
     if CilType.Varinfo.equal x y then

--- a/src/cdomain/value/cdomains/mval_intf.ml
+++ b/src/cdomain/value/cdomains/mval_intf.ml
@@ -17,9 +17,6 @@ sig
 
       @return [Some o] if it is (such that the variables are equal and [add_offset m1 o = m2]), [None] if it is not. *)
 
-  val top_indices: t -> t
-  (** Change all indices to top indices. *)
-
   val to_cil: t -> GoblintCil.lval
   (** Convert to CIL lvalue. *)
 
@@ -34,6 +31,9 @@ module type Lattice =
 sig
   include Printable (** @closed *)
   include Lattice.S with type t := t (** @closed *)
+
+  val top_indices: t -> t
+  (** Change all indices to top indices. *)
 
   val semantic_equal: t -> t -> bool option
   (** Check semantic equality of two mvalues.

--- a/src/cdomain/value/cdomains/mval_intf.ml
+++ b/src/cdomain/value/cdomains/mval_intf.ml
@@ -57,4 +57,7 @@ sig
 
   (** Mvalue with {!Offset.Exp} indices in offset. *)
   module Exp: Printable with type idx = GoblintCil.exp
+
+  (** Mvalue with {!Offset.Z} indices in offset. *)
+  module Z: Printable with type idx = Z.t
 end

--- a/src/cdomain/value/cdomains/offset.ml
+++ b/src/cdomain/value/cdomains/offset.ml
@@ -43,6 +43,29 @@ struct
     let to_int _ = None (* TODO: more precise for definite indices *)
     let top () = Lazy.force any
   end
+
+  module Z =
+  struct
+    include Printable.StdLeaf (* TODO: move to GobZ *)
+    include GobZ
+    let name () = "Z index"
+
+    (* TODO: move to GobZ *)
+    include Printable.SimplePretty (
+      struct
+        type nonrec t = t
+        let pretty = pretty
+      end
+      )
+
+    let top () = failwith "Offset.Index.Z.top" (* TODO: remove from interface? *)
+    let to_int z = Some z
+    let equal_to z1 z2 =
+      if Z.equal z2 z2 then
+        `Eq
+      else
+        `Neq
+  end
 end
 
 
@@ -256,6 +279,13 @@ struct
     | `NoOffset    -> NoOffset
     | `Index (i,o) -> Index (i, to_cil o)
     | `Field (f,o) -> Field (f, to_cil o)
+end
+
+module Z =
+struct
+  include MakePrintable (Index.Z)
+
+  let is_definite _ = true (* override to avoid iterating over offset *)
 end
 
 

--- a/src/cdomain/value/cdomains/offset.ml
+++ b/src/cdomain/value/cdomains/offset.ml
@@ -45,18 +45,8 @@ struct
 
   module Z =
   struct
-    include Printable.StdLeaf (* TODO: move to GobZ *)
-    include GobZ
+    include Printable.Z
     let name () = "Z index"
-
-    (* TODO: move to GobZ *)
-    include Printable.SimplePretty (
-      struct
-        type nonrec t = t
-        let pretty = pretty
-      end
-      )
-
     let to_int z = Some z
     let equal_to z1 z2 =
       if Z.equal z2 z2 then

--- a/src/cdomain/value/cdomains/offset.ml
+++ b/src/cdomain/value/cdomains/offset.ml
@@ -41,7 +41,6 @@ struct
 
     let equal_to _ _ = `Top (* TODO: more precise for definite indices *)
     let to_int _ = None (* TODO: more precise for definite indices *)
-    let top () = Lazy.force any
   end
 
   module Z =
@@ -58,7 +57,6 @@ struct
       end
       )
 
-    let top () = failwith "Offset.Index.Z.top" (* TODO: remove from interface? *)
     let to_int z = Some z
     let equal_to z1 z2 =
       if Z.equal z2 z2 then
@@ -156,8 +154,6 @@ struct
     | `Field (f, o) -> `Field (f, map_indices g o)
     | `Index (i, o) -> `Index (g i, map_indices g o)
 
-  let top_indices = map_indices (fun _ -> Idx.top ())
-
   (* tries to follow o in t *)
   let rec type_of ~base:t o = match unrollType t, o with (* resolves TNamed *)
     | t, `NoOffset -> t
@@ -201,6 +197,8 @@ struct
   let meet x y = merge `Meet x y
   let widen x y = merge `Widen x y
   let narrow x y = merge `Narrow x y
+
+  let top_indices = map_indices (fun _ -> Idx.top ())
 
   (* NB! Currently we care only about concrete indexes. Base (seeing only a int domain
      element) answers with any_index_exp on all non-concrete cases. *)
@@ -268,6 +266,8 @@ end
 module Exp =
 struct
   include MakePrintable (Index.Exp)
+
+  let top_indices = map_indices (fun _ -> Lazy.force Index.Exp.any)
 
   let rec of_cil: offset -> t = function
     | NoOffset    -> `NoOffset

--- a/src/cdomain/value/cdomains/offset_intf.ml
+++ b/src/cdomain/value/cdomains/offset_intf.ml
@@ -15,9 +15,6 @@ struct
   sig
     include Printable.S (** @closed *)
 
-    val top: unit -> t
-    (** Unknown index. *)
-
     val equal_to: Z.t -> t -> [`Eq | `Neq | `Top]
     (** Check semantic equality of an integer and the index.
 
@@ -59,9 +56,6 @@ sig
   val map_indices: (idx -> idx) -> t -> t
   (** Apply function to all indexing. *)
 
-  val top_indices: t -> t
-  (** Change all indices to top indices. *)
-
   val to_cil: t -> GoblintCil.offset
   (** Convert to CIL offset. *)
 
@@ -88,6 +82,9 @@ module type Lattice =
 sig
   include Printable (** @closed *)
   include Lattice.S with type t := t (** @closed *)
+
+  val top_indices: t -> t
+  (** Change all indices to top indices. *)
 
   val of_exp: GoblintCil.exp offs -> t
   (** Convert from Goblint offset with {!GoblintCil.exp} indices. *)
@@ -169,6 +166,9 @@ sig
   module Exp:
   sig
     include Printable with type idx = GoblintCil.exp
+
+    val top_indices: t -> t
+    (** Change all indices to top indices. *)
 
     val of_cil : GoblintCil.offset -> t
     (** Convert from CIL offset. *)

--- a/src/cdomain/value/cdomains/offset_intf.ml
+++ b/src/cdomain/value/cdomains/offset_intf.ml
@@ -136,6 +136,10 @@ sig
           Used for Goblint-specific witness invariants. *)
       val all: GoblintCil.exp Lazy.t
     end
+
+    module Z: Printable with type t = Z.t
+    (** {!Z} index.
+        Represents a definite index. *)
   end
 
   exception Type_of_error of GoblintCil.typ * string
@@ -172,4 +176,7 @@ sig
     val to_cil : t -> GoblintCil.offset
     (** Convert to CIL offset. *)
   end
+
+  (** Offset with {!Index.Z} indices. *)
+  module Z: Printable with type idx = Z.t
 end

--- a/src/cdomain/value/cdomains/offset_intf.ml
+++ b/src/cdomain/value/cdomains/offset_intf.ml
@@ -142,6 +142,15 @@ sig
   exception Type_of_error of GoblintCil.typ * string
   (** {!Printable.type_of} could not follow offset completely. *)
 
+  (** Polymorphic offset operations. *)
+  module Poly:
+  sig
+    val map_indices: ('a -> 'b) -> 'a t -> 'b t
+    (** Apply function to all indexing. *)
+
+    (* TODO: include more operations *)
+  end
+
   module type Printable = Printable
   module type Lattice = Lattice
 

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -34,7 +34,7 @@ struct
     )
 end
 
-module MLockset =
+module Lockset =
 struct
 
   (* true means exclusive lock and false represents reader lock*)

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -55,11 +55,11 @@ end
 
 module Lock = MakeLockRW (Addr)
 
+module MustLockRW = MakeLockRW (MustLock)
+
 module MustLocksetRW =
 struct
-  module Lock = MakeLockRW (MustLock)
-
-  include SetDomain.Reverse(SetDomain.ToppedSet (Lock) (struct let topname = "All mutexes" end))
+  include SetDomain.Reverse (SetDomain.ToppedSet (MustLockRW) (struct let topname = "All mutexes" end))
   let name () = "lockset"
 
   let add (mv, rw) set =

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -16,15 +16,15 @@ module Priorities = IntDomain.Lifted
 module RW   = IntDomain.Booleans
 
 (* pair Addr and RW; also change pretty printing*)
-module Lock =
+module MakeLockRW (P: Printable.S) =
 struct
-  include Printable.Prod (Addr) (RW)
+  include Printable.Prod (P) (RW)
 
   let pretty () (a, write) =
     if write then
-      Addr.pretty () a
+      P.pretty () a
     else
-      Pretty.dprintf "read lock %a" Addr.pretty a
+      Pretty.dprintf "read lock %a" P.pretty a
 
   include Printable.SimplePretty (
     struct
@@ -34,30 +34,11 @@ struct
     )
 end
 
+module Lock = MakeLockRW (Addr)
+
 module Lockset =
 struct
-
-  (* true means exclusive lock and false represents reader lock*)
-  module RW   = IntDomain.Booleans
-
-  (* pair Addr and RW; also change pretty printing*)
-  module Lock =
-  struct
-    include Printable.Prod (Mval) (RW)
-
-    let pretty () (a, write) =
-      if write then
-        Mval.pretty () a
-      else
-        Pretty.dprintf "read lock %a" Mval.pretty a
-
-    include Printable.SimplePretty (
-      struct
-        type nonrec t = t
-        let pretty = pretty
-      end
-      )
-  end
+  module Lock = MakeLockRW (Mval)
 
   include SetDomain.Reverse(SetDomain.ToppedSet (Lock) (struct let topname = "All mutexes" end))
   let name () = "lockset"

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -43,20 +43,18 @@ struct
   include SetDomain.Reverse(SetDomain.ToppedSet (Lock) (struct let topname = "All mutexes" end))
   let name () = "lockset"
 
-  let add ((addr, _) as lock) set =
-    match addr with
-    | mv when Addr.Mval.is_definite mv -> (* avoids NULL *)
+  let add ((mv, _) as lock) set =
+    if Addr.Mval.is_definite mv then
       add lock set
-    | _ ->
+    else
       set
 
-  let remove ((addr, _) as lock) set =
-    match addr with
-    | mv when Addr.Mval.is_definite mv -> (* avoids NULL *)
+  let remove ((mv, _) as lock) set =
+    if Addr.Mval.is_definite mv then
       remove lock set
-    | _ ->
-      filter (fun (addr', _) ->
-          Mval.semantic_equal addr addr' = Some false
+    else
+      filter (fun (mv', _) ->
+          Mval.semantic_equal mv mv' = Some false
         ) set
 
   let export_locks ls =

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -79,7 +79,7 @@ struct
 
   let mem_rw mv set =
     ValueDomain.Mval.is_definite mv && (
-    mem (Mval.of_mval mv, true) set || mem (Mval.of_mval mv, false) set)
+      mem (Mval.of_mval mv, true) set || mem (Mval.of_mval mv, false) set)
 
   let remove_rw mv set =
     remove (mv, true) (remove (mv, false) set)

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -36,29 +36,6 @@ struct
       end
       )
   end
-
-  include SetDomain.Reverse(SetDomain.ToppedSet (Lock) (struct let topname = "All mutexes" end))
-  let name () = "lockset"
-
-  let add ((addr, _) as lock) set =
-    match addr with
-    | Addr.Addr mv when Addr.Mval.is_definite mv -> (* avoids NULL *)
-      add lock set
-    | _ ->
-      set
-
-  let remove ((addr, _) as lock) set =
-    match addr with
-    | Addr.Addr mv when Addr.Mval.is_definite mv -> (* avoids NULL *)
-      remove lock set
-    | _ ->
-      filter (fun (addr', _) ->
-          Addr.semantic_equal addr addr' = Some false
-        ) set
-
-  let export_locks ls =
-    let f (x,_) set = Mutexes.add x set in
-    fold f ls (Mutexes.empty ())
 end
 
 module MLockset =

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -89,7 +89,7 @@ struct
     fold f ls (Simple.empty ())
 end
 
-module Multiplicity = struct
+module MustMultiplicity = struct
   (* the maximum multiplicity which we keep track of precisely *)
   let max_count () = 4
 

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -55,7 +55,7 @@ end
 
 module Lock = MakeLockRW (Addr)
 
-module Lockset =
+module MustLocksetRW =
 struct
   module Lock = MakeLockRW (MustLock)
 

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -110,16 +110,6 @@ struct
     fold f ls (Mutexes.empty ())
 end
 
-module MayLockset =
-struct
-  include Lockset
-  let leq x y = leq y x
-  let join = Lockset.meet
-  let meet = Lockset.join
-  let top = Lockset.bot
-  let bot = Lockset.top
-end
-
 module MayLocksetNoRW =
 struct
   include PreValueDomain.AD

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -6,20 +6,10 @@ struct
   include Mval.Z
 
   let of_mval ((v, o): ValueDomain.Mval.t): t =
-    let rec offs = function
-      | `NoOffset -> `NoOffset
-      | `Field (f, os') -> `Field (f, offs os')
-      | `Index (i, os') -> `Index (ValueDomain.IndexDomain.to_int i |> Option.get, offs os')
-    in
-    (v, offs o)
+    (v, Offset.Poly.map_indices (fun i -> ValueDomain.IndexDomain.to_int i |> Option.get) o)
 
   let to_mval ((v, o): t): ValueDomain.Mval.t =
-    let rec offs = function
-      | `NoOffset -> `NoOffset
-      | `Field (f, os') -> `Field (f, offs os')
-      | `Index (i, os') -> `Index (ValueDomain.IndexDomain.of_int (Cilfacade.ptrdiff_ikind ()) i, offs os')
-    in
-    (v, offs o)
+    (v, Offset.Poly.map_indices (ValueDomain.IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) o)
 end
 module Offs = ValueDomain.Offs
 module Exp = CilType.Exp

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -57,6 +57,12 @@ struct
           Mval.semantic_equal mv mv' = Some false
         ) set
 
+  let mem_rw mv set =
+    mem (mv, true) set || mem (mv, false) set
+
+  let remove_rw mv set =
+    remove (mv, true) (remove (mv, false) set)
+
   let export_locks ls =
     let f (x,_) set = Simple.add x set in
     fold f ls (Simple.empty ())

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -9,7 +9,7 @@ module IdxDom = ValueDomain.IndexDomain
 open GoblintCil
 
 module Mutexes = SetDomain.ToppedSet (Addr) (struct let topname = "All mutexes" end) (* TODO: AD? *)
-module Simple = Lattice.Reverse (Mutexes)
+module Simple = SetDomain.Reverse (SetDomain.ToppedSet (Mval) (struct let topname = "All mutexes" end))
 module Priorities = IntDomain.Lifted
 
 (* true means exclusive lock and false represents reader lock*)
@@ -58,8 +58,8 @@ struct
         ) set
 
   let export_locks ls =
-    let f (x,_) set = Mutexes.add (Addr.Addr x) set in
-    fold f ls (Mutexes.empty ())
+    let f (x,_) set = Simple.add x set in
+    fold f ls (Simple.empty ())
 end
 
 module MayLocksetNoRW =

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -28,7 +28,7 @@ module IdxDom = ValueDomain.IndexDomain
 open GoblintCil
 
 module Mutexes = SetDomain.ToppedSet (Addr) (struct let topname = "All mutexes" end) (* TODO: AD? *)
-module Simple = SetDomain.Reverse (SetDomain.ToppedSet (MustLock) (struct let topname = "All mutexes" end))
+module MustLockset = SetDomain.Reverse (SetDomain.ToppedSet (MustLock) (struct let topname = "All mutexes" end))
 module Priorities = IntDomain.Lifted
 
 (* true means exclusive lock and false represents reader lock*)
@@ -85,8 +85,8 @@ struct
     remove (mv, true) (remove (mv, false) set)
 
   let export_locks ls =
-    let f (x,_) set = Simple.add x set in
-    fold f ls (Simple.empty ())
+    let f (x,_) set = MustLockset.add x set in
+    fold f ls (MustLockset.empty ())
 end
 
 module MustMultiplicity = struct

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -33,7 +33,7 @@ end
 module RW   = IntDomain.Booleans
 
 (* pair Addr and RW; also change pretty printing*)
-module MakeLockRW (P: Printable.S) =
+module MakeRW (P: Printable.S) =
 struct
   include Printable.Prod (P) (RW)
 
@@ -51,9 +51,8 @@ struct
     )
 end
 
-module Lock = MakeLockRW (Addr)
-
-module MustLockRW = MakeLockRW (MustLock)
+module AddrRW = MakeRW (Addr)
+module MustLockRW = MakeRW (MustLock)
 
 module MustLocksetRW =
 struct

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -28,7 +28,13 @@ module IdxDom = ValueDomain.IndexDomain
 open GoblintCil
 
 module Mutexes = SetDomain.ToppedSet (Addr) (struct let topname = "All mutexes" end) (* TODO: AD? *)
-module MustLockset = SetDomain.Reverse (SetDomain.ToppedSet (MustLock) (struct let topname = "All mutexes" end))
+module MustLockset =
+struct
+  include SetDomain.Reverse (SetDomain.ToppedSet (MustLock) (struct let topname = "All mutexes" end))
+
+  let all (): t = `Top
+  let is_all (set: t) = set = `Top
+end
 
 (* true means exclusive lock and false represents reader lock*)
 module RW   = IntDomain.Booleans
@@ -82,6 +88,9 @@ struct
 
   let remove_rw mv set =
     remove (mv, true) (remove (mv, false) set)
+
+  let all (): t = `Top
+  let is_all (set: t) = set = `Top
 
   let export_locks ls =
     let f (x,_) set = MustLockset.add x set in

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -20,7 +20,6 @@ struct
     (v, Offset.Poly.map_indices (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) o)
 end
 
-module Mutexes = SetDomain.ToppedSet (Addr) (struct let topname = "All mutexes" end) (* TODO: AD? *)
 module MustLockset =
 struct
   include SetDomain.Reverse (SetDomain.ToppedSet (MustLock) (struct let topname = "All mutexes" end))

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -29,7 +29,6 @@ open GoblintCil
 
 module Mutexes = SetDomain.ToppedSet (Addr) (struct let topname = "All mutexes" end) (* TODO: AD? *)
 module MustLockset = SetDomain.Reverse (SetDomain.ToppedSet (MustLock) (struct let topname = "All mutexes" end))
-module Priorities = IntDomain.Lifted
 
 (* true means exclusive lock and false represents reader lock*)
 module RW   = IntDomain.Booleans

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -1,6 +1,5 @@
 (** Lockset domains. *)
 
-open GoblintCil
 open struct
   module MvalZ = Mval.Z (* So we can define MustLock using Mval.Z after redefining Mval *)
 end
@@ -52,7 +51,7 @@ struct
     if write then
       P.pretty () a
     else
-      Pretty.dprintf "read lock %a" P.pretty a
+      GoblintCil.Pretty.dprintf "read lock %a" P.pretty a
 
   include Printable.SimplePretty (
     struct
@@ -159,54 +158,4 @@ end
 module MayLocksetNoRW =
 struct
   include PreValueDomain.AD
-end
-
-module Symbolic =
-struct
-  (* TODO: use SetDomain.Reverse *)
-  module S = SetDomain.ToppedSet (CilType.Exp) (struct let topname = "All mutexes" end)
-  include Lattice.Reverse (S)
-
-  let rec eq_set (ask: Queries.ask) e =
-    S.union
-      (match ask.f (Queries.EqualSet e) with
-       | es when not (Queries.ES.is_bot es) ->
-         Queries.ES.fold S.add es (S.empty ())
-       | _ -> S.empty ())
-      (match e with
-       | SizeOf _
-       | SizeOfE _
-       | SizeOfStr _
-       | AlignOf _
-       | Const _
-       | AlignOfE _
-       | UnOp _
-       | BinOp _
-       | Question _
-       | Real _
-       | Imag _
-       | AddrOfLabel _ -> S.empty ()
-       | AddrOf  (Var _,_)
-       | StartOf (Var _,_)
-       | Lval    (Var _,_) -> S.singleton e
-       | AddrOf  (Mem e,ofs) -> S.map (fun e -> AddrOf  (Mem e,ofs)) (eq_set ask e)
-       | StartOf (Mem e,ofs) -> S.map (fun e -> StartOf (Mem e,ofs)) (eq_set ask e)
-       | Lval    (Mem e,ofs) -> S.map (fun e -> Lval    (Mem e,ofs)) (eq_set ask e)
-       | CastE (_,e)           -> eq_set ask e
-      )
-
-  let add (ask: Queries.ask) e st =
-    let no_casts = S.map Expcompare.stripCastsDeepForPtrArith (eq_set ask e) in
-    let addrs = S.filter (function AddrOf _ -> true | _ -> false) no_casts in
-    S.union addrs st
-  let remove ask e st =
-    (* TODO: Removing based on must-equality sets is not sound! *)
-    let no_casts = S.map Expcompare.stripCastsDeepForPtrArith (eq_set ask e) in
-    let addrs = S.filter (function AddrOf _ -> true | _ -> false) no_casts in
-    S.diff st addrs
-  let remove_var v st = S.filter (fun x -> not (SymbLocksDomain.Exp.contains_var v x)) st
-
-  let filter = S.filter
-  let fold = S.fold
-
 end

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -12,30 +12,26 @@ module Mutexes = SetDomain.ToppedSet (Addr) (struct let topname = "All mutexes" 
 module Simple = Lattice.Reverse (Mutexes)
 module Priorities = IntDomain.Lifted
 
-module Lockset =
+(* true means exclusive lock and false represents reader lock*)
+module RW   = IntDomain.Booleans
+
+(* pair Addr and RW; also change pretty printing*)
+module Lock =
 struct
+  include Printable.Prod (Addr) (RW)
 
-  (* true means exclusive lock and false represents reader lock*)
-  module RW   = IntDomain.Booleans
+  let pretty () (a, write) =
+    if write then
+      Addr.pretty () a
+    else
+      Pretty.dprintf "read lock %a" Addr.pretty a
 
-  (* pair Addr and RW; also change pretty printing*)
-  module Lock =
-  struct
-    include Printable.Prod (Addr) (RW)
-
-    let pretty () (a, write) =
-      if write then
-        Addr.pretty () a
-      else
-        Pretty.dprintf "read lock %a" Addr.pretty a
-
-    include Printable.SimplePretty (
-      struct
-        type nonrec t = t
-        let pretty = pretty
-      end
-      )
-  end
+  include Printable.SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
 end
 
 module MLockset =

--- a/src/cdomains/symbLocksDomain.ml
+++ b/src/cdomains/symbLocksDomain.ml
@@ -317,3 +317,54 @@ struct
 
   let of_mval (v, o) = of_mval (v, conv_const_offset o)
 end
+
+
+module Symbolic =
+struct
+  (* TODO: use SetDomain.Reverse *)
+  module S = SetDomain.ToppedSet (CilType.Exp) (struct let topname = "All mutexes" end)
+  include Lattice.Reverse (S)
+
+  let rec eq_set (ask: Queries.ask) e =
+    S.union
+      (match ask.f (Queries.EqualSet e) with
+       | es when not (Queries.ES.is_bot es) ->
+         Queries.ES.fold S.add es (S.empty ())
+       | _ -> S.empty ())
+      (match e with
+       | SizeOf _
+       | SizeOfE _
+       | SizeOfStr _
+       | AlignOf _
+       | Const _
+       | AlignOfE _
+       | UnOp _
+       | BinOp _
+       | Question _
+       | Real _
+       | Imag _
+       | AddrOfLabel _ -> S.empty ()
+       | AddrOf  (Var _,_)
+       | StartOf (Var _,_)
+       | Lval    (Var _,_) -> S.singleton e
+       | AddrOf  (Mem e,ofs) -> S.map (fun e -> AddrOf  (Mem e,ofs)) (eq_set ask e)
+       | StartOf (Mem e,ofs) -> S.map (fun e -> StartOf (Mem e,ofs)) (eq_set ask e)
+       | Lval    (Mem e,ofs) -> S.map (fun e -> Lval    (Mem e,ofs)) (eq_set ask e)
+       | CastE (_,e)           -> eq_set ask e
+      )
+
+  let add (ask: Queries.ask) e st =
+    let no_casts = S.map Expcompare.stripCastsDeepForPtrArith (eq_set ask e) in
+    let addrs = S.filter (function AddrOf _ -> true | _ -> false) no_casts in
+    S.union addrs st
+  let remove ask e st =
+    (* TODO: Removing based on must-equality sets is not sound! *)
+    let no_casts = S.map Expcompare.stripCastsDeepForPtrArith (eq_set ask e) in
+    let addrs = S.filter (function AddrOf _ -> true | _ -> false) no_casts in
+    S.diff st addrs
+  let remove_var v st = S.filter (fun x -> not (Exp.contains_var v x)) st
+
+  let filter = S.filter
+  let fold = S.fold
+
+end

--- a/src/common/domains/printable.ml
+++ b/src/common/domains/printable.ml
@@ -605,7 +605,7 @@ struct
       match BatDeque.front q with
       | None -> ()
       | Some (x, xs) -> (BatPrintf.fprintf f "<key>%d</key>\n%a\n" n Base.printXml x; 
-                   loop (n+1) (xs))
+                         loop (n+1) (xs))
     in
     BatPrintf.fprintf f "<value>\n<map>\n";
     loop 0 xs; 

--- a/src/common/domains/printable.ml
+++ b/src/common/domains/printable.ml
@@ -840,3 +840,17 @@ struct
 
   let to_yojson x = x (* override SimplePretty *)
 end
+
+module Z: S with type t = Z.t =
+struct
+  include StdLeaf
+  include GobZ
+  let name () = "Z"
+
+  include SimplePretty (
+    struct
+      type nonrec t = t
+      let pretty = pretty
+    end
+    )
+end

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -4,7 +4,7 @@ open GoblintCil
 open Pretty
 
 type t =
-  | Lock of LockDomain.Lockset.Lock.t
+  | Lock of LockDomain.Lock.t
   | Unlock of LockDomain.Addr.t
   | Escape of EscapeDomain.EscapedVars.t
   | EnterMultiThreaded
@@ -35,7 +35,7 @@ let emit_on_deadcode = function
     false
 
 let pretty () = function
-  | Lock m -> dprintf "Lock %a" LockDomain.Lockset.Lock.pretty m
+  | Lock m -> dprintf "Lock %a" LockDomain.Lock.pretty m
   | Unlock m -> dprintf "Unlock %a" LockDomain.Addr.pretty m
   | Escape escaped -> dprintf "Escape %a" EscapeDomain.EscapedVars.pretty escaped
   | EnterMultiThreaded -> text "EnterMultiThreaded"

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -4,7 +4,7 @@ open GoblintCil
 open Pretty
 
 type t =
-  | Lock of LockDomain.Lock.t
+  | Lock of LockDomain.AddrRW.t
   | Unlock of LockDomain.Addr.t
   | Escape of EscapeDomain.EscapedVars.t
   | EnterMultiThreaded
@@ -35,7 +35,7 @@ let emit_on_deadcode = function
     false
 
 let pretty () = function
-  | Lock m -> dprintf "Lock %a" LockDomain.Lock.pretty m
+  | Lock m -> dprintf "Lock %a" LockDomain.AddrRW.pretty m
   | Unlock m -> dprintf "Unlock %a" LockDomain.Addr.pretty m
   | Escape escaped -> dprintf "Escape %a" EscapeDomain.EscapedVars.pretty escaped
   | EnterMultiThreaded -> text "EnterMultiThreaded"

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -51,7 +51,7 @@ end
 type maybepublic = {global: CilType.Varinfo.t; write: bool; protection: Protection.t} [@@deriving ord, hash]
 type maybepublicwithout = {global: CilType.Varinfo.t; write: bool; without_mutex: PreValueDomain.Addr.t; protection: Protection.t} [@@deriving ord, hash]
 type mustbeprotectedby = {mutex: PreValueDomain.Addr.t; global: CilType.Varinfo.t; write: bool; protection: Protection.t} [@@deriving ord, hash]
-type mustprotectedvars = {mutex: PreValueDomain.Addr.t; write: bool} [@@deriving ord, hash]
+type mustprotectedvars = {mutex: LockDomain.MustLock.t; write: bool} [@@deriving ord, hash]
 type access =
   | Memory of {exp: CilType.Exp.t; var_opt: CilType.Varinfo.t option; kind: AccessKind.t} (** Memory location access (race). *)
   | Point (** Program point and state access (MHP), independent of memory location. *)

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -74,7 +74,7 @@ type _ t =
   | MayBePublic: maybepublic -> MayBool.t t (* old behavior with write=false *)
   | MayBePublicWithout: maybepublicwithout -> MayBool.t t
   | MustBeProtectedBy: mustbeprotectedby -> MustBool.t t
-  | MustLockset: AD.t t
+  | MustLockset: LockDomain.MustLockset.t t
   | MustBeAtomic: MustBool.t t
   | MustBeSingleThreaded: {since_start: bool} -> MustBool.t t
   | MustBeUniqueThread: MustBool.t t
@@ -147,7 +147,7 @@ struct
     | MayPointTo _ -> (module AD)
     | ReachableFrom _ -> (module AD)
     | Regions _ -> (module LS)
-    | MustLockset -> (module AD)
+    | MustLockset -> (module LockDomain.MustLockset)
     | EvalFunvar _ -> (module AD)
     | ReachableUkTypes _ -> (module TS)
     | MayEscape _ -> (module MayBool)
@@ -216,7 +216,7 @@ struct
     | MayPointTo _ -> AD.top ()
     | ReachableFrom _ -> AD.top ()
     | Regions _ -> LS.top ()
-    | MustLockset -> AD.top ()
+    | MustLockset -> LockDomain.MustLockset.top ()
     | EvalFunvar _ -> AD.top ()
     | ReachableUkTypes _ -> TS.top ()
     | MayEscape _ -> MayBool.top ()

--- a/tests/regression/06-symbeq/21-mult_accs_rc.t
+++ b/tests/regression/06-symbeq/21-mult_accs_rc.t
@@ -10,6 +10,9 @@ Disable info messages because race summary contains (safe) memory location count
   [Warning][Race] Memory location (struct s).data (race with conf. 100):
     write with thread:[main, t_fun@21-mult_accs_rc.c:31:3-31:37] (conf. 100)  (exp: & s->data) (21-mult_accs_rc.c:16:3-16:14)
     write with [symblock:{p-lock:*.mutex}, mhp:{created={[main, t_fun@21-mult_accs_rc.c:31:3-31:37]}}, thread:[main]] (conf. 100)  (exp: & *d) (21-mult_accs_rc.c:34:3-34:9)
+  [Warning][Unknown] locking NULL mutex (21-mult_accs_rc.c:14:3-14:32)
+  [Warning][Unknown] locking NULL mutex (21-mult_accs_rc.c:17:3-17:32)
+  [Warning][Unknown] locking NULL mutex (21-mult_accs_rc.c:33:3-33:24)
   [Warning][Unknown] unlocking NULL mutex (21-mult_accs_rc.c:35:3-35:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (21-mult_accs_rc.c:35:3-35:26)
   [Error][Imprecise][Unsound] Function definition missing for get_s (21-mult_accs_rc.c:13:3-13:14)
@@ -26,6 +29,9 @@ Disable info messages because race summary contains (safe) memory location count
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (21-mult_accs_rc.c:34:3-34:9)
   [Success][Race] Memory location (struct s).data (safe):
     write with thread:[main, t_fun@21-mult_accs_rc.c:31:3-31:37] (conf. 100)  (exp: & s->data) (21-mult_accs_rc.c:16:3-16:14)
+  [Warning][Unknown] locking NULL mutex (21-mult_accs_rc.c:14:3-14:32)
+  [Warning][Unknown] locking NULL mutex (21-mult_accs_rc.c:17:3-17:32)
+  [Warning][Unknown] locking NULL mutex (21-mult_accs_rc.c:33:3-33:24)
   [Warning][Unknown] unlocking NULL mutex (21-mult_accs_rc.c:35:3-35:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (21-mult_accs_rc.c:35:3-35:26)
   [Error][Imprecise][Unsound] Function definition missing for get_s (21-mult_accs_rc.c:13:3-13:14)

--- a/tests/regression/06-symbeq/21-mult_accs_rc.t
+++ b/tests/regression/06-symbeq/21-mult_accs_rc.t
@@ -10,6 +10,7 @@ Disable info messages because race summary contains (safe) memory location count
   [Warning][Race] Memory location (struct s).data (race with conf. 100):
     write with thread:[main, t_fun@21-mult_accs_rc.c:31:3-31:37] (conf. 100)  (exp: & s->data) (21-mult_accs_rc.c:16:3-16:14)
     write with [symblock:{p-lock:*.mutex}, mhp:{created={[main, t_fun@21-mult_accs_rc.c:31:3-31:37]}}, thread:[main]] (conf. 100)  (exp: & *d) (21-mult_accs_rc.c:34:3-34:9)
+  [Warning][Unknown] unlocking NULL mutex (21-mult_accs_rc.c:35:3-35:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (21-mult_accs_rc.c:35:3-35:26)
   [Error][Imprecise][Unsound] Function definition missing for get_s (21-mult_accs_rc.c:13:3-13:14)
   [Error][Imprecise][Unsound] Function definition missing for get_s (21-mult_accs_rc.c:15:3-15:14)
@@ -25,6 +26,7 @@ Disable info messages because race summary contains (safe) memory location count
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (21-mult_accs_rc.c:34:3-34:9)
   [Success][Race] Memory location (struct s).data (safe):
     write with thread:[main, t_fun@21-mult_accs_rc.c:31:3-31:37] (conf. 100)  (exp: & s->data) (21-mult_accs_rc.c:16:3-16:14)
+  [Warning][Unknown] unlocking NULL mutex (21-mult_accs_rc.c:35:3-35:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (21-mult_accs_rc.c:35:3-35:26)
   [Error][Imprecise][Unsound] Function definition missing for get_s (21-mult_accs_rc.c:13:3-13:14)
   [Error][Imprecise][Unsound] Function definition missing for get_s (21-mult_accs_rc.c:15:3-15:14)

--- a/tests/regression/06-symbeq/21-mult_accs_rc.t
+++ b/tests/regression/06-symbeq/21-mult_accs_rc.t
@@ -10,7 +10,6 @@ Disable info messages because race summary contains (safe) memory location count
   [Warning][Race] Memory location (struct s).data (race with conf. 100):
     write with thread:[main, t_fun@21-mult_accs_rc.c:31:3-31:37] (conf. 100)  (exp: & s->data) (21-mult_accs_rc.c:16:3-16:14)
     write with [symblock:{p-lock:*.mutex}, mhp:{created={[main, t_fun@21-mult_accs_rc.c:31:3-31:37]}}, thread:[main]] (conf. 100)  (exp: & *d) (21-mult_accs_rc.c:34:3-34:9)
-  [Warning][Unknown] unlocking mutex (NULL) which may not be held (21-mult_accs_rc.c:35:3-35:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (21-mult_accs_rc.c:35:3-35:26)
   [Error][Imprecise][Unsound] Function definition missing for get_s (21-mult_accs_rc.c:13:3-13:14)
   [Error][Imprecise][Unsound] Function definition missing for get_s (21-mult_accs_rc.c:15:3-15:14)
@@ -26,7 +25,6 @@ Disable info messages because race summary contains (safe) memory location count
   [Warning][Behavior > Undefined > NullPointerDereference][CWE-476] May dereference NULL pointer (21-mult_accs_rc.c:34:3-34:9)
   [Success][Race] Memory location (struct s).data (safe):
     write with thread:[main, t_fun@21-mult_accs_rc.c:31:3-31:37] (conf. 100)  (exp: & s->data) (21-mult_accs_rc.c:16:3-16:14)
-  [Warning][Unknown] unlocking mutex (NULL) which may not be held (21-mult_accs_rc.c:35:3-35:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (21-mult_accs_rc.c:35:3-35:26)
   [Error][Imprecise][Unsound] Function definition missing for get_s (21-mult_accs_rc.c:13:3-13:14)
   [Error][Imprecise][Unsound] Function definition missing for get_s (21-mult_accs_rc.c:15:3-15:14)


### PR DESCRIPTION
Currently must-locksets are (reversed) sets of addresses, which can be the usual addresses (as mvals), but the type also allows `UnknownPtr`, `NullPtr` and `StrPtr`. None of these should be in must-locksets, but currently this is enforced by the combination of three different checks in three different files.

The goal of this PR is to refine the type of must-lockset elements from addresses to mvals with definite indices, whereby this correctness property is enforced by the type system.
**This immediately paid off:** it revealed _two cases_ of unsoundness in recursive mutex handling because definite indices were only checked for the must-lockset, but not for the recursive locking counter map (which must duplicate all the set logic to avoid becoming unsound). See #1432.

Hopefully this also allows some `Addr` wrapping and unwrapping to be avoided, which should be less verbose.

### TODO
- [x] Enforce definite indices in must-locks by type.
- [x] Rename `Simple`.
- [x] Add `all` and `is_all` operations to `Simple`.
- [x] Fix `NULL` warning in cram test.