### PR TITLE
Make `update_offset` idempotent for blobs

### DIFF
--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -1001,10 +1001,10 @@ struct
             else
               mu (Blob (join x (do_update_offset ask x offs value exp l' o' v t), s, zeroinit))
           end
-        | Blob (x,s,zeroinit), _ ->
+        | Blob (x,s,zeroinit), `NoOffset -> (* `NoOffset is only remaining possibility for Blob here *)
           begin
-            match offs, value with
-            | `NoOffset, Blob (x2, s2, zeroinit2) -> mu (Blob (join x x2, ID.join s s2, zeroinit))
+            match value with
+            | Blob (x2, s2, zeroinit2) -> mu (Blob (join x x2, ID.join s s2, zeroinit))
             | _ ->
               let l', o' = shift_one_over l o in
               let x = zero_init_calloced_memory zeroinit x t in

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -1004,7 +1004,7 @@ struct
         | Blob (x,s,zeroinit), _ ->
           begin
             match offs, value with
-            | `NoOffset, Blob (x2, s2, zeroinit2) -> mu (Blob (join x x2, ID.join s s2,ZeroInit.join zeroinit zeroinit2))
+            | `NoOffset, Blob (x2, s2, zeroinit2) -> mu (Blob (join x x2, ID.join s s2, zeroinit))
             | _ ->
               let l', o' = shift_one_over l o in
               let x = zero_init_calloced_memory zeroinit x t in

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -1003,26 +1003,29 @@ struct
           end
         | Blob (x,s,zeroinit), _ ->
           begin
-            let l', o' = shift_one_over l o in
-            let x = zero_init_calloced_memory zeroinit x t in
-            (* Strong update of scalar variable is possible if the variable is unique and size of written value matches size of blob being written to. *)
-            let do_strong_update =
-              begin match v with
-                | (Var var, _) ->
-                  let blob_size_opt = ID.to_int s in
-                  not @@ ask.is_multiple var
-                  && GobOption.exists (fun blob_size -> (* Size of blob is known *)
-                      (not @@ Cil.isVoidType t     (* Size of value is known *)
-                       && Z.equal blob_size (Z.of_int @@ Cil.alignOf_int t))
-                      || blob_destructive
-                    ) blob_size_opt
-                | _ -> false
-              end
-            in
-            if do_strong_update then
-              Blob ((do_update_offset ask x offs value exp l' o' v t), s, zeroinit)
-            else
-              mu (Blob (join x (do_update_offset ask x offs value exp l' o' v t), s, zeroinit))
+            match offs, value with
+            | `NoOffset, Blob (x2, s2, zeroinit2) -> mu (Blob (join x x2, ID.join s s2,ZeroInit.join zeroinit zeroinit2))
+            | _ ->
+              let l', o' = shift_one_over l o in
+              let x = zero_init_calloced_memory zeroinit x t in
+              (* Strong update of scalar variable is possible if the variable is unique and size of written value matches size of blob being written to. *)
+              let do_strong_update =
+                begin match v with
+                  | (Var var, _) ->
+                    let blob_size_opt = ID.to_int s in
+                    not @@ ask.is_multiple var
+                    && GobOption.exists (fun blob_size -> (* Size of blob is known *)
+                        (not @@ Cil.isVoidType t     (* Size of value is known *)
+                         && Z.equal blob_size (Z.of_int @@ Cil.alignOf_int t))
+                        || blob_destructive
+                      ) blob_size_opt
+                  | _ -> false
+                end
+              in
+              if do_strong_update then
+                Blob ((do_update_offset ask x offs value exp l' o' v t), s, zeroinit)
+              else
+                mu (Blob (join x (do_update_offset ask x offs value exp l' o' v t), s, zeroinit))
           end
         | Thread _, _ ->
           (* hack for pthread_t variables *)

--- a/tests/regression/13-privatized/95-mm-calloc.c
+++ b/tests/regression/13-privatized/95-mm-calloc.c
@@ -1,0 +1,28 @@
+// PARAM: --set ana.base.privatization mutex-meet
+#include<pthread.h>
+#include<stdlib.h>
+#include<stdio.h>
+struct a {
+  void (*b)();
+};
+
+int g = 0;
+
+struct a* t;
+void m() {
+  // Reachable!
+  g = 1;
+}
+
+void* j(void* arg) {};
+
+void main() {
+  pthread_t tid;
+  pthread_create(&tid, 0, j, NULL);
+  t = calloc(1, sizeof(struct a));
+  t->b = &m;
+  struct a r = *t;
+  r.b();
+
+  __goblint_check(g ==0); //UNKNOWN!
+}


### PR DESCRIPTION
**Recreates #1559 which at the time was only merged into the branch for my thesis.**

Otherwise, a publish lead to a Blob value being placed inside a zero-inited Blob, which lead to value Top inside the blob, which caused function calls to be lost.

See #1558 which shows how Goblint without this fix is unsound.