### PR TITLE
Update bash-completion for arg-complete 0.2.x, remove `Arg_complete.Rest_all_compat`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -58,7 +58,7 @@ Goblint includes analyses for assertions, overflows, deadlocks, etc and can be e
     (sha (>= 1.12))
     (fileutils (>= 0.6.4))
     cpu
-    arg-complete
+    (arg-complete (>= 0.2.1))
     (yaml (>= 3.0.0))
     uuidm
     catapult

--- a/goblint.opam
+++ b/goblint.opam
@@ -58,7 +58,7 @@ depends: [
   "sha" {>= "1.12"}
   "fileutils" {>= "0.6.4"}
   "cpu"
-  "arg-complete"
+  "arg-complete" {>= "0.2.1"}
   "yaml" {>= "3.0.0"}
   "uuidm"
   "catapult"

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -24,7 +24,7 @@ bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
   "angstrom" {= "0.16.0"}
   "apron" {= "v0.9.15"}
-  "arg-complete" {= "0.1.0"}
+  "arg-complete" {= "0.2.1"}
   "astring" {= "0.8.5"}
   "base-bigarray" {= "base"}
   "base-bytes" {= "base"}

--- a/scripts/bash-completion.sh
+++ b/scripts/bash-completion.sh
@@ -6,10 +6,27 @@
 # Permanent usage:
 #   Run: echo "source $(readlink -f .)/scripts/bash-completion.sh" >> ~/.bash_completion
 
+# Bypass = in COMP_WORDBREAKS (https://stackoverflow.com/a/57437406/854540)
+# Copied & modified from standard __ltrim_colon_completions
+__ltrim_equal_completions()
+{
+    if [[ $1 == *=* && $COMP_WORDBREAKS == *=* ]]; then
+        # Remove equal-word prefix from COMPREPLY items
+        local equal_word=${1%"${1##*=}"}
+        local i=${#COMPREPLY[*]}
+        while ((i-- > 0)); do
+            COMPREPLY[i]=${COMPREPLY[i]#"$equal_word"}
+        done
+    fi
+}
+
 _goblint ()
 {
     IFS=$'\n'
-    COMPREPLY=($(${COMP_WORDS[0]} --complete "${COMP_WORDS[@]:1:COMP_CWORD}"))
+    local words cword cur
+    _get_comp_words_by_ref -n = cur words cword # Bypass = in COMP_WORDBREAKS (https://stackoverflow.com/a/57437406/854540)
+    COMPREPLY=($(${words[0]} --complete "${words[@]:1:cword}"))
+    __ltrim_equal_completions "$cur" # Bypass = in COMP_WORDBREAKS (https://stackoverflow.com/a/57437406/854540)
 }
 
 complete -o default -F _goblint goblint
@@ -26,7 +43,10 @@ _regtest ()
             COMPREPLY=($(ls -1 tests/regression/${COMP_WORDS[1]}-* | sed -n -r 's/([0-9][0-9])-.*/\1/p' | grep "^${COMP_WORDS[2]}"))
             ;;
         *)
-            COMPREPLY=($($(dirname ${COMP_WORDS[0]})/goblint --complete "${COMP_WORDS[@]:3:COMP_CWORD}"))
+            local words cword cur
+            _get_comp_words_by_ref -n = cur words cword # Bypass = in COMP_WORDBREAKS (https://stackoverflow.com/a/57437406/854540)
+            COMPREPLY=($($(dirname ${words[0]})/goblint --complete "${words[@]:3:cword}"))
+            __ltrim_equal_completions "$cur" # Bypass = in COMP_WORDBREAKS (https://stackoverflow.com/a/57437406/854540)
             ;;
     esac
 }

--- a/src/maingoblint.ml
+++ b/src/maingoblint.ml
@@ -120,10 +120,9 @@ let rec option_spec_list: Arg_complete.speclist Lazy.t = lazy (
   ; "--html"               , Arg_complete.Unit (fun _ -> configure_html ()),""
   ; "--sarif"               , Arg_complete.Unit (fun _ -> configure_sarif ()),""
   ; "--compare_runs"       , Arg_complete.Tuple [Arg_complete.Set_string (tmp_arg, Arg_complete.empty); Arg_complete.String ((fun x -> set_auto "compare_runs" (sprintf "['%s','%s']" !tmp_arg x)), Arg_complete.empty)], ""
-  ; "--complete"           , Arg_complete.Rest_all_compat.spec (Lazy.force rest_all_complete), ""
+  ; "--complete"           , Arg_complete.Rest_all (complete, Arg_complete.empty_all), ""
   ] @ defaults_spec_list (* lowest priority *)
 )
-and rest_all_complete = lazy (Arg_complete.Rest_all_compat.create complete Arg_complete.empty_all)
 and complete args =
   Arg_complete.complete_argv args (Lazy.force option_spec_list) Arg_complete.empty
   |> List.iter print_endline; (* nosemgrep: print-not-logging *)
@@ -215,7 +214,6 @@ let parse_arguments () =
   let anon_arg = set_string "files[+]" in
   let arg_speclist = Arg_complete.arg_speclist (Lazy.force option_spec_list) in
   Arg.parse arg_speclist anon_arg "Look up options using 'goblint --help'.";
-  Arg_complete.Rest_all_compat.finish (Lazy.force rest_all_complete);
   begin match !writeconffile with
     | Some writeconffile ->
       GobConfig.write_file writeconffile;


### PR DESCRIPTION
`Arg_complete.Rest_all_compat` was necessary for OCaml < 4.12 support, but we require >= 4.14 now.

arg-complete 0.2.x handles some additional `Stdlib.Arg` and bash oddities, but they don't practically affect us.

### TODO
- [x] Wait for https://github.com/ocaml/opam-repository/pull/27364 merge.