### PR TITLE
[Thesis MS] Fixes for Self-Validation Issues

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -56,7 +56,8 @@ struct
       Priv.read_global ask getg st g x
     else (
       let rel = st.rel in
-      let g_var = RV.global g in
+      (* If it has escaped and we have never been multi-threaded, we can still refer to the local *)
+      let g_var = if g.vglob then RV.global g else RV.local g in
       let x_var = RV.local x in
       let rel' = RD.add_vars rel [g_var] in
       let rel' = RD.assign_var rel' x_var g_var in
@@ -87,7 +88,7 @@ struct
     let e' = visitCilExpr visitor e in
     let rel = RD.add_vars st.rel (List.map RV.local (VH.values v_ins |> List.of_enum)) in (* add temporary g#in-s *)
     let rel' = VH.fold (fun v v_in rel ->
-        if M.tracing then M.trace "relation" "read_global %a %a" CilType.Varinfo.pretty v CilType.Varinfo.pretty v_in;
+        if M.tracing then M.trace "gurki" "read_global %a %a" CilType.Varinfo.pretty v CilType.Varinfo.pretty v_in;
         read_global ask getg {st with rel} v v_in (* g#in = g; *)
       ) v_ins rel
     in

--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -88,7 +88,6 @@ struct
     let e' = visitCilExpr visitor e in
     let rel = RD.add_vars st.rel (List.map RV.local (VH.values v_ins |> List.of_enum)) in (* add temporary g#in-s *)
     let rel' = VH.fold (fun v v_in rel ->
-        if M.tracing then M.trace "gurki" "read_global %a %a" CilType.Varinfo.pretty v CilType.Varinfo.pretty v_in;
         read_global ask getg {st with rel} v v_in (* g#in = g; *)
       ) v_ins rel
     in

--- a/tests/regression/46-apron2/95-witness-mm-escape.c
+++ b/tests/regression/46-apron2/95-witness-mm-escape.c
@@ -1,0 +1,19 @@
+// PARAM: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.relation.privatization mutex-meet-tid-cluster12 --set witness.yaml.validate 95-witness-mm-escape.yml
+#include <pthread.h>
+#include <goblint.h>
+
+int *b;
+pthread_mutex_t e;
+
+void main() {
+
+    int g = 8;
+    int a;
+    if(a) {
+        g = 10;
+    }
+
+    b = &g;
+
+    pthread_mutex_lock(&e);
+}

--- a/tests/regression/46-apron2/95-witness-mm-escape.t
+++ b/tests/regression/46-apron2/95-witness-mm-escape.t
@@ -1,0 +1,25 @@
+  $ goblint --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.relation.privatization mutex-meet-tid-cluster12 --set witness.yaml.validate 95-witness-mm-escape.yml 95-witness-mm-escape.c
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 7
+    dead: 0
+    total lines: 7
+  [Success][Witness] invariant confirmed: 0 <= g (95-witness-mm-escape.c:19:1)
+  [Success][Witness] invariant confirmed: 0 <= *b (95-witness-mm-escape.c:19:1)
+  [Success][Witness] invariant confirmed: g <= 127 (95-witness-mm-escape.c:19:1)
+  [Success][Witness] invariant confirmed: *b <= 127 (95-witness-mm-escape.c:19:1)
+  [Success][Witness] invariant confirmed: (2147483638LL + (long long )a) + (long long )g >= 0LL (95-witness-mm-escape.c:19:1)
+  [Success][Witness] invariant confirmed: (2147483637LL - (long long )a) + (long long )g >= 0LL (95-witness-mm-escape.c:19:1)
+  [Success][Witness] invariant confirmed: (2147483658LL + (long long )a) - (long long )g >= 0LL (95-witness-mm-escape.c:19:1)
+  [Success][Witness] invariant confirmed: (2147483657LL - (long long )a) - (long long )g >= 0LL (95-witness-mm-escape.c:19:1)
+  [Success][Witness] invariant confirmed: b == & g (95-witness-mm-escape.c:19:1)
+  [Success][Witness] invariant confirmed: g != 0 (95-witness-mm-escape.c:19:1)
+  [Success][Witness] invariant confirmed: *b != 0 (95-witness-mm-escape.c:19:1)
+  [Info][Witness] witness validation summary:
+    confirmed: 22
+    unconfirmed: 0
+    refuted: 0
+    error: 0
+    unchecked: 0
+    unsupported: 0
+    disabled: 0
+    total validation entries: 22

--- a/tests/regression/46-apron2/95-witness-mm-escape.yml
+++ b/tests/regression/46-apron2/95-witness-mm-escape.yml
@@ -1,0 +1,449 @@
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: bd605de4-9e24-4df2-a8b6-7a20973f08c3
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: 0 <= g
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: d52450ae-a439-4c7e-9cd7-88a4d7b2729d
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: 0 <= *b
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: 934e24ac-ff4e-4ce8-b10e-28c96d1d9a85
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: g <= 127
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: b67ec3d2-1506-4a5a-a019-b959fa02c710
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: '*b <= 127'
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: 799dbde2-5854-4786-b784-22941410dd4c
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: (2147483638LL + (long long )a) + (long long )g >= 0LL
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: fbf9961a-853f-4bc0-be9b-a12f6d49ab20
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: (2147483637LL - (long long )a) + (long long )g >= 0LL
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: c7d1d801-2b2a-4f34-a0ed-29e496ae2bbf
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: (2147483658LL + (long long )a) - (long long )g >= 0LL
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: f626d0f0-9ab2-4e7e-8568-194a3ba0f671
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: (2147483657LL - (long long )a) - (long long )g >= 0LL
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: 70ebfa4c-8b42-439e-bb6f-f8b87b8bebe9
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: b == & g
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: 1b25d102-ebc5-4dde-854d-ac5525aa4fed
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: g != 0
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: bc5e8286-3029-4002-b87b-1288f32e44c4
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  location:
+    file_name: 95-witness-mm-escape.c
+    file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+    line: 19
+    column: 1
+    function: main
+  location_invariant:
+    string: '*b != 0'
+    type: assertion
+    format: C
+- entry_type: invariant_set
+  metadata:
+    format_version: "0.1"
+    uuid: 8cad3de5-98bb-4400-833c-bae232e13530
+    creation_time: 2024-07-16T16:10:49Z
+    producer:
+      name: Goblint
+      version: heads/check_overflow_convert-0-gc35fd8620-dirty
+      command_line: '''../../../goblint'' ''95-witness-mm-escape.c'' ''--set'' ''ana.activated[+]''
+        ''apron'' ''--set'' ''ana.path_sens[+]'' ''threadflag'' ''--set'' ''ana.relation.privatization''
+        ''mutex-meet-tid-cluster12'' ''--enable'' ''witness.yaml.enabled'' ''--disable''
+        ''witness.invariant.other'' ''--set'' ''witness.yaml.path'' ''95-witness-mm-escape.yml'''
+    task:
+      input_files:
+      - 95-witness-mm-escape.c
+      input_file_hashes:
+        95-witness-mm-escape.c: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: 0 <= g
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: 0 <= *b
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: g <= 127
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: '*b <= 127'
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: (2147483638LL + (long long )a) + (long long )g >= 0LL
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: (2147483637LL - (long long )a) + (long long )g >= 0LL
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: (2147483658LL + (long long )a) - (long long )g >= 0LL
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: (2147483657LL - (long long )a) - (long long )g >= 0LL
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: b == & g
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: g != 0
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 95-witness-mm-escape.c
+        file_hash: 59ef053c97b76b763526674d2e5f5a4bb304200ec4b738e93dcf7b42738b8ebe
+        line: 19
+        column: 1
+        function: main
+      value: '*b != 0'
+      format: c_expression

--- a/tests/regression/46-apron2/dune
+++ b/tests/regression/46-apron2/dune
@@ -12,4 +12,4 @@
 (cram
  (alias runaprontest)
  (enabled_if %{lib-available:apron})
- (deps (glob_files *.c)))
+ (deps (glob_files *.c) (glob_files *.yml)))


### PR DESCRIPTION
Should address #1542.

Contains:

- Fix for issue where `read_global` read in from a global variable which does not exist in single-threaded mode
- ...

Related but not part of the diff: 

- 3a30b0cb9bf532920fbf211408a439fc39717d87 (check whether cast to `long long` is injective before emitting invariants)