### PR TITLE
Add primitive verdict-based YAML violation witness rejection

### DIFF
--- a/conf/svcomp-validate.json
+++ b/conf/svcomp-validate.json
@@ -1,0 +1,142 @@
+{
+  "ana": {
+    "sv-comp": {
+      "enabled": true,
+      "functions": true
+    },
+    "int": {
+      "def_exc": true,
+      "enums": false,
+      "interval": true
+    },
+    "float": {
+      "interval": true
+    },
+    "activated": [
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "mallocWrapper",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "race",
+      "escape",
+      "expRelation",
+      "mhp",
+      "assert",
+      "var_eq",
+      "symb_locks",
+      "region",
+      "thread",
+      "threadJoins",
+      "abortUnless",
+      "unassume"
+    ],
+    "path_sens": [
+      "mutex",
+      "malloc_null",
+      "uninit",
+      "expsplit",
+      "activeSetjmp",
+      "memLeak",
+      "threadflag"
+    ],
+    "context": {
+      "widen": false
+    },
+    "malloc": {
+      "wrappers": [
+        "kmalloc",
+        "__kmalloc",
+        "usb_alloc_urb",
+        "__builtin_alloca",
+        "kzalloc",
+
+        "ldv_malloc",
+
+        "kzalloc_node",
+        "ldv_zalloc",
+        "kmalloc_array",
+        "kcalloc",
+
+        "ldv_xmalloc",
+        "ldv_xzalloc",
+        "ldv_calloc",
+        "ldv_kzalloc"
+      ]
+    },
+    "base": {
+      "arrays": {
+        "domain": "partitioned"
+      }
+    },
+    "race": {
+      "free": false,
+      "call": false
+    },
+    "autotune": {
+      "enabled": true,
+      "activated": [
+        "singleThreaded",
+        "mallocWrappers",
+        "noRecursiveIntervals",
+        "enums",
+        "congruence",
+        "octagon",
+        "wideningThresholds",
+        "loopUnrollHeuristic",
+        "memsafetySpecification",
+        "termination",
+        "tmpSpecialAnalysis"
+      ]
+    },
+    "widen": {
+      "tokens": true
+    }
+  },
+  "exp": {
+    "region-offsets": true
+  },
+  "solver": "td3",
+  "sem": {
+    "unknown_function": {
+      "spawn": false
+    },
+    "int": {
+      "signed_overflow": "assume_none"
+    },
+    "null-pointer": {
+      "dereference": "assume_none"
+    }
+  },
+  "witness": {
+    "graphml": {
+      "enabled": false
+    },
+    "yaml": {
+      "enabled": false,
+      "strict": true,
+      "format-version": "2.0",
+      "entry-types": [
+        "location_invariant",
+        "loop_invariant",
+        "invariant_set",
+        "violation_sequence"
+      ],
+      "invariant-types": [
+        "location_invariant",
+        "loop_invariant"
+      ]
+    },
+    "invariant": {
+      "loop-head": true,
+      "after-lock": true,
+      "other": true
+    }
+  },
+  "pre": {
+    "enabled": false
+  }
+}

--- a/src/cdomains/apron/linearTwoVarEqualityDomain.apron.ml
+++ b/src/cdomains/apron/linearTwoVarEqualityDomain.apron.ml
@@ -249,13 +249,13 @@ module EqualitiesConjunction = struct
     if nontrivial econ i then (* i cannot occur on any other rhs apart from itself *)
       set_rhs econ i (Rhs.subst (get_rhs econ i) i (Some (coeff,j), offs, divi))
     else (* var_i = var_i, i.e. it may occur on the rhs of other equalities *)
