### PR TITLE
Port all remaining library functions 

### DIFF
--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -1344,7 +1344,8 @@
               "zstd",
               "pcre",
               "zlib",
-              "liblzma"
+              "liblzma",
+              "legacy"
             ]
           },
           "default": [
@@ -1355,7 +1356,8 @@
             "glibc",
             "linux-userspace",
             "goblint",
-            "ncurses"
+            "ncurses",
+            "legacy"
           ]
         }
       },

--- a/src/util/library/libraryDsl.ml
+++ b/src/util/library/libraryDsl.ml
@@ -102,3 +102,5 @@ let f = Access.{ kind = Free; deep = false; }
 let f_deep = Access.{ kind = Free; deep = true; }
 let s = Access.{ kind = Spawn; deep = false; }
 let s_deep = Access.{ kind = Spawn; deep = true; }
+let c = Access.{ kind = Spawn; deep = false; } (* TODO: Sound, but very imprecise hack for calls to function pointers given as arguments. *)
+let c_deep = Access.{ kind = Spawn; deep = true; }

--- a/src/util/library/libraryDsl.mli
+++ b/src/util/library/libraryDsl.mli
@@ -71,3 +71,9 @@ val s: LibraryDesc.Access.t
 (** Deep {!AccessKind.Spawn} access.
     Rarely needed. *)
 val s_deep: LibraryDesc.Access.t
+
+(** Shallow {!AccessKind.Spawn} access, substituting function pointer calls for now (TODO). *)
+val c: LibraryDesc.Access.t
+
+(** Deep {!AccessKind.Spawn} access, substituting deep function pointer calls for now (TODO)  *)
+val c_deep: LibraryDesc.Access.t

--- a/src/util/library/libraryFunctions.ml
+++ b/src/util/library/libraryFunctions.ml
@@ -120,8 +120,6 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("asprintf", unknown (drop "strp" [w] :: drop "format" [r] :: VarArgs (drop' [r_deep]))); (* TODO: glibc section? *)
     ("vasprintf", unknown [drop "strp" [w]; drop "format" [r]; drop "ap" [r_deep]]); (* TODO: what to do with a va_list type? is r_deep correct? *)
     ("vsnprintf", unknown [drop "str" [w]; drop "size" []; drop "format" [r]; drop "ap" [r_deep]]); (* TODO: what to do with a va_list type? is r_deep correct? *)
-    ("__builtin_vsnprintf", unknown [drop "str" [w]; drop "size" []; drop "format" [r]; drop "ap" [r_deep]]);
-    ("__builtin___vsnprintf", unknown [drop "str" [w]; drop "size" []; drop "format" [r]; drop "ap" [r_deep]]); (* TODO: does this actually exist?! *)
     ("mktime", unknown [drop "tm" [r;w]]);
     ("ctime", unknown ~attrs:[ThreadUnsafe] [drop "rm" [r]]);
     ("clearerr", unknown [drop "stream" [w]]); (* TODO: why only w? *)
@@ -169,12 +167,8 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("timespec_get", unknown [drop "ts" [w]; drop "base" []]);
     ("signal", unknown [drop "signum" []; drop "handler" [s]]);
     ("va_arg", unknown [drop "ap" [r_deep]; drop "T" []]);
-    ("__builtin_va_arg", unknown [drop "ap" [r_deep]; drop "T" []; drop "lhs" [w]]); (* cil: "__builtin_va_arg is special: in CIL, the left hand side is stored as the last argument" *)
     ("va_start", unknown [drop "ap" [r_deep]; drop "parmN" []]);
-    ("__builtin_va_start", unknown [drop "ap" [r_deep]]); (* cil: "When we parse builtin_{va,stdarg}_start, we drop the second argument" *)
     ("va_end", unknown [drop "ap" [r_deep]]);
-    ("__builtin_va_end", unknown [drop "ap" [r_deep]]);
-    ("__builtin_va_arg_pack_len", unknown []);
   ]
 [@@coverage off]
 
@@ -619,6 +613,12 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_va_copy", unknown [drop "dest" [w]; drop "src" [r]]);
     ("alloca", special [__ "size" []] @@ fun size -> Alloca size);
     ("__builtin_alloca", special [__ "size" []] @@ fun size -> Alloca size);
+    ("__builtin_vsnprintf", unknown [drop "str" [w]; drop "size" []; drop "format" [r]; drop "ap" [r_deep]]);
+    ("__builtin___vsnprintf", unknown [drop "str" [w]; drop "size" []; drop "format" [r]; drop "ap" [r_deep]]); (* TODO: does this actually exist?! *)
+    ("__builtin_va_arg", unknown [drop "ap" [r_deep]; drop "T" []; drop "lhs" [w]]); (* cil: "__builtin_va_arg is special: in CIL, the left hand side is stored as the last argument" *)
+    ("__builtin_va_start", unknown [drop "ap" [r_deep]]); (* cil: "When we parse builtin_{va,stdarg}_start, we drop the second argument" *)
+    ("__builtin_va_end", unknown [drop "ap" [r_deep]]);
+    ("__builtin_va_arg_pack_len", unknown []);
   ]
 [@@coverage off]
 

--- a/src/util/library/libraryFunctions.ml
+++ b/src/util/library/libraryFunctions.ml
@@ -169,7 +169,7 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("timespec_get", unknown [drop "ts" [w]; drop "base" []]);
     ("signal", unknown [drop "signum" []; drop "handler" [s]]);
     ("va_arg", unknown [drop "ap" [r_deep]; drop "T" []]);
-    ("__builtin_va_arg", unknown [drop "ap" [r_deep]; drop "T" []; drop "lhs" []]); (* cil: "__builtin_va_arg is special: in CIL, the left hand side is stored as the last argument" *)
+    ("__builtin_va_arg", unknown [drop "ap" [r_deep]; drop "T" []; drop "lhs" [w]]); (* cil: "__builtin_va_arg is special: in CIL, the left hand side is stored as the last argument" *)
     ("va_start", unknown [drop "ap" [r_deep]; drop "parmN" []]);
     ("__builtin_va_start", unknown [drop "ap" [r_deep]]); (* cil: "When we parse builtin_{va,stdarg}_start, we drop the second argument" *)
     ("va_end", unknown [drop "ap" [r_deep]]);

--- a/src/util/library/libraryFunctions.ml
+++ b/src/util/library/libraryFunctions.ml
@@ -651,7 +651,7 @@ let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__readlink_alias", unknown [drop "path" [r]; drop "buf" [w]; drop "len" []]);
     ("__overflow", unknown [drop "f" [r]; drop "ch" []]);
     ("__ctype_get_mb_cur_max", unknown []);
-    ("__maskrune", unknown [drop "c" [w]; drop "f" []]);
+    ("__maskrune", unknown [drop "c" []; drop "f" []]);
     ("__xmknod", unknown [drop "ver" []; drop "path" [r]; drop "mode" []; drop "dev" [r; w]]);
     ("yp_get_default_domain", unknown [drop "outdomain" [w]]);
     ("__nss_configure_lookup", unknown [drop "db" [r]; drop "service_line" [r]]);

--- a/src/util/library/libraryFunctions.ml
+++ b/src/util/library/libraryFunctions.ml
@@ -694,7 +694,7 @@ let glibc_desc_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("pmap_unset", unknown [drop "prognum" []; drop "versnum" []]);
     ("svcudp_create", unknown [drop "sock" []]);
     ("svc_register", unknown [drop "xprt" [r_deep; w_deep]; drop "prognum" []; drop "versnum" []; drop "dispatch" [r; w; c]; drop "protocol" []]);
-    ("svc_run", special [] Abort);
+    ("svc_run", unknown []); (* TODO: make new special kind "NoReturn" for this: the following node will be dead (like Abort), but the program doesn't exit (so it shouldn't be Abort) *)
     (* RPC library end *)
   ]
 [@@coverage off]

