### PR TITLE
Error on must-relocking of non-recursive mutex

### DIFF
--- a/tests/regression/03-practical/21-pfscan_combine_minimal.c
+++ b/tests/regression/03-practical/21-pfscan_combine_minimal.c
@@ -18,7 +18,7 @@ int pqueue_init(PQUEUE *qp)
 
 void pqueue_close(PQUEUE *qp )
 {
-  pthread_mutex_lock(& qp->mtx);
+  pthread_mutex_lock(& qp->mtx); // WARN (must double locking)
   qp->closed = 1;
   pthread_mutex_unlock(& qp->mtx);
   return;
@@ -26,7 +26,7 @@ void pqueue_close(PQUEUE *qp )
 
 int pqueue_put(PQUEUE *qp)
 {
-  pthread_mutex_lock(& qp->mtx);
+  pthread_mutex_lock(& qp->mtx); // WARN (must double locking)
   if (qp->closed) {
     // pfscan actually has a bug and is missing the following unlock at early return
     // pthread_mutex_unlock(& qp->mtx);

--- a/tests/regression/03-practical/21-pfscan_combine_minimal.c
+++ b/tests/regression/03-practical/21-pfscan_combine_minimal.c
@@ -18,7 +18,7 @@ int pqueue_init(PQUEUE *qp)
 
 void pqueue_close(PQUEUE *qp )
 {
-  pthread_mutex_lock(& qp->mtx); // WARN (must double locking)
+  pthread_mutex_lock(& qp->mtx); // TODO (OSX): WARN (must double locking)
   qp->closed = 1;
   pthread_mutex_unlock(& qp->mtx);
   return;
@@ -26,7 +26,7 @@ void pqueue_close(PQUEUE *qp )
 
 int pqueue_put(PQUEUE *qp)
 {
-  pthread_mutex_lock(& qp->mtx); // WARN (must double locking)
+  pthread_mutex_lock(& qp->mtx); // TODO (OSX): WARN (must double locking)
   if (qp->closed) {
     // pfscan actually has a bug and is missing the following unlock at early return
     // pthread_mutex_unlock(& qp->mtx);

--- a/tests/regression/04-mutex/32-allfuns.c
+++ b/tests/regression/04-mutex/32-allfuns.c
@@ -8,11 +8,11 @@ pthread_mutex_t B_mutex = PTHREAD_MUTEX_INITIALIZER;
 void t1() {
   pthread_mutex_lock(&A_mutex);
   myglobal++; //RACE!
-  pthread_mutex_lock(&A_mutex);
+  pthread_mutex_unlock(&A_mutex);
 }
 
 void t2() {
   pthread_mutex_lock(&B_mutex);
   myglobal++; //RACE!
-  pthread_mutex_lock(&B_mutex);
+  pthread_mutex_unlock(&B_mutex);
 }

--- a/tests/regression/09-regions/31-equ_rc.c
+++ b/tests/regression/09-regions/31-equ_rc.c
@@ -15,7 +15,7 @@ struct s {
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A.mutex);
   B.datum = 5; // RACE!
-  pthread_mutex_lock(&A.mutex);
+  pthread_mutex_unlock(&A.mutex);
   return NULL;
 }
 

--- a/tests/regression/09-regions/32-equ_nr.c
+++ b/tests/regression/09-regions/32-equ_nr.c
@@ -15,7 +15,7 @@ struct s {
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A.mutex);
   A.datum = 5; // NORACE
-  pthread_mutex_lock(&A.mutex);
+  pthread_mutex_unlock(&A.mutex);
   return NULL;
 }
 


### PR DESCRIPTION
mayLocks analysis can warn on it, but mutex analysis can be definite about it.

Inspired by https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/merge_requests/1587 which we clearly have the information for, but didn't say anything.

We cannot go to dead code in this case because we don't distinguish error-checking mutexes.