### PR TITLE
Remove witness `exclude-vars` from svcomp conf

### DIFF
--- a/conf/svcomp.json
+++ b/conf/svcomp.json
@@ -128,17 +128,7 @@
       "after-lock": false,
       "other": false,
       "accessed": false,
-      "exact": true,
-      "exclude-vars": [
-        "tmp\\(___[0-9]+\\)?",
-        "cond",
-        "RETURN",
-        "__\\(cil_\\)?tmp_?[0-9]*\\(_[0-9]+\\)?",
-        ".*____CPAchecker_TMP_[0-9]+",
-        "__VERIFIER_assert__cond",
-        "__ksymtab_.*",
-        "\\(ldv_state_variable\\|ldv_timer_state\\|ldv_timer_list\\|ldv_irq_\\(line_\\|data_\\)?[0-9]+\\|ldv_retval\\)_[0-9]+"
-      ]
+      "exact": true
     }
   },
   "pre": {


### PR DESCRIPTION
Similarly to #1592, this is something where we appear to fingerprint tasks... Although these exclusion don't affect our verdict, only the generated witnesses.
But witness validation still affects SV-COMP scores, so it's not harmless.

I want to do some runs with witnesses to see what difference this really makes. Over time we've improved invariant generation to be smarter and avoid redundant data, so maybe this sort of witness size reduction is unnecessary now.