### PR TITLE
Make `update_offset` idempotent for blobs

### DIFF
--- a/tests/regression/13-privatized/95-mm-calloc.c
+++ b/tests/regression/13-privatized/95-mm-calloc.c
@@ -1,0 +1,28 @@
+// PARAM: --set ana.base.privatization mutex-meet
+#include<pthread.h>
+#include<stdlib.h>
+#include<stdio.h>
+struct a {
+  void (*b)();
+};
+
+int g = 0;
+
+struct a* t;
+void m() {
+  // Reachable!
+  g = 1;
+}
+
+void* j(void* arg) {};
+
+void main() {
+  pthread_t tid;
+  pthread_create(&tid, 0, j, NULL);
+  t = calloc(1, sizeof(struct a));
+  t->b = &m;
+  struct a r = *t;
+  r.b();
+
+  __goblint_check(g ==0); //UNKNOWN!
+}


### PR DESCRIPTION
Otherwise, a publish lead to a `Blob` value being placed inside a zero-inited `Blob`, which lead to value `Top` inside the blob, which caused function calls to be lost.


Closes #1558 