### PR TITLE
Narrowing from widening thresholds

### DIFF
--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -714,8 +714,8 @@ struct
     | Some (x1,x2), Some (y1,y2) ->
       let threshold = get_interval_threshold_widening () in
       let (min_ik, max_ik) = range ik in
-      let lr = if Ints_t.compare min_ik x1 = 0 || threshold && IArith.is_lower_threshold x1 then y1 else x1 in
-      let ur = if Ints_t.compare max_ik x2 = 0 || threshold && IArith.is_upper_threshold x2 then y2 else x2 in
+      let lr = if Ints_t.compare min_ik x1 = 0 || threshold && Ints_t.compare y1 x1 > 0 && IArith.is_lower_threshold x1 then y1 else x1 in
+      let ur = if Ints_t.compare max_ik x2 = 0 || threshold && Ints_t.compare y2 x2 < 0 && IArith.is_upper_threshold x2 then y2 else x2 in
       norm ik @@ Some (lr,ur) |> fst
 
 

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -575,11 +575,11 @@ module IntervalArith (Ints_t : IntOps.IntOps) = struct
   let is_upper_threshold u =
     let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.upper_thresholds () else ResettableLazy.force widening_thresholds in
     let u = Ints_t.to_bigint u in
-    List.exists (fun x -> Z.compare u x = 0) ts
+    List.exists (Z.equal u) ts
   let is_lower_threshold l =
     let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.lower_thresholds () else ResettableLazy.force widening_thresholds_desc in
     let l = Ints_t.to_bigint l in
-    List.exists (fun x -> Z.compare l x = 0) ts
+    List.exists (Z.equal l) ts
 end
 
 module IntervalFunctor (Ints_t : IntOps.IntOps): SOverflow with type int_t = Ints_t.t and type t = (Ints_t.t * Ints_t.t) option =

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -575,13 +575,11 @@ module IntervalArith (Ints_t : IntOps.IntOps) = struct
   let is_upper_threshold u =
     let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.upper_thresholds () else ResettableLazy.force widening_thresholds in
     let u = Ints_t.to_bigint u in
-    let t = List.find_opt (fun x -> Z.compare u x = 0) ts in
-    Option.is_some t
+    List.exists (fun x -> Z.compare u x = 0) ts
   let is_lower_threshold l =
     let ts = if get_interval_threshold_widening_constants () = "comparisons" then WideningThresholds.lower_thresholds () else ResettableLazy.force widening_thresholds_desc in
     let l = Ints_t.to_bigint l in
-    let t = List.find_opt (fun x -> Z.compare l x = 0) ts in
-    Option.is_some t
+    List.exists (fun x -> Z.compare l x = 0) ts
 end
 
 module IntervalFunctor (Ints_t : IntOps.IntOps): SOverflow with type int_t = Ints_t.t and type t = (Ints_t.t * Ints_t.t) option =
@@ -1394,7 +1392,7 @@ struct
       let max_ys = maximal ys |> Option.get in
       let min_range,max_range = range ik in
       let threshold = get_interval_threshold_widening () in
-      let min = if min_xs =. min_range || threshold && min_ys <. min_xs && IArith.is_lower_threshold min_xs then min_ys else min_xs in
+      let min = if min_xs =. min_range || threshold && min_ys >. min_xs && IArith.is_lower_threshold min_xs then min_ys else min_xs in
       let max = if max_xs =. max_range || threshold && max_ys <. max_xs && IArith.is_upper_threshold max_xs then max_ys else max_xs in
       xs
       |> (function (_, y)::z -> (min, y)::z | _ -> [])

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -1393,8 +1393,9 @@ struct
       let min_ys = minimal ys |> Option.get in
       let max_ys = maximal ys |> Option.get in
       let min_range,max_range = range ik in
-      let min = if min_xs =. min_range then min_ys else min_xs in
-      let max = if max_xs =. max_range then max_ys else max_xs in
+      let threshold = get_interval_threshold_widening () in
+      let min = if min_xs =. min_range || threshold && min_ys <. min_xs && IArith.is_lower_threshold min_xs then min_ys else min_xs in
+      let max = if max_xs =. max_range || threshold && max_ys <. max_xs && IArith.is_upper_threshold max_xs then max_ys else max_xs in
       xs
       |> (function (_, y)::z -> (min, y)::z | _ -> [])
       |> List.rev

--- a/tests/regression/03-practical/33-threshold-narrowing-intervals.c
+++ b/tests/regression/03-practical/33-threshold-narrowing-intervals.c
@@ -5,4 +5,9 @@ int main() {
     int i;
     for(i = 0; i < 10 && i < 20; i += 3);
     __goblint_check(i <= 12);
+
+    int j;
+    for(j = 0; j > -10 && j > -20; j-= 3);
+    __goblint_check(j >= -12);
+    
 }

--- a/tests/regression/03-practical/33-threshold-narrowing.c
+++ b/tests/regression/03-practical/33-threshold-narrowing.c
@@ -1,0 +1,8 @@
+// PARAM: --enable ana.int.interval --enable ana.int.interval_threshold_widening --set ana.int.interval_threshold_widening_constants comparisons
+#include <goblint.h>
+
+int main() {
+    int i;
+    for(i = 0; i < 10 && i < 20; i += 3);
+    __goblint_check(i <= 12);
+}

--- a/tests/regression/03-practical/34-threshold-narrowing-interval-sets.c
+++ b/tests/regression/03-practical/34-threshold-narrowing-interval-sets.c
@@ -1,0 +1,13 @@
+// PARAM: --enable ana.int.interval_set --enable ana.int.interval_threshold_widening --set ana.int.interval_threshold_widening_constants comparisons
+#include <goblint.h>
+
+int main() {
+    int i;
+    for(i = 0; i < 10 && i < 20; i += 3);
+    __goblint_check(i <= 12);
+
+    int j;
+    for(j = 0; j > -10 && j > -20; j-= 3);
+    __goblint_check(j >= -12);
+    
+}


### PR DESCRIPTION
This PR allows narrowing of integer intervals when the bound being narrowed is a widening threshold. Beforehand, when an interval was widened to a threshold and the threshold fit (e.g. `widen [0, 0] [0,1] = [0, 10]` for an upper threshold 10), it could no longer be narrowed (even if []). This is because int intervals implement accelerated narrowing and will only narrow from from maximal upper or minimal lower bounds.
This PR will use the more precise bound, only when old bound is maximal/minimal or an upper/lower threshold. The narrowing must still terminate, since upper/lower bounds can only shrink/grow as often as there are thresholds.

Example:
```c
int main() {
    int i;
    for(i = 0; i < 10 && i < 20; i += 3);
    __goblint_check(i <= 12);
}
```
The `i < 20` condition is only in this example to be identified as an upper threshold.
Without this PR, the invariant cannot be shown when wideningThresholds are enabled: i is first widened to `[0, 10]`, then `[0, 20]` at the loop head. Then, the narrowing iteration cannot reduce i to the more precise interval `[0, 12]`. With these changes, the more precise interval is inferred.