--- a/src/util/library/libraryFunctions.ml
+++ b/src/util/library/libraryFunctions.ml
@@ -169,9 +169,9 @@ let c_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("timespec_get", unknown [drop "ts" [w]; drop "base" []]);
     ("signal", unknown [drop "signum" []; drop "handler" [s]]);
     ("va_arg", unknown [drop "ap" [r_deep]; drop "T" []]);
-    ("__builtin_va_arg", unknown [drop "ap" [r_deep]; drop "T" []]);
+    ("__builtin_va_arg", unknown [drop "ap" [r_deep]; drop "T" []; drop "lhs" []]); (* cil: "__builtin_va_arg is special: in CIL, the left hand side is stored as the last argument" *)
     ("va_start", unknown [drop "ap" [r_deep]; drop "parmN" []]);
-    ("__builtin_va_start", unknown [drop "ap" [r_deep]; drop "parmN" []]);
+    ("__builtin_va_start", unknown [drop "ap" [r_deep]]); (* cil: "When we parse builtin_{va,stdarg}_start, we drop the second argument" *)
     ("va_end", unknown [drop "ap" [r_deep]]);
     ("__builtin_va_end", unknown [drop "ap" [r_deep]]);
     ("__builtin_va_arg_pack_len", unknown []);

--- a/src/util/library/libraryFunctions.ml
+++ b/src/util/library/libraryFunctions.ml
@@ -440,11 +440,11 @@ let posix_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("times", unknown [drop "buf" [w]]);
     ("mmap", unknown [drop "addr" []; drop "length" []; drop "prot" []; drop "flags" []; drop "fd" []; drop "offset" []]);
     ("munmap", unknown [drop "addr" []; drop "length" []]);
