### PR TITLE
Remove fixed malloc wrappers from svcomp conf

### DIFF
--- a/conf/svcomp-validate.json
+++ b/conf/svcomp-validate.json
@@ -46,27 +46,6 @@
     "context": {
       "widen": false
     },
-    "malloc": {
-      "wrappers": [
-        "kmalloc",
-        "__kmalloc",
-        "usb_alloc_urb",
-        "__builtin_alloca",
-        "kzalloc",
-
-        "ldv_malloc",
-
-        "kzalloc_node",
-        "ldv_zalloc",
-        "kmalloc_array",
-        "kcalloc",
-
-        "ldv_xmalloc",
-        "ldv_xzalloc",
-        "ldv_calloc",
-        "ldv_kzalloc"
-      ]
-    },
     "base": {
       "arrays": {
         "domain": "partitioned"

--- a/conf/svcomp.json
+++ b/conf/svcomp.json
@@ -45,27 +45,6 @@
     "context": {
       "widen": false
     },
-    "malloc": {
-      "wrappers": [
-        "kmalloc",
-        "__kmalloc",
-        "usb_alloc_urb",
-        "__builtin_alloca",
-        "kzalloc",
-
-        "ldv_malloc",
-
-        "kzalloc_node",
-        "ldv_zalloc",
-        "kmalloc_array",
-        "kcalloc",
-
-        "ldv_xmalloc",
-        "ldv_xzalloc",
-        "ldv_calloc",
-        "ldv_kzalloc"
-      ]
-    },
     "base": {
       "arrays": {
         "domain": "partitioned"


### PR DESCRIPTION
This list was based on one from CPAchecker and over time extended, but that was all before we had the autotuner for malloc wrappers.
I did some full resources runs some time ago and found that they make absolutely no difference: we lost _one_ task on the entire SV-COMP suite. And even that's just noise: there were some tasks flipping to true and others flipping from true, canceling them out (timeouts and segfaults).

It also makes us look very bad, fingerprinting tasks when it's not even useful...