### PR TITLE
Make privatization `sync Join` more precise when threadflag is path-sensitive

### DIFF
--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -97,8 +97,8 @@ struct
 
   let sync (ask: Q.ask) getg sideg (st: relation_components_t) reason =
     match reason with
-    | `Join ->
-      if ConfCheck.no_branched_thread_creation () || ask.f (Q.MustBeSingleThreaded {since_start = true}) then
+    | `Join when ConfCheck.branched_thread_creation () ->
+      if ask.f (Q.MustBeSingleThreaded {since_start = true}) then
         st
       else
         (* must be like enter_multithreaded *)
@@ -110,6 +110,7 @@ struct
           )
         in
         {st with rel = rel_local}
+    | `Join
     | `Normal
     | `Init
     | `Thread
@@ -346,8 +347,8 @@ struct
         | _ ->
           st
       end
-    | `Join ->
-      if ConfCheck.no_branched_thread_creation () || (ask.f (Q.MustBeSingleThreaded { since_start= true })) then
+    | `Join when ConfCheck.branched_thread_creation () ->
+      if ask.f (Q.MustBeSingleThreaded { since_start= true }) then
         st
       else
         (* must be like enter_multithreaded *)
@@ -375,6 +376,7 @@ struct
            let rel_local' = RD.meet rel_local (getg ()) in
            {st with rel = rel_local'} *)
         st
+    | `Join
     | `Normal
     | `Init
     | `Thread ->
@@ -634,8 +636,8 @@ struct
         | _ ->
           st
       end
-    | `Join ->
-      if ConfCheck.no_branched_thread_creation () || (ask.f (Q.MustBeSingleThreaded {since_start = true})) then
+    | `Join when ConfCheck.branched_thread_creation () ->
+      if ask.f (Q.MustBeSingleThreaded {since_start = true}) then
         st
       else
         let rel = st.rel in
@@ -657,6 +659,7 @@ struct
           )
         in
         {st with rel = rel_local}
+    | `Join
     | `Normal
     | `Init
     | `Thread ->
@@ -1189,8 +1192,8 @@ struct
   let sync (ask:Q.ask) getg sideg (st: relation_components_t) reason =
     match reason with
     | `Return -> st (* TODO: implement? *)
-    | `Join ->
-      if ConfCheck.no_branched_thread_creation () || (ask.f (Q.MustBeSingleThreaded {since_start = true})) then
+    | `Join when ConfCheck.branched_thread_creation () ->
+      if ask.f (Q.MustBeSingleThreaded {since_start = true}) then
         st
       else
         let rel = st.rel in
@@ -1204,6 +1207,7 @@ struct
           )
         in
         {st with rel = rel_local}
+    | `Join
     | `Normal
     | `Init
     | `Thread ->

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -98,7 +98,7 @@ struct
   let sync (ask: Q.ask) getg sideg (st: relation_components_t) reason =
     match reason with
     | `Join ->
-      if ask.f (Q.MustBeSingleThreaded {since_start = true}) then
+      if ConfCheck.no_branched_thread_creation () || ask.f (Q.MustBeSingleThreaded {since_start = true}) then
         st
       else
         (* must be like enter_multithreaded *)
@@ -347,7 +347,7 @@ struct
           st
       end
     | `Join ->
-      if (ask.f (Q.MustBeSingleThreaded { since_start= true })) then
+      if ConfCheck.no_branched_thread_creation () || (ask.f (Q.MustBeSingleThreaded { since_start= true })) then
         st
       else
         (* must be like enter_multithreaded *)
@@ -1190,7 +1190,7 @@ struct
     match reason with
     | `Return -> st (* TODO: implement? *)
     | `Join ->
-      if (ask.f (Q.MustBeSingleThreaded {since_start = true})) then
+      if ConfCheck.no_branched_thread_creation () || (ask.f (Q.MustBeSingleThreaded {since_start = true})) then
         st
       else
         let rel = st.rel in

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -635,7 +635,7 @@ struct
           st
       end
     | `Join ->
-      if (ask.f (Q.MustBeSingleThreaded {since_start = true})) then
+      if ConfCheck.no_branched_thread_creation () || (ask.f (Q.MustBeSingleThreaded {since_start = true})) then
         st
       else
         let rel = st.rel in

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -307,7 +307,7 @@ struct
 
   let sync ask getg sideg (st: BaseComponents (D).t) reason =
     match reason with
-    | `Join -> (* required for branched thread creation *)
+    | `Join when ConfCheck.branched_thread_creation () -> (* required for branched thread creation *)
       let global_cpa = CPA.filter (fun x _ -> is_global ask x && is_unprotected ask x) st.cpa in
       sideg V.mutex_inits global_cpa; (* must be like enter_multithreaded *)
       (* TODO: this makes mutex-oplus less precise in 28-race_reach/10-ptrmunge_racefree and 28-race_reach/trylock2_racefree, why? *)
@@ -318,6 +318,7 @@ struct
             sideg (V.global x) (CPA.singleton x v)
         ) st.cpa;
       st
+    | `Join
     | `Return
     | `Normal
     | `Init
@@ -404,7 +405,7 @@ struct
 
   let sync ask getg sideg (st: BaseComponents (D).t) reason =
     match reason with
-    | `Join -> (* required for branched thread creation *)
+    | `Join when ConfCheck.branched_thread_creation () -> (* required for branched thread creation *)
       let global_cpa = CPA.filter (fun x _ -> is_global ask x && is_unprotected ask x) st.cpa in
       sideg V.mutex_inits global_cpa; (* must be like enter_multithreaded *)
 