-    ("getline", unknown [drop "lineptr" [r_deep; w_deep]; drop "n" [r]; drop "stream" [r_deep; w_deep]]);
-    ("getwline", unknown [drop "lineptr" [r_deep; w_deep]; drop "n" [r]; drop "stream" [r_deep; w_deep]]);
-    ("getdelim", unknown [drop "lineptr" [r_deep; w_deep]; drop "n" [r];  drop "delimiter" [];drop "stream" [r_deep; w_deep]]);
-    ("__getdelim", unknown [drop "lineptr" [r_deep; w_deep]; drop "n" [r];  drop "delimiter" [];drop "stream" [r_deep; w_deep]]);
-    ("getwdelim", unknown [drop "lineptr" [r_deep; w_deep]; drop "n" [r];  drop "delimiter" [];drop "stream" [r_deep; w_deep]]);
+    ("getline", unknown [drop "lineptr" [r_deep; w_deep]; drop "n" [r; w]; drop "stream" [r_deep; w_deep]]);
+    ("getwline", unknown [drop "lineptr" [r_deep; w_deep]; drop "n" [r; w]; drop "stream" [r_deep; w_deep]]);
+    ("getdelim", unknown [drop "lineptr" [r_deep; w_deep]; drop "n" [r; w]; drop "delimiter" []; drop "stream" [r_deep; w_deep]]);
+    ("__getdelim", unknown [drop "lineptr" [r_deep; w_deep]; drop "n" [r; w]; drop "delimiter" []; drop "stream" [r_deep; w_deep]]);
+    ("getwdelim", unknown [drop "lineptr" [r_deep; w_deep]; drop "n" [r; w]; drop "delimiter" []; drop "stream" [r_deep; w_deep]]);
   ]
 [@@coverage off]
 

--- a/src/util/library/libraryFunctions.ml
+++ b/src/util/library/libraryFunctions.ml
@@ -552,7 +552,7 @@ let gcc_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__assert", special [drop "assertion" [r]; drop "file" [r]; drop "line" []] @@ Abort); (* header says: The following is not at all used here but needed for standard compliance. *)
     ("__builtin_return_address", unknown [drop "level" []]);
     ("__builtin___sprintf_chk", unknown (drop "s" [w] :: drop "flag" [] :: drop "os" [] :: drop "fmt" [r] :: VarArgs (drop' [r])));
-    ("__builtin___snprintf_chk", unknown [drop "s" [w]; drop "maxlen" []; drop "flag" []; drop "os" []]);
+    ("__builtin___snprintf_chk", unknown (drop "s" [w] :: drop "maxlen" [] :: drop "flag" [] :: drop "os" [] :: drop "fmt" [r] :: VarArgs (drop' [r])));
     ("__builtin___vsprintf_chk", unknown [drop "s" [w]; drop "flag" []; drop "os" []; drop "fmt" [r]; drop "ap" [r_deep]]); (* TODO: what to do with a va_list type? is r_deep correct? *)
     ("__builtin___vsnprintf_chk", unknown [drop "s" [w]; drop "maxlen" []; drop "flag" []; drop "os" []; drop "fmt" [r]; drop "ap" [r_deep]]); (* TODO: what to do with a va_list type? is r_deep correct? *)
     ("__builtin___printf_chk", unknown (drop "flag" [] :: drop "format" [r] :: VarArgs (drop' [r])));


### PR DESCRIPTION
- [x] Must be thoroughly checked by someone before merging, because the last bit was quite difficult and can likely contain mistakes
- [x] Revealed some bug: test `02/34 builtin_va_list` fails and has to be looked into, ~something to do with the autotuner~:
```
Fatal error: exception LibraryDsl.Pattern.Expected("Library function is called with more arguments than expected.")
Raised at LibraryDsl.Pattern.fail in file "src/util/library/libraryDsl.ml", line 14, characters 15-33
Called from Goblint_lib__AutoTune.hasFunction.relevant_static.(fun) in file "src/autoTune.ml", line 158, characters 41-60
Called from Stdlib__Map.Make.exists in file "map.ml", line 329, characters 29-34
Called from Goblint_lib__AutoTune.hasFunction in file "src/autoTune.ml", line 175, characters 2-77
Called from Goblint_lib__AutoTune.activateLongjmpAnalysesWhenRequired in file "src/autoTune.ml", line 210, characters 5-26
Called from Dune__exe__Goblint.main in file "src/goblint.ml", line 59, characters 6-53
Called from Stdlib.at_exit.new_exit in file "stdlib.ml", line 560, characters 59-63
Called from Stdlib.do_at_exit in file "stdlib.ml" (inlined), line 566, characters 20-61
Called from Std_exit in file "std_exit.ml", line 18, characters 8-20
See result/index.xml
```
The latter was caused by the fact that cil has special cases for handling `va_arg` and `va_start` functions. Thus, I fixed their argument definitions according to what is written in CIL and left comments.