### PR TITLE
Restrict unrolling to loops that are nested within less than 4 loops

### DIFF
--- a/src/util/loopUnrolling.ml
+++ b/src/util/loopUnrolling.ml
@@ -316,17 +316,12 @@ let max_default_unrolls_per_spec (spec: Svcomp.Specification.t) =
 let loop_unrolling_factor loopStatement func totalLoops =
   let configFactor = get_int "exp.unrolling-factor" in
   if AutoTune0.isActivated "loopUnrollHeuristic" then
-    let loopStats = AutoTune0.collectFactors visitCilStmt loopStatement in
-    if loopStats.instructions > 0 then
-      match fixedLoopSize loopStatement func with
-      | Some i when i <= 20 -> Logs.debug "fixed loop size %d" i; i
-      | _ ->
-        match Svcomp.Specification.of_option () with
-        | [] -> 4
-        | specs -> BatList.max @@ List.map max_default_unrolls_per_spec specs
-    else
-      (* Don't unroll empty (= while(1){}) loops*)
-      0
+    match fixedLoopSize loopStatement func with
+    | Some i when i <= 20 -> Logs.debug "fixed loop size %d" i; i
+    | _ ->
+      match Svcomp.Specification.of_option () with
+      | [] -> 4
+      | specs -> BatList.max @@ List.map max_default_unrolls_per_spec specs
   else
     configFactor
 

--- a/tests/regression/55-loop-unrolling/08-bad.t
+++ b/tests/regression/55-loop-unrolling/08-bad.t
@@ -1,6 +1,4 @@
   $ goblint --set lib.activated '[]' --set exp.unrolling-factor 1 --enable justcil --set dbg.justcil-printer clean 08-bad.c
-  [Info] unrolling loop at 08-bad.c:9:7-9:23 with factor 1
-  [Info] unrolling loop at 08-bad.c:15:8-15:24 with factor 1
   int main(void) 
   { 
     int m ;
@@ -8,11 +6,6 @@
     {
     {
     goto switch_default;
-    {
-    if (! 0) {
-      goto loop_end;
-    }
-    loop_continue_0: /* CIL Label */ ;
     switch_default: /* CIL Label */ 
     {
     while (1) {
@@ -23,16 +16,9 @@
     }
     while_break: /* CIL Label */ ;
     }
-    loop_end: /* CIL Label */ ;
-    }
     switch_break: /* CIL Label */ ;
     }
     goto lab;
-    {
-    if (! 0) {
-      goto loop_end___0;
-    }
-    loop_continue_0___0: /* CIL Label */ ;
     lab: 
     {
     while (1) {
@@ -42,8 +28,6 @@
       }
     }
     while_break___0: /* CIL Label */ ;
-    }
-    loop_end___0: /* CIL Label */ ;
     }
     return (0);
   }


### PR DESCRIPTION
This PR addresses the excessive resource usage introduced in [bb6f9aa](https://github.com/goblint/analyzer/compare/060004c...bb6f9aa).

As the amount of unrolling grows exponentially with the number of nested loops, we determined what would be a reasonable amount of nestings with a 5s run on the sv-benchmarks and found that unrolling less than 4 loops is a reasonable metric.

On the downside, this PR introduces an issue where some termination tasks do not reach a fixpoint. Unfortunately, I was not able to trace it to the cause, but we made a quick run, and it seems to not impact our overall scores (compared to SV-COMP 2023, we lost 2 termination tasks, but we also currently run out of resources for these).

So, (hopefully) this PR fixes more things than it breaks. *Edit*: we made a run and, indeed, this PR does not break anything else but fixes the excessive resource usage with 717 tasks going from errors back to unknowns.