### PR TITLE
Simplify relational witness invariants

### DIFF
--- a/src/cdomains/apron/sharedFunctions.apron.ml
+++ b/src/cdomains/apron/sharedFunctions.apron.ml
@@ -249,41 +249,52 @@ module CilOfApron (V: SV) =
 struct
   exception Unsupported_Linexpr1
 
-  let cil_exp_of_linexpr1 ?scalewith (linexpr1:Linexpr1.t) =
-    let longlong = TInt(ILongLong,[]) in
-    let coeff_to_const consider_flip (c:Coeff.union_5) = match c with
-      | Scalar c ->
-        (match int_of_scalar ?scalewith c with
-         | Some i ->
-           let ci,truncation = truncateCilint ILongLong i in
-           if truncation = NoTruncation then
-             if not consider_flip || Z.compare i Z.zero >= 0 then
-               Const (CInt(i,ILongLong,None)), false
-             else
-               (* attempt to negate if that does not cause an overflow *)
-               let cneg, truncation = truncateCilint ILongLong (Z.neg i) in
-               if truncation = NoTruncation then
-                 Const (CInt((Z.neg i),ILongLong,None)), true
-               else
-                 Const (CInt(i,ILongLong,None)), false
-           else
-             (M.warn ~category:Analyzer "Invariant Apron: coefficient is not int: %a" Scalar.pretty c; raise Unsupported_Linexpr1)
-         | None -> raise Unsupported_Linexpr1)
-      | _ -> raise Unsupported_Linexpr1
-    in
-    let expr = ref (fst @@ coeff_to_const false (Linexpr1.get_cst linexpr1)) in
-    let append_summand (c:Coeff.union_5) v =
-      match V.to_cil_varinfo v with
-      | Some vinfo when IntDomain.Size.is_cast_injective ~from_type:vinfo.vtype ~to_type:(TInt(ILongLong,[]))   ->
-        let var = Cilfacade.mkCast ~e:(Lval(Var vinfo,NoOffset)) ~newt:longlong in
-        let coeff, flip = coeff_to_const true c in
-        let prod = BinOp(Mult, coeff, var, longlong) in
-        if flip then
-          expr := BinOp(MinusA,!expr,prod,longlong)
+  let longlong = TInt(ILongLong,[])
+
+
+  let coeff_to_const ~scalewith consider_flip (c:Coeff.union_5) =
+    match c with
+    | Scalar c ->
+      (match int_of_scalar ?scalewith c with
+      | Some i ->
+        let ci,truncation = truncateCilint ILongLong i in
+        if truncation = NoTruncation then
+          if not consider_flip || Z.compare i Z.zero >= 0 then
+            Const (CInt(i,ILongLong,None)), false
+          else
+            (* attempt to negate if that does not cause an overflow *)
+            let cneg, truncation = truncateCilint ILongLong (Z.neg i) in
+            if truncation = NoTruncation then
+              Const (CInt((Z.neg i),ILongLong,None)), true
+            else
+              Const (CInt(i,ILongLong,None)), false
         else
-          expr := BinOp(PlusA,!expr,prod,longlong)
-      | None -> M.warn ~category:Analyzer "Invariant Apron: cannot convert to cil var: %a" Var.pretty v; raise Unsupported_Linexpr1
-      | _ -> M.warn ~category:Analyzer "Invariant Apron: cannot convert to cil var in overflow preserving manner: %a" Var.pretty v; raise Unsupported_Linexpr1
+          (M.warn ~category:Analyzer "Invariant Apron: coefficient is not int: %a" Scalar.pretty c; raise Unsupported_Linexpr1)
+      | None -> raise Unsupported_Linexpr1)
+    | _ -> raise Unsupported_Linexpr1
+
+  let cil_exp_of_linexpr1_term ~scalewith (c: Coeff.t) v =
+    match V.to_cil_varinfo v with
+    | Some vinfo when IntDomain.Size.is_cast_injective ~from_type:vinfo.vtype ~to_type:(TInt(ILongLong,[]))   ->
+      let var = Cilfacade.mkCast ~e:(Lval(Var vinfo,NoOffset)) ~newt:longlong in
+      let coeff, flip = coeff_to_const ~scalewith true c in
+      let prod = BinOp(Mult, coeff, var, longlong) in
+      prod, flip
+    | None ->
+      M.warn ~category:Analyzer "Invariant Apron: cannot convert to cil var: %a" Var.pretty v;
+      raise Unsupported_Linexpr1
+    | _ ->
+      M.warn ~category:Analyzer "Invariant Apron: cannot convert to cil var in overflow preserving manner: %a" Var.pretty v;
+      raise Unsupported_Linexpr1
+
+  let cil_exp_of_linexpr1 ?scalewith (linexpr1:Linexpr1.t) =
+    let expr = ref (fst @@ coeff_to_const ~scalewith false (Linexpr1.get_cst linexpr1)) in
+    let append_summand (c:Coeff.union_5) v =
+      let prod, flip = cil_exp_of_linexpr1_term ~scalewith c v in
+      if flip then
+        expr := BinOp(MinusA,!expr,prod,longlong)
+      else
+        expr := BinOp(PlusA,!expr,prod,longlong)
     in
     Linexpr1.iter append_summand linexpr1;
     !expr

