### PR TITLE
Fix privatization unsoundness due to non-definite and unknown mutexes

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -685,13 +685,35 @@ struct
     let st = ctx.local in
     match e with
     | Events.Lock (addr, _) when ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      Priv.lock (Analyses.ask_of_ctx ctx) ctx.global st addr
+      begin match addr with
+        | UnknownPtr -> ctx.local
+        | Addr (v, _) when ctx.ask (IsMultiple v) -> ctx.local
+        | Addr (v, o) when LockDomain.Mval.is_definite (v, o) ->
+          Priv.lock (Analyses.ask_of_ctx ctx) ctx.global st addr
+        | _ -> ctx.local
+      end
     | Events.Unlock addr when ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      if addr = UnknownPtr then
-        M.info ~category:Unsound "Unknown mutex unlocked, relation privatization unsound"; (* TODO: something more sound *)
-      WideningTokens.with_local_side_tokens (fun () ->
-          Priv.unlock (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st addr
-        )
+      begin match addr with
+        | UnknownPtr ->
+          M.info ~category:Unsound "Unknown mutex unlocked, relation privatization unsound"; (* TODO: something more sound *)
+          ctx.local (* TODO: remove all! *)
+        | Addr (v, o) when LockDomain.Mval.is_definite (v, o) ->
+          WideningTokens.with_local_side_tokens (fun () ->
+              Priv.unlock (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st addr
+            )
+        | Addr (v, o) ->
+          WideningTokens.with_local_side_tokens (fun () ->
+              let s = ctx.ask MustLockset in
+              LockDomain.MustLockset.fold (fun ml st ->
+                  if LockDomain.MustLock.semantic_equal_mval ml (v, o) = Some false then
+                    st
+                  else
+                    let addr = LockDomain.Addr.Addr (LockDomain.MustLock.to_mval ml) in
+                    Priv.unlock (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st addr
+                ) s st
+            )
+        | _ -> ctx.local
+      end
     | Events.EnterMultiThreaded ->
       Priv.enter_multithreaded (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st
     | Events.Escape escaped ->

--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -682,38 +682,19 @@ struct
     ctx.local
 
   let event ctx e octx =
+    let ask = Analyses.ask_of_ctx ctx in
     let st = ctx.local in
     match e with
-    | Events.Lock (addr, _) when ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      begin match addr with
-        | UnknownPtr -> ctx.local
-        | Addr (v, _) when ctx.ask (IsMultiple v) -> ctx.local
-        | Addr (v, o) when LockDomain.Mval.is_definite (v, o) ->
-          Priv.lock (Analyses.ask_of_ctx ctx) ctx.global st addr
-        | _ -> ctx.local
-      end
-    | Events.Unlock addr when ThreadFlag.has_ever_been_multi (Analyses.ask_of_ctx ctx) -> (* TODO: is this condition sound? *)
-      begin match addr with
-        | UnknownPtr ->
-          M.info ~category:Unsound "Unknown mutex unlocked, relation privatization unsound"; (* TODO: something more sound *)
-          ctx.local (* TODO: remove all! *)
-        | Addr (v, o) when LockDomain.Mval.is_definite (v, o) ->
-          WideningTokens.with_local_side_tokens (fun () ->
-              Priv.unlock (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st addr
-            )
-        | Addr (v, o) ->
-          WideningTokens.with_local_side_tokens (fun () ->
-              let s = ctx.ask MustLockset in
-              LockDomain.MustLockset.fold (fun ml st ->
-                  if LockDomain.MustLock.semantic_equal_mval ml (v, o) = Some false then
-                    st
-                  else
-                    let addr = LockDomain.Addr.Addr (LockDomain.MustLock.to_mval ml) in
-                    Priv.unlock (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st addr
-                ) s st
-            )
-        | _ -> ctx.local
-      end
+    | Events.Lock (addr, _) when ThreadFlag.has_ever_been_multi ask -> (* TODO: is this condition sound? *)
+      CommonPriv.lift_lock ask (fun st m ->
+          Priv.lock ask ctx.global st m
+        ) st addr
+    | Events.Unlock addr when ThreadFlag.has_ever_been_multi ask -> (* TODO: is this condition sound? *)
+      WideningTokens.with_local_side_tokens (fun () ->
+          CommonPriv.lift_unlock ask (fun st m ->
+              Priv.unlock ask ctx.global ctx.sideg st m
+            ) st addr
+        )
     | Events.EnterMultiThreaded ->
       Priv.enter_multithreaded (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg st
     | Events.Escape escaped ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -3062,13 +3062,35 @@ struct
     match e with
     | Events.Lock (addr, _) when ThreadFlag.has_ever_been_multi ask -> (* TODO: is this condition sound? *)
       if M.tracing then M.tracel "priv" "LOCK EVENT %a" LockDomain.Addr.pretty addr;
-      Priv.lock ask (priv_getg ctx.global) st addr
+      begin match addr with
+        | UnknownPtr -> ctx.local
+        | Addr (v, _) when ctx.ask (IsMultiple v) -> ctx.local
+        | Addr (v, o) when Addr.Mval.is_definite (v, o) ->
+          Priv.lock ask (priv_getg ctx.global) st addr
+        | _ -> ctx.local
+      end
     | Events.Unlock addr when ThreadFlag.has_ever_been_multi ask -> (* TODO: is this condition sound? *)
-      if addr = UnknownPtr then
-        M.info ~category:Unsound "Unknown mutex unlocked, base privatization unsound"; (* TODO: something more sound *)
-      WideningTokens.with_local_side_tokens (fun () ->
-          Priv.unlock ask (priv_getg ctx.global) (priv_sideg ctx.sideg) st addr
-        )
+      begin match addr with
+        | UnknownPtr ->
+          M.info ~category:Unsound "Unknown mutex unlocked, base privatization unsound"; (* TODO: something more sound *)
+          ctx.local (* TODO: remove all! *)
+        | Addr (v, o) when Addr.Mval.is_definite (v, o) ->
+          WideningTokens.with_local_side_tokens (fun () ->
+              Priv.unlock ask (priv_getg ctx.global) (priv_sideg ctx.sideg) st addr
+            )
+        | Addr (v, o) ->
+          WideningTokens.with_local_side_tokens (fun () ->
+              let s = ctx.ask MustLockset in
+              LockDomain.MustLockset.fold (fun ml st ->
+                  if LockDomain.MustLock.semantic_equal_mval ml (v, o) = Some false then
+                    st
+                  else
+                    let addr = Addr.Addr (LockDomain.MustLock.to_mval ml) in
+                    Priv.unlock ask (priv_getg ctx.global) (priv_sideg ctx.sideg) st addr
+                ) s st
+            )
+        | _ -> ctx.local
+      end
     | Events.Escape escaped ->
       Priv.escape ask (priv_getg ctx.global) (priv_sideg ctx.sideg) st escaped
     | Events.EnterMultiThreaded ->

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -328,8 +328,10 @@ let lift_unlock (ask: Q.ask) f st (addr: LockDomain.Addr.t) =
      4. LockDomain.MustLocksetRW.remove_mval_rw *)
   match addr with
   | UnknownPtr ->
-    M.info ~category:Unsound "Unknown mutex unlocked, privatization unsound"; (* TODO: something more sound *)
-    st (* TODO: remove all! *)
+    LockDomain.MustLockset.fold (fun ml st ->
+        (* call privatization's unlock only with definite lock *)
+        f st (LockDomain.Addr.Addr (LockDomain.MustLock.to_mval ml)) (* TODO: no conversion *)
+      ) (ask.f MustLockset) st
   | StrPtr _
   | NullPtr -> st
   | Addr mv when LockDomain.Mval.is_definite mv -> f st addr

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -308,27 +308,36 @@ end
 
 
 let lift_lock (ask: Q.ask) f st (addr: LockDomain.Addr.t) =
+  (* Should be in sync with:
+     1. LocksetAnalysis.MakeMust.event
+     2. MutexAnalysis.Spec.Arg.add
+     3. LockDomain.MustLocksetRW.add_mval_rw *)
   match addr with
   | UnknownPtr -> st
   | Addr (v, _) when ask.f (IsMultiple v) -> st
-  | Addr (v, o) when LockDomain.Mval.is_definite (v, o) ->
-    f st addr
-  | _ -> st
+  | Addr mv when LockDomain.Mval.is_definite mv -> f st addr
+  | Addr _
+  | NullPtr
+  | StrPtr _ -> st
 
 let lift_unlock (ask: Q.ask) f st (addr: LockDomain.Addr.t) =
+  (* Should be in sync with:
+     1. LocksetAnalysis.MakeMust.event
+     2. MutexAnalysis.Spec.Arg.remove
+     3. MutexAnalysis.Spec.Arg.remove_all
+     4. LockDomain.MustLocksetRW.remove_mval_rw *)
   match addr with
   | UnknownPtr ->
     M.info ~category:Unsound "Unknown mutex unlocked, privatization unsound"; (* TODO: something more sound *)
     st (* TODO: remove all! *)
-  | Addr (v, o) when LockDomain.Mval.is_definite (v, o) ->
-    f st addr
-  | Addr (v, o) ->
-    let s = ask.f MustLockset in
+  | StrPtr _
+  | NullPtr -> st
+  | Addr mv when LockDomain.Mval.is_definite mv -> f st addr
+  | Addr mv ->
     LockDomain.MustLockset.fold (fun ml st ->
-        if LockDomain.MustLock.semantic_equal_mval ml (v, o) = Some false then
+        if LockDomain.MustLock.semantic_equal_mval ml mv = Some false then
           st
         else
-          let addr = LockDomain.Addr.Addr (LockDomain.MustLock.to_mval ml) in
-          f st addr
-      ) s st
-  | _ -> st
+          (* call privatization's unlock only with definite lock *)
+          f st (Addr (LockDomain.MustLock.to_mval ml)) (* TODO: no conversion *)
+      ) (ask.f MustLockset) st

--- a/tests/regression/13-privatized/93-unlock-idx-ambiguous.c
+++ b/tests/regression/13-privatized/93-unlock-idx-ambiguous.c
@@ -1,0 +1,27 @@
+// PARAM: --set ana.base.privatization protection --enable ana.sv-comp.functions
+#include <pthread.h>
+#include <goblint.h>
+extern _Bool __VERIFIER_nondet_bool();
+
+int g;
+pthread_mutex_t m[2] = {PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER};
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&m[0]);
+  pthread_mutex_lock(&m[1]); // so we're unlocking a mutex we definitely hold
+  g++;
+  int r = __VERIFIER_nondet_bool();
+  pthread_mutex_unlock(&m[r]); // TODO NOWARN (definitely held either way)
+  // could have unlocked m[0], so should have published g there
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_mutex_lock(&m[0]);
+  __goblint_check(g == 0); // UNKNOWN!
+  pthread_mutex_unlock(&m[0]);
+  return 0;
+}

--- a/tests/regression/13-privatized/93-unlock-idx-ambiguous.t
+++ b/tests/regression/13-privatized/93-unlock-idx-ambiguous.t
@@ -1,0 +1,75 @@
+TODO: should not succeed
+
+  $ goblint --set ana.base.privatization protection --enable ana.sv-comp.functions 93-unlock-idx-ambiguous.c
+  [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (93-unlock-idx-ambiguous.c:14:3-14:30)
+  [Success][Assert] Assertion "g == 0" will succeed (93-unlock-idx-ambiguous.c:24:3-24:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 14
+    dead: 0
+    total lines: 14
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+TODO: should not succeed
+
+  $ goblint --set ana.base.privatization mutex-meet --enable ana.sv-comp.functions 93-unlock-idx-ambiguous.c
+  [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (93-unlock-idx-ambiguous.c:14:3-14:30)
+  [Success][Assert] Assertion "g == 0" will succeed (93-unlock-idx-ambiguous.c:24:3-24:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 14
+    dead: 0
+    total lines: 14
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+TODO: should not succeed
+
+  $ goblint --set ana.base.privatization lock --enable ana.sv-comp.functions 93-unlock-idx-ambiguous.c
+  [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (93-unlock-idx-ambiguous.c:14:3-14:30)
+  [Success][Assert] Assertion "g == 0" will succeed (93-unlock-idx-ambiguous.c:24:3-24:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 14
+    dead: 0
+    total lines: 14
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+TODO: should not succeed
+
+  $ goblint --set ana.base.privatization write --enable ana.sv-comp.functions 93-unlock-idx-ambiguous.c
+  [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (93-unlock-idx-ambiguous.c:14:3-14:30)
+  [Success][Assert] Assertion "g == 0" will succeed (93-unlock-idx-ambiguous.c:24:3-24:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 14
+    dead: 0
+    total lines: 14
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+TODO: should not succeed
+
+  $ goblint --set ana.base.privatization mine-nothread --enable ana.sv-comp.functions 93-unlock-idx-ambiguous.c
+  [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (93-unlock-idx-ambiguous.c:14:3-14:30)
+  [Success][Assert] Assertion "g == 0" will succeed (93-unlock-idx-ambiguous.c:24:3-24:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 14
+    dead: 0
+    total lines: 14
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+

--- a/tests/regression/13-privatized/93-unlock-idx-ambiguous.t
+++ b/tests/regression/13-privatized/93-unlock-idx-ambiguous.t
@@ -1,8 +1,6 @@
-TODO: should not succeed
-
   $ goblint --set ana.base.privatization protection --enable ana.sv-comp.functions 93-unlock-idx-ambiguous.c
   [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (93-unlock-idx-ambiguous.c:14:3-14:30)
-  [Success][Assert] Assertion "g == 0" will succeed (93-unlock-idx-ambiguous.c:24:3-24:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (93-unlock-idx-ambiguous.c:24:3-24:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 14
     dead: 0
@@ -12,12 +10,10 @@ TODO: should not succeed
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
-
-TODO: should not succeed
 
   $ goblint --set ana.base.privatization mutex-meet --enable ana.sv-comp.functions 93-unlock-idx-ambiguous.c
   [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (93-unlock-idx-ambiguous.c:14:3-14:30)
-  [Success][Assert] Assertion "g == 0" will succeed (93-unlock-idx-ambiguous.c:24:3-24:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (93-unlock-idx-ambiguous.c:24:3-24:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 14
     dead: 0
@@ -27,12 +23,10 @@ TODO: should not succeed
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
-
-TODO: should not succeed
 
   $ goblint --set ana.base.privatization lock --enable ana.sv-comp.functions 93-unlock-idx-ambiguous.c
   [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (93-unlock-idx-ambiguous.c:14:3-14:30)
-  [Success][Assert] Assertion "g == 0" will succeed (93-unlock-idx-ambiguous.c:24:3-24:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (93-unlock-idx-ambiguous.c:24:3-24:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 14
     dead: 0
@@ -42,12 +36,10 @@ TODO: should not succeed
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
-
-TODO: should not succeed
 
   $ goblint --set ana.base.privatization write --enable ana.sv-comp.functions 93-unlock-idx-ambiguous.c
   [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (93-unlock-idx-ambiguous.c:14:3-14:30)
-  [Success][Assert] Assertion "g == 0" will succeed (93-unlock-idx-ambiguous.c:24:3-24:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (93-unlock-idx-ambiguous.c:24:3-24:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 14
     dead: 0
@@ -58,11 +50,9 @@ TODO: should not succeed
     unsafe: 0
     total memory locations: 1
 
-TODO: should not succeed
-
   $ goblint --set ana.base.privatization mine-nothread --enable ana.sv-comp.functions 93-unlock-idx-ambiguous.c
   [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (93-unlock-idx-ambiguous.c:14:3-14:30)
-  [Success][Assert] Assertion "g == 0" will succeed (93-unlock-idx-ambiguous.c:24:3-24:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (93-unlock-idx-ambiguous.c:24:3-24:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 14
     dead: 0

--- a/tests/regression/13-privatized/94-unlock-unknown.c
+++ b/tests/regression/13-privatized/94-unlock-unknown.c
@@ -1,0 +1,25 @@
+// PARAM: --set ana.base.privatization protection --enable ana.sv-comp.functions
+#include <pthread.h>
+#include <goblint.h>
+
+int g;
+pthread_mutex_t m[2] = {PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER};
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&m[0]);
+  g++;
+  pthread_mutex_t *r; // rand
+  pthread_mutex_unlock(r);
+  // could have unlocked m[0], so should have published g there
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_mutex_lock(&m[0]);
+  __goblint_check(g == 0); // UNKNOWN!
+  pthread_mutex_unlock(&m[0]);
+  return 0;
+}

--- a/tests/regression/13-privatized/94-unlock-unknown.t
+++ b/tests/regression/13-privatized/94-unlock-unknown.t
@@ -1,8 +1,7 @@
   $ goblint --set ana.base.privatization protection --enable ana.sv-comp.functions 94-unlock-unknown.c
-  [Info][Unsound] Unknown mutex unlocked, privatization unsound (94-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (94-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking NULL mutex (94-unlock-unknown.c:12:3-12:26)
-  [Success][Assert] Assertion "g == 0" will succeed (94-unlock-unknown.c:22:3-22:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (94-unlock-unknown.c:22:3-22:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 11
     dead: 0
@@ -14,10 +13,9 @@
     total memory locations: 1
 
   $ goblint --set ana.base.privatization mutex-meet --enable ana.sv-comp.functions 94-unlock-unknown.c
-  [Info][Unsound] Unknown mutex unlocked, privatization unsound (94-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (94-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking NULL mutex (94-unlock-unknown.c:12:3-12:26)
-  [Success][Assert] Assertion "g == 0" will succeed (94-unlock-unknown.c:22:3-22:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (94-unlock-unknown.c:22:3-22:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 11
     dead: 0
@@ -29,10 +27,9 @@
     total memory locations: 1
 
   $ goblint --set ana.base.privatization lock --enable ana.sv-comp.functions 94-unlock-unknown.c
-  [Info][Unsound] Unknown mutex unlocked, privatization unsound (94-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (94-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking NULL mutex (94-unlock-unknown.c:12:3-12:26)
-  [Success][Assert] Assertion "g == 0" will succeed (94-unlock-unknown.c:22:3-22:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (94-unlock-unknown.c:22:3-22:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 11
     dead: 0
@@ -44,10 +41,9 @@
     total memory locations: 1
 
   $ goblint --set ana.base.privatization write --enable ana.sv-comp.functions 94-unlock-unknown.c
-  [Info][Unsound] Unknown mutex unlocked, privatization unsound (94-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (94-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking NULL mutex (94-unlock-unknown.c:12:3-12:26)
-  [Success][Assert] Assertion "g == 0" will succeed (94-unlock-unknown.c:22:3-22:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (94-unlock-unknown.c:22:3-22:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 11
     dead: 0
@@ -59,10 +55,9 @@
     total memory locations: 1
 
   $ goblint --set ana.base.privatization mine-nothread --enable ana.sv-comp.functions 94-unlock-unknown.c
-  [Info][Unsound] Unknown mutex unlocked, privatization unsound (94-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (94-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking NULL mutex (94-unlock-unknown.c:12:3-12:26)
-  [Success][Assert] Assertion "g == 0" will succeed (94-unlock-unknown.c:22:3-22:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (94-unlock-unknown.c:22:3-22:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 11
     dead: 0

--- a/tests/regression/13-privatized/94-unlock-unknown.t
+++ b/tests/regression/13-privatized/94-unlock-unknown.t
@@ -1,0 +1,75 @@
+  $ goblint --set ana.base.privatization protection --enable ana.sv-comp.functions 94-unlock-unknown.c
+  [Info][Unsound] Unknown mutex unlocked, privatization unsound (94-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking unknown mutex which may not be held (94-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking NULL mutex (94-unlock-unknown.c:12:3-12:26)
+  [Success][Assert] Assertion "g == 0" will succeed (94-unlock-unknown.c:22:3-22:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 11
+    dead: 0
+    total lines: 11
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+  $ goblint --set ana.base.privatization mutex-meet --enable ana.sv-comp.functions 94-unlock-unknown.c
+  [Info][Unsound] Unknown mutex unlocked, privatization unsound (94-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking unknown mutex which may not be held (94-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking NULL mutex (94-unlock-unknown.c:12:3-12:26)
+  [Success][Assert] Assertion "g == 0" will succeed (94-unlock-unknown.c:22:3-22:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 11
+    dead: 0
+    total lines: 11
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+  $ goblint --set ana.base.privatization lock --enable ana.sv-comp.functions 94-unlock-unknown.c
+  [Info][Unsound] Unknown mutex unlocked, privatization unsound (94-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking unknown mutex which may not be held (94-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking NULL mutex (94-unlock-unknown.c:12:3-12:26)
+  [Success][Assert] Assertion "g == 0" will succeed (94-unlock-unknown.c:22:3-22:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 11
+    dead: 0
+    total lines: 11
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+  $ goblint --set ana.base.privatization write --enable ana.sv-comp.functions 94-unlock-unknown.c
+  [Info][Unsound] Unknown mutex unlocked, privatization unsound (94-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking unknown mutex which may not be held (94-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking NULL mutex (94-unlock-unknown.c:12:3-12:26)
+  [Success][Assert] Assertion "g == 0" will succeed (94-unlock-unknown.c:22:3-22:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 11
+    dead: 0
+    total lines: 11
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+  $ goblint --set ana.base.privatization mine-nothread --enable ana.sv-comp.functions 94-unlock-unknown.c
+  [Info][Unsound] Unknown mutex unlocked, privatization unsound (94-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking unknown mutex which may not be held (94-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking NULL mutex (94-unlock-unknown.c:12:3-12:26)
+  [Success][Assert] Assertion "g == 0" will succeed (94-unlock-unknown.c:22:3-22:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 11
+    dead: 0
+    total lines: 11
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+

--- a/tests/regression/13-privatized/dune
+++ b/tests/regression/13-privatized/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps (glob_files *.c)))

--- a/tests/regression/46-apron2/87-unlock-idx-ambiguous.c
+++ b/tests/regression/46-apron2/87-unlock-idx-ambiguous.c
@@ -1,0 +1,28 @@
+// PARAM: --set ana.activated[+] apron --set ana.relation.privatization mutex-meet --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag
+// TODO: why nonterm without threadflag path-sens?
+#include <pthread.h>
+#include <goblint.h>
+extern _Bool __VERIFIER_nondet_bool();
+
+int g;
+pthread_mutex_t m[2] = {PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER};
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&m[0]);
+  pthread_mutex_lock(&m[1]); // so we're unlocking a mutex we definitely hold
+  g++;
+  int r = __VERIFIER_nondet_bool();
+  pthread_mutex_unlock(&m[r]); // TODO NOWARN (definitely held either way)
+  // could have unlocked m[0], so should have published g there
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_mutex_lock(&m[0]);
+  __goblint_check(g == 0); // UNKNOWN!
+  pthread_mutex_unlock(&m[0]);
+  return 0;
+}

--- a/tests/regression/46-apron2/87-unlock-idx-ambiguous.t
+++ b/tests/regression/46-apron2/87-unlock-idx-ambiguous.t
@@ -1,0 +1,39 @@
+  $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag 87-unlock-idx-ambiguous.c
+  [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (87-unlock-idx-ambiguous.c:15:3-15:30)
+  [Success][Assert] Assertion "g == 0" will succeed (87-unlock-idx-ambiguous.c:25:3-25:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 14
+    dead: 0
+    total lines: 14
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+  $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet-tid --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag 87-unlock-idx-ambiguous.c
+  [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (87-unlock-idx-ambiguous.c:15:3-15:30)
+  [Success][Assert] Assertion "g == 0" will succeed (87-unlock-idx-ambiguous.c:25:3-25:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 14
+    dead: 0
+    total lines: 14
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+  $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet-tid-cluster12 --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag 87-unlock-idx-ambiguous.c
+  [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (87-unlock-idx-ambiguous.c:15:3-15:30)
+  [Success][Assert] Assertion "g == 0" will succeed (87-unlock-idx-ambiguous.c:25:3-25:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 14
+    dead: 0
+    total lines: 14
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+

--- a/tests/regression/46-apron2/87-unlock-idx-ambiguous.t
+++ b/tests/regression/46-apron2/87-unlock-idx-ambiguous.t
@@ -1,6 +1,6 @@
   $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag 87-unlock-idx-ambiguous.c
   [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (87-unlock-idx-ambiguous.c:15:3-15:30)
-  [Success][Assert] Assertion "g == 0" will succeed (87-unlock-idx-ambiguous.c:25:3-25:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (87-unlock-idx-ambiguous.c:25:3-25:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 14
     dead: 0
@@ -13,7 +13,7 @@
 
   $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet-tid --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag 87-unlock-idx-ambiguous.c
   [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (87-unlock-idx-ambiguous.c:15:3-15:30)
-  [Success][Assert] Assertion "g == 0" will succeed (87-unlock-idx-ambiguous.c:25:3-25:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (87-unlock-idx-ambiguous.c:25:3-25:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 14
     dead: 0
@@ -26,7 +26,7 @@
 
   $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet-tid-cluster12 --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag 87-unlock-idx-ambiguous.c
   [Warning][Unknown] unlocking mutex (m[def_exc:Unknown int([0,1])]) which may not be held (87-unlock-idx-ambiguous.c:15:3-15:30)
-  [Success][Assert] Assertion "g == 0" will succeed (87-unlock-idx-ambiguous.c:25:3-25:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (87-unlock-idx-ambiguous.c:25:3-25:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 14
     dead: 0

--- a/tests/regression/46-apron2/88-unlock-unknown.c
+++ b/tests/regression/46-apron2/88-unlock-unknown.c
@@ -1,0 +1,25 @@
+// PARAM: --set ana.activated[+] apron --set ana.relation.privatization mutex-meet --enable ana.sv-comp.functions
+#include <pthread.h>
+#include <goblint.h>
+
+int g;
+pthread_mutex_t m[2] = {PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER};
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&m[0]);
+  g++;
+  pthread_mutex_t *r; // rand
+  pthread_mutex_unlock(r);
+  // could have unlocked m[0], so should have published g there
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_mutex_lock(&m[0]);
+  __goblint_check(g == 0); // UNKNOWN!
+  pthread_mutex_unlock(&m[0]);
+  return 0;
+}

--- a/tests/regression/46-apron2/88-unlock-unknown.t
+++ b/tests/regression/46-apron2/88-unlock-unknown.t
@@ -1,0 +1,45 @@
+  $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet --enable ana.sv-comp.functions 88-unlock-unknown.c
+  [Info][Unsound] Unknown mutex unlocked, privatization unsound (88-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking unknown mutex which may not be held (88-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking NULL mutex (88-unlock-unknown.c:12:3-12:26)
+  [Success][Assert] Assertion "g == 0" will succeed (88-unlock-unknown.c:22:3-22:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 11
+    dead: 0
+    total lines: 11
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+  $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet-tid --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag 88-unlock-unknown.c
+  [Info][Unsound] Unknown mutex unlocked, privatization unsound (88-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking unknown mutex which may not be held (88-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking NULL mutex (88-unlock-unknown.c:12:3-12:26)
+  [Success][Assert] Assertion "g == 0" will succeed (88-unlock-unknown.c:22:3-22:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 11
+    dead: 0
+    total lines: 11
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+
+  $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet-tid-cluster12 --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag 88-unlock-unknown.c
+  [Info][Unsound] Unknown mutex unlocked, privatization unsound (88-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking unknown mutex which may not be held (88-unlock-unknown.c:12:3-12:26)
+  [Warning][Unknown] unlocking NULL mutex (88-unlock-unknown.c:12:3-12:26)
+  [Success][Assert] Assertion "g == 0" will succeed (88-unlock-unknown.c:22:3-22:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 11
+    dead: 0
+    total lines: 11
+  [Info][Race] Memory locations race summary:
+    safe: 1
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 1
+

--- a/tests/regression/46-apron2/88-unlock-unknown.t
+++ b/tests/regression/46-apron2/88-unlock-unknown.t
@@ -1,8 +1,7 @@
   $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet --enable ana.sv-comp.functions 88-unlock-unknown.c
-  [Info][Unsound] Unknown mutex unlocked, privatization unsound (88-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (88-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking NULL mutex (88-unlock-unknown.c:12:3-12:26)
-  [Success][Assert] Assertion "g == 0" will succeed (88-unlock-unknown.c:22:3-22:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (88-unlock-unknown.c:22:3-22:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 11
     dead: 0
@@ -14,10 +13,9 @@
     total memory locations: 1
 
   $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet-tid --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag 88-unlock-unknown.c
-  [Info][Unsound] Unknown mutex unlocked, privatization unsound (88-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (88-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking NULL mutex (88-unlock-unknown.c:12:3-12:26)
-  [Success][Assert] Assertion "g == 0" will succeed (88-unlock-unknown.c:22:3-22:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (88-unlock-unknown.c:22:3-22:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 11
     dead: 0
@@ -29,10 +27,9 @@
     total memory locations: 1
 
   $ goblint --set ana.activated[+] apron --set ana.relation.privatization mutex-meet-tid-cluster12 --enable ana.sv-comp.functions --set ana.path_sens[+] threadflag 88-unlock-unknown.c
-  [Info][Unsound] Unknown mutex unlocked, privatization unsound (88-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking unknown mutex which may not be held (88-unlock-unknown.c:12:3-12:26)
   [Warning][Unknown] unlocking NULL mutex (88-unlock-unknown.c:12:3-12:26)
-  [Success][Assert] Assertion "g == 0" will succeed (88-unlock-unknown.c:22:3-22:26)
+  [Warning][Assert] Assertion "g == 0" is unknown. (88-unlock-unknown.c:22:3-22:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 11
     dead: 0

--- a/tests/regression/46-apron2/dune
+++ b/tests/regression/46-apron2/dune
@@ -8,3 +8,6 @@
    (glob_files ??-*.c))
  (locks /update_suite)
  (action (chdir ../../.. (run %{update_suite} group apron2 -q))))
+
+(cram
+ (deps (glob_files *.c)))


### PR DESCRIPTION
## Problem
As mentioned in https://github.com/goblint/analyzer/pull/1430#issuecomment-2075246339, privatizations don't do anything special with non-definite mutexes.

> > What are privatizations supposed to do with those? It seems to me that we completely forgot about the non-definite possibilities, which might make things even unsound.
> 
> I think I considered this issue when designing the privatizations. They should still be sound for the original setting according to the following arguments:
> 
> - For `lock` & `mine-W`: Incorporating too many values early makes the analysis imprecise, not unsound; All other operations are based on must-locksets, and for background locksets and minimal locksets only definite elements are kept 
> - For `write`: lock is a no-op, other actions are based on must-lockset
> - For `per-mutex` flavors incl. relational & protection-based: Protection by one of these indefinite addresses means they are always held when the global is accessed, so that is not harmful either
> 
> However, these are indeed a bit shaky in some places and may easily be subject to breakage. So in the long run, it does make sense to refactor this as well.
> 
> Also, with the new additions such as `atomic` and invariants about unprotected globals, I'm not sure if this still all holds.
> 
> _Originally posted by @michael-schwarz in https://github.com/goblint/analyzer/issues/1430#issuecomment-2132284679_

As the added test case shows, this is wrong and all of them are unsound.

## Solution
As discussed during GobCon, the fix is to only call `lock` and `unlock` of privatizations with definite mutexes. This PR adapts the recently-fixed-and-refactored (#1430) must lockset analysis logic to base and relation analyses for these events. Notably, `unlock` of indefinite mutex calls privatization's `unlock` for all may-aliasing held locks. This PR also fixes the long-standing unsoundness in privatizations of unlocking unknown mutexes: just by unlocking all held locks unconditionally.