### PR TITLE
Try to fix sv-benchmarks termination-restricted-15/IntPath Apron normalization

### DIFF
--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -535,6 +535,10 @@ struct
           if M.tracing then M.trace "apron" "assert_constraint st: %a" D.pretty d;
           if M.tracing then M.trace "apron" "assert_constraint tcons1: %a" Tcons1.pretty tcons1;
           let r = meet_tcons ask d tcons1 e in
+          (* sv-benchmarks termination-restricted-15/IntPath needs stronger normalization for integers *)
+          (* let r = meet_tcons ask r tcons1 e in *) (* meeting twice works (polyhedra and octagon) *)
+          (* A.canonicalize Man.mgr r; *) (* this doesn't help *)
+          A.approximate Man.mgr r (-1); (* this also works, but does it approximate something away? (polyhedra only, octagon crashes) *)
           if M.tracing then M.trace "apron" "assert_constraint r: %a" D.pretty r;
           r
         | exception Convert.Unsupported_CilExp reason ->


### PR DESCRIPTION
As identified in https://github.com/goblint/analyzer/issues/1576#issuecomment-2378939924, this SV-COMP task causes a weird both branches dead situation which actually is sound. With both octagon and polyhedra, there are constraints like `2x=1` where `x` is an integer. Neither domain seems to immediately reduce this to bottom to make it dead.
Only later when re-asserting some (even the same) constraint, it's somehow checked again and does become dead, but in both branches.

Here are a few attempts to try to make this come out early, but I don't think none are particularly nice. It's hard to tell where Apron actually applies some integer reduction. It seems to be a separate thing from other kinds of normalization/closure/canonicalization that Apron has and does.