### PR TITLE
Remove restriction that no loop unrolling is done when breaks are in the loop

### DIFF
--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -45,20 +45,19 @@ class findBreakVisitor(compOption: exp option ref) = object
   method! vstmt stmt =
     match stmt.skind with
     | Block _ -> DoChildren
-    | Break _ -> raise WrongOrMultiple
+    | Break _ -> SkipChildren
     | If (cond, t, e, _, _) ->  (
-        checkNoBreakBlock t;
         match e.bstmts with
         | [s] -> (
             match s.skind with
             | Break _ -> (
                 match !compOption with
-                | Some _ -> raise WrongOrMultiple (*more than one loop break*)
+                | Some _ -> SkipChildren (*more than one loop break*)
                 | _ -> compOption := Some cond; SkipChildren
               )
-            | _ -> checkNoBreakStmt stmt; SkipChildren
+            | _ -> SkipChildren
           )
-        | _ -> checkNoBreakStmt stmt; SkipChildren
+        | _ -> SkipChildren
       )
     | _ ->  SkipChildren
 

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -31,14 +31,6 @@ class checkNoBreakVisitor = object
 
 end
 
-let checkNoBreakStmt stmt =
-  let visitor = new checkNoBreakVisitor in
-  ignore @@ visitCilStmt visitor stmt
-
-let checkNoBreakBlock block =
-  let visitor = new checkNoBreakVisitor in
-  ignore @@ visitCilBlock visitor block
-
 class findBreakVisitor(compOption: exp option ref) = object
   inherit nopCilVisitor
 

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -253,7 +253,7 @@ let fixedLoopSize loopStatement func =
   in let assignmentDifference loop var = try
          let diff = ref None in
          let visitor = new findAssignmentConstDiff(diff, var) in
-         ignore @@ visitCilStmt visitor loop;
+         ignore @@ visitCilBlock visitor loop;
          !diff
        with | WrongOrMultiple ->  None
   in
@@ -264,7 +264,7 @@ let fixedLoopSize loopStatement func =
     None
   else
     constBefore var loopStatement func >>= fun start ->
-    assignmentDifference loopStatement var >>= fun diff ->
+    assignmentDifference (loopBody loopStatement) var >>= fun diff ->
     Logs.debug "comparison: ";
     Pretty.fprint stderr (dn_exp () comparison) ~width:max_int;
     Logs.debug "";
@@ -344,7 +344,7 @@ let loop_unrolling_factor loopStatement func totalLoops =
       (* Unroll at least 10 times if there are only few (17?) loops *)
       let unroll_min = if totalLoops < 17 && AutoTune0.isActivated "forceLoopUnrollForFewLoops" then 10 else 0 in
       match fixedLoop with
-      | Some i -> if i * loopStats.instructions < 100 then (Logs.debug "fixed loop size"; i) else max unroll_min (100 / loopStats.instructions)
+      | Some i -> if i * loopStats.instructions < 100 || totalLoops < 10 then (Logs.debug "fixed loop size"; i) else max unroll_min (100 / loopStats.instructions)
       | _ -> max unroll_min (targetInstructions / loopStats.instructions)
     else
       (* Don't unroll empty (= while(1){}) loops*)

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -264,7 +264,11 @@ let fixedLoopSize loopStatement func =
     None
   else
     constBefore var loopStatement func >>= fun start ->
-    assignmentDifference (loopBody loopStatement) var >>= fun diff ->
+    let diff =
+      match assignmentDifference (loopBody loopStatement) var with
+      | Some d -> d
+      | None -> Z.one (* When we find a fixed loop and its start, but cannot detect the increment within the loop, we assume the increment is 1 *)
+    in
     Logs.debug "comparison: ";
     Pretty.fprint stderr (dn_exp () comparison) ~width:max_int;
     Logs.debug "";


### PR DESCRIPTION
In SV-COMP no-overflow tasks there are cases similar to the following example:

```c
int counter = 0;
int main() {
    int  X = __VERIFIER_nondet_int();
    long long x = 0;

    while (counter++<10) {
        ...
        if (!(x <= X))
            break;
        ...
    }
    ...
```

Where we do not detect loops with fixed iterations due to the restriction:
> There is one single break in an if statement where the condition compares a local variable v to a constant e.

First, this PR removes this restriction, as reaching these breaks should make the loop iterations smaller anyway.

However, all these tasks also have the increment `counter++` in the loop condition, which we do not handle and which is very difficult to handle using only the semantics, as these statements are picked into pieces by CIL:
```c
int counter = 0;
int main() {
    int  X = __VERIFIER_nondet_int();
    long long x = 0;

    tmp = counter;
    counter = counter + 1;
    while (tmp<10) {
        ...
        if (!(x <= X))
            break;
        ...
        tmp = counter;
        counter = counter + 1;
    }
    ...
```

Thus, I opted for another assumption that when we find a fixed loop and its start but cannot detect the increment within the loop, we assume the increment is 1.

This solved the tasks with the bounds being 5 and 10, but for bounds 20 and 50, I also had to apply the hack introduced in #1516 to just use the fixed loop size that was found by the heuristics if there are less than 10 loops in the program (the only stat I could find/access to estimate the size of the program (being small)).