### PR TITLE
⛽: Use minimum to combine incoming gas values in per-context gas

### DIFF
--- a/tests/regression/80-context_gas/25-per-fun-nonterm.c
+++ b/tests/regression/80-context_gas/25-per-fun-nonterm.c
@@ -1,0 +1,29 @@
+//PARAM: --enable ana.int.interval_set --set ana.context.gas_value 3 --set ana.context.gas_scope function
+// NOTIMEOUT
+void h(int n) {
+    int x;
+
+    if(x) {
+        return;
+    }
+
+    g(n+1);
+    h(n+1);
+}
+
+void g(int n) {
+    int x;
+
+    if(x) {
+        return;
+    }
+
+    g(n+1);
+    h(n+1);
+}
+
+int main()
+{
+    g(0);
+    h(0);
+}


### PR DESCRIPTION
As observed by @jerhard for our extended version of the context paper, the gas (if tracked per `fundec`) needs to be combined with the  minimum operation as otherwise it can be replenished unboundedly in the case of several mutually recursive functions.

This PR adds an example that was previously problematic, and fixes the issue.