### PR TITLE
Fix `thread` for non-unique spawns

### DIFF
--- a/src/analyses/threadAnalysis.ml
+++ b/src/analyses/threadAnalysis.ml
@@ -95,9 +95,7 @@ struct
   let startstate v = D.bot ()
 
   let threadenter ctx ~multiple lval f args =
-    if multiple then
-      (let tid = ThreadId.get_current_unlift (Analyses.ask_of_ctx ctx) in
-       ctx.sideg tid (true, TS.bot (), false));
+    (* ctx is of creator, side-effects to denote non-uniqueness are performed in threadspawn *)
     [D.bot ()]
 
   let threadspawn ctx ~multiple lval f args fctx =
@@ -106,9 +104,9 @@ struct
     let repeated = D.mem tid ctx.local in
     let eff =
       match creator with
-      | `Lifted ctid -> (repeated, TS.singleton ctid, false)
-      | `Top         -> (true,     TS.bot (),         false)
-      | `Bot         -> (false,    TS.bot (),         false)
+      | `Lifted ctid -> (repeated || multiple, TS.singleton ctid, false)
+      | `Top         -> (true, TS.bot (), false)
+      | `Bot         -> (false || multiple, TS.bot (), false)
     in
     ctx.sideg tid eff;
     D.join ctx.local (D.singleton tid)

--- a/tests/regression/40-threadid/12-multiple-created-only.c
+++ b/tests/regression/40-threadid/12-multiple-created-only.c
@@ -1,0 +1,26 @@
+// PARAM: --set ana.activated[+] thread --set ana.activated[+] threadid --set ana.thread.domain plain
+
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+int myglobal2;
+
+void* bla(void *arg) {
+  // This is created multiple times, it should race with itself
+  myglobal = 10; //RACE
+  return NULL;
+}
+
+void* other(void) {
+  // This is created only once, it should not be marked as non-unique
+  unknown(bla);
+  myglobal2 = 30; //NORACE
+}
+
+int main(void) {
+    pthread_t id;
+    pthread_create(&id, NULL, other, NULL);
+
+    return 0;
+}

--- a/tests/regression/40-threadid/13-no-crash.c
+++ b/tests/regression/40-threadid/13-no-crash.c
@@ -1,0 +1,31 @@
+// PARAM: --set ana.context.gas_value 0 --set ana.activated[+] thread --set ana.activated[+] threadid
+
+#include <pthread.h>
+#include <stdio.h>
+
+int myglobal;
+int myglobal2;
+
+void *t_flurb(void *arg) {
+  myglobal=40; //RACE
+  return NULL;
+}
+
+void* bla(void *arg) {
+    return NULL;
+}
+
+void *t_fun(void *arg) {
+  unknown(t_flurb); // NOCRASH
+  return NULL;
+}
+
+int main(void) {
+    pthread_t id;
+    pthread_create(&id, NULL, t_fun, NULL);
+    pthread_create(&id, NULL, t_fun, NULL);
+
+    unknown(bla);
+
+    return 0;
+}


### PR DESCRIPTION
The handling of `threadenter` in the case of a thread being spawned non-uniquely was broken:

- It failed when thread ids where non-unique.
- It actually caused a side-effect to the thread id of the **creator** marking that as non-unique rather than the created thread.

This PR fixes this issue which hopefully means our experiments for PLDI can continue (CC @Red-Panda64: try if merging this into your branch helps), and also increases precision for cases where the non-history thread id is enabled.

Closes #1615 