-        (* so now, we transform with the inverse of the transformer: *)
-        let inv = snd (inverse i (coeff,j,offs,divi)) in
-        IntMap.fold (fun k v acc -> 
-            match v with
-            | (Some (c,x),o,d) when x=i-> set_rhs acc k (Rhs.subst inv i v)
-            | _ -> acc
-          ) (snd econ) econ
+      (* so now, we transform with the inverse of the transformer: *)
+      let inv = snd (inverse i (coeff,j,offs,divi)) in
+      IntMap.fold (fun k v acc -> 
+          match v with
+          | (Some (c,x),o,d) when x=i-> set_rhs acc k (Rhs.subst inv i v)
+          | _ -> acc
+        ) (snd econ) econ
 
 end
 

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -2574,7 +2574,8 @@
                   "precondition_loop_invariant",
                   "loop_invariant_certificate",
                   "precondition_loop_invariant_certificate",
-                  "invariant_set"
+                  "invariant_set",
+                  "violation_sequence"
                 ]
               },
               "default": [

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -802,6 +802,15 @@ struct
         None
       in
 
+      let validate_violation_sequence (violation_sequence: YamlWitnessType.ViolationSequence.t) =
+        (* TODO: update cnt-s appropriately (needs access to SV-COMP result pre-witness validation) *)
+        (* Nothing needs to be checked here!
+           If program is correct and we can prove it, we output true, which counts as refutation of violation witness.
+           If program is correct and we cannot prove it, we output unknown.
+           If program is incorrect, we output unknown. *)
+        None
+      in
+
       match entry_type_enabled target_type, entry.entry_type with
       | true, LocationInvariant x ->
         validate_location_invariant x
@@ -811,7 +820,9 @@ struct
         validate_precondition_loop_invariant x
       | true, InvariantSet x ->
         validate_invariant_set x
-      | false, (LocationInvariant _ | LoopInvariant _ | PreconditionLoopInvariant _ | InvariantSet _) ->
+      | true, ViolationSequence x ->
+        validate_violation_sequence x
+      | false, (LocationInvariant _ | LoopInvariant _ | PreconditionLoopInvariant _ | InvariantSet _ | ViolationSequence _) ->
         incr cnt_disabled;
         M.info_noloc ~category:Witness "disabled entry of type %s" target_type;
         None

--- a/src/witness/yamlWitnessType.ml
+++ b/src/witness/yamlWitnessType.ml
@@ -449,20 +449,25 @@ struct
   struct
     type t = {
       value: string;
-      format: string;
+      format: string option;
     }
     [@@deriving ord]
 
     let to_yaml {value; format} =
-      `O [
-        ("value", `String value);
-        ("format", `String format);
-      ]
+      `O ([
+          ("value", `String value);
+        ] @ (match format with
+          | Some format -> [
+              ("format", `String format);
+            ]
+          | None ->
+            []
+        ))
 
     let of_yaml y =
       let open GobYaml in
       let+ value = y |> find "value" >>= to_string
-      and+ format = y |> find "format" >>= to_string in
+      and+ format = y |> Yaml.Util.find "format" >>= option_map to_string in
       {value; format}
   end
 
@@ -593,8 +598,8 @@ struct
     let to_yaml {waypoint_type} =
       `O [
         ("waypoint", `O ([
-            ("type", `String (WaypointType.waypoint_type waypoint_type));
-          ] @ WaypointType.to_yaml' waypoint_type)
+             ("type", `String (WaypointType.waypoint_type waypoint_type));
+           ] @ WaypointType.to_yaml' waypoint_type)
         )
       ]
 

--- a/tests/regression/witness/violation.t/correct-hard.c
+++ b/tests/regression/witness/violation.t/correct-hard.c
@@ -1,0 +1,9 @@
+void reach_error(){}
+extern int __VERIFIER_nondet_int();
+
+int main() {
+  int x = __VERIFIER_nondet_int();
+  if (x != x)
+    reach_error();
+  return 0;
+}

