### PR TITLE
Binary operations on pointers should not generate overflow warnings in SV-COMP

### DIFF
--- a/docs/user-guide/assumptions.md
+++ b/docs/user-guide/assumptions.md
@@ -17,3 +17,12 @@ _NB! This list is likely incomplete._
 
     See [PR #1414](https://github.com/goblint/analyzer/pull/1414).
 
+2. Goblint's does not give any guarantees about overflows not happening during pointer arithmetics.
+
+    Although the analysis can detect and warn about overflows that might happen during operations with pointer offsets,
+    the analysis does not warn about overflows from operations with the possible addresses (as integers) of the pointers themselves.
+
+    This affects the `no-overflows` analysis from `ana.int.interval` analysis.
+
+    See further discussion from [PR #1511](https://github.com/goblint/analyzer/pull/1511).
+

--- a/docs/user-guide/assumptions.md
+++ b/docs/user-guide/assumptions.md
@@ -17,12 +17,22 @@ _NB! This list is likely incomplete._
 
     See [PR #1414](https://github.com/goblint/analyzer/pull/1414).
 
-2. Goblint's does not give any guarantees about overflows not happening during pointer arithmetics.
+2.  Pointer arithmetic does not overflow.
 
-    Although the analysis can detect and warn about overflows that might happen during operations with pointer offsets,
-    the analysis does not warn about overflows from operations with the possible addresses (as integers) of the pointers themselves.
+    [C11's N1570][n1570] at 6.5.6.8 states that
 
-    This affects the `no-overflows` analysis from `ana.int.interval` analysis.
+    > When an expression that has integer type is added to or subtracted from a pointer, the result has the type of the pointer operand.
+    > [...]
+    > the evaluation shall not produce an overflow; otherwise, the behavior is undefined.
 
-    See further discussion from [PR #1511](https://github.com/goblint/analyzer/pull/1511).
+    after a long list of defined behaviors.
 
+    Goblint does not report overflow and out-of-bounds pointer arithmetic (when the pointer _is not dereferenced_).
+    This affects the overflow analysis (SV-COMP no-overflow property) in the `base` analysis.
+
+    This _does not_ affect the `memOutOfBounds` analysis (SV-COMP valid-memsafety property), which is for undefined behavior from _dereferencing_ such out-of-bounds pointers.
+
+    See [PR #1511](https://github.com/goblint/analyzer/pull/1511).
+
+
+[n1570]: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -261,6 +261,8 @@ struct
       (* adds n to the last offset *)
       let rec addToOffset n (t:typ option) = function
         | `Index (i, `NoOffset) ->
+          (* Binary operations on pointer types should not generate warnings in SV-COMP *)
+          GobRef.wrap AnalysisState.executing_speculative_computations true @@ fun () ->
           (* If we have arrived at the last Offset and it is an Index, we add our integer to it *)
           `Index(IdxDom.add i (iDtoIdx n), `NoOffset)
         | `Field (f, `NoOffset) ->

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -885,11 +885,7 @@ struct
           | None -> evalbinop ~ctx st LOr ~e1 ~e2 typ (* fallback to general case *)
         end
       | BinOp (op,e1,e2,typ) ->
-        begin match typ with
-          | TPtr _ -> (* Binary operations on pointer types should not generate warnings in SV-COMP *)
-            GobRef.wrap AnalysisState.executing_speculative_computations true @@ fun () -> evalbinop ~ctx st op ~e1 ~e2 typ
-          | _ -> evalbinop ~ctx st op ~e1 ~e2 typ
-        end
+        evalbinop ~ctx st op ~e1 ~e2 typ
       (* Unary operators *)
       | UnOp (op,arg1,typ) ->
         let a1 = eval_rv ~ctx st arg1 in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -885,7 +885,11 @@ struct
           | None -> evalbinop ~ctx st LOr ~e1 ~e2 typ (* fallback to general case *)
         end
       | BinOp (op,e1,e2,typ) ->
-        evalbinop ~ctx st op ~e1 ~e2 typ
+        begin match typ with
+          | TPtr _ -> (* Binary operations on pointer types should not generate warnings in SV-COMP *)
+            GobRef.wrap AnalysisState.executing_speculative_computations true @@ fun () -> evalbinop ~ctx st op ~e1 ~e2 typ
+          | _ -> evalbinop ~ctx st op ~e1 ~e2 typ
+        end
       (* Unary operators *)
       | UnOp (op,arg1,typ) ->
         let a1 = eval_rv ~ctx st arg1 in

--- a/src/cdomain/value/cdomains/offset.ml
+++ b/src/cdomain/value/cdomains/offset.ml
@@ -213,7 +213,7 @@ struct
         let bits_offset, _size = GoblintCil.bitsOffset (TComp (field.fcomp, [])) field_as_offset  in
         let bits_offset = idx_of_int bits_offset in
         let remaining_offset = offset_to_index_offset ~typ:field.ftype o in
-        Idx.add bits_offset remaining_offset
+        GobRef.wrap AnalysisState.executing_speculative_computations true @@ fun () -> Idx.add bits_offset remaining_offset
       | `Index (x, o) ->
         let (item_typ, item_size_in_bits) =
           match Option.map unrollType typ with

--- a/src/cdomain/value/cdomains/offset.ml
+++ b/src/cdomain/value/cdomains/offset.ml
@@ -223,9 +223,10 @@ struct
           | _ ->
             (None, Idx.top ())
         in
-        let bits_offset = Idx.mul item_size_in_bits x in
+        (* Binary operations on offsets should not generate overflow warnings in SV-COMP *)
+        let bits_offset = GobRef.wrap AnalysisState.executing_speculative_computations true @@ fun () -> Idx.mul item_size_in_bits x in
         let remaining_offset = offset_to_index_offset ?typ:item_typ o in
-        Idx.add bits_offset remaining_offset
+        GobRef.wrap AnalysisState.executing_speculative_computations true @@ fun () -> Idx.add bits_offset remaining_offset
     in
     offset_to_index_offset ?typ offs
 

--- a/tests/regression/55-loop-unrolling/12-loop-no-overflows.c
+++ b/tests/regression/55-loop-unrolling/12-loop-no-overflows.c
@@ -1,0 +1,37 @@
+// PARAM: --enable ana.int.interval_set
+// extracted from SV-COMP task ldv-memsafety/memleaks_test12-2.i
+
+typedef unsigned int size_t;
+struct ldv_list_head {
+    struct ldv_list_head *next, *prev;
+};
+struct ldv_list_head ldv_global_msg_list = {&(ldv_global_msg_list), &(ldv_global_msg_list)};
+struct ldv_msg {
+    void *data;
+    struct ldv_list_head list;
+};
+
+static inline void __ldv_list_del(struct ldv_list_head *prev, struct ldv_list_head *next) {
+    next->prev = prev;
+    prev->next = next;
+}
+
+static inline void ldv_list_del(struct ldv_list_head *entry) {
+    __ldv_list_del(entry->prev, entry->next);
+}
+
+void ldv_msg_free(struct ldv_msg *msg) {
+    free(msg->data);
+    free(msg);
+}
+
+// ldv_destroy_msgs
+void main(void) {
+    struct ldv_msg *msg;
+    struct ldv_msg *n;
+    for (msg = ({ const typeof( ((typeof(*msg) *)0)->list ) *__mptr = ((&ldv_global_msg_list)->next); (typeof(*msg) *)( (char *)__mptr - ((size_t) &((typeof(*msg) *)0)->list) ); }), n = ({ const typeof( ((typeof(*(msg)) *)0)->list ) *__mptr = ((msg)->list.next); (typeof(*(msg)) *)( (char *)__mptr - ((size_t) &((typeof(*(msg)) *)0)->list) ); }); &msg->list != (&ldv_global_msg_list); msg = n, n = ({ const typeof( ((typeof(*(n)) *)0)->list ) *__mptr = ((n)->list.next); (typeof(*(n)) *)( (char *)__mptr - ((size_t) &((typeof(*(n)) *)0)->list) ); })) // NOWARN
+    {
+        ldv_list_del(&msg->list);
+        ldv_msg_free(msg);
+    }
+}

--- a/tests/regression/55-loop-unrolling/13-unrolled-loop-no-overflows.c
+++ b/tests/regression/55-loop-unrolling/13-unrolled-loop-no-overflows.c
@@ -1,0 +1,72 @@
+// PARAM: --enable ana.int.interval_set
+// extracted from SV-COMP task ldv-memsafety/memleaks_test12-2.i with --set exp.unrolling-factor 1
+
+typedef unsigned int size_t;
+struct ldv_list_head {
+    struct ldv_list_head *next, *prev;
+};
+struct ldv_list_head ldv_global_msg_list = {&(ldv_global_msg_list), &(ldv_global_msg_list)};
+struct ldv_msg {
+    void *data;
+    struct ldv_list_head list;
+};
+
+__inline static void __ldv_list_del(struct ldv_list_head *prev, struct ldv_list_head *next) {
+    next->prev = prev;
+    prev->next = next;
+    return;
+}
+
+__inline static void ldv_list_del(struct ldv_list_head *entry) {
+    __ldv_list_del(entry->prev, entry->next);
+    return;
+}
+
+void ldv_msg_free(struct ldv_msg *msg) {
+    free(msg->data);
+    free((void *)msg);
+    return;
+}
+
+// ldv_destroy_msgs
+void main(void) {
+    struct ldv_msg *msg;
+    struct ldv_msg *n;
+    struct ldv_list_head const *__mptr;
+    struct ldv_list_head const *__mptr___0;
+    struct ldv_list_head const *__mptr___1;
+
+    __mptr = (struct ldv_list_head const *)ldv_global_msg_list.next;
+    msg = (struct ldv_msg *)((char *)__mptr - (size_t)(&((struct ldv_msg *)0)->list));
+    __mptr___0 = (struct ldv_list_head const *)msg->list.next;
+    n = (struct ldv_msg *)((char *)__mptr___0 - (size_t)(&((struct ldv_msg *)0)->list));
+
+    if (!((unsigned long)(&msg->list) != (unsigned long)(&ldv_global_msg_list))) { // NOWARN
+        goto loop_end;
+    }
+
+    ldv_list_del(&msg->list);
+    ldv_msg_free(msg);
+    msg = n;
+    __mptr___1 = (struct ldv_list_head const *)n->list.next;
+    n = (struct ldv_msg *)((char *)__mptr___1 - (size_t)(&((struct ldv_msg *)0)->list));
+
+    loop_continue_0: /* CIL Label */;
+        {
+            while (1) {
+            while_continue: /* CIL Label */;
+                if (!((unsigned long)(&msg->list) != (unsigned long)(&ldv_global_msg_list))) {
+                    goto while_break;
+                }
+
+                ldv_list_del(&msg->list);
+                ldv_msg_free(msg);
+                msg = n;
+                __mptr___1 = (struct ldv_list_head const *)n->list.next;
+                n = (struct ldv_msg *)((char *)__mptr___1 - (size_t)(&((struct ldv_msg *)0)->list));
+            }
+        while_break: /* CIL Label */;
+        }
+    loop_end: /* CIL Label */;
+    return;
+}


### PR DESCRIPTION
Looking into the no-overflow tasks, there were many tasks (`array-memsafety/cstr..-alloca-..`) where the signed integer overflow warnings came from pointer arithmetic. For example:

```c
char* nondetArea = (char*) __builtin_alloca (length1 * sizeof(char));
char* nondetString = (char*) __builtin_alloca (length2 * sizeof(char));

char *(cstrcpy)(char *s1, const char *s2)
 {
     char *dst = s1;
     const char *src = s2;
     while ((*dst++ = *src++) != '\0') // [Warning][Integer > Overflow][CWE-190] Signed integer overflow 
         ;
     return s1;
 }

cstrcpy(nondetArea,nondetString);
```

This PR turns off producing the overflow warnings when `IntDomain` values are used for pointer arithmetic.