### PR TITLE
Fix `ctx.split` and `ctx.spawn` in non-call transfer functions

### DIFF
--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -713,11 +713,13 @@ struct
 
   let tf_assign var edge prev_node lv e getl sidel getg sideg d =
     let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
-    common_join ctx (S.assign ctx lv e) !r !spawns
+    let d = S.assign ctx lv e in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
+    common_join ctx d !r !spawns
 
   let tf_vdecl var edge prev_node v getl sidel getg sideg d =
     let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
-    common_join ctx (S.vdecl ctx v) !r !spawns
+    let d = S.vdecl ctx v in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
+    common_join ctx d !r !spawns
 
   let normal_return r fd ctx sideg =
     let spawning_return = S.return ctx r fd in
@@ -732,7 +734,7 @@ struct
 
   let tf_ret var edge prev_node ret fd getl sidel getg sideg d =
     let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
-    let d =
+    let d = (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
       if (CilType.Fundec.equal fd MyCFG.dummy_func ||
           List.mem fd.svar.vname (get_string_list "mainfun")) &&
          get_bool "kernel"
@@ -747,11 +749,13 @@ struct
     let c: unit -> S.C.t = snd var |> Obj.obj in
     side_context sideg fd (c ());
     let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
-    common_join ctx (S.body ctx fd) !r !spawns
+    let d = S.body ctx fd in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
+    common_join ctx d !r !spawns
 
   let tf_test var edge prev_node e tv getl sidel getg sideg d =
     let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
-    common_join ctx (S.branch ctx e tv) !r !spawns
+    let d = S.branch ctx e tv in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
+    common_join ctx d !r !spawns
 
   let tf_normal_call ctx lv e (f:fundec) args getl sidel getg sideg =
     let combine (cd, fc, fd) =
@@ -870,11 +874,13 @@ struct
 
   let tf_asm var edge prev_node getl sidel getg sideg d =
     let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
-    common_join ctx (S.asm ctx) !r !spawns
+    let d = S.asm ctx in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
+    common_join ctx d !r !spawns
 
   let tf_skip var edge prev_node getl sidel getg sideg d =
     let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
-    common_join ctx (S.skip ctx) !r !spawns
+    let d = S.skip ctx in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
+    common_join ctx d !r !spawns
 
   let tf var getl sidel getg sideg prev_node edge d =
     begin match edge with


### PR DESCRIPTION
Since OCaml evaluates arguments right-to-left, `!r` and `!spawns` are dereferenced before calling the transfer function, which will populate them (uselessly). By using let, evaluation order is enforced.

So far we've used `ctx.split` and `ctx.spawn` only on function call edges, specifically from `special`, which has a lot of other stuff around it, so it already had the evaluation order enforced by a let. That's why splitting worked at all (for those). But trying to split on other edges for more involved #1301 revealed paths not appearing due to this very subtle evaluation order issue.

It's not possible to test this with existing analyses, but it's also not possible to write sensible analysis for #1301 without this already being fixed.