--- a/tests/regression/36-apron/12-traces-min-rpb1.t
+++ b/tests/regression/36-apron/12-traces-min-rpb1.t
@@ -29,7 +29,7 @@
       column: 3
       function: main
     location_invariant:
-      string: (0LL - (long long )g) + (long long )h == 0LL
+      string: '- ((long long )g) + (long long )h == 0LL'
       type: assertion
       format: C
   - entry_type: location_invariant
@@ -40,7 +40,7 @@
       column: 3
       function: t_fun
     location_invariant:
-      string: (0LL - (long long )g) + (long long )h == 0LL
+      string: '- ((long long )g) + (long long )h == 0LL'
       type: assertion
       format: C
   - entry_type: location_invariant
@@ -51,6 +51,6 @@
       column: 3
       function: t_fun
     location_invariant:
-      string: (0LL - (long long )g) + (long long )h == 0LL
+      string: '- ((long long )g) + (long long )h == 0LL'
       type: assertion
       format: C

--- a/tests/regression/36-apron/52-queuesize.t
+++ b/tests/regression/36-apron/52-queuesize.t
@@ -53,7 +53,7 @@ Without diff-box:
       column: 3
       function: push
     location_invariant:
-      string: 2147483647LL - (long long )capacity >= 0LL
+      string: '- ((long long )capacity) >= -2147483647LL'
       type: assertion
       format: C
   - entry_type: location_invariant
@@ -86,8 +86,7 @@ Without diff-box:
       column: 3
       function: push
     location_invariant:
-      string: ((0LL - (long long )capacity) + (long long )free) + (long long )used ==
-        0LL
+      string: (- ((long long )capacity) + (long long )free) + (long long )used == 0LL
       type: assertion
       format: C
   - entry_type: location_invariant
@@ -98,7 +97,7 @@ Without diff-box:
       column: 3
       function: pop
     location_invariant:
-      string: 2147483647LL - (long long )capacity >= 0LL
+      string: '- ((long long )capacity) >= -2147483647LL'
       type: assertion
       format: C
   - entry_type: location_invariant
@@ -131,8 +130,7 @@ Without diff-box:
       column: 3
       function: pop
     location_invariant:
-      string: ((0LL - (long long )capacity) + (long long )free) + (long long )used ==
-        0LL
+      string: (- ((long long )capacity) + (long long )free) + (long long )used == 0LL
       type: assertion
       format: C
 
@@ -211,8 +209,7 @@ With diff-box:
       column: 3
       function: push
     location_invariant:
-      string: ((0LL - (long long )capacity) + (long long )free) + (long long )used ==
-        0LL
+      string: (- ((long long )capacity) + (long long )free) + (long long )used == 0LL
       type: assertion
       format: C
   - entry_type: location_invariant
@@ -245,8 +242,7 @@ With diff-box:
       column: 3
       function: pop
     location_invariant:
-      string: ((0LL - (long long )capacity) + (long long )free) + (long long )used ==
-        0LL
+      string: (- ((long long )capacity) + (long long )free) + (long long )used == 0LL
       type: assertion
       format: C
 
@@ -262,7 +258,7 @@ Compare witnesses:
       column: 3
       function: push
     location_invariant:
-      string: 2147483647LL - (long long )capacity >= 0LL
+      string: '- ((long long )capacity) >= -2147483647LL'
       type: assertion
       format: C
   - entry_type: location_invariant
@@ -273,7 +269,7 @@ Compare witnesses:
       column: 3
       function: pop
     location_invariant:
-      string: 2147483647LL - (long long )capacity >= 0LL
+      string: '- ((long long )capacity) >= -2147483647LL'
       type: assertion
       format: C
   ---


### PR DESCRIPTION
### Simplifications
1. Use unary minus instead of subtraction from 0: `0 - x >= 0` → `-x >= 0`.
2. Move constant to other side instead of always comparing with 0: `-10 + x >= 0` → `x >= 10`.
3. Don't add variables with coefficient 0. Apparently they are also iterated over.

### TODO
- [ ] Avoid negation on both sides: `-x >= -5` → `5 >= x`.
- [ ] Avoid initial unary minus if possible: `-x + y >= 0` → `y - x >= 0`.