### PR TITLE
Introduce sync reason `JoinCall` & Limit `sync` at function start nodes

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -772,7 +772,7 @@ struct
       PCU.RH.replace results ctx.node new_value;
     end;
     WideningTokens.with_local_side_tokens (fun () ->
-        Priv.sync (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg ctx.local (reason :> [`Normal | `Join | `Return | `Init | `Thread])
+        Priv.sync (Analyses.ask_of_ctx ctx) ctx.global ctx.sideg ctx.local (reason :> [`Normal | `Join | `JoinCall | `Return | `Init | `Thread])
       )
 
   let init marshal =

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -385,7 +385,7 @@ struct
       end
     | `Join when ConfCheck.branched_thread_creation () ->
       branched_sync ()
-    | `JoinCall when ConfCheck.branched_thread_creation_at_call () ->
+    | `JoinCall when ConfCheck.branched_thread_creation_at_call ask ->
       branched_sync ()
     | `Join
     | `JoinCall
@@ -674,7 +674,7 @@ struct
       end
     | `Join when ConfCheck.branched_thread_creation () ->
       branched_sync ()
-    | `JoinCall when ConfCheck.branched_thread_creation_at_call () ->
+    | `JoinCall when ConfCheck.branched_thread_creation_at_call ask ->
       branched_sync ()
     | `Join
     | `JoinCall
@@ -1230,7 +1230,7 @@ struct
     | `Return -> st (* TODO: implement? *)
     | `Join when ConfCheck.branched_thread_creation () ->
       branched_sync ()
-    | `JoinCall when ConfCheck.branched_thread_creation_at_call () ->
+    | `JoinCall when ConfCheck.branched_thread_creation_at_call ask ->
       branched_sync ()
     | `Join
     | `JoinCall

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -451,7 +451,7 @@ struct
     else
       ctx.local
 
-  let sync ctx reason = sync' (reason :> [`Normal | `Join | `Return | `Init | `Thread]) ctx
+  let sync ctx reason = sync' (reason :> [`Normal | `Join | `JoinCall | `Return | `Init | `Thread]) ctx
 
   let publish_all ctx reason =
     ignore (sync' reason ctx)

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -322,7 +322,7 @@ struct
     match reason with
     | `Join when ConfCheck.branched_thread_creation () ->
       branched_sync ()
-    | `JoinCall when ConfCheck.branched_thread_creation_at_call () ->
+    | `JoinCall when ConfCheck.branched_thread_creation_at_call ask ->
       branched_sync ()
     | `Join
     | `JoinCall
@@ -433,7 +433,7 @@ struct
     match reason with
     | `Join when ConfCheck.branched_thread_creation () ->
       branched_sync ()
-    | `JoinCall when ConfCheck.branched_thread_creation_at_call () ->
+    | `JoinCall when ConfCheck.branched_thread_creation_at_call ask ->
       branched_sync ()
     | `Join
     | `JoinCall
@@ -802,7 +802,7 @@ struct
     match reason with
     | `Join when ConfCheck.branched_thread_creation () ->
       branched_sync ()
-    | `JoinCall when ConfCheck.branched_thread_creation_at_call () ->
+    | `JoinCall when ConfCheck.branched_thread_creation_at_call ask ->
       branched_sync ()
     | `Join
     | `JoinCall

--- a/src/analyses/basePriv.mli
+++ b/src/analyses/basePriv.mli
@@ -20,7 +20,7 @@ sig
   val lock: Queries.ask -> (V.t -> G.t) -> BaseDomain.BaseComponents (D).t -> LockDomain.Addr.t -> BaseDomain.BaseComponents (D).t
   val unlock: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> LockDomain.Addr.t -> BaseDomain.BaseComponents (D).t
 
-  val sync: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> [`Normal | `Join | `Return | `Init | `Thread] -> BaseDomain.BaseComponents (D).t
+  val sync: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> [`Normal | `Join | `JoinCall | `Return | `Init | `Thread] -> BaseDomain.BaseComponents (D).t
 
   val escape: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> EscapeDomain.EscapedVars.t -> BaseDomain.BaseComponents (D).t
   val enter_multithreaded: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> BaseDomain.BaseComponents (D).t

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -59,6 +59,21 @@ struct
       not threadflag_path_sens
     else
       true
+
+  (** Whether branched thread creation at start nodes of procedures needs to be handled by [sync `JoinCall] of privatization. *)
+  let branched_thread_creation_at_call () =
+    let threadflag_active = List.mem "threadflag" (GobConfig.get_string_list "ana.activated") in
+    if threadflag_active then
+      let sens = GobConfig.get_string_list "ana.ctx_sens" in
+      let threadflag_ctx_sens = match sens with
+        | [] -> (* use values of "ana.ctx_insens" (blacklist) *)
+          not (List.mem "threadflag" @@ GobConfig.get_string_list "ana.ctx_insens")
+        | sens -> (* use values of "ana.ctx_sens" (whitelist) *)
+          List.mem "threadflag" sens
+      in
+      not threadflag_ctx_sens
+    else
+      true
 end
 
 module Protection =

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -61,7 +61,7 @@ struct
       true
 
   (** Whether branched thread creation at start nodes of procedures needs to be handled by [sync `JoinCall] of privatization. *)
-  let branched_thread_creation_at_call () =
+  let branched_thread_creation_at_call (ask:Queries.ask) =
     let threadflag_active = List.mem "threadflag" (GobConfig.get_string_list "ana.activated") in
     if threadflag_active then
       let sens = GobConfig.get_string_list "ana.ctx_sens" in
@@ -71,7 +71,10 @@ struct
         | sens -> (* use values of "ana.ctx_sens" (whitelist) *)
           List.mem "threadflag" sens
       in
-      not threadflag_ctx_sens
+      if not threadflag_ctx_sens then
+        true
+      else
+        ask.f (Queries.GasExhausted)
     else
       true
 end

--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -318,6 +318,13 @@ struct
              f (Result.top ()) (!base_id, spec !base_id, assoc !base_id ctx.local) *)
           | Queries.DYojson ->
             `Lifted (D.to_yojson ctx.local)
+          | Queries.GasExhausted ->
+            if (get_int "ana.context.gas_value" >= 0) then
+              (* There is a lifter above this that will answer it, save to ask *)
+              ctx.ask (Queries.GasExhausted)
+            else
+              (* Abort to avoid infinite recursion *)
+              false
           | _ ->
             let r = fold_left (f ~q) (Result.top ()) @@ spec_list ctx.local in
             do_sideg ctx !sides;

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -980,7 +980,7 @@
             },
             "gas_value": {
               "title": "ana.context.gas_value",
-              "description": "Denotes the gas value x for the ContextGasLifter. Negative values deactivate the context gas, zero yields a context-insensitve analysis. If enabled, the first x recursive calls of the call stack are analyzed context-sensitively. Any calls deeper in the call stack are analyzed with the same (empty) context.",
+              "description": "Denotes the gas value x for the ContextGasLifter. Negative values deactivate the context gas, zero yields a context-insensitive analysis. If enabled, the first x recursive calls of the call stack are analyzed context-sensitively. Any calls deeper in the call stack are analyzed with the same (empty) context.",
               "type": "integer",
               "default": -1
             },

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -126,6 +126,7 @@ type _ t =
   | IsEverMultiThreaded: MayBool.t t
   | TmpSpecial:  Mval.Exp.t -> ML.t t
   | MaySignedOverflow: exp -> MayBool.t t
+  | GasExhausted: MustBool.t t
 
 type 'a result = 'a
 
@@ -196,6 +197,7 @@ struct
     | IsEverMultiThreaded -> (module MayBool)
     | TmpSpecial _ -> (module ML)
     | MaySignedOverflow  _ -> (module MayBool)
+    | GasExhausted -> (module MustBool)
 
   (** Get bottom result for query. *)
   let bot (type a) (q: a t): a result =
@@ -265,6 +267,7 @@ struct
     | IsEverMultiThreaded -> MayBool.top ()
     | TmpSpecial _ -> ML.top ()
     | MaySignedOverflow _ -> MayBool.top ()
+    | GasExhausted -> MustBool.top ()
 end
 
 (* The type any_query can't be directly defined in Any as t,
@@ -331,6 +334,7 @@ struct
     | Any (TmpSpecial _) -> 56
     | Any (IsAllocVar _) -> 57
     | Any (MaySignedOverflow _) -> 58
+    | Any GasExhausted -> 59
 
   let rec compare a b =
     let r = Stdlib.compare (order a) (order b) in
@@ -490,6 +494,7 @@ struct
     | Any IsEverMultiThreaded -> Pretty.dprintf "IsEverMultiThreaded"
     | Any (TmpSpecial lv) -> Pretty.dprintf "TmpSpecial %a" Mval.Exp.pretty lv
     | Any (MaySignedOverflow e) -> Pretty.dprintf "MaySignedOverflow %a" CilType.Exp.pretty e
+    | Any GasExhausted -> Pretty.dprintf "GasExhausted"
 end
 
 let to_value_domain_ask (ask: ask) =

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -209,7 +209,7 @@ sig
   val context: (D.t, G.t, C.t, V.t) ctx -> fundec -> D.t -> C.t
   val startcontext: unit -> C.t
 
-  val sync  : (D.t, G.t, C.t, V.t) ctx -> [`Normal | `Join | `Return] -> D.t
+  val sync  : (D.t, G.t, C.t, V.t) ctx -> [`Normal | `Join | `JoinCall | `Return] -> D.t
   val query : (D.t, G.t, C.t, V.t) ctx -> 'a Queries.t -> 'a Queries.result
 
   (** A transfer function which handles the assignment of a rval to a lval, i.e.,

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -575,8 +575,14 @@ struct
     let liftmap f = List.map (fun (x) -> (x, max 0 (cg_val ctx - 1))) f in
     liftmap (S.threadenter (conv ctx) ~multiple lval f args)
 
+  let query ctx (type a) (q: a Queries.t):a Queries.result =
+    match q with
+    | Queries.GasExhausted ->
+      let (d,i) = ctx.local in
+      (i <= 0)
+    | _ -> S.query (conv ctx) q
+
   let sync ctx reason                             = S.sync (conv ctx) reason, cg_val ctx
-  let query ctx q                                 = S.query (conv ctx) q
   let assign ctx lval expr                        = S.assign (conv ctx) lval expr, cg_val ctx
   let vdecl ctx v                                 = S.vdecl (conv ctx) v, cg_val ctx
   let body ctx fundec                             = S.body (conv ctx) fundec, cg_val ctx

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -624,9 +624,10 @@ struct
 
   let sync ctx =
     match ctx.prev_node, Cfg.prev ctx.prev_node with
-    | _, _ :: _ :: _ (* Join in CFG. *)
-    | FunctionEntry _, _ -> (* Function entry, also needs sync because partial contexts joined by solver, see 00-sanity/35-join-contexts. *)
+    | _, _ :: _ :: _ -> (* Join in CFG. *)
       S.sync ctx `Join
+    | FunctionEntry _, _ -> (* Function entry, also needs sync because partial contexts joined by solver, see 00-sanity/35-join-contexts. *)
+      S.sync ctx `JoinCall
     | _, _ -> S.sync ctx `Normal
 
   let side_context sideg f c =

--- a/tests/regression/46-apron2/89-flag-ctx-sens.c
+++ b/tests/regression/46-apron2/89-flag-ctx-sens.c
@@ -1,5 +1,6 @@
 // SKIP PARAM: --set ana.activated[+] apron --set ana.relation.privatization mutex-meet
 // NOTIMEOUT
+// See https://github.com/goblint/analyzer/pull/1508
 #include <pthread.h>
 #include <goblint.h>
 

--- a/tests/regression/46-apron2/89-sides-pp.c
+++ b/tests/regression/46-apron2/89-sides-pp.c
@@ -1,0 +1,27 @@
+// SKIP PARAM: --set ana.activated[+] apron --set ana.relation.privatization mutex-meet
+// NOTIMEOUT
+#include <pthread.h>
+#include <goblint.h>
+
+int g;
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void fn() {
+  // Just do nothing
+  return;
+}
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&m);
+  g = g+1;
+  fn();
+  pthread_mutex_unlock(&m);
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  return 0;
+}

--- a/tests/regression/80-context_gas/21-sync.c
+++ b/tests/regression/80-context_gas/21-sync.c
@@ -1,0 +1,35 @@
+// PARAM: --set ana.context.gas_value 3
+// Like 00/35 but with gas this time!
+// Misbehaves for gas <= 3
+#include <goblint.h>
+#include <pthread.h>
+
+int g = 1;
+
+void foo() {
+  // Single-threaded: g = 1 in local state
+  // Multi-threaded: g = 2 in global unprotected invariant
+  // Joined contexts: g is unprotected, so read g = 2 from global unprotected invariant (only)
+  // Was soundly claiming that check will succeed!
+  int x = g;
+  __goblint_check(x == 2); // UNKNOWN!
+}
+
+void *t_fun(void *arg) {
+  foo();
+}
+
+int do_stuff() {
+  foo();
+  g = 2;
+
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  return 0;
+}
+
+int main() {
+  do_stuff();
+  return 0;
+}

--- a/tests/regression/80-context_gas/22-sync-precision.c
+++ b/tests/regression/80-context_gas/22-sync-precision.c
@@ -1,4 +1,4 @@
-// PARAM: --set ana.context.gas_value 1
+// PARAM: --set ana.context.gas_value 4
 // Like 00/35 but with gas this time!
 // Misbehaves for gas <= 3
 #include <goblint.h>
@@ -7,12 +7,13 @@
 int g = 1;
 
 void foo() {
-  // Single-threaded: g = 1 in local state
-  // Multi-threaded: g = 2 in global unprotected invariant
-  // Joined contexts: g is unprotected, so read g = 2 from global unprotected invariant (only)
-  // Was soundly claiming that check will succeed!
+  // Check that we don't lose precision due to JoinCall
   int x = g;
-  __goblint_check(x == 2); // UNKNOWN!
+  int x2 = g;
+  // A hack: In both contexts g has a single possible value, so we check that x = x2
+  // to verify there is no precision loss
+
+  __goblint_check(x == x2);
 }
 
 void *t_fun(void *arg) {


### PR DESCRIPTION
Helps avoid "sync" calls for function start nodes when threadflag is context-sensitive. Previously, it was only avoided when the flag was path-sensitive (c.f. #1475).

This has some immediate termination advantages, and can potentially also boost precision.


TODO:

- [x] Investigate what happens if `threadflag` is path-sensitive but not context-sensitive? (It seems sound, but this notion may require re-thinking in general #1509 )
- [x] Investigate interplay with https://github.com/goblint/analyzer/pull/1340 (Does the check have to be dynamic?)



Closes #1507 