### PR TITLE
Fix unsoundness bug in interval sets and refactor interval widen thresholds

### DIFF
--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -563,12 +563,14 @@ module IntervalArith (Ints_t : IntOps.IntOps) = struct
   let upper_threshold u max_ik =
     let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.upper_thresholds () else ResettableLazy.force widening_thresholds in
     let u = Ints_t.to_bigint u in
-    let t = List.find_opt (fun x -> Z.compare u x <= 0 && Z.compare x (Ints_t.to_bigint max_ik) <= 0) ts in
+    let max_ik' = Ints_t.to_bigint max_ik in
+    let t = List.find_opt (fun x -> Z.compare u x <= 0 && Z.compare x max_ik' <= 0) ts in
     BatOption.map_default Ints_t.of_bigint max_ik t
   let lower_threshold l min_ik =
     let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.lower_thresholds () else ResettableLazy.force widening_thresholds_desc in
     let l = Ints_t.to_bigint l in
-    let t = List.find_opt (fun x -> Z.compare l x >= 0 && Z.compare x (Ints_t.to_bigint min_ik) >= 0) ts in
+    let min_ik' = Ints_t.to_bigint min_ik in
+    let t = List.find_opt (fun x -> Z.compare l x >= 0 && Z.compare x min_ik' >= 0) ts in
     BatOption.map_default Ints_t.of_bigint min_ik t
 end
 

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -686,14 +686,14 @@ struct
           l0
         else
           let lt = if threshold then IArith.lower_threshold l1 min_ik else min_ik in
-          Ints_t.min l1 (Ints_t.max lt min_ik)
+          Ints_t.min l1 lt
       in
       let u2 =
         if Ints_t.compare u0 u1 = 0 then
           u0
         else
           let ut = if threshold then IArith.upper_threshold u1 max_ik else max_ik in
-          Ints_t.max u1 (Ints_t.min ut max_ik)
+          Ints_t.max u1 ut
       in
       norm ik @@ Some (l2,u2) |> fst
   let widen ik x y =

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -1393,18 +1393,8 @@ struct
   let widen ik xs ys =
     let (min_ik,max_ik) = range ik in
     let threshold = get_bool "ana.int.interval_threshold_widening" in
-    let upper_threshold (_,u) =
-      let ts = if GobConfig.get_string "ana.int.interval_threshold_widening_constants" = "comparisons" then WideningThresholds.upper_thresholds () else ResettableLazy.force widening_thresholds in
-      let u = Ints_t.to_bigint u in
-      let t = List.find_opt (fun x -> Z.compare u x <= 0 && Z.compare x (Ints_t.to_bigint max_ik) <= 0) ts in
-      BatOption.map_default Ints_t.of_bigint max_ik t
-    in
-    let lower_threshold (l,_) =
-      let ts = if GobConfig.get_string "ana.int.interval_threshold_widening_constants" = "comparisons" then WideningThresholds.lower_thresholds () else ResettableLazy.force widening_thresholds_desc in
-      let l = Ints_t.to_bigint l in
-      let t = List.find_opt (fun x -> Z.compare l x >= 0 && Z.compare x (Ints_t.to_bigint min_ik) >= 0) ts in
-      BatOption.map_default Ints_t.of_bigint min_ik t
-    in
+    let upper_threshold (_,u) = IArith.upper_threshold u max_ik in
+    let lower_threshold (l,_) = IArith.lower_threshold l min_ik in
     (*obtain partitioning of xs intervals according to the ys interval that includes them*)
     let rec interval_sets_to_partitions (ik: ikind) (acc : (int_t * int_t) option) (xs: t) (ys: t)=
       match xs,ys with

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -671,13 +671,13 @@ struct
       let upper_threshold u =
         let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.upper_thresholds () else ResettableLazy.force widening_thresholds in
         let u = Ints_t.to_bigint u in
-        let t = List.find_opt (fun x -> Z.compare u x <= 0) ts in
+        let t = List.find_opt (fun x -> Z.compare u x <= 0 && Z.compare x (Ints_t.to_bigint max_ik) <= 0) ts in
         BatOption.map_default Ints_t.of_bigint max_ik t
       in
       let lower_threshold l =
         let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.lower_thresholds () else ResettableLazy.force widening_thresholds_desc in
         let l = Ints_t.to_bigint l in
-        let t = List.find_opt (fun x -> Z.compare l x >= 0) ts in
+        let t = List.find_opt (fun x -> Z.compare l x >= 0 && Z.compare x (Ints_t.to_bigint min_ik) >= 0) ts in
         BatOption.map_default Ints_t.of_bigint min_ik t
       in
       let lt = if threshold then lower_threshold l1 else min_ik in
@@ -1397,13 +1397,13 @@ struct
     let upper_threshold (_,u) =
       let ts = if GobConfig.get_string "ana.int.interval_threshold_widening_constants" = "comparisons" then WideningThresholds.upper_thresholds () else ResettableLazy.force widening_thresholds in
       let u = Ints_t.to_bigint u in
-      let t = List.find_opt (fun x -> Z.compare u x <= 0) ts in
+      let t = List.find_opt (fun x -> Z.compare u x <= 0 && Z.compare x (Ints_t.to_bigint max_ik) <= 0) ts in
       BatOption.map_default Ints_t.of_bigint max_ik t
     in
     let lower_threshold (l,_) =
       let ts = if GobConfig.get_string "ana.int.interval_threshold_widening_constants" = "comparisons" then WideningThresholds.lower_thresholds () else ResettableLazy.force widening_thresholds_desc in
       let l = Ints_t.to_bigint l in
-      let t = List.find_opt (fun x -> Z.compare l x >= 0) ts in
+      let t = List.find_opt (fun x -> Z.compare l x >= 0 && Z.compare x (Ints_t.to_bigint min_ik) >= 0) ts in
       BatOption.map_default Ints_t.of_bigint min_ik t
     in
     (*obtain partitioning of xs intervals according to the ys interval that includes them*)

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -681,10 +681,20 @@ struct
     | Some (l0,u0), Some (l1,u1) ->
       let (min_ik, max_ik) = range ik in
       let threshold = get_interval_threshold_widening () in
-      let lt = if threshold then IArith.lower_threshold l1 min_ik else min_ik in
-      let l2 = if Ints_t.compare l0 l1 = 0 then l0 else Ints_t.min l1 (Ints_t.max lt min_ik) in
-      let ut = if threshold then IArith.upper_threshold u1 max_ik else max_ik in
-      let u2 = if Ints_t.compare u0 u1 = 0 then u0 else Ints_t.max u1 (Ints_t.min ut max_ik) in
+      let l2 =
+        if Ints_t.compare l0 l1 = 0 then
+          l0
+        else
+          let lt = if threshold then IArith.lower_threshold l1 min_ik else min_ik in
+          Ints_t.min l1 (Ints_t.max lt min_ik)
+      in
+      let u2 =
+        if Ints_t.compare u0 u1 = 0 then
+          u0
+        else
+          let ut = if threshold then IArith.upper_threshold u1 max_ik else max_ik in
+          Ints_t.max u1 (Ints_t.min ut max_ik)
+      in
       norm ik @@ Some (l2,u2) |> fst
   let widen ik x y =
     let r = widen ik x y in

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -662,27 +662,26 @@ struct
 
   let cast_to ?(suppress_ovwarn=false) ?torg ?no_ov t = norm ~cast:true t (* norm does all overflow handling *)
 
+  let upper_threshold u max_ik =
+    let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.upper_thresholds () else ResettableLazy.force widening_thresholds in
+    let u = Ints_t.to_bigint u in
+    let t = List.find_opt (fun x -> Z.compare u x <= 0 && Z.compare x (Ints_t.to_bigint max_ik) <= 0) ts in
+    BatOption.map_default Ints_t.of_bigint max_ik t
+  let lower_threshold l min_ik =
+    let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.lower_thresholds () else ResettableLazy.force widening_thresholds_desc in
+    let l = Ints_t.to_bigint l in
+    let t = List.find_opt (fun x -> Z.compare l x >= 0 && Z.compare x (Ints_t.to_bigint min_ik) >= 0) ts in
+    BatOption.map_default Ints_t.of_bigint min_ik t
+
   let widen ik x y =
     match x, y with
     | None, z | z, None -> z
     | Some (l0,u0), Some (l1,u1) ->
       let (min_ik, max_ik) = range ik in
       let threshold = get_interval_threshold_widening () in
-      let upper_threshold u =
-        let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.upper_thresholds () else ResettableLazy.force widening_thresholds in
-        let u = Ints_t.to_bigint u in
-        let t = List.find_opt (fun x -> Z.compare u x <= 0 && Z.compare x (Ints_t.to_bigint max_ik) <= 0) ts in
-        BatOption.map_default Ints_t.of_bigint max_ik t
-      in
-      let lower_threshold l =
-        let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.lower_thresholds () else ResettableLazy.force widening_thresholds_desc in
-        let l = Ints_t.to_bigint l in
-        let t = List.find_opt (fun x -> Z.compare l x >= 0 && Z.compare x (Ints_t.to_bigint min_ik) >= 0) ts in
-        BatOption.map_default Ints_t.of_bigint min_ik t
-      in
-      let lt = if threshold then lower_threshold l1 else min_ik in
+      let lt = if threshold then lower_threshold l1 min_ik else min_ik in
       let l2 = if Ints_t.compare l0 l1 = 0 then l0 else Ints_t.min l1 (Ints_t.max lt min_ik) in
-      let ut = if threshold then upper_threshold u1 else max_ik in
+      let ut = if threshold then upper_threshold u1 max_ik else max_ik in
       let u2 = if Ints_t.compare u0 u1 = 0 then u0 else Ints_t.max u1 (Ints_t.min ut max_ik) in
       norm ik @@ Some (l2,u2) |> fst
   let widen ik x y =

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -682,18 +682,14 @@ struct
       let (min_ik, max_ik) = range ik in
       let threshold = get_interval_threshold_widening () in
       let l2 =
-        if Ints_t.compare l0 l1 = 0 then
-          l0
-        else
-          let lt = if threshold then IArith.lower_threshold l1 min_ik else min_ik in
-          Ints_t.min l1 lt
+        if Ints_t.compare l0 l1 = 0 then l0
+        else if threshold then IArith.lower_threshold l1 min_ik
+        else min_ik
       in
       let u2 =
-        if Ints_t.compare u0 u1 = 0 then
-          u0
-        else
-          let ut = if threshold then IArith.upper_threshold u1 max_ik else max_ik in
-          Ints_t.max u1 ut
+        if Ints_t.compare u0 u1 = 0 then u0
+        else if threshold then IArith.upper_threshold u1 max_ik
+        else max_ik
       in
       norm ik @@ Some (l2,u2) |> fst
   let widen ik x y =


### PR DESCRIPTION
* Makes sure that if the next widen threshold is bigger than `max_ik` (or smaller than `man_ik`), `max_ik` (or `min_ik`) is picked instead. (solves #1473)
* Refactors the duplicate code of `widen.upper_threshold` and `widen.lower_threshold` of `IntervalFunctor` and `IntervalSetFunctor` to `IntervalArith` module, and uses this function for both.