### PR TITLE
Refactor loopUnrolling autotuner

### DIFF
--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -276,8 +276,8 @@ let fixedLoopSize loopStatement func =
     assignmentDifference loopStatement var >>= fun diff ->
     Logs.debug "comparison: %a" CilType.Exp.pretty comparison;
     Logs.debug "variable: %s" var.vname;
-    Logs.debug "start: %s" @@ Z.to_string start;
-    Logs.debug "diff: %s" @@ Z.to_string diff;
+    Logs.debug "start: %a" GobZ.pretty start;
+    Logs.debug "diff: %a" GobZ.pretty diff;
     let iterations = loopIterations start diff comparison in
     match iterations with
     | None -> Logs.debug "iterations failed"; None

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -274,8 +274,7 @@ let fixedLoopSize loopStatement func =
   else
     constBefore var loopStatement func >>= fun start ->
     assignmentDifference loopStatement var >>= fun diff ->
-    Logs.debug "comparison: ";
-    Pretty.fprint stderr (dn_exp () comparison) ~width:max_int;
+    Logs.debug "comparison: %a" CilType.Exp.pretty comparison;
     Logs.debug "";
     Logs.debug "variable: ";
     Logs.debug "%s" var.vname;

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -250,9 +250,9 @@ let fixedLoopSize loopStatement func =
       !compOption
     with | WrongOrMultiple ->  None
   in let getLoopVar = function
-      | BinOp (op, (Const (CInt _ )), Lval ((Var info), NoOffset), (TInt _))
-      | BinOp (op, Lval ((Var info), NoOffset), (Const (CInt _ )), (TInt _)) when isCompare op && not info.vglob->
-        Some info
+      | BinOp (op, (Const (CInt (goal, _, _) )), Lval ((Var info), NoOffset), (TInt _))
+      | BinOp (op, Lval ((Var info), NoOffset), (Const (CInt (goal, _, _) )), (TInt _)) when isCompare op && not info.vglob->
+        Some (info, goal)
       | _ -> None
   in let getsPointedAt var = try
          let visitor = new isPointedAtVisitor(var) in
@@ -268,7 +268,7 @@ let fixedLoopSize loopStatement func =
   in
 
   findBreakComparison >>= fun comparison ->
-  getLoopVar comparison >>= fun var ->
+  getLoopVar comparison >>= fun (var, goal) ->
   if getsPointedAt var then
     None
   else

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -275,21 +275,16 @@ let fixedLoopSize loopStatement func =
     constBefore var loopStatement func >>= fun start ->
     assignmentDifference loopStatement var >>= fun diff ->
     Logs.debug "comparison: %a" CilType.Exp.pretty comparison;
-    Logs.debug "";
-    Logs.debug "variable: ";
-    Logs.debug "%s" var.vname;
-    Logs.debug "start:";
-    Logs.debug "%s" @@ Z.to_string start;
-    Logs.debug "diff:";
-    Logs.debug "%s" @@ Z.to_string diff;
+    Logs.debug "variable: %s" var.vname;
+    Logs.debug "start: %s" @@ Z.to_string start;
+    Logs.debug "diff: %s" @@ Z.to_string diff;
     let iterations = loopIterations start diff comparison in
     match iterations with
     | None -> Logs.debug "iterations failed"; None
     | Some s ->
       try
         let s' = Z.to_int s in
-        Logs.debug "iterations:";
-        Logs.debug "%d" s';
+        Logs.debug "iterations: %d" s';
         Some s'
       with Z.Overflow -> Logs.debug "iterations too big for integer"; None
 


### PR DESCRIPTION
Refactor some code in `loopUnrolling.ml`, simplifies the following:
- Use Log instead of printing to stderr
- Improve debug messages and simplify their syntax
- Make sure the goal (bound) of the loop is found from the exact same loop statement comparison expression where the var was found
- Move functions defined in `fixedLoopSize` to top level to make function definitions' style consistent
- Use `let*` option monad syntax from `GobOption.Syntax` in LoopUnrolling