### PR TITLE
Simplify `IntDomTuple` witness invariants

### DIFF
--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -3536,7 +3536,7 @@ module IntDomTupleImpl = struct
     let merge ps =
       let (vs, rs) = List.split ps in
       let (mins, maxs) = List.split rs in
-      (List.concat vs, (List.min mins, List.max maxs))
+      (List.concat vs |> List.sort_uniq Z.compare, (List.min mins, List.max maxs))
     in
     mapp2 { fp2 = fun (type a) (module I:SOverflow with type t = a and type int_t = int_t) -> I.to_excl_list } x |> flat merge
 

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -615,6 +615,12 @@ struct
       let i2 = if inexact_type_bounds || Z.compare x2 max_ik <> 0 then Invariant.of_exp Cil.(BinOp (Le, e, kintegerCilint ik x2, intType)) else Invariant.none in
       Invariant.(i1 && i2)
     )
+
+  let of_excl_list e ik ns =
+    List.fold_left (fun a x ->
+        let i = Invariant.of_exp Cil.(BinOp (Ne, e, kintegerCilint ik x, intType)) in
+        Invariant.(a && i)
+      ) (Invariant.top ()) ns
 end
 
 module IntervalFunctor (Ints_t : IntOps.IntOps): SOverflow with type int_t = Ints_t.t and type t = (Ints_t.t * Ints_t.t) option =
@@ -2327,10 +2333,8 @@ struct
          This can be more precise than interval, which has been widened. *)
       let (rmin, rmax) = (Exclusion.min_of_range r, Exclusion.max_of_range r) in
       let ri = IntInvariant.of_interval e ik (rmin, rmax) in
