### PR TITLE
`mine-W` privatization undermines Miné, `lock` is less precise than `mine`/`protection`

### DIFF
--- a/tests/regression/13-privatized/95-mine-W-part-by-S.c
+++ b/tests/regression/13-privatized/95-mine-W-part-by-S.c
@@ -1,0 +1,32 @@
+// PARAM: --set ana.base.privatization mine-W
+#include <pthread.h>
+#include <goblint.h>
+
+int g, h;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t B = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&A);
+  g = 5;
+  pthread_mutex_unlock(&A);
+
+  pthread_mutex_lock(&B);
+  // __goblint_check(g == 5); // UNKNOWN! (data race, so weak read)
+  h = 6;
+  pthread_mutex_unlock(&B);
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_mutex_lock(&A);
+  g = 8;
+  pthread_mutex_lock(&B);
+  __goblint_check(g == 8);
+  pthread_mutex_unlock(&B);
+  pthread_mutex_unlock(&A);
+  return 0;
+}

--- a/tests/regression/13-privatized/95-mine-W-part-by-S.t
+++ b/tests/regression/13-privatized/95-mine-W-part-by-S.t
@@ -1,0 +1,99 @@
+Miné succeeds:
+
+  $ goblint --set ana.base.privatization mine 95-mine-W-part-by-S.c
+  [Success][Assert] Assertion "g == 8" will succeed (95-mine-W-part-by-S.c:28:3-28:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 17
+    dead: 0
+    total lines: 17
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 2
+
+Miné without thread IDs even succeeds:
+
+  $ goblint --set ana.base.privatization mine-nothread 95-mine-W-part-by-S.c
+  [Success][Assert] Assertion "g == 8" will succeed (95-mine-W-part-by-S.c:28:3-28:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 17
+    dead: 0
+    total lines: 17
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 2
+
+TODO: Our Miné with W should also succeed, but doesn't:
+
+  $ goblint --set ana.base.privatization mine-W 95-mine-W-part-by-S.c
+  [Warning][Assert] Assertion "g == 8" is unknown. (95-mine-W-part-by-S.c:28:3-28:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 17
+    dead: 0
+    total lines: 17
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 2
+
+The noinit variant makes no difference:
+
+  $ goblint --set ana.base.privatization mine-W-noinit 95-mine-W-part-by-S.c
+  [Warning][Assert] Assertion "g == 8" is unknown. (95-mine-W-part-by-S.c:28:3-28:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 17
+    dead: 0
+    total lines: 17
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 2
+
+
+
+Protection-Based succeeds:
+
+  $ goblint --set ana.base.privatization protection 95-mine-W-part-by-S.c
+  [Success][Assert] Assertion "g == 8" will succeed (95-mine-W-part-by-S.c:28:3-28:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 17
+    dead: 0
+    total lines: 17
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 2
+
+Write-Centered succeeds:
+
+  $ goblint --set ana.base.privatization write 95-mine-W-part-by-S.c
+  [Success][Assert] Assertion "g == 8" will succeed (95-mine-W-part-by-S.c:28:3-28:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 17
+    dead: 0
+    total lines: 17
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 2
+
+TODO Lock-Centered should also succeed, but doesn't:
+
+  $ goblint --set ana.base.privatization lock 95-mine-W-part-by-S.c
+  [Warning][Assert] Assertion "g == 8" is unknown. (95-mine-W-part-by-S.c:28:3-28:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 17
+    dead: 0
+    total lines: 17
+  [Info][Race] Memory locations race summary:
+    safe: 2
+    vulnerable: 0
+    unsafe: 0
+    total memory locations: 2


### PR DESCRIPTION
Our `mine-W` privatization replaces the mechanism `mine` uses to convert weak interferences into synchronized ones. However, this `W` set undermines the precision by not considering locksets at the time of write.

What I'm more surprised about is that `lock` privatization is less precise than `mine` and `protection` on the same example.

### TODO
- [ ] Try to fix `mine-W` precision by partitioning by lockset.
- [ ] Figure out why  `lock` is imprecise.