### PR TITLE
Fix `fixpoint` option `ana.int.refinement` - loop was never executed

### DIFF
--- a/src/cdomain/value/cdomains/int/intDomTuple.ml
+++ b/src/cdomain/value/cdomains/int/intDomTuple.ml
@@ -265,7 +265,7 @@ module IntDomTupleImpl = struct
          let old_dt = !dt in
          List.iter (fun f -> dt := f !dt) (refine_functions ik);
          quit_loop := equal old_dt !dt;
-         if is_bot !dt then dt := bot_of ik; quit_loop := true;
+         if is_bot !dt then (dt := bot_of ik; quit_loop := true);
          if M.tracing then M.trace "cong-refine-loop" "old: %a, new: %a" pretty old_dt pretty !dt;
        done;
      | _ -> ()


### PR DESCRIPTION
While investigating #1671, @jerhard and i discovered that the option to refine int domains until a fixpoint is reached has been broken since the very beginning.

In the PR #260 adding refinement, commit https://github.com/goblint/analyzer/commit/1aee2eb26d8276cb41a920736ba086e3757e3dca added a special detection for bottom to ensure bottom values are normalized across all domains.

~~~Ocaml
if is_bot !dt then dt := bot_of ik; quit_loop := true;
~~~

There, parentheses are missing. Thus, the loop is always left after one iteration.