-      S.fold (fun x a ->
-          let i = Invariant.of_exp Cil.(BinOp (Ne, e, kintegerCilint ik x, intType)) in
-          Invariant.(a && i)
-        ) s ri
+      let si = IntInvariant.of_excl_list e ik (S.elements s) in
+      Invariant.(ri && si)
     | `Bot -> Invariant.none
 
   let arbitrary ik =
@@ -2754,10 +2758,8 @@ module Enums : S with type int_t = Z.t = struct
          This can be more precise than interval, which has been widened. *)
       let (rmin, rmax) = (Exclusion.min_of_range r, Exclusion.max_of_range r) in
       let ri = IntInvariant.of_interval e ik (rmin, rmax) in
-      BISet.fold (fun x a ->
-          let i = Invariant.of_exp Cil.(BinOp (Ne, e, kintegerCilint ik x, intType)) in
-          Invariant.(a && i)
-        ) ns ri
+      let nsi = IntInvariant.of_excl_list e ik (BISet.elements ns) in
+      Invariant.(ri && nsi)
 
 
   let arbitrary ik =

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -3797,10 +3797,14 @@ module IntDomTupleImpl = struct
       else
         Invariant.top ()
     | None ->
-      let is = to_list (mapp { fp = fun (type a) (module I:SOverflow with type t = a) -> I.invariant_ikind e ik } x)
-      in List.fold_left (fun a i ->
-          Invariant.(a && i)
-        ) (Invariant.top ()) is
+      match to_incl_list x with
+      | Some ps ->
+        IntInvariant.of_incl_list e ik ps
+      | None ->
+        let is = to_list (mapp { fp = fun (type a) (module I:SOverflow with type t = a) -> I.invariant_ikind e ik } x)
+        in List.fold_left (fun a i ->
+            Invariant.(a && i)
+          ) (Invariant.top ()) is
 
   let arbitrary ik = QCheck.(set_print show @@ tup5 (option (I1.arbitrary ik)) (option (I2.arbitrary ik)) (option (I3.arbitrary ik)) (option (I4.arbitrary ik)) (option (I5.arbitrary ik)))
 

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -3803,6 +3803,8 @@ module IntDomTupleImpl = struct
         let min = minimal x in
         let max = maximal x in
         let ns = Option.map fst (to_excl_list x) |? [] in
+        let ns = Option.map_default (fun min -> List.filter (Z.leq min) ns) ns min in
+        let ns = Option.map_default (fun max -> List.filter (Z.geq max) ns) ns max in
         Invariant.(
           IntInvariant.of_interval_opt e ik (min, max) &&
           IntInvariant.of_excl_list e ik ns &&

--- a/src/cdomain/value/cdomains/intDomain.ml
+++ b/src/cdomain/value/cdomains/intDomain.ml
@@ -2794,7 +2794,7 @@ module Enums : S with type int_t = Z.t = struct
     | Inc e, Some (c, m) -> Inc (BISet.filter (contains c m) e)
     | _ -> a
 
-  let refine_with_interval ik a b = a
+  let refine_with_interval ik a b = a (* TODO: refine inclusion (exclusion?) set *)
 
   let refine_with_excl_list ik a b =
     match b with
@@ -3577,7 +3577,7 @@ module IntDomTupleImpl = struct
     in
     [(fun (a, b, c, d, e) -> refine_with_excl_list ik (a, b, c, d, e) (to_excl_list (a, b, c, d, e)));
      (fun (a, b, c, d, e) -> refine_with_incl_list ik (a, b, c, d, e) (to_incl_list (a, b, c, d, e)));
-     (fun (a, b, c, d, e) -> maybe refine_with_interval ik (a, b, c, d, e) b);
+     (fun (a, b, c, d, e) -> maybe refine_with_interval ik (a, b, c, d, e) b); (* TODO: get interval across all domains with minimal and maximal *)
      (fun (a, b, c, d, e) -> maybe refine_with_congruence ik (a, b, c, d, e) d)]
 
   let refine ik ((a, b, c, d, e) : t ) : t =
@@ -3791,6 +3791,7 @@ module IntDomTupleImpl = struct
     | _ -> BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (show x)
 
   let invariant_ikind e ik ((_, _, _, x_cong, x_intset) as x) =
+    (* TODO: do refinement before to ensure incl_list being more precise than intervals, etc (https://github.com/goblint/analyzer/pull/1517#discussion_r1693998515), requires refine functions to actually refine that *)
     let simplify_int fallback =
       match to_int x with
       | Some v ->

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -807,6 +807,20 @@
                   "type": "string",
                   "enum": ["once", "fixpoint"],
                   "default": "once"
+                },
+                "int": {
+                  "title": "ana.base.invariant.int",
+                  "type": "object",
+                  "properties": {
+                    "simplify": {
+                      "title": "ana.base.invariant.int.simplify",
+                      "description": "How much to simplify int domain invariants. Value \"int\" only simplifies definite integers. Without int domain refinement \"all\" might not be maximally precise.",
+                      "type": "string",
+                      "enum": ["none", "int", "all"],
+                      "default": "all"
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "additionalProperties": false

--- a/tests/regression/56-witness/46-top-bool-invariant.t
+++ b/tests/regression/56-witness/46-top-bool-invariant.t
@@ -144,7 +144,7 @@ all:
     dead: 0
     total lines: 2
   [Info][Witness] witness generation summary:
-    total generation entries: 3
+    total generation entries: 1
 
   $ yamlWitnessStrip < witness.yml
   - entry_type: location_invariant
@@ -156,28 +156,6 @@ all:
       function: main
     location_invariant:
       string: x == (_Bool)0 || x == (_Bool)1
-      type: assertion
-      format: C
-  - entry_type: location_invariant
-    location:
-      file_name: 46-top-bool-invariant.c
-      file_hash: $FILE_HASH
-      line: 5
-      column: 3
-      function: main
-    location_invariant:
-      string: x <= (_Bool)1
-      type: assertion
-      format: C
-  - entry_type: location_invariant
-    location:
-      file_name: 46-top-bool-invariant.c
-      file_hash: $FILE_HASH
-      line: 5
-      column: 3
-      function: main
-    location_invariant:
-      string: (_Bool)0 <= x
       type: assertion
       format: C
 

--- a/tests/regression/cfg/foo.t/run.t
+++ b/tests/regression/cfg/foo.t/run.t
@@ -67,7 +67,7 @@
     total lines: 6
   [Warning][Deadcode][CWE-571] condition 'a > 0' (possibly inserted by CIL) is always true (foo.c:3:10-3:20)
   [Info][Witness] witness generation summary:
-    total generation entries: 13
+    total generation entries: 10
 
   $ yamlWitnessStrip < witness.yml
   - entry_type: loop_invariant
@@ -111,17 +111,6 @@
       column: 3
       function: main
     location_invariant:
-      string: a != 0
-      type: assertion
-      format: C
-  - entry_type: location_invariant
-    location:
-      file_name: foo.c
-      file_hash: $FILE_HASH
-      line: 7
-      column: 3
-      function: main
-    location_invariant:
       string: 1 <= a
       type: assertion
       format: C
@@ -155,17 +144,6 @@
       column: 5
       function: main
     location_invariant:
-      string: a != 1
-      type: assertion
-      format: C
-  - entry_type: location_invariant
-    location:
-      file_name: foo.c
-      file_hash: $FILE_HASH
-      line: 5
-      column: 5
-      function: main
-    location_invariant:
       string: 2 <= a
       type: assertion
       format: C
@@ -189,17 +167,6 @@
       function: main
     location_invariant:
       string: b != 0
-      type: assertion
-      format: C
-  - entry_type: location_invariant
-    location:
-      file_name: foo.c
-      file_hash: $FILE_HASH
-      line: 4
-      column: 5
-      function: main
-    location_invariant:
-      string: a != 0
       type: assertion
       format: C
   - entry_type: location_invariant

--- a/tests/regression/cfg/foo.t/run.t
+++ b/tests/regression/cfg/foo.t/run.t
@@ -67,7 +67,7 @@
     total lines: 6
   [Warning][Deadcode][CWE-571] condition 'a > 0' (possibly inserted by CIL) is always true (foo.c:3:10-3:20)
   [Info][Witness] witness generation summary:
-    total generation entries: 15
+    total generation entries: 13
 
   $ yamlWitnessStrip < witness.yml
   - entry_type: loop_invariant
@@ -123,17 +123,6 @@
       function: main
     location_invariant:
       string: 1 <= a
-      type: assertion
-      format: C
-  - entry_type: location_invariant
-    location:
-      file_name: foo.c
-      file_hash: $FILE_HASH
-      line: 7
-      column: 3
-      function: main
-    location_invariant:
-      string: 0 <= a
       type: assertion
       format: C
   - entry_type: location_invariant
@@ -222,16 +211,5 @@
       function: main
     location_invariant:
       string: 1 <= a
-      type: assertion
-      format: C
-  - entry_type: location_invariant
-    location:
-      file_name: foo.c
-      file_hash: $FILE_HASH
-      line: 4
-      column: 5
-      function: main
-    location_invariant:
-      string: 0 <= a
       type: assertion
       format: C

--- a/tests/regression/witness/int.t/int.c
+++ b/tests/regression/witness/int.t/int.c
@@ -1,0 +1,17 @@
+#include <goblint.h>
+extern int __VERIFIER_nondet_int();
+
+int main() {
+  int i;
+  i = __VERIFIER_nondet_int();
+
+  if (i < 100)
+    __goblint_check(1);
+
+  if (50 < i && i < 100)
+    __goblint_check(1);
+
+  if (i == 42 || i == 5 || i == 101)
+    __goblint_check(1);
+  return 0;
+}

--- a/tests/regression/witness/int.t/run.t
+++ b/tests/regression/witness/int.t/run.t
@@ -29,7 +29,7 @@
       column: 5
       function: main
     location_invariant:
-      string: (51 <= i && i <= 99) && ((i != 0 && i != 0) && (51 <= i && i <= 99))
+      string: (51 <= i && i <= 99) && (i != 0 && (51 <= i && i <= 99))
       type: assertion
       format: C
   - entry_type: location_invariant

--- a/tests/regression/witness/int.t/run.t
+++ b/tests/regression/witness/int.t/run.t
@@ -1,4 +1,4 @@
-  $ goblint --enable ana.sv-comp.functions --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.enums --enable ana.int.interval --enable ana.int.congruence --enable ana.int.interval_set --disable witness.invariant.split-conjunction int.c
+  $ goblint --enable ana.sv-comp.functions --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.enums --enable ana.int.interval --enable ana.int.congruence --disable ana.int.interval_set --disable witness.invariant.split-conjunction int.c
   [Success][Assert] Assertion "1" will succeed (int.c:9:5-9:23)
   [Success][Assert] Assertion "1" will succeed (int.c:12:5-12:23)
   [Success][Assert] Assertion "1" will succeed (int.c:15:5-15:23)
@@ -29,7 +29,7 @@
       column: 5
       function: main
     location_invariant:
-      string: (51 <= i && i <= 99) && (51 <= i && i <= 99)
+      string: 51 <= i && i <= 99
       type: assertion
       format: C
   - entry_type: location_invariant
@@ -40,6 +40,6 @@
       column: 5
       function: main
     location_invariant:
-      string: i <= 99 && i <= 99
+      string: i <= 99
       type: assertion
       format: C

--- a/tests/regression/witness/int.t/run.t
+++ b/tests/regression/witness/int.t/run.t
@@ -29,8 +29,7 @@
       column: 5
       function: main
     location_invariant:
-      string: (((0 <= i && i != 0) && (51 <= i && i <= 99)) && (0 <= i && i != 0)) &&
-        (51 <= i && i <= 99)
+      string: (51 <= i && i <= 99) && ((i != 0 && i != 0) && (51 <= i && i <= 99))
       type: assertion
       format: C
   - entry_type: location_invariant

--- a/tests/regression/witness/int.t/run.t
+++ b/tests/regression/witness/int.t/run.t
@@ -18,8 +18,7 @@
       column: 5
       function: main
     location_invariant:
-      string: ((((0 <= i && i <= 127) && i != 0) && (5 <= i && i <= 101)) && ((i ==
-        5 || i == 42) || i == 101)) && ((i == 5 || i == 42) || i == 101)
+      string: (i == 5 || i == 42) || i == 101
       type: assertion
       format: C
   - entry_type: location_invariant

--- a/tests/regression/witness/int.t/run.t
+++ b/tests/regression/witness/int.t/run.t
@@ -1,0 +1,47 @@
+  $ goblint --enable ana.sv-comp.functions --enable witness.yaml.enabled --set witness.yaml.entry-types '["location_invariant"]' --enable ana.int.def_exc --enable ana.int.enums --enable ana.int.interval --enable ana.int.congruence --enable ana.int.interval_set --disable witness.invariant.split-conjunction int.c
+  [Success][Assert] Assertion "1" will succeed (int.c:9:5-9:23)
+  [Success][Assert] Assertion "1" will succeed (int.c:12:5-12:23)
+  [Success][Assert] Assertion "1" will succeed (int.c:15:5-15:23)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 10
+    dead: 0
+    total lines: 10
+  [Info][Witness] witness generation summary:
+    total generation entries: 3
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: location_invariant
+    location:
+      file_name: int.c
+      file_hash: $FILE_HASH
+      line: 15
+      column: 5
+      function: main
+    location_invariant:
+      string: ((((0 <= i && i <= 127) && i != 0) && (5 <= i && i <= 101)) && ((i ==
+        5 || i == 42) || i == 101)) && ((i == 5 || i == 42) || i == 101)
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: int.c
+      file_hash: $FILE_HASH
+      line: 12
+      column: 5
+      function: main
+    location_invariant:
+      string: (((0 <= i && i != 0) && (51 <= i && i <= 99)) && (0 <= i && i != 0)) &&
+        (51 <= i && i <= 99)
+      type: assertion
+      format: C
+  - entry_type: location_invariant
+    location:
+      file_name: int.c
+      file_hash: $FILE_HASH
+      line: 9
+      column: 5
+      function: main
+    location_invariant:
+      string: i <= 99 && i <= 99
+      type: assertion
+      format: C

--- a/tests/regression/witness/int.t/run.t
+++ b/tests/regression/witness/int.t/run.t
@@ -29,7 +29,7 @@
       column: 5
       function: main
     location_invariant:
-      string: (51 <= i && i <= 99) && (i != 0 && (51 <= i && i <= 99))
+      string: (51 <= i && i <= 99) && (51 <= i && i <= 99)
       type: assertion
       format: C
   - entry_type: location_invariant


### PR DESCRIPTION
Before this PR, `IntDomTuple` outputted witness invariants as conjunction of those from each int domain. Except when it was a definite integer, then only the single equality was returned.

This PR extends this logic to avoid obviously redundant and duplicate information in witness invariants, which can make them annoyingly large:
1. If it is a definite integer, output single equality.
2. If it is inclusion set, output conjunction of equalities (interval bounds and exclusions are redundant).
3. Otherwise, output interval bounds based on all integer domains (avoids duplicate bounds from def_exc exclusion bit ranges). Moreover, exclusion set is filtered based on that interval because often def_exc has `x != 0` which is pointless if interval has some strictly positive bounds. Congruence and interval set (latter not used in SV-COMP) domains are added unchanged, so all known information should still be there.

### TODO
- [x] Add option: `ana.base.invariant.int.simplify`.