### PR TITLE
Print innermost backtrace mark for uncaught exception even with backtrace printing off

### DIFF
--- a/src/util/backtrace/goblint_backtrace.ml
+++ b/src/util/backtrace/goblint_backtrace.ml
@@ -76,12 +76,19 @@ let print_marktrace oc e =
       Printf.fprintf oc "Marked with %s\n" (mark_to_string m)
     ) ms
 
+let print_innermost_mark oc e =
+  match find_marks e with
+  | m :: _ -> Printf.fprintf oc "Marked with %s\n" (mark_to_string m)
+  | [] -> ()
+
 let () =
   Printexc.set_uncaught_exception_handler (fun e bt ->
       (* Copied & modified from Printexc.default_uncaught_exception_handler. *)
       Printf.eprintf "Fatal error: exception %s\n" (Printexc.to_string e); (* nosemgrep: print-not-logging *)
       if Printexc.backtrace_status () then
-        print_marktrace stderr e;
+        print_marktrace stderr e
+      else
+        print_innermost_mark stderr e;
       Printexc.print_raw_backtrace stderr bt;
       flush stderr
     )

--- a/src/util/backtrace/goblint_backtrace.mli
+++ b/src/util/backtrace/goblint_backtrace.mli
@@ -32,5 +32,10 @@ val print_marktrace: out_channel -> exn -> unit
 
     Used by default for uncaught exceptions. *)
 
+val print_innermost_mark: out_channel -> exn -> unit
+(** Print innermost mark of an exception.
+
+    Used by default for uncaught exceptions. *)
+
 val find_marks: exn -> mark list
 (** Find all marks of an exception. *)


### PR DESCRIPTION
Closes #1616.

The output for the problematic example is now
```
Fatal error: exception LibraryDsl.Pattern.Expected("^::")
Marked with function pthread_create
```

It's still not the best output like https://github.com/goblint/analyzer/issues/1616#issuecomment-2454143344. That's the intended output for such problem with the clearest error message, but if the problematic call is the only one in the program, then CIL doesn't seem to be doing some unification with the declaration that it otherwise would.