### PR TITLE
Detect fixed loops with autotuner even if there is no assignment of const value to the loop variable before loop

### DIFF
--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -277,7 +277,8 @@ let fixedLoopSize loopStatement func =
   if getsPointedAt var func then
     None
   else
-    let* start = constBefore var loopStatement func in
+    (* Assume var value to be 0 if there was no constant assignment to the var before loop *)
+    let start = Option.value (constBefore var loopStatement func) ~default:Z.zero in
     let* diff = assignmentDifference (loopBody loopStatement) var in
     let* goal = adjustGoal diff goal op in
     let iterations = loopIterations start diff goal (op=Ne) in

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -277,9 +277,10 @@ let fixedLoopSize loopStatement func =
   if getsPointedAt var func then
     None
   else
-    (* Assume var value to be 0 if there was no constant assignment to the var before loop *)
-    let start = Option.value (constBefore var loopStatement func) ~default:Z.zero in
-    let* diff = assignmentDifference (loopBody loopStatement) var in
+    let diff = Option.value (assignmentDifference (loopBody loopStatement) var) ~default:Z.one in
+    (* Assume var start value if there was no constant assignment to the var before loop;
+       Assume it to be 0, if loop is increasing and 11 (TODO: can we do better than just 11?) if loop is decreasing *)
+    let start = Option.value (constBefore var loopStatement func) ~default:(if diff < Z.zero then Z.of_int 11 else Z.zero) in
     let* goal = adjustGoal diff goal op in
     let iterations = loopIterations start diff goal (op=Ne) in
     Logs.debug "comparison: %a" CilType.Exp.pretty comparison;


### PR DESCRIPTION
In SV-COMP no-overflow tasks there are cases similar to the following example:

```c
int main() {
  int i = __VERIFIER_nondet_int();
  int j = __VERIFIER_nondet_int();
  
  if (!(i==0 && j==0)) return 0;
  while (i<100) {
    j+=2;
    i++;
  }
  __VERIFIER_assert(j==200);
  return 0;
}
```

where the loop has a fixed size of iterations from `i == 0` to `i == 99`, which the autotuner is unable to detect because it only relies on finding the starting value through assignments.

As the CIL representation of the if-statement `if (!(i==0 && j==0)) return 0;` is too complicated to extract the value from there, I opted for assuming that if the variable is not assigned to a constant value before the loop, its' value is 0 (or 11, if the loop is decreasing).

Similarly, I propose assuming that the diff is 1 if it is not found, as loops are more often increasing the start value than decreasing.

~This revealed another bug, which makes me wonder if the autotuner even was ever able to find any fixed-size loops previously, as it checked for the condition:~
> ~"The loop should modify the loop variable only once per iteration in its body and the difference needs to be constant. (This way the maximum number of steps can be estimated.)"~

~using the loop statement itself, not its body, making it always think that there is a nested loop present that is also modifying the loop variable.~

~Also, loops with size 100 were deemed too big to unroll if there were more than 0 instructions (function calls or assignments) in the loop.~