### PR TITLE
Fix `BaseDomain` top `priv` typo

### DIFF
--- a/src/cdomains/baseDomain.ml
+++ b/src/cdomains/baseDomain.ml
@@ -92,7 +92,7 @@ struct
 
   let bot () = { cpa = CPA.bot (); deps = PartDeps.bot (); weak = WeakUpdates.bot (); priv = PrivD.bot ()}
   let is_bot {cpa; deps; weak; priv} = CPA.is_bot cpa && PartDeps.is_bot deps && WeakUpdates.is_bot weak && PrivD.is_bot priv
-  let top () = {cpa = CPA.top (); deps = PartDeps.top ();  weak = WeakUpdates.top () ; priv = PrivD.bot ()}
+  let top () = {cpa = CPA.top (); deps = PartDeps.top ();  weak = WeakUpdates.top () ; priv = PrivD.top ()}
   let is_top {cpa; deps; weak; priv} = CPA.is_top cpa && PartDeps.is_top deps && WeakUpdates.is_top weak && PrivD.is_top priv
 
   let leq {cpa=x1; deps=x2; weak=x3; priv=x4 } {cpa=y1; deps=y2; weak=y3; priv=y4} =


### PR DESCRIPTION
While having a quick look at the alternative fix in https://github.com/goblint/analyzer/pull/1458#discussion_r1599661735, I spotted that `BaseDomain`'s `top` has a typo: it has been copied from `bot` but the `priv` field hasn't been updated.

`is_top` also suggests that it should be this way: https://github.com/goblint/analyzer/blob/6783a4db6477d5cc9bd5d65bbe08c175c9c4f5fa/src/cdomains/baseDomain.ml#L96

Inserting `assert false` there and running all our tests reveals that it never even gets used, so this doesn't have any surprising consequences.
Still, it's better to have things consistent, even if they're currently unused and only there to satisfy the signature.