### PR TITLE
More useful stats output by `privPrecCompare`

### DIFF
--- a/src/util/precCompare.ml
+++ b/src/util/precCompare.ml
@@ -103,8 +103,12 @@ struct
 
   module CompareDump = MakeHashtbl (Key) (Dom) (RH)
 
+  let comparisons = ref []
+
   let compare_dumps ({name = name1; results = lvh1}: result) ({name = name2; results = lvh2}: result) =
-    CompareDump.compare ~verbose:true ~name1 lvh1 ~name2 lvh2
+    let (c, d) = CompareDump.compare ~verbose:true ~name1 lvh1 ~name2 lvh2 in
+    comparisons := (name1, name2, c) :: !comparisons;
+    (c, d)
 
   let count_locations (dumps: result list) =
     let module LH = Hashtbl.Make (CilType.Location) in
@@ -117,6 +121,29 @@ struct
           ) results
       ) dumps;
     (LH.length locations, RH.length location_vars)
+
+  let group () =
+    let new_bucket_id = ref 0 in
+    let equality_buckets = Hashtbl.create 113 in
+    let sorted = List.sort (fun (n1, _, _) (n2, _, _) -> String.compare n1 n2) !comparisons in
+    List.iter (fun (name1, name2, (c:Comparison.t)) ->
+        (if not (Hashtbl.mem equality_buckets name1) then
+           (* Make its own bucket if it does not appear yet *)
+           (let bucket_id = !new_bucket_id in
+            incr new_bucket_id;
+            Hashtbl.add equality_buckets name1 bucket_id));
+        if c.more_precise = 0 && c.less_precise = 0 && c.incomparable = 0 then
+          Hashtbl.replace equality_buckets name2 (Hashtbl.find equality_buckets name1)
+        else
+          ()
+      ) sorted;
+    let bindings = Hashtbl.bindings equality_buckets in
+    let buckets = List.group (fun (_, b) (_, b') -> compare b b') bindings in
+    List.iter (fun bucket ->
+        Logs.result "Bucket %d:" (snd (List.hd bucket));
+        List.iter (fun (name, _) -> Logs.result "  %s" name) bucket
+      ) buckets
+
 
   let main () =
     Util.init ();
@@ -131,5 +158,6 @@ struct
     |> List.map (uncurry compare_dumps)
     |> List.iter (fun (_, msg) -> Logs.result "%t" (fun () -> msg));
     Logs.newline ();
-    Logs.result "Total locations: %d\nTotal %s: %d" locations_count (Key.name ()) location_vars_count
+    Logs.result "Total locations: %d\nTotal %s: %d" locations_count (Key.name ()) location_vars_count;
+    group ()
 end


### PR DESCRIPTION
For my thesis, I was considering many different configurations, and the pairwise output got tedious: 

```
protection equal to mine-W    (equal: 427, more precise: 0, less precise: 0, incomparable: 0, total: 427)
protection equal to lock    (equal: 427, more precise: 0, less precise: 0, incomparable: 0, total: 427)
protection equal to write    (equal: 427, more precise: 0, less precise: 0, incomparable: 0, total: 427)
protection equal to write+lock    (equal: 427, more precise: 0, less precise: 0, incomparable: 0, total: 427)
protection less precise than protection-interval    (equal: 51, more precise: 0, less precise: 376, incomparable: 0, total: 427)
protection less precise than mine-W-interval    (equal: 51, more precise: 0, less precise: 376, incomparable: 0, total: 427)
protection less precise than lock-interval    (equal: 51, more precise: 0, less precise: 376, incomparable: 0, total: 427)
protection less precise than write-interval    (equal: 51, more precise: 0, less precise: 376, incomparable: 0, total: 427)
protection less precise than write+lock-interval    (equal: 51, more precise: 0, less precise: 376, incomparable: 0, total: 427)
protection equal to protection-tid    (equal: 427, more precise: 0, less precise: 0, incomparable: 0, total: 427)
protection equal to lock-tid    (equal: 427, more precise: 0, less precise: 0, incomparable: 0, total: 427)
protection equal to write-tid    (equal: 427, more precise: 0, less precise: 0, incomparable: 0, total: 427)
protection equal to write+lock-tid    (equal: 427, more precise: 0, less precise: 0, incomparable: 0, total: 427)
protection less precise than protection-tid-interval    (equal: 51, more precise: 0, less precise: 376, incomparable: 0, total: 427)
protection less precise than lock-tid-interval    (equal: 51, more precise: 0, less precise: 376, incomparable: 0, total: 427)
protection less precise than write-tid-interval    (equal: 51, more precise: 0, less precise: 376, incomparable: 0, total: 427)
protection less precise than write+lock-tid-interval    (equal: 51, more precise: 0, less precise: 376, incomparable: 0, total: 427)
...
```
I had 18 configurations and thus 288 more pairwise comparisons like this (where many have equal precision).

With this PR, we still create the detailed output, but then at the end create buckets of approaches that have the same precision and then output one comparison per bucket.

For example, this output here (all approaches equally precise, TIDs do not matter, intervals pay off) is much easier to intuitively grasp than the 306 pairwise comparisons.

```
Bucket 0:
  protection-tid
  write
  write+lock-tid
  write+lock
  write-tid
  protection
  mine-W
  lock
  lock-tid
Bucket 1:
  write-interval
  lock-tid-interval
  write-tid-interval
  protection-interval
  mine-W-interval
  protection-tid-interval
  lock-interval
  write+lock-interval
  write+lock-tid-interval
Comparison between bucket 0 and 1: lock less precise than write+lock-tid-interval    (equal: 51, more precise: 0, less precise: 376, incomparable: 0, total: 427)
```

I merged this only into my dissertation branch back then (#1431 ). I opened this PR so we can consider if we want to have this or  not.