### PR TITLE
Handle loop statement comparison between two variables in loop unrolling

### DIFF
--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -220,13 +220,21 @@ let findBreakComparison loopStatement =
   with WrongOrMultiple ->
     None
 
-let getLoopVar = function
+let getLoopVar loopStatement func = function
   | BinOp (op, (Const (CInt (goal, _, _) )), Lval ((Var varinfo), NoOffset), (TInt _)) when isCompare op && not varinfo.vglob ->
     (* TODO: define isCompare and flip in cilfacade and refactor to use instead of the many separately defined similar functions *)
     let flip = function | Lt -> Gt | Gt -> Lt | Ge -> Le | Le -> Ge | s -> s in
     Some (flip op, varinfo, goal)
   | BinOp (op, Lval ((Var varinfo), NoOffset), (Const (CInt (goal, _, _) )), (TInt _)) when isCompare op && not varinfo.vglob ->
     Some (op, varinfo, goal)
+  (* When loop condition has a comparison between variables, we assume that the left one is the counter and right one is the bound.
+     TODO: can we do something more meaningful instead of this assumption? *)
+  | BinOp (op, Lval ((Var varinfo), NoOffset), Lval ((Var varinfo2), NoOffset), (TInt _)) 
+  | BinOp (op, CastE ((TInt _), (Lval ((Var varinfo), NoOffset))), Lval ((Var varinfo2), NoOffset), (TInt _)) when isCompare op && not varinfo.vglob && not varinfo2.vglob ->
+    begin match constBefore varinfo2 loopStatement func with
+      | Some goal -> Logs.debug "const: %a %a" CilType.Varinfo.pretty varinfo2 GobZ.pretty goal; Some (op, varinfo, goal)
+      | None -> None
+    end;
   | _ -> None
 
 let getsPointedAt var func =
@@ -273,7 +281,7 @@ let loopIterations start diff goal shouldBeExact =
 let fixedLoopSize loopStatement func =
   let open GobOption.Syntax in
   let* comparison = findBreakComparison loopStatement in
-  let* op, var, goal = getLoopVar comparison in
+  let* op, var, goal = getLoopVar loopStatement func comparison in
   if getsPointedAt var func then
     None
   else

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -164,7 +164,6 @@ let constBefore var loop f =
             else
               current
           in
-          (* let current' = current in *)
           match st.skind with
           | Instr list -> (
               match lastAssignToVar var list with

--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -154,7 +154,17 @@ let constBefore var loop f =
   let targetLocation = loopLocation loop
   in let rec lastAssignmentToVarBeforeLoop (current: (Z.t option)) (statements: stmt list) = match statements with
       | st::stmts -> (
-          let current' = if st.labels <> [] then (Logs.debug "has Label"; (None)) else current in
+          let current' =
+            (* If there exists labels that are not the ones inserted by loop unrolling, forget the found assigned constant value *)
+            if List.exists (function
+                | Label (s,_,_) -> not (String.starts_with ~prefix:"loop_continue" s || String.starts_with ~prefix:"loop_end" s)
+                | _ -> true) st.labels
+            then
+              (Logs.debug "has Label"; (None))
+            else
+              current
+          in
+          (* let current' = current in *)
           match st.skind with
           | Instr list -> (
               match lastAssignToVar var list with


### PR DESCRIPTION
Previously, we only detected fixed-sized loops when the loop comparison was between a variable and a constant. However, we already found the last assignment to the variable being changed in the loop body, and thus, we have a function for finding the last assigned value.

This PR adds the functionality also to detect fixed loops when the loop condition compares variables by finding the last assignment for the other compared variable.

This PR was inspired by the following loop from the SV-COMP task `loops/invert_string-3.c`, which we were lucky to solve based on the old heuristics but cannot solve anymore due to the new, more conservative heuristic.

```c
unsigned int max = 5;
char str1[max], str2[max];
int i, j;

for (i=0; i<max; i++) {
    str1[i]=__VERIFIER_nondet_char();
}
```

This task has the case including a cast. I added another case that would handle similar conditions without a cast as a precaution.