--- a/tests/regression/witness/violation.t/correct-hard.yml
+++ b/tests/regression/witness/violation.t/correct-hard.yml
@@ -1,0 +1,26 @@
+- entry_type: violation_sequence
+  metadata:
+    format_version: "2.0"
+    uuid: 4412af70-389a-475e-849c-e57e5b92019e
+    creation_time: 2024-06-14T15:35:00+03:00
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - correct-hard.c
+      input_file_hashes:
+        correct-hard.c: 5cc49c1ce5a9aef64286c2a6e57f6955c5f4f9b19b43056507ae87a802802447
+      specification: G ! call(reach_error())
+      data_model: ILP32
+      language: C
+  content:
+  - segment:
+    - waypoint:
+        type: target
+        action: follow
+        location:
+          file_name: correct-hard.c
+          line: 7
+          column: 5
+          function: main

--- a/tests/regression/witness/violation.t/correct.c
+++ b/tests/regression/witness/violation.t/correct.c
@@ -1,0 +1,5 @@
+void reach_error(){}
+
+int main() {
+  return 0;
+}

--- a/tests/regression/witness/violation.t/correct.yml
+++ b/tests/regression/witness/violation.t/correct.yml
@@ -1,0 +1,26 @@
+- entry_type: violation_sequence
+  metadata:
+    format_version: "2.0"
+    uuid: 4412af70-389a-475e-849c-e57e5b92019d
+    creation_time: 2024-06-14T15:35:00+03:00
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - correct.c
+      input_file_hashes:
+        correct.c: 6f760cf7f33fc152738bf3514fe623cc94e52cad9ddc2f0e744595ce0de07530
+      specification: G ! call(reach_error())
+      data_model: ILP32
+      language: C
+  content:
+  - segment:
+    - waypoint:
+        type: target
+        action: follow
+        location:
+          file_name: correct.c
+          line: 4
+          column: 3
+          function: main

--- a/tests/regression/witness/violation.t/incorrect.c
+++ b/tests/regression/witness/violation.t/incorrect.c
@@ -1,0 +1,6 @@
+void reach_error(){}
+
+int main() {
+  reach_error();
+  return 0;
+}

--- a/tests/regression/witness/violation.t/incorrect.yml
+++ b/tests/regression/witness/violation.t/incorrect.yml
@@ -1,0 +1,26 @@
+- entry_type: violation_sequence
+  metadata:
+    format_version: "2.0"
+    uuid: 4412af70-389a-475e-849c-e57e5b92019c
+    creation_time: 2024-06-14T15:35:00+03:00
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - incorrect.c
+      input_file_hashes:
+        incorrect.c: 1af4fd9e76418e4b95af9950b58248127e7c2d9eb791e1c9b92da53952e0fca2
+      specification: G ! call(reach_error())
+      data_model: ILP32
+      language: C
+  content:
+  - segment:
+    - waypoint:
+        type: target
+        action: follow
+        location:
+          file_name: incorrect.c
+          line: 4
+          column: 3
+          function: main

