### PR TITLE
Do not unroll loops in stub functions

### DIFF
--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -468,6 +468,8 @@ class loopUnrollingVisitor(func, totalLoops) = object
 end
 
 let unroll_loops fd totalLoops =
-  Cil.populateLabelAlphaTable fd;
-  let thisVisitor = new loopUnrollingVisitor(fd, totalLoops) in
-  ignore (visitCilFunction thisVisitor fd)
+  if not (Cil.hasAttribute "goblint_stub" fd.svar.vattr) then (
+    Cil.populateLabelAlphaTable fd;
+    let thisVisitor = new loopUnrollingVisitor(fd, totalLoops) in
+    ignore (visitCilFunction thisVisitor fd)
+  )


### PR DESCRIPTION
The inspection of not enabling vs enabling `loopUnrolling` showed that unrolling loops in the stub functions do not aid in solving the tasks but only slows down the verification process. Furthermore, in some cases unrolling the loops in stubs too many times causes some regression tests (`29/35 nla-sqrt` and `46/30 autotune-stub`) to fail for some (unknown) reason.