### PR TITLE
Remove some `Option.is_some` usages

### DIFF
--- a/src/analyses/condVars.ml
+++ b/src/analyses/condVars.ml
@@ -116,7 +116,7 @@ struct
     match rval with
     | BinOp (op, _, _, _) when is_cmp op -> (* logical expression *)
       save_expr lval rval
-    | Lval k when Option.is_some (mustPointTo ctx (AddrOf k) >? flip D.get d) -> (* var-eq for transitive closure *)
+    | Lval k -> (* var-eq for transitive closure *)
       mustPointTo ctx (AddrOf k) >? flip D.get_elt d |> Option.map (save_expr lval) |? d
     | _ -> d
 

--- a/src/cdomain/value/cdomains/addressDomain.ml
+++ b/src/cdomain/value/cdomains/addressDomain.ml
@@ -320,7 +320,7 @@ struct
 
   let string_writing_defined dest =
     (* if the destination address set contains a StrPtr, writing to such a string literal is undefined behavior *)
-    if List.exists Option.is_some (List.map Addr.to_c_string (elements dest)) then
+    if exists (fun a -> Option.is_some (Addr.to_c_string a)) dest then
       (M.warn ~category:M.Category.Behavior.Undefined.other "May write to a string literal, which leads to a segmentation fault in most cases";
        false)
     else

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -978,8 +978,9 @@ struct
                 let blob_size_opt = ID.to_int s in
                 not @@ ask.is_multiple var
                 && not @@ Cil.isVoidType t      (* Size of value is known *)
-                && Option.is_some blob_size_opt (* Size of blob is known *)
-                && Z.equal (Option.get blob_size_opt) (Z.of_int @@ Cil.bitsSizeOf (TComp (toptype, []))/8)
+                && GobOption.exists (fun blob_size -> (* Size of blob is known *)
+                    Z.equal blob_size (Z.of_int @@ Cil.bitsSizeOf (TComp (toptype, []))/8)
+                  ) blob_size_opt
               | _ -> false
             in
             if do_strong_update then
@@ -997,11 +998,11 @@ struct
                 | (Var var, _) ->
                   let blob_size_opt = ID.to_int s in
                   not @@ ask.is_multiple var
-                  && Option.is_some blob_size_opt (* Size of blob is known *)
-                  && ((
-                      not @@ Cil.isVoidType t     (* Size of value is known *)
-                      && Z.equal (Option.get blob_size_opt) (Z.of_int @@ Cil.alignOf_int t)
-                    ) || blob_destructive)
+                  && GobOption.exists (fun blob_size -> (* Size of blob is known *)
+                      (not @@ Cil.isVoidType t     (* Size of value is known *)
+                       && Z.equal blob_size (Z.of_int @@ Cil.alignOf_int t))
+                      || blob_destructive
+                    ) blob_size_opt
                 | _ -> false
               end
             in

--- a/src/solver/generic.ml
+++ b/src/solver/generic.ml
@@ -44,7 +44,7 @@ struct
   let histo = HM.create 1024
   let increase (v:Var.t) =
     let set v c =
-      if not full_trace && (c > start_c && c > !max_c && (Option.is_none !max_var || not (Var.equal (Option.get !max_var) v))) then begin
+      if not full_trace && (c > start_c && c > !max_c && not (GobOption.exists (Var.equal v) !max_var)) then begin
         if tracing then trace "sol" "Switched tracing to %a" Var.pretty_trace v;
         max_c := c;
         max_var := Some v
@@ -75,7 +75,7 @@ struct
 
   let update_var_event x o n =
     if tracing then increase x;
-    if full_trace || ((not (Dom.is_bot o)) && Option.is_some !max_var && Var.equal (Option.get !max_var) x) then begin
+    if full_trace || (not (Dom.is_bot o) && GobOption.exists (Var.equal x) !max_var) then begin
       if tracing then tracei "sol_max" "(%d) Update to %a" !max_c Var.pretty_trace x;
       if tracing then traceu "sol_max" "%a" Dom.pretty_diff (n, o)
     end


### PR DESCRIPTION
This mainly switches `Option.is_some` followed by `Option.get` patterns with `GobOption.exists`, which is exactly for this purpose and avoids the double pattern match.

Two tiny refactorings at other `Option.is_some` usages are also included.