### PR TITLE
Union: `meet` in `Field`: Do not raise `Uncomparable` when one arg is `Top`

### DIFF
--- a/src/cdomain/value/cdomains/unionDomain.ml
+++ b/src/cdomain/value/cdomains/unionDomain.ml
@@ -26,7 +26,10 @@ module Field = struct
     if equal f g then
       f
     else
-      raise Lattice.Uncomparable
+      match f, g with
+      | `Top, f
+      | f, `Top -> f
+      | _ -> raise Lattice.Uncomparable
 end
 
 module Simple (Values: Arg) =

--- a/src/cdomain/value/cdomains/unionDomain.ml
+++ b/src/cdomain/value/cdomains/unionDomain.ml
@@ -23,13 +23,9 @@ module Field = struct
     end) (CilType.Fieldinfo)
 
   let meet f g =
-    if equal f g then
-      f
-    else
-      match f, g with
-      | `Top, f
-      | f, `Top -> f
-      | _ -> raise Lattice.Uncomparable
+    match meet f g with
+    | `Bot -> raise Lattice.Uncomparable
+    | m -> m
 end
 
 module Simple (Values: Arg) =

--- a/tests/regression/13-privatized/90-union.c
+++ b/tests/regression/13-privatized/90-union.c
@@ -1,0 +1,29 @@
+// PARAM: --set ana.base.privatization write
+#include<pthread.h>
+#include<stdlib.h>
+#include<string.h>
+union g {
+  int h;
+  int i;
+};
+struct j {
+  union g data;
+};
+
+
+void* af(void* arg) {
+  int top;
+  struct j* jptr = (struct j*) malloc(sizeof(struct j));
+  memset(jptr, 0, sizeof(struct j));
+
+  while (top) {
+    if (jptr->data.i);
+
+    __goblint_check(jptr->data.i == 0); // Should alo work for write!
+  }
+}
+
+void main() {
+  pthread_t ah;
+  pthread_create(&ah, 0, af, 0);
+}

--- a/tests/regression/13-privatized/91-union-direct.c
+++ b/tests/regression/13-privatized/91-union-direct.c
@@ -1,0 +1,26 @@
+// PARAM: --set ana.base.privatization write
+#include<pthread.h>
+#include<stdlib.h>
+#include<string.h>
+union g {
+  int h;
+  int i;
+};
+
+void* af(void* arg) {
+  // Go MT
+}
+
+void main() {
+  pthread_t ah;
+  pthread_create(&ah, 0, af, 0);
+
+  int top;
+  union g* jptr = (union g*) malloc(sizeof(union g));
+  memset(jptr, 0, sizeof(union g));
+
+  while (top) {
+    if (jptr->i);
+    __goblint_check(jptr->i == 0); // Should alo work for write!
+  }
+}


### PR DESCRIPTION
This behavior leads to unnecessary imprecision in combination with the invariant refinement for privatizations at branches.

This was added  in https://github.com/goblint/analyzer/pull/1109 but it seems we were a bit overzealous in raising this exception even if one of the arguments is `Top`.

This fixes some of the issues described in #1456.