### PR TITLE
Analysis of `pthread_barrier`s

### DIFF
--- a/src/analyses/pthreadBarriers.ml
+++ b/src/analyses/pthreadBarriers.ml
@@ -1,0 +1,43 @@
+(** Must have waited barriers for Pthread barriers ([pthreadBarriers]). *)
+
+open GoblintCil
+open Analyses
+module LF = LibraryFunctions
+
+module Spec =
+struct
+  module Barriers = SetDomain.ToppedSet (ValueDomain.Addr) (struct let topname = "All barriers" end)
+  module MustBarriers = Lattice.Reverse (Barriers)
+
+  include Analyses.IdentitySpec
+  module V = VarinfoV
+
+  let name () = "pthreadBarriers"
+  module D = Lattice.Prod (Barriers) (MustBarriers)
+
+  include Analyses.ValueContexts(D)
+
+  let possible_vinfos (a: Queries.ask) barrier =
+    Queries.AD.to_var_may (a.f (Queries.MayPointTo barrier))
+
+  let special man (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
+    let desc = LF.find f in
+    match desc.special arglist with
+    | BarrierWait barrier ->
+      let may, must = man.local in
+      let barriers = possible_vinfos (Analyses.ask_of_man man) barrier in
+      let may = List.fold_left (fun may a -> Barriers.add (ValueDomain.Addr.of_var a) may) may barriers in
+      let must = match barriers with
+      | [a] -> Barriers.add (ValueDomain.Addr.of_var a) must
+      | _ -> must
+      in
+      (may, must)
+    | _ -> man.local
+
+  let startstate v = (Barriers.empty (), Barriers.empty ())
+  let threadenter man ~multiple lval f args = [man.local]
+  let exitstate  v = (Barriers.empty (), Barriers.empty ())
+end
+
+let _ =
+  MCP.register_analysis (module Spec : MCPSpec)

--- a/src/cdomains/mHP.ml
+++ b/src/cdomains/mHP.ml
@@ -92,3 +92,8 @@ let may_happen_in_parallel one two =
     else
       true
   | _ -> true
+
+let may_be_non_unique_thread mhp =
+  match mhp.tid with
+  | `Lifted tid -> not (TID.is_unique tid)
+  | _ -> true

--- a/src/goblint_lib.ml
+++ b/src/goblint_lib.ml
@@ -129,6 +129,7 @@ module BasePriv = BasePriv
 module RelationPriv = RelationPriv
 module ThreadEscape = ThreadEscape
 module PthreadSignals = PthreadSignals
+module PthreadBarriers = PthreadBarriers
 module ExtractPthread = ExtractPthread
 
 (** {2 Longjmp}

--- a/src/util/library/libraryDesc.ml
+++ b/src/util/library/libraryDesc.ml
@@ -69,6 +69,8 @@ type special =
   | SemDestroy of Cil.exp
   | Wait of { cond: Cil.exp; mutex: Cil.exp; }
   | TimedWait of { cond: Cil.exp; mutex: Cil.exp; abstime: Cil.exp; (** Unused *) }
+  | BarrierWait of Cil.exp
+  | BarrierInit of { barrier: Cil.exp; count: Cil.exp; }
   | Math of { fun_args: math; }
   | Memset of { dest: Cil.exp; ch: Cil.exp; count: Cil.exp; }
   | Bzero of { dest: Cil.exp; count: Cil.exp; }

--- a/src/util/library/libraryFunctions.ml
+++ b/src/util/library/libraryFunctions.ml
@@ -520,6 +520,8 @@ let pthread_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("pthread_getspecific", unknown ~attrs:[InvalidateGlobals] [drop "key" []]);
     ("pthread_key_create", unknown [drop "key" [w]; drop "destructor" [s]]);
     ("pthread_key_delete", unknown [drop "key" [f]]);
+    ("pthread_barrier_init", special [__ "barrier" []; __ "attr" []; __ "count" []] @@ fun barrier attr count -> BarrierInit {barrier; count});
+    ("pthread_barrier_wait", special [__ "barrier" []] @@ fun barrier -> BarrierWait barrier);
     ("pthread_cancel", unknown [drop "thread" []]);
     ("pthread_testcancel", unknown []);
     ("pthread_setcancelstate", unknown [drop "state" []; drop "oldstate" [w]]);

--- a/tests/regression/82-barrier/01-simple.c
+++ b/tests/regression/82-barrier/01-simple.c
@@ -1,0 +1,34 @@
+// PARAM: --set ana.activated[+] 'pthreadBarriers'
+#include<pthread.h>
+#include<stdio.h>
+#include<unistd.h>
+
+int g;
+
+pthread_barrier_t barrier;
+
+void* f1(void* ptr) {
+    return NULL;
+}
+
+void* f2(void* ptr) {
+    return NULL;
+}
+
+int main(int argc, char const *argv[])
+{
+    pthread_barrier_init(&barrier, NULL, 2);
+    pthread_barrier_wait(&barrier);
+    
+    pthread_t t1;
+    pthread_t t2;
+
+    pthread_create(&t1,NULL,f1,NULL);
+    sleep(1);
+    pthread_create(&t2,NULL,f2,NULL);
+
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+
+    return 0;
+}

--- a/tests/regression/82-barrier/02-more.c
+++ b/tests/regression/82-barrier/02-more.c
@@ -7,13 +7,25 @@ int g;
 
 pthread_barrier_t barrier;
 
+void* f2(void* ptr) {
+    return NULL;
+}
+
+void* f1(void* ptr) {
+    pthread_barrier_wait(&barrier);
+
+    pthread_t t2;
+    pthread_create(&t2,NULL,f2,NULL);
+
+    return NULL;
+}
 
 int main(int argc, char const *argv[])
 {
     int top;
     int i = 0;
     
-    pthread_barrier_init(&barrier, NULL, 2);
+    pthread_barrier_init(&barrier, NULL, 3);
     
     if(top) {
         pthread_barrier_wait(&barrier);
@@ -22,5 +34,10 @@ int main(int argc, char const *argv[])
     }
 
     __goblint_check(i == 0);
+    pthread_t t1;
+
+
+    pthread_create(&t1,NULL,f1,NULL);
+
     return 0;
 }

--- a/tests/regression/82-barrier/02-more.c
+++ b/tests/regression/82-barrier/02-more.c
@@ -8,12 +8,14 @@ int g;
 pthread_barrier_t barrier;
 
 void* f2(void* ptr) {
+    pthread_barrier_wait(&barrier);
     return NULL;
 }
 
 void* f1(void* ptr) {
     pthread_barrier_wait(&barrier);
 
+    // This is past the barrier, so it will not be reached
     pthread_t t2;
     pthread_create(&t2,NULL,f2,NULL);
 
@@ -26,6 +28,9 @@ int main(int argc, char const *argv[])
     int i = 0;
     
     pthread_barrier_init(&barrier, NULL, 3);
+
+    pthread_t t1;
+    pthread_create(&t1,NULL,f1,NULL);
     
     if(top) {
         pthread_barrier_wait(&barrier);
@@ -33,11 +38,12 @@ int main(int argc, char const *argv[])
         i = 1;
     }
 
+    // Created too late to have any effect
+    pthread_t t2;
+    pthread_create(&t2,NULL,f1,NULL);
+
     __goblint_check(i == 0);
-    pthread_t t1;
 
-
-    pthread_create(&t1,NULL,f1,NULL);
 
     return 0;
 }

--- a/tests/regression/82-barrier/03-problem.c
+++ b/tests/regression/82-barrier/03-problem.c
@@ -7,18 +7,9 @@ int g;
 
 pthread_barrier_t barrier;
 
-void* f2(void* ptr) {
-    pthread_barrier_wait(&barrier);
-    return NULL;
-}
 
 void* f1(void* ptr) {
     pthread_barrier_wait(&barrier);
-
-    // This is past the barrier, so it will not be reached
-    pthread_t t2;
-    pthread_create(&t2,NULL,f2,NULL);
-
     return NULL;
 }
 
@@ -27,18 +18,18 @@ int main(int argc, char const *argv[])
     int top;
     int i = 0;
     
-    pthread_barrier_init(&barrier, NULL, 3);
+    pthread_barrier_init(&barrier, NULL, 2);
 
     pthread_t t1;
     pthread_create(&t1,NULL,f1,NULL);
     
     if(top) {
         pthread_barrier_wait(&barrier);
-        // Unreachable
+        // Live!
         i = 1;
     }
 
-    __goblint_check(i == 0);
+    __goblint_check(i == 0); //UNKNOWN!
 
 
     return 0;

--- a/tests/regression/82-barrier/04-challenge.c
+++ b/tests/regression/82-barrier/04-challenge.c
@@ -38,6 +38,10 @@ int main(int argc, char const *argv[])
         i = 1;
     }
 
+    // Created too late to have any effect
+    pthread_t t2;
+    pthread_create(&t2,NULL,f1,NULL);
+
     __goblint_check(i == 0);
 
 

--- a/tests/regression/82-barrier/05-mhp-not-enough.c
+++ b/tests/regression/82-barrier/05-mhp-not-enough.c
@@ -20,7 +20,6 @@ void* f1(void* ptr) {
 int main(int argc, char const *argv[])
 {
     int top;
-    int top2;
     int i = 0;
     
     pthread_barrier_init(&barrier, NULL, 3);

--- a/tests/regression/82-barrier/05-mhp-not-enough.c
+++ b/tests/regression/82-barrier/05-mhp-not-enough.c
@@ -7,17 +7,12 @@ int g;
 
 pthread_barrier_t barrier;
 
-void* f2(void* ptr) {
-    pthread_barrier_wait(&barrier);
-    return NULL;
-}
 
 void* f1(void* ptr) {
     pthread_barrier_wait(&barrier);
 
-    // This is past the barrier, so it will not be reached
-    pthread_t t2;
-    pthread_create(&t2,NULL,f2,NULL);
+    // This should not be reached as either main calls wait or the other thread is created
+    // -> In the concrete, there never are three threads calling wait
 
     return NULL;
 }
@@ -25,6 +20,7 @@ void* f1(void* ptr) {
 int main(int argc, char const *argv[])
 {
     int top;
+    int top2;
     int i = 0;
     
     pthread_barrier_init(&barrier, NULL, 3);
@@ -36,7 +32,11 @@ int main(int argc, char const *argv[])
         pthread_barrier_wait(&barrier);
         // Unreachable
         i = 1;
+    } else {
+        pthread_t t2;
+        pthread_create(&t2,NULL,f1,NULL);    
     }
+
 
     __goblint_check(i == 0);
 


### PR DESCRIPTION
Makes use of the $$||_{\\mathcal{A}}: \\mathcal{A} \to \\mathcal{A} \to \\{ \textsf{false},\top \\}$$ predicate we want to define for (abstract) digests to provide a sound basis for all of our MHP stuff for races and give a principled account of what I added in #518 .

Interestingly, it even does so outside of the context of data races --- which may be a cute insight on top of putting the race analysis on solid foundations with this predicate (and hopefully finding a way to get `pthread_once` to also fit (potentially in a reduced fashion)).

Technically, it accumulates the `capacity` and `MHP` information for all calls to `wait` for each barrier at a global unknown, and checks upon a call to `wait` that there are at least `min(capacity)-1` other accesses where $$||_{\\mathcal{A}}$$ is true pairwise among these, as well as with the caller to `wait`.

TODO:

- [x] Use TIDs and Joins
- [ ] Use further abstract digests (such as must-lockset digest)
- [ ] Use information also for excluding races (beyond unreachability)
- [ ] Come up with a less expensive algorithm for checking there are `min(capacity)-1` elements where $$||_{\\mathcal{A}}$$  holds pairwise



Closes #1651.