### PR TITLE
Improve autotune for octagon

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -440,8 +440,10 @@ struct
     if RD.Tracked.type_tracked (Cilfacade.fundec_return_type f) then (
       let unify_st' = match r with
         | Some lv ->
-          assign_to_global_wrapper (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg unify_st lv (fun st v ->
-              RD.assign_var st.rel (RV.local v) RV.return
+          let ask = Analyses.ask_of_ctx ctx in
+          assign_to_global_wrapper ask ctx.global ctx.sideg unify_st lv (fun st v ->
+              let rel = RD.assign_var st.rel (RV.local v) RV.return in
+              assert_type_bounds ask rel v (* TODO: should be done in return instead *)
             )
         | None ->
           unify_st

--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -365,8 +365,8 @@ class octagonVariableVisitor(varMap, globals) = object
   method! vexpr = function
     (*an expression of type +/- a +/- b where a,b are either variables or constants*)
     | BinOp (op, e1,e2, (TInt _)) when isComparison op -> (
-        let extractedVars = List.append (extractOctagonVars e1) (extractOctagonVars e2) in
-        List.iter (fun var -> addOrCreateVarMapping varMap var 5 globals) extractedVars;
+        List.iter (fun var -> addOrCreateVarMapping varMap var 5 globals) (extractOctagonVars e1);
+        List.iter (fun var -> addOrCreateVarMapping varMap var 5 globals) (extractOctagonVars e2);
         DoChildren
       )
     | Lval ((Var info),_) when not (isGoblintStub info) -> addOrCreateVarMapping varMap info 1 globals; SkipChildren

--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -345,8 +345,8 @@ let extractOctagonVars = function
   | BinOp (MinusA, e1,e2, (TInt _)) -> (
       match extractVar e1, extractVar e2 with
       | Some a, Some b -> Some (`Left (a,b))
-      | Some a, None
-      | None, Some a -> if isConstant e1 then Some (`Right a) else None
+      | Some a, None when isConstant e2 -> Some (`Right a)
+      | None, Some a when isConstant e1 -> Some (`Right a)
       | _,_ -> None
     )
   | _ -> None

--- a/tests/regression/29-svcomp/35-nla-sqrt.c
+++ b/tests/regression/29-svcomp/35-nla-sqrt.c
@@ -1,0 +1,18 @@
+// SKIP PARAM: --enable ana.sv-comp.functions --enable ana.autotune.enabled --set ana.autotune.activated[+] octagon
+// Extracted from: nla-digbench-scaling/sqrt1-ll_unwindbound5.c
+#include <goblint.h>
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+  int n;
+  long long s;
+  n = __VERIFIER_nondet_int();
+
+  if (!(s <= n)) {
+    __goblint_check(s > n);
+  } else {
+    __goblint_check(s <= 2147483647);
+  }
+
+  return 0;
+}

--- a/tests/regression/29-svcomp/dune
+++ b/tests/regression/29-svcomp/dune
@@ -1,2 +1,16 @@
+(rule
+ (aliases runtest runaprontest)
+ (enabled_if %{lib-available:apron})
+ (deps
+   (package goblint)
+   ../../../goblint ; update_suite calls local goblint
+   (:update_suite ../../../scripts/update_suite.rb)
+   (glob_files ??-*.c))
+ (locks /update_suite)
+ (action
+  (chdir ../../..
+   (progn
+     (run %{update_suite} nla-sqrt -q)))))
+
 (cram
  (deps (glob_files *.c)))


### PR DESCRIPTION
I analyzed the SV-COMP NoOverflows tasks where Mopsa succeeded, but we failed, and uncovered some tasks where we succeeded when activating apron analysis but failed with autotune.

This PR proposes a fix that allows us to further succeed in 11 tasks (`nla-digbench-scaling/sqrt1-.*`) with autotune.

TODO:
- [x] Generalize the case handling operations inside `LNot`