--- a/tests/regression/witness/violation.t/run.t
+++ b/tests/regression/witness/violation.t/run.t
@@ -1,0 +1,57 @@
+Violation witness for a correct program can be refuted by proving the program correct and returning `true`:
+
+  $ goblint --enable ana.sv-comp.enabled --set witness.yaml.entry-types[+] violation_sequence --set ana.specification "CHECK( init(main()), LTL(G ! call(reach_error())) )" correct.c --set witness.yaml.validate correct.yml
+  [Info] SV-COMP specification: CHECK( init(main()), LTL(G ! call(reach_error())) )
+  [Warning][Deadcode] Function 'reach_error' is uncalled: 1 LLoC (correct.c:1:1-1:20)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 2
+    dead: 1 (1 in uncalled functions)
+    total lines: 3
+  [Info][Witness] witness validation summary:
+    confirmed: 0
+    unconfirmed: 0
+    refuted: 0
+    error: 0
+    unchecked: 0
+    unsupported: 0
+    disabled: 0
+    total validation entries: 0
+  SV-COMP result: true
+
+If a correct progtam cannot be proven correct, return `unknown` for the violation witness:
+
+  $ goblint --set ana.activated[-] expRelation --enable ana.sv-comp.functions --enable ana.sv-comp.enabled --set witness.yaml.entry-types[+] violation_sequence --set ana.specification "CHECK( init(main()), LTL(G ! call(reach_error())) )" correct-hard.c --set witness.yaml.validate correct-hard.yml
+  [Info] SV-COMP specification: CHECK( init(main()), LTL(G ! call(reach_error())) )
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Info][Witness] witness validation summary:
+    confirmed: 0
+    unconfirmed: 0
+    refuted: 0
+    error: 0
+    unchecked: 0
+    unsupported: 0
+    disabled: 0
+    total validation entries: 0
+  SV-COMP result: unknown
+
+Violation witness for an incorrect program cannot be proven correct, so return `unknown`:
+
+  $ goblint --enable ana.sv-comp.enabled --set witness.yaml.entry-types[+] violation_sequence --set ana.specification "CHECK( init(main()), LTL(G ! call(reach_error())) )" incorrect.c --set witness.yaml.validate incorrect.yml
+  [Info] SV-COMP specification: CHECK( init(main()), LTL(G ! call(reach_error())) )
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 4
+    dead: 0
+    total lines: 4
+  [Info][Witness] witness validation summary:
+    confirmed: 0
+    unconfirmed: 0
+    refuted: 0
+    error: 0
+    unchecked: 0
+    unsupported: 0
+    disabled: 0
+    total validation entries: 0
+  SV-COMP result: unknown

--- a/tests/util/yamlWitnessStrip.ml
+++ b/tests/util/yamlWitnessStrip.ml
@@ -26,6 +26,25 @@ struct
       in
       {invariant_type}
     in
+    let waypoint_strip_file_hash ({waypoint_type}: ViolationSequence.Waypoint.t): ViolationSequence.Waypoint.t =
+      let waypoint_type: ViolationSequence.WaypointType.t =
+        match waypoint_type with
+        | Assumption x ->
+          Assumption {x with location = location_strip_file_hash x.location}
+        | Target x ->
+          Target {x with location = location_strip_file_hash x.location}
+        | FunctionEnter x ->
+          FunctionEnter {x with location = location_strip_file_hash x.location}
+        | FunctionReturn x ->
+          FunctionReturn {x with location = location_strip_file_hash x.location}
+        | Branching x ->
+          Branching {x with location = location_strip_file_hash x.location}
+      in
+      {waypoint_type}
+    in
+    let segment_strip_file_hash ({segment}: ViolationSequence.Segment.t): ViolationSequence.Segment.t =
+      {segment = List.map waypoint_strip_file_hash segment}
+    in
     let entry_type: EntryType.t =
       match entry_type with
       | LocationInvariant x ->
@@ -42,6 +61,8 @@ struct
         PreconditionLoopInvariantCertificate {x with target = target_strip_file_hash x.target}
       | InvariantSet x ->
         InvariantSet {content = List.map invariant_strip_file_hash x.content}
+      | ViolationSequence x ->
+        ViolationSequence {content = List.map segment_strip_file_hash x.content}
     in
     {entry_type}
 


### PR DESCRIPTION
Closes #1301.

Most of this is just adding YAML witness `violation_sequence` parsing support and adapting the parsing of locations in YAML witnesses to allow for fields which the updated 2.0 format allows to omit.

The actual rejection part is laughably trivial: do nothing!
1. If program is correct and we can prove it, we output `true`, which counts as refutation of violation witness.
2. If program is correct and we cannot prove it, we output `unknown`.
3. If program is incorrect, we output `unknown`.

Actually using any of the information in the violation sequence is a separate issue. We should be able to kill some paths or refine some values based on that, a la (linear) observer automaton.

### TODO
- [x] Add some tests.