### PR TITLE
Fix enums domain to not emit witness invariants for top booleans

### DIFF
--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -2725,10 +2725,10 @@ module Enums : S with type int_t = Z.t = struct
     match x with
     | Inc ps ->
       if BISet.cardinal ps > 1 || get_bool "witness.invariant.exact" then
-        List.fold_left (fun a x ->
+        BISet.fold (fun x a ->
             let i = Invariant.of_exp Cil.(BinOp (Eq, e, kintegerCilint ik x, intType)) in
             Invariant.(a || i) [@coverage off] (* bisect_ppx cannot handle redefined (||) *)
-          ) (Invariant.bot ()) (BISet.elements ps)
+          ) ps (Invariant.bot ())
       else
         Invariant.top ()
     | Exc (ns, r) ->
@@ -2742,10 +2742,10 @@ module Enums : S with type int_t = Z.t = struct
       let inexact_type_bounds = get_bool "witness.invariant.inexact-type-bounds" in
       let imin = if inexact_type_bounds || Z.compare ikmin rmin <> 0 then Invariant.of_exp Cil.(BinOp (Le, kintegerCilint ik rmin, e, intType)) else Invariant.none in
       let imax = if inexact_type_bounds || Z.compare rmax ikmax <> 0 then Invariant.of_exp Cil.(BinOp (Le, e, kintegerCilint ik rmax, intType)) else Invariant.none in
-      List.fold_left (fun a x ->
+      BISet.fold (fun x a ->
           let i = Invariant.of_exp Cil.(BinOp (Ne, e, kintegerCilint ik x, intType)) in
           Invariant.(a && i)
-        ) Invariant.(imin && imax) (BISet.elements ns)
+        ) ns Invariant.(imin && imax)
 
 
   let arbitrary ik =

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -1910,7 +1910,6 @@ struct
     | `Definite x -> if i = x then `Eq else `Neq
     | `Excluded (s,r) -> if S.mem i s then `Neq else `Top
 
-  let top_of ik = `Excluded (S.empty (), size ik)
   let cast_to ?(suppress_ovwarn=false) ?torg ?no_ov ik = function
     | `Excluded (s,r) ->
       let r' = size ik in

