### PR TITLE
Exclude multithreaded main-main races by threadflag

### DIFF
--- a/tests/regression/10-synch/29-threadflag-main.c
+++ b/tests/regression/10-synch/29-threadflag-main.c
@@ -1,0 +1,18 @@
+// PARAM: --set ana.activated[-] threadid
+// Deactivate threadid to rely on threadflag only.
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  myglobal=myglobal+1; // NORACE
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/tests/regression/13-privatized/63-access-threadspawn-lval.t
+++ b/tests/regression/13-privatized/63-access-threadspawn-lval.t
@@ -12,7 +12,7 @@ Should have (safe) write accesses to id1 and id2:
     dead: 0
     total lines: 13
   [Success][Race] Memory location id1 (safe): (63-access-threadspawn-lval.c:4:11-4:14)
-    write with [multi:false, thread:[main]] (conf. 110)  (exp: & *((pthread_t * __restrict  )(& id1))) (63-access-threadspawn-lval.c:27:3-27:37)
+    write with [flag:Singlethreaded, thread:[main]] (conf. 110)  (exp: & *((pthread_t * __restrict  )(& id1))) (63-access-threadspawn-lval.c:27:3-27:37)
   [Success][Race] Memory location id2 (safe): (63-access-threadspawn-lval.c:5:11-5:14)
     write with [mhp:{created={[main, f@63-access-threadspawn-lval.c:27:3-27:37]}}, thread:[main]] (conf. 110)  (exp: (pthread_t * __restrict  )(& id2)) (63-access-threadspawn-lval.c:28:3-28:37)
     write with [mhp:{created={[main, f@63-access-threadspawn-lval.c:27:3-27:37]}}, thread:[main]] (conf. 110)  (exp: & *((pthread_t * __restrict  )(& id2))) (63-access-threadspawn-lval.c:28:3-28:37)

--- a/tests/regression/13-privatized/64-access-invalidate.t
+++ b/tests/regression/13-privatized/64-access-invalidate.t
@@ -12,7 +12,7 @@ Should have (safe) write access to id1 and magic2 invalidate to A:
     dead: 0
     total lines: 10
   [Success][Race] Memory location id (safe): (64-access-invalidate.c:4:11-4:13)
-    write with [multi:false, thread:[main]] (conf. 110)  (exp: & *((pthread_t * __restrict  )(& id))) (64-access-invalidate.c:21:3-21:36)
+    write with [flag:Singlethreaded, thread:[main]] (conf. 110)  (exp: & *((pthread_t * __restrict  )(& id))) (64-access-invalidate.c:21:3-21:36)
   [Info][Race] Memory locations race summary:
     safe: 1
     vulnerable: 0


### PR DESCRIPTION
This is a bit silly but the threadflag analysis `may_race` did not exclude `main`-`main` races even though it has all the information to do so.
It almost never makes a difference because threadflag answers the `MustBeUniqueThread` query based on its flag still, and the threadid analysis uses that information in its `may_race`.

The more notable thing is the unexpected cram test (change). Usually accesses while single-threaded aren't even added to `allglobs`, but apparently the thread ID variable write in `pthread_create` is added although as if single-threaded. This is odd for two reasons:
1. As single-threaded it shouldn't even be in `allglobs`.
2. It's actually ambiguous whether it should be written before or after the thread is created. Maybe it should be done after, thus in multi-threaded mode altogether to over-approximate the possibility.

This was always in the cram test but went unnoticed until I played around with this.