### PR TITLE
Activate abortUnless in svcomp conf

### DIFF
--- a/conf/svcomp.json
+++ b/conf/svcomp.json
@@ -30,7 +30,8 @@
       "symb_locks",
       "region",
       "thread",
-      "threadJoins"
+      "threadJoins",
+      "abortUnless"
     ],
     "path_sens": [
       "mutex",


### PR DESCRIPTION
This is on top of #1462 to fix #1453, but the following benchmarking was also done with #1450 included.

In https://github.com/goblint/analyzer/pull/875#issuecomment-1302204561, when the abortUnless analysis was added, it didn't seem to pay off. Now with Apron and autotuning, it seems that it might now.

## sv-benchmarks no-overflow
With 60s timeout, we gain **92 new correct trues**. There are also **3 new TIMEOUTs** to be investigated.

### CPU time linear scale
Always activating abortUnless has ~1% overhead, which is negligible.
![image](https://github.com/goblint/analyzer/assets/378740/53df5ede-8bd7-4090-84fb-cbd1da17ca5f)

### CPU time log scale
Visible differences are only at the low end and the slowdown cases are precisely those nla-digbench tasks where we become more precise because of this, which is expected.
![image](https://github.com/goblint/analyzer/assets/378740/718fe138-257f-46c3-b7f2-09f407fd3f59)


## TODO
New TIMEOUTs to investigate:
- [x] 13-privatized_01-priv_nr_true — This is embarassing... (#1475)
- [x] 13-privatized_25-struct_nr_true (#1475)
- [x] recursified_knuth