--- a/tests/regression/56-witness/46-top-bool-invariant.c
+++ b/tests/regression/56-witness/46-top-bool-invariant.c
@@ -1,4 +1,4 @@
-// PARAM: --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.interval --enable ana.int.enums --enable ana.int.congruence --enable ana.int.interval_set 46-top-bool-invariant.c --disable witness.invariant.inexact-type-bounds
+// PARAM: --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.interval --enable ana.int.enums --enable ana.int.congruence --enable ana.int.interval_set --disable witness.invariant.inexact-type-bounds
 
 int main() {
   _Bool x;

--- a/tests/regression/56-witness/46-top-bool-invariant.c
+++ b/tests/regression/56-witness/46-top-bool-invariant.c
@@ -1,0 +1,6 @@
+// PARAM: --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.interval --enable ana.int.enums --enable ana.int.congruence --enable ana.int.interval_set 46-top-bool-invariant.c --disable witness.invariant.inexact-type-bounds
+
+int main() {
+  _Bool x;
+  return 0;
+}

--- a/tests/regression/56-witness/46-top-bool-invariant.t
+++ b/tests/regression/56-witness/46-top-bool-invariant.t
@@ -189,19 +189,7 @@ all without inexact-type-bounds:
     dead: 0
     total lines: 2
   [Info][Witness] witness generation summary:
-    total generation entries: 1
-
-TODO: should not have any invariants
+    total generation entries: 0
 
   $ yamlWitnessStrip < witness.yml
-  - entry_type: location_invariant
-    location:
-      file_name: 46-top-bool-invariant.c
-      file_hash: $FILE_HASH
-      line: 5
-      column: 3
-      function: main
-    location_invariant:
-      string: x == (_Bool)0 || x == (_Bool)1
-      type: assertion
-      format: C
+  []

--- a/tests/regression/56-witness/46-top-bool-invariant.t
+++ b/tests/regression/56-witness/46-top-bool-invariant.t
@@ -1,0 +1,207 @@
+def_exc only:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --disable ana.int.interval --disable ana.int.enums --disable ana.int.congruence --disable ana.int.interval_set 46-top-bool-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 2
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x <= (_Bool)1
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: (_Bool)0 <= x
+      type: assertion
+      format: C
+
+interval only:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --disable ana.int.def_exc --enable ana.int.interval --disable ana.int.enums --disable ana.int.congruence --disable ana.int.interval_set 46-top-bool-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 2
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x <= (_Bool)1
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: (_Bool)0 <= x
+      type: assertion
+      format: C
+
+enums only:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --disable ana.int.def_exc --disable ana.int.interval --enable ana.int.enums --disable ana.int.congruence --disable ana.int.interval_set 46-top-bool-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 1
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x == (_Bool)0 || x == (_Bool)1
+      type: assertion
+      format: C
+
+congruence only:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --disable ana.int.def_exc --disable ana.int.interval --disable ana.int.enums --enable ana.int.congruence --disable ana.int.interval_set 46-top-bool-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 0
+
+  $ yamlWitnessStrip < witness.yml
+  []
+
+interval_set only:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --disable ana.int.def_exc --disable ana.int.interval --disable ana.int.enums --disable ana.int.congruence --enable ana.int.interval_set 46-top-bool-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 2
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x <= (_Bool)1
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: (_Bool)0 <= x
+      type: assertion
+      format: C
+
+all:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.interval --enable ana.int.enums --enable ana.int.congruence --enable ana.int.interval_set 46-top-bool-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 3
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x == (_Bool)0 || x == (_Bool)1
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x <= (_Bool)1
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: (_Bool)0 <= x
+      type: assertion
+      format: C
+
+all without inexact-type-bounds:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.interval --enable ana.int.enums --enable ana.int.congruence --enable ana.int.interval_set 46-top-bool-invariant.c --disable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 1
+
+TODO: should not have any invariants
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: 46-top-bool-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x == (_Bool)0 || x == (_Bool)1
+      type: assertion
+      format: C

--- a/tests/regression/56-witness/47-top-int-invariant.c
+++ b/tests/regression/56-witness/47-top-int-invariant.c
@@ -1,4 +1,4 @@
-// PARAM: --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.interval --enable ana.int.enums --enable ana.int.congruence --enable ana.int.interval_set 47-top-int-invariant.c --disable witness.invariant.inexact-type-bounds
+// PARAM: --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.interval --enable ana.int.enums --enable ana.int.congruence --enable ana.int.interval_set --disable witness.invariant.inexact-type-bounds
 
 int main() {
   int x;

--- a/tests/regression/56-witness/47-top-int-invariant.c
+++ b/tests/regression/56-witness/47-top-int-invariant.c
@@ -1,0 +1,6 @@
+// PARAM: --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.interval --enable ana.int.enums --enable ana.int.congruence --enable ana.int.interval_set 47-top-int-invariant.c --disable witness.invariant.inexact-type-bounds
+
+int main() {
+  int x;
+  return 0;
+}

--- a/tests/regression/56-witness/47-top-int-invariant.t
+++ b/tests/regression/56-witness/47-top-int-invariant.t
@@ -74,12 +74,31 @@ enums only:
     dead: 0
     total lines: 2
   [Info][Witness] witness generation summary:
-    total generation entries: 0
-
-TODO: should have range invariants
+    total generation entries: 2
 
   $ yamlWitnessStrip < witness.yml
-  []
+  - entry_type: location_invariant
+    location:
+      file_name: 47-top-int-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x <= 2147483647
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: 47-top-int-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: (-0x7FFFFFFF-1) <= x
+      type: assertion
+      format: C
 
 congruence only:
 

--- a/tests/regression/56-witness/47-top-int-invariant.t
+++ b/tests/regression/56-witness/47-top-int-invariant.t
@@ -1,0 +1,176 @@
+def_exc only:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --disable ana.int.interval --disable ana.int.enums --disable ana.int.congruence --disable ana.int.interval_set 47-top-int-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 2
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: 47-top-int-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x <= 2147483647
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: 47-top-int-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: (-0x7FFFFFFF-1) <= x
+      type: assertion
+      format: C
+
+interval only:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --disable ana.int.def_exc --enable ana.int.interval --disable ana.int.enums --disable ana.int.congruence --disable ana.int.interval_set 47-top-int-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 2
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: 47-top-int-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x <= 2147483647
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: 47-top-int-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: (-0x7FFFFFFF-1) <= x
+      type: assertion
+      format: C
+
+enums only:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --disable ana.int.def_exc --disable ana.int.interval --enable ana.int.enums --disable ana.int.congruence --disable ana.int.interval_set 47-top-int-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 0
+
+TODO: should have range invariants
+
+  $ yamlWitnessStrip < witness.yml
+  []
+
+congruence only:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --disable ana.int.def_exc --disable ana.int.interval --disable ana.int.enums --enable ana.int.congruence --disable ana.int.interval_set 47-top-int-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 0
+
+  $ yamlWitnessStrip < witness.yml
+  []
+
+interval_set only:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --disable ana.int.def_exc --disable ana.int.interval --disable ana.int.enums --disable ana.int.congruence --enable ana.int.interval_set 47-top-int-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 2
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: 47-top-int-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x <= 2147483647
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: 47-top-int-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: (-0x7FFFFFFF-1) <= x
+      type: assertion
+      format: C
+
+all:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.interval --enable ana.int.enums --enable ana.int.congruence --enable ana.int.interval_set 47-top-int-invariant.c --enable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 2
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: 47-top-int-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: x <= 2147483647
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: 47-top-int-invariant.c
+      file_hash: $FILE_HASH
+      line: 5
+      column: 3
+      function: main
+    location_invariant:
+      string: (-0x7FFFFFFF-1) <= x
+      type: assertion
+      format: C
+
+all without inexact-type-bounds:
+
+  $ goblint --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.interval --enable ana.int.enums --enable ana.int.congruence --enable ana.int.interval_set 47-top-int-invariant.c --disable witness.invariant.inexact-type-bounds
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 0
+    total lines: 2
+  [Info][Witness] witness generation summary:
+    total generation entries: 0
+
+  $ yamlWitnessStrip < witness.yml
+  []


### PR DESCRIPTION
This is related to a point in #1356.

The SV-COMP autotuner can enable the enums domain, which emitted invariants like `x == (_Bool)0 || x == (_Bool)1` for `_Bool` variables with top value. These are pointless because they match the type bounds (although indirectly), so we should avoid emitting them as we do in other domains and for other types.

This is because the enums domain normalizes top booleans to `Inc {0, 1}`, which then needs to be handled separately for `invariant_ikind`. In other cases, we can output some bounds using `Exc` ranges of enums, just like we do with the def_exc domain, although they're quite likely to match and get deduplicated for witness generation.