### PR TITLE
Simplify `SetDomain.FiniteSet` for first analysis tutorial

### DIFF
--- a/docs/developer-guide/firstanalysis.md
+++ b/docs/developer-guide/firstanalysis.md
@@ -35,7 +35,7 @@ This program is in the Goblint repository: `tests/regression/99-tutorials/01-fir
 But if you run Goblint out of the box on this example, it will not work:
 
 ```console
-./goblint --enable warn.debug tests/regression/99-tutorials/01-first.c
+./goblint tests/regression/99-tutorials/01-first.c
 ```
 
 This will claim that the assertion in unknown.

--- a/docs/developer-guide/firstanalysis.md
+++ b/docs/developer-guide/firstanalysis.md
@@ -80,4 +80,4 @@ For example, have a look at the following program: `tests/regression/99-tutorial
 _Hint:_
 The easiest way to do this is to use the powerset lattice of `{-, 0, +}`.
 For example, "non-negative" is represented by `{0, +}`, while negative is represented by `{-}`.
-To do this, modify `SL` by using `SetDomain.FiniteSet` (takes a `struct` with a list of finite elements as second parameter) instead of `Lattice.Flat` and reimplementing the two functions using `singleton` and `for_all`.
+To do this, modify `SL` by using `SetDomain.FiniteSet` (which needs a finite list of elements to be added to `Signs`) instead of `Lattice.Flat` and reimplementing the two functions using `singleton` and `for_all`.

--- a/docs/developer-guide/firstanalysis.md
+++ b/docs/developer-guide/firstanalysis.md
@@ -74,7 +74,7 @@ For more information on the signature of the individual transfer functions, plea
 ## Extending the domain
 
 You could now enrich the lattice to also have a representation for non-negative (i.e., zero or positive) values.
-Then the join of `Zero` and `Pos` would be "non-negative" instead of `Top`, allowing you to prove that such join is greated than `Neg`.
+Then the join of `Zero` and `Pos` would be "non-negative" instead of `Top`, allowing you to prove that such join is greater than `Neg`.
 For example, have a look at the following program: `tests/regression/99-tutorials/02-first-extend.c`.
 
 _Hint:_

--- a/src/domain/setDomain.ml
+++ b/src/domain/setDomain.ml
@@ -436,23 +436,23 @@ struct
   include Lattice.Reverse (Base)
 end
 
-module type FiniteSetElems =
+module type FiniteSetElem =
 sig
-  type t
+  include Printable.S
   val elems: t list
+  (** List of all possible elements. *)
 end
 
-(* TODO: put elems into E *)
-module FiniteSet (E:Printable.S) (Elems:FiniteSetElems with type t = E.t) =
+module FiniteSet (E: FiniteSetElem) =
 struct
   module E =
   struct
     include E
-    let arbitrary () = QCheck.oneofl Elems.elems
+    let arbitrary () = QCheck.oneofl E.elems
   end
 
   include Make (E)
-  let top () = of_list Elems.elems
+  let top () = of_list E.elems
   let is_top x = equal x (top ())
 end
 

--- a/tests/unit/maindomaintest.ml
+++ b/tests/unit/maindomaintest.ml
@@ -15,14 +15,11 @@ struct
     let show = show
   end
   include Printable.SimpleShow (P)
+
+  let elems = ['a'; 'b'; 'c'; 'd']
 end
 
-module ArbitraryLattice = SetDomain.FiniteSet (PrintableChar) (
-  struct
-    type t = char
-    let elems = ['a'; 'b'; 'c'; 'd']
-  end
-  )
+module ArbitraryLattice = SetDomain.FiniteSet (PrintableChar)
 
 module HoareArbitrary = HoareDomain.Set_LiftTop (ArbitraryLattice) (struct let topname = "Top" end)
 module HoareArbitrary_NoTop = HoareDomain.Set (ArbitraryLattice)


### PR DESCRIPTION
This completes an existing code TODO. It's a lot easier to add the elements list to the existing module rather than need a second functor argument with funky type constraints.