### PR TITLE
PrivPrecCompare: Add `bot_in_blob_leq_bot` so `bot` and `Blob(bot)` are considered equal

### DIFF
--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -561,7 +561,13 @@ struct
     | (_, Top) -> true
     | (Top, _) -> false
     | (Bot, _) -> true
-    | (_, Bot) -> false
+    | (x, Bot) ->
+      if !AnalysisState.bot_in_blob_leq_bot then
+        match x with
+        | Blob (x,s,o) -> leq x Bot
+        | _ -> false
+      else
+        false
     | (Int x, Int y) -> ID.leq x y
     | (Float x, Float y) -> FD.leq x y
     | (Int x, Address y) when ID.to_int x = Some Z.zero && not (AD.is_not_null y) -> true

--- a/src/common/framework/analysisState.ml
+++ b/src/common/framework/analysisState.ml
@@ -41,5 +41,6 @@ let unsound_both_branches_dead: bool option ref = ref None
 (** [Some true] if unsound both branches dead occurs in analysis results.
     [Some false] if it doesn't occur.
     [None] if [ana.dead-code.branches] option is disabled and this isn't checked. *)
+
 (* Comparison mode where blobs with bot content that are not zero-initalized are considered equivalent to top-level bot *)
 let bot_in_blob_leq_bot = ref false

--- a/src/common/framework/analysisState.ml
+++ b/src/common/framework/analysisState.ml
@@ -41,3 +41,5 @@ let unsound_both_branches_dead: bool option ref = ref None
 (** [Some true] if unsound both branches dead occurs in analysis results.
     [Some false] if it doesn't occur.
     [None] if [ana.dead-code.branches] option is disabled and this isn't checked. *)
+(* Comparison mode where blobs with bot content that are not zero-initalized are considered equivalent to top-level bot *)
+let bot_in_blob_leq_bot = ref false

--- a/src/privPrecCompare.ml
+++ b/src/privPrecCompare.ml
@@ -4,4 +4,5 @@ open Goblint_lib
 module A = PrecCompare.MakeDump (PrivPrecCompareUtil)
 
 let () =
+  AnalysisState.bot_in_blob_leq_bot := true;
   A.main ()


### PR DESCRIPTION
This was needed to not report spurious precision differences for the benchmarks in my thesis.
If we want this on the main branch, we can merge, otherwise we can close it.