### PR TITLE
Fix `global_init` for escaped globals in mutex-meet-tid cluster configuration

### DIFF
--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -813,7 +813,9 @@ struct
     let g_var = V.global g in
     (* normal (strong) mapping: contains only still fully protected *)
     let g' = VS.singleton g in
-    let oct = LRD.find g' octs in
+    (* If there is no map entry yet which contains the global, default to top rather than bot *)
+    (* Happens e.g. in 46/86 because of escape *)
+    let oct = Option.default (RD.top ()) (LRD.find_opt g' octs) in
     LRD.singleton g' (RD.keep_vars oct [g_var])
 
   let lock_get_m oct local_m get_m =

--- a/tests/regression/46-apron2/86-escape-cluster12.c
+++ b/tests/regression/46-apron2/86-escape-cluster12.c
@@ -1,0 +1,21 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.relation.privatization mutex-meet-tid-cluster12
+#include<pthread.h>
+#include<goblint.h>
+void *a;
+
+void* nothing(void* arg) {
+  // Go multithreaded!
+}
+
+void main() {
+  pthread_t t;
+  pthread_create(&t, 0, nothing, 0);
+
+  int d = 5;
+  a = &d;
+
+  if (0)
+    ;
+
+  __goblint_check(1); // Should be reachable!
+}


### PR DESCRIPTION
For escaping locals, the lookup in the cluster map yielded the `bot` element, which in turn caused an unsoundness causing all branches to be dead. This PR addresses this issue.


Closes #1479 