### PR TITLE
Change `Offset.MakeLattice.to_index` to return bytes, not bits

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -271,8 +271,8 @@ struct
           let n_offset = iDtoIdx n in
           begin match t with
             | Some t ->
-              let (f_offset_bits, _) = bitsOffset t (Field (f, NoOffset)) in
-              let f_offset = IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) (Z.of_int (f_offset_bits / 8)) in
+              let f_offset_bytes = Cilfacade.bytesOffsetOnly t (Field (f, NoOffset)) in
+              let f_offset = IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) (Z.of_int f_offset_bytes) in
               begin match IdxDom.(to_bool (eq f_offset (neg n_offset))) with
                 | Some true -> `NoOffset
                 | _ -> `Field (f, `Index (n_offset, `NoOffset))

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2286,8 +2286,7 @@ struct
       ID.of_int (Cilfacade.ptrdiff_ikind ()) (Z.of_int x)
     in
     let size_of_type_in_bytes typ =
-      let typ_size_in_bytes = (bitsSizeOf typ) / 8 in
-      intdom_of_int typ_size_in_bytes
+      intdom_of_int (Cilfacade.bytesSizeOf typ)
     in
     if points_to_heap_only man ptr then
       (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -278,7 +278,7 @@ struct
              M.warn "Size of lval dereference expression %a is bot. Out-of-bounds memory access may occur" d_exp e)
           | `Lifted es ->
             let casted_es = ID.cast_to (Cilfacade.ptrdiff_ikind ()) es in
-            let casted_offs = ID.div (ID.cast_to (Cilfacade.ptrdiff_ikind ()) offs_intdom) (ID.of_int (Cilfacade.ptrdiff_ikind ()) (Z.of_int 8)) in
+            let casted_offs = ID.cast_to (Cilfacade.ptrdiff_ikind ()) offs_intdom in
             let ptr_size_lt_offs =
               let one = intdom_of_int 1 in
               let casted_es = ID.sub casted_es one in

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -32,8 +32,7 @@ struct
     ID.of_int (Cilfacade.ptrdiff_ikind ()) (Z.of_int x)
 
   let size_of_type_in_bytes typ =
-    let typ_size_in_bytes = (bitsSizeOf typ) / 8 in
-    intdom_of_int typ_size_in_bytes
+    intdom_of_int (Cilfacade.bytesSizeOf typ)
 
   let rec exp_contains_a_ptr (exp:exp) =
     match exp with

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -148,8 +148,8 @@ struct
     | `NoOffset -> intdom_of_int 0
     | `Field (field, o) ->
       let field_as_offset = Field (field, NoOffset) in
-      let bits_offset, _size = GoblintCil.bitsOffset (TComp (field.fcomp, [])) field_as_offset in
-      let bytes_offset = intdom_of_int (bits_offset / 8) in
+      let bytes_offset = Cilfacade.bytesOffsetOnly (TComp (field.fcomp, [])) field_as_offset in
+      let bytes_offset = intdom_of_int bytes_offset in
       let remaining_offset = offs_to_idx field.ftype o in
       begin
         try ID.add bytes_offset remaining_offset

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -992,7 +992,7 @@ struct
                 not @@ ask.is_multiple var
                 && not @@ Cil.isVoidType t      (* Size of value is known *)
                 && GobOption.exists (fun blob_size -> (* Size of blob is known *)
-                    Z.equal blob_size (Z.of_int @@ Cil.bitsSizeOf (TComp (toptype, []))/8)
+                    Z.equal blob_size (Z.of_int @@ Cilfacade.bytesSizeOf (TComp (toptype, [])))
                   ) blob_size_opt
               | _ -> false
             in

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -14,8 +14,8 @@ struct
 
   let semantic_equal_mval ((v, o): t) ((v', o'): Mval.t): bool option =
     if CilType.Varinfo.equal v v' then (
-      let (index1, _) = GoblintCil.bitsOffset v.vtype (Offset.Z.to_cil o) in (* TODO: better way to compute this? as Z.t not int *)
-      let index2: IndexDomain.t = ValueDomain.Offs.to_index ~typ:v.vtype o' in (* TODO: is this bits or bytes? *)
+      let index1 = Cilfacade.bytesOffsetOnly v.vtype (Offset.Z.to_cil o) in (* TODO: better way to compute this? as Z.t not int *)
+      let index2: IndexDomain.t = ValueDomain.Offs.to_index ~typ:v.vtype o' in
       match IndexDomain.equal_to (Z.of_int index1) index2 with
       | `Eq -> Some true
       | `Neq -> Some false

--- a/src/common/util/cilfacade.ml
+++ b/src/common/util/cilfacade.ml
@@ -381,6 +381,12 @@ let typeSigBlendAttributes baseAttrs =
   typeSigAddAttrs contageous
 
 
+let bytesSizeOf t =
+  let bits = bitsSizeOf t in
+  assert (bits mod 8 = 0);
+  bits / 8
+
+
 (** {!Cil.mkCast} using our {!typeOf}. *)
 let mkCast ~(e: exp) ~(newt: typ) =
   let oldt =

--- a/src/common/util/cilfacade.ml
+++ b/src/common/util/cilfacade.ml
@@ -386,6 +386,11 @@ let bytesSizeOf t =
   assert (bits mod 8 = 0);
   bits / 8
 
+let bytesOffsetOnly t o =
+  let bits_offset, _ = bitsOffset t o in
+  assert (bits_offset mod 8 = 0);
+  bits_offset / 8
+
 
 (** {!Cil.mkCast} using our {!typeOf}. *)
 let mkCast ~(e: exp) ~(newt: typ) =


### PR DESCRIPTION
Follow-up to https://github.com/goblint/analyzer/pull/1676#discussion_r1954764094.
A TODO in `LockDomain` also anticipated this: `(* TODO: is this bits or bytes? *)`.

Fixes `Offset.MakeLattice.to_index` to return bytes instead of bits, as per documentation:
https://github.com/goblint/analyzer/blob/153ce288ada8ecf6d8276cae512e5ad58ef65d88/src/cdomain/value/cdomains/offset_intf.ml#L92-L96

Also extracts a few other similar utility functions for offsets and sizes in bytes, not bits. These now assert divisibility by 8 before doing so. Usually this is fine because points to bitfields are impossible.
However, `to_index` violates it in some memOutOfBounds bitfield tests because the analysis also refers to things accessed more directly, not just those whose addresses have been taken. To handle that, an interval from floor to ceil division is constructed.

Theoretically, doing it in bits is more precise than after having rounded to bytes, but I don't know if this has practical relevance.
The blind division by 8 from #1676 and others wouldn't have done it correctly either for bitfields spanning multiple bytes.