### PR TITLE
Fix `mine-W-noinit` not resetting W in `threadenter`

### DIFF
--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -1255,11 +1255,11 @@ struct
     else
       st
 
-  let threadenter =
+  let threadenter ask st =
     if Param.side_effect_global_init then
-      startstate_threadenter startstate
+      startstate_threadenter startstate ask st
     else
-      old_threadenter
+      {(old_threadenter ask st) with priv = W.empty ()}
 end
 
 module LockCenteredD =

--- a/tests/regression/13-privatized/96-mine-W-threadenter.c
+++ b/tests/regression/13-privatized/96-mine-W-threadenter.c
@@ -1,0 +1,32 @@
+// PARAM: --set ana.base.privatization mine-W-noinit --enable ana.int.enums
+#include <pthread.h>
+#include <goblint.h>
+
+int g;
+pthread_mutex_t A = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  return NULL;
+}
+
+void *t_fun2(void *arg) {
+  pthread_mutex_lock(&A);
+  pthread_mutex_unlock(&A); // spuriously publishes g = 8
+  return NULL;
+}
+
+int main() {
+  pthread_t id, id2;
+  pthread_create(&id, NULL, t_fun, NULL); // enter multithreaded
+
+  pthread_mutex_lock(&A);
+  g = 8;
+  pthread_create(&id2, NULL, t_fun2, NULL); // passes g = 8 and W: A -> {g} to t_fun2
+  g = 0;
+  pthread_mutex_unlock(&A);
+
+  pthread_mutex_lock(&A);
+  __goblint_check(g == 0); // TODO
+  pthread_mutex_unlock(&A);
+  return 0;
+}

--- a/tests/regression/13-privatized/96-mine-W-threadenter.c
+++ b/tests/regression/13-privatized/96-mine-W-threadenter.c
@@ -11,7 +11,7 @@ void *t_fun(void *arg) {
 
 void *t_fun2(void *arg) {
   pthread_mutex_lock(&A);
-  pthread_mutex_unlock(&A); // spuriously publishes g = 8
+  pthread_mutex_unlock(&A); // used to spuriously publish g = 8
   return NULL;
 }
 
@@ -21,12 +21,12 @@ int main() {
 
   pthread_mutex_lock(&A);
   g = 8;
-  pthread_create(&id2, NULL, t_fun2, NULL); // passes g = 8 and W: A -> {g} to t_fun2
+  pthread_create(&id2, NULL, t_fun2, NULL); // used to pass g = 8 and W: A -> {g} to t_fun2
   g = 0;
   pthread_mutex_unlock(&A);
 
   pthread_mutex_lock(&A);
-  __goblint_check(g == 0); // TODO
+  __goblint_check(g == 0);
   pthread_mutex_unlock(&A);
   return 0;
 }


### PR DESCRIPTION
This privatization is supposed to keep in the set $$W$$ globals may-written by the current thread. Currently `threadenter` propagates this set to the created thread which may thus create spurious side effects on behalf of the created thread who doesn't ever write the global.

This PR fixes that by resetting $$W$$ in `threadenter`.

(This is orthogonal to #1613 which also suffers from the same issue on the same test.)