@@ -421,6 +422,7 @@ struct
         ) st.cpa st.cpa
       in
       {st with cpa = cpa'}
+    | `Join
     | `Return
     | `Normal
     | `Init
@@ -772,7 +774,7 @@ struct
   let sync ask getg sideg (st: BaseComponents (D).t) reason =
     let sideg = Wrapper.sideg ask sideg in
     match reason with
-    | `Join -> (* required for branched thread creation *)
+    | `Join when ConfCheck.branched_thread_creation () -> (* required for branched thread creation *)
       CPA.fold (fun x v (st: BaseComponents (D).t) ->
           if is_global ask x && is_unprotected ask x then (
             sideg (V.unprotected x) v;
@@ -782,6 +784,7 @@ struct
           else
             st
         ) st.cpa st
+    | `Join
     | `Return
     | `Normal
     | `Init

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -50,6 +50,19 @@ struct
         if not threadflag_path_sens then failwith "The activated privatization requires the 'threadflag' analysis to be path sensitive if it is enabled (it is currently enabled, but not path sensitive)";
         ()
   end
+
+  let branched_thread_creation () =
+    let threadflag_active = List.mem "threadflag" (GobConfig.get_string_list "ana.activated") in
+    if threadflag_active then
+      let threadflag_path_sens = List.mem "threadflag" (GobConfig.get_string_list "ana.path_sens") in
+      if not threadflag_path_sens then
+        true
+      else
+        false
+    else
+      true
+
+  let no_branched_thread_creation () = not (branched_thread_creation ())
 end
 
 module Protection =

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -51,14 +51,12 @@ struct
         ()
   end
 
+  (** Whether branched thread creation needs to be handled by [sync `Join] of privatization. *)
   let branched_thread_creation () =
     let threadflag_active = List.mem "threadflag" (GobConfig.get_string_list "ana.activated") in
     if threadflag_active then
       let threadflag_path_sens = List.mem "threadflag" (GobConfig.get_string_list "ana.path_sens") in
-      if not threadflag_path_sens then
-        true
-      else
-        false
+      not threadflag_path_sens
     else
       true
 end

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -61,8 +61,6 @@ struct
         false
     else
       true
-
-  let no_branched_thread_creation () = not (branched_thread_creation ())
 end
 
 module Protection =

--- a/tests/regression/62-abortUnless/05-apron-mutex-meet-abortUnless.c
+++ b/tests/regression/62-abortUnless/05-apron-mutex-meet-abortUnless.c
@@ -1,0 +1,39 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.activated[+] abortUnless --set ana.path_sens[+] threadflag
+// Minimized SV-COMP version of our regression test
+// NOTIMEOUT
+#include <assert.h>
+#include <pthread.h>
+
+void reach_error() {
+  assert(0); // NOWARN
+}
+void __VERIFIER_assert(int cond) { // NOWARN
+  if(!(cond)) { ERROR: {reach_error();abort();} }
+}
+
+int glob1 = 5;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+void *t_fun(void *arg) {
+  int t;
+  pthread_mutex_lock(&mutex1);
+  t = glob1;
+  __VERIFIER_assert(t == 5); // NOWARN
+  glob1 = -10;
+  __VERIFIER_assert(glob1 == -10); // NOWARN
+  glob1 = t;
+  pthread_mutex_unlock(&mutex1);
+  return ((void *)0);
+}
+int main(void) {
+  pthread_t id;
+  __VERIFIER_assert(glob1 == 5); // NOWARN
+  pthread_create(&id, ((void *)0), t_fun, ((void *)0));
+  pthread_mutex_lock(&mutex1);
+  glob1++;
+  __VERIFIER_assert(glob1 == 6); // NOWARN
+  glob1--;
+  pthread_mutex_unlock(&mutex1);
+  pthread_join (id, ((void *)0));
+  return 0;
+}

--- a/tests/regression/62-abortUnless/dune
+++ b/tests/regression/62-abortUnless/dune
@@ -1,0 +1,14 @@
+(rule
+ (aliases runtest runaprontest)
+ (enabled_if %{lib-available:apron})
+ (deps
+   (package goblint)
+   ../../../goblint ; update_suite calls local goblint
+   (:update_suite ../../../scripts/update_suite.rb)
+   (glob_files ??-*.c))
+ (locks /update_suite)
+ (action
+  (chdir ../../..
+   (progn
+     (run %{update_suite} apron-mutex-meet-abortUnless -q)))))
+


### PR DESCRIPTION
In #1464, just enabling abortUnless caused two of our simple regression tests in sv-benchmarks to time out:
1. 13-privatized_01-priv_nr_true — This is embarassing...
2. 13-privatized_25-struct_nr_true

Tracing the first one revealed `MUTEX_INITS` of relational mutex-meet getting additional unwidened increasing side-effects from the body of `__VERIFIER_assert`, in particular, the join point there. The `sync Join` which causes these is unnecessary in SV-COMP where threadflag is path-sensitive, so branched thread creation doesn't need to be accounted for by privatizations.

Therefore, this PR makes such privatizations check that and avoid unnecessary side-effects from `sync Join`. It fixes the two cases, which are probably somewhat outliers that they got an explosion of contexts with abortUnless.
Really, this could make us both more precise (by side-effecting less crap to `MUTEX_INITS` etc) and more efficient (not modifying `MUTEX_INITS` which everything depends on).