### PR TITLE
Improve output for component of blob indicating whether it was created with `malloc` or `calloc`

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -17,6 +17,7 @@ module IdxDom = ValueDomain.IndexDomain
 module AD = ValueDomain.AD
 module Addr = ValueDomain.Addr
 module Offs = ValueDomain.Offs
+module ZeroInit = ValueDomain.ZeroInit
 module LF = LibraryFunctions
 module CArrays = ValueDomain.CArrays
 module PU = PrecisionUtil
@@ -2652,7 +2653,7 @@ struct
         | Some lv ->
           let heap_var = AD.of_var (heap_var true ctx) in
           (* ignore @@ printf "alloca will allocate %a bytes\n" ID.pretty (eval_int ~ctx size); *)
-          set_many ~ctx st [(heap_var, TVoid [], Blob (VD.bot (), eval_int ~ctx st size, true));
+          set_many ~ctx st [(heap_var, TVoid [], Blob (VD.bot (), eval_int ~ctx st size, ZeroInit.malloc));
                             (eval_lv ~ctx st lv, (Cilfacade.typeOfLval lv), Address heap_var)]
         | _ -> st
       end
@@ -2665,7 +2666,7 @@ struct
             else AD.of_var (heap_var false ctx)
           in
           (* ignore @@ printf "malloc will allocate %a bytes\n" ID.pretty (eval_int ~ctx size); *)
-          set_many ~ctx st [(heap_var, TVoid [], Blob (VD.bot (), eval_int ~ctx st size, true));
+          set_many ~ctx st [(heap_var, TVoid [], Blob (VD.bot (), eval_int ~ctx st size, ZeroInit.malloc));
                             (eval_lv ~ctx st lv, (Cilfacade.typeOfLval lv), Address heap_var)]
         | _ -> st
       end
@@ -2682,7 +2683,7 @@ struct
           let countval = eval_int ~ctx st n in
           if ID.to_int countval = Some Z.one then (
             set_many ~ctx st [
-              (add_null (AD.of_var heap_var), TVoid [], Blob (VD.bot (), sizeval, false));
+              (add_null (AD.of_var heap_var), TVoid [], Blob (VD.bot (), sizeval, ZeroInit.calloc));
               (eval_lv ~ctx st lv, (Cilfacade.typeOfLval lv), Address (add_null (AD.of_var heap_var)))
             ]
           )
@@ -2690,7 +2691,7 @@ struct
             let blobsize = ID.mul (ID.cast_to ik @@ sizeval) (ID.cast_to ik @@ countval) in
             (* the memory that was allocated by calloc is set to bottom, but we keep track that it originated from calloc, so when bottom is read from memory allocated by calloc it is turned to zero *)
             set_many ~ctx st [
-              (add_null (AD.of_var heap_var), TVoid [], Array (CArrays.make (IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) Z.one) (Blob (VD.bot (), blobsize, false))));
+              (add_null (AD.of_var heap_var), TVoid [], Array (CArrays.make (IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) Z.one) (Blob (VD.bot (), blobsize, ZeroInit.calloc))));
               (eval_lv ~ctx st lv, (Cilfacade.typeOfLval lv), Address (add_null (AD.of_mval (heap_var, `Index (IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) Z.zero, `NoOffset)))))
             ]
           )
@@ -2713,7 +2714,7 @@ struct
           let p_addr' = AD.remove NullPtr p_addr in (* realloc with NULL is same as malloc, remove to avoid unknown value from NullPtr access *)
           let p_addr_get = get ~ctx st p_addr' None in (* implicitly includes join of malloc value (VD.bot) *)
           let size_int = eval_int ~ctx st size in
-          let heap_val:value = Blob (p_addr_get, size_int, true) in (* copy old contents with new size *)
+          let heap_val:value = Blob (p_addr_get, size_int, ZeroInit.malloc) in (* copy old contents with new size *)
           let heap_addr = AD.of_var (heap_var false ctx) in
           let heap_addr' =
             if get_bool "sem.malloc.fail" then

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -49,8 +49,8 @@ module type Blob =
 sig
   type value
   type size
-  type origin
-  include Lattice.S with type t = value * size * origin
+  type zeroinit
+  include Lattice.S with type t = value * size * zeroinit
 
   val map: (value -> value) -> t -> t
   val value: t -> value
@@ -83,7 +83,7 @@ struct
   let name () = "blob"
   type value = Value.t
   type size = Size.t
-  type origin = ZeroInit.t
+  type zeroinit = ZeroInit.t
 
   let map f (v, s, o) = f v, s, o
   let value (a, b, c) = a
@@ -891,23 +891,23 @@ struct
       if M.tracing then M.traceli "eval_offset" "do_eval_offset %a %a (%a)" pretty x Offs.pretty offs (Pretty.docOpt (CilType.Exp.pretty ())) exp;
       let r =
         match x, offs with
-        | Blob((va, _, orig) as c), `Index (_, ox) ->
+        | Blob((va, _, zeroinit) as c), `Index (_, ox) ->
           begin
             let l', o' = shift_one_over l o in
             let ev = do_eval_offset ask f (Blobs.value c) ox exp l' o' v t in
-            zero_init_calloced_memory orig ev t
+            zero_init_calloced_memory zeroinit ev t
           end
-        | Blob((va, _, orig) as c), `Field _ ->
+        | Blob((va, _, zeroinit) as c), `Field _ ->
           begin
             let l', o' = shift_one_over l o in
             let ev = do_eval_offset ask f (Blobs.value c) offs exp l' o' v t in
-            zero_init_calloced_memory orig ev t
+            zero_init_calloced_memory zeroinit ev t
           end
-        | Blob((va, _, orig) as c), `NoOffset ->
+        | Blob((va, _, zeroinit) as c), `NoOffset ->
           begin
             let l', o' = shift_one_over l o in
             let ev = do_eval_offset ask f (Blobs.value c) offs exp l' o' v t in
-            zero_init_calloced_memory orig ev t
+            zero_init_calloced_memory zeroinit ev t
           end
         | Bot, _ -> Bot
         | _ ->
@@ -965,24 +965,24 @@ struct
   let update_offset ?(blob_destructive=false) (ask: VDQ.t) (x:t) (offs:offs) (value:t) (exp:exp option) (v:lval) (t:typ): t =
     let rec do_update_offset (ask:VDQ.t) (x:t) (offs:offs) (value:t) (exp:exp option) (l:lval option) (o:offset option) (v:lval) (t:typ):t =
       if M.tracing then M.traceli "update_offset" "do_update_offset %a %a (%a) %a" pretty x Offs.pretty offs (Pretty.docOpt (CilType.Exp.pretty ())) exp pretty value;
-      let mu = function Blob (Blob (y, s', orig), s, orig2) -> Blob (y, ID.join s s',orig) | x -> x in
+      let mu = function Blob (Blob (y, s', zeroinit), s, _) -> Blob (y, ID.join s s', zeroinit) | x -> x in
       let r =
         match x, offs with
         | Mutex, _ -> (* hide mutex structure contents, not updated anyway *)
           Mutex
-        | Blob (x,s,orig), `Index (_,ofs) ->
+        | Blob (x,s,zeroinit), `Index (_,ofs) ->
           begin
             let l', o' = shift_one_over l o in
-            let x = zero_init_calloced_memory orig x t in
-            mu (Blob (join x (do_update_offset ask x ofs value exp l' o' v t), s, orig))
+            let x = zero_init_calloced_memory zeroinit x t in
+            mu (Blob (join x (do_update_offset ask x ofs value exp l' o' v t), s, zeroinit))
           end
-        | Blob (x,s,orig), `Field(f, _) ->
+        | Blob (x,s,zeroinit), `Field(f, _) ->
           begin
             (* We only have Blob for dynamically allocated memory. In these cases t is the type of the lval used to access it, i.e. for a struct s {int x; int y;} a; accessed via a->x     *)
             (* will be int. Here, we need a zero_init of the entire contents of the blob though, which we get by taking the associated f.fcomp. Putting [] for attributes is ok, as we don't *)
             (* consider them in VD *)
             let l', o' = shift_one_over l o in
-            let x = zero_init_calloced_memory orig x (TComp (f.fcomp, [])) in
+            let x = zero_init_calloced_memory zeroinit x (TComp (f.fcomp, [])) in
             (* Strong update of scalar variable is possible if the variable is unique and size of written value matches size of blob being written to. *)
             let do_strong_update =
               match v with
@@ -996,14 +996,14 @@ struct
               | _ -> false
             in
             if do_strong_update then
-              Blob ((do_update_offset ask x offs value exp l' o' v t), s, orig)
+              Blob ((do_update_offset ask x offs value exp l' o' v t), s, zeroinit)
             else
-              mu (Blob (join x (do_update_offset ask x offs value exp l' o' v t), s, orig))
+              mu (Blob (join x (do_update_offset ask x offs value exp l' o' v t), s, zeroinit))
           end
-        | Blob (x,s,orig), _ ->
+        | Blob (x,s,zeroinit), _ ->
           begin
             let l', o' = shift_one_over l o in
-            let x = zero_init_calloced_memory orig x t in
+            let x = zero_init_calloced_memory zeroinit x t in
             (* Strong update of scalar variable is possible if the variable is unique and size of written value matches size of blob being written to. *)
             let do_strong_update =
               begin match v with
@@ -1019,9 +1019,9 @@ struct
               end
             in
             if do_strong_update then
-              Blob ((do_update_offset ask x offs value exp l' o' v t), s, orig)
+              Blob ((do_update_offset ask x offs value exp l' o' v t), s, zeroinit)
             else
-              mu (Blob (join x (do_update_offset ask x offs value exp l' o' v t), s, orig))
+              mu (Blob (join x (do_update_offset ask x offs value exp l' o' v t), s, zeroinit))
           end
         | Thread _, _ ->
           (* hack for pthread_t variables *)
@@ -1049,7 +1049,7 @@ struct
             match offs with
             | `NoOffset -> begin
                 match value with
-                | Blob (y, s, orig) -> mu (Blob (join x y, s, orig))
+                | Blob (y, s, zeroinit) -> mu (Blob (join x y, s, zeroinit))
                 | Int _ -> cast t value
                 | _ -> value
               end
@@ -1302,7 +1302,7 @@ and Unions: UnionDomain.S with type t = UnionDomain.Field.t * Compound.t and typ
 
 and CArrays: ArrayDomain.StrWithDomain with type value = Compound.t and type idx = ArrIdxDomain.t = ArrayDomain.AttributeConfiguredAndNullByteArrayDomain(Compound)(ArrIdxDomain)
 
-and Blobs: Blob with type size = ID.t and type value = Compound.t and type origin = ZeroInit.t = Blob (Compound) (ID)
+and Blobs: Blob with type size = ID.t and type value = Compound.t and type zeroinit = ZeroInit.t = Blob (Compound) (ID)
 
 
 module type InvariantArg =


### PR DESCRIPTION
Solves #1451