### PR TITLE
Default the value of `CilType.Location.Byte` to -1 if missing in JSON

### DIFF
--- a/src/common/util/cilType.ml
+++ b/src/common/util/cilType.ml
@@ -79,8 +79,8 @@ struct
 
   let of_yojson = function
     | `Assoc l ->
-      begin match List.assoc_opt "file" l, List.assoc_opt "line" l, List.assoc_opt "column" l, List.assoc_opt "byte" l with
-        | Some (`String file), Some (`Int line), Some (`Int column), Some (`Int byte) ->
+      begin match List.assoc_opt "file" l, List.assoc_opt "line" l, List.assoc_opt "column" l, Option.value ~default:(`Int (-1)) (List.assoc_opt "byte" l) with
+        | Some (`String file), Some (`Int line), Some (`Int column), `Int byte ->
           let loc = {file; line; column; byte; endLine = -1; endColumn = -1; endByte = -1; synthetic = false} in
           begin match List.assoc_opt "endLine" l, List.assoc_opt "endColumn" l, List.assoc_opt "endByte" l with
             | Some (`Int endLine), Some (`Int endColumn), Some (`Int endByte) ->


### PR DESCRIPTION
While refactoring some GobPie's classes to records, I accidentally removed a seemingly unused field
```java
@SerializedName("byte")
private static int startByte = -1;
```

from the `GoblintLocation` class.

This made Goblint crash when using breakpoints for which the requests are done using `Location`.
Instead of putting the field back into GobPie, we decided to fix it in Goblint, as the `of_yojson` of a location is anyways only used by GobPie.