### PR TITLE
Ensure that `__goblint_check` does not affect memLeak analysis

### DIFF
--- a/src/analyses/memLeak.ml
+++ b/src/analyses/memLeak.ml
@@ -227,7 +227,7 @@ struct
       (* Upon a call to the "Abort" special function in the multi-threaded case, we give up and conservatively warn *)
       warn_for_multi_threaded_due_to_abort man;
       state
-    | Assert { exp; _ } ->
+    | Assert { exp; refine = true; _ } ->
       begin match man.ask (Queries.EvalInt exp) with
         | a when Queries.ID.is_bot a -> M.warn ~category:Assert "assert expression %a is bottom" d_exp exp
         | a ->

--- a/tests/regression/76-memleak/32-no-mem-leak-goblint-check.c
+++ b/tests/regression/76-memleak/32-no-mem-leak-goblint-check.c
@@ -1,8 +1,9 @@
 // PARAM: --set ana.activated[+] memLeak --set ana.malloc.unique_address_count 1
+#include <stdlib.h>
 #include <goblint.h>
 
 int main() {
     int *ptr = malloc(sizeof(int));
-    __goblint_check(ptr); // UNKNOWN
+    __goblint_check(ptr == 0); // FAIL
     free(ptr);
 }

--- a/tests/regression/76-memleak/32-no-mem-leak-goblint-check.c
+++ b/tests/regression/76-memleak/32-no-mem-leak-goblint-check.c
@@ -1,0 +1,8 @@
+// PARAM: --set ana.activated[+] memLeak --set ana.malloc.unique_address_count 1
+#include <goblint.h>
+
+int main() {
+    int *ptr = malloc(sizeof(int));
+    __goblint_check(ptr); // UNKNOWN
+    free(ptr);
+}

--- a/tests/regression/76-memleak/32-no-mem-leak-goblint-check.t
+++ b/tests/regression/76-memleak/32-no-mem-leak-goblint-check.t
@@ -1,0 +1,6 @@
+  $ goblint --set ana.activated[+] memLeak --set ana.malloc.unique_address_count 1 32-no-mem-leak-goblint-check.c
+  [Warning][Assert] Assertion "(int )ptr" is unknown. (32-no-mem-leak-goblint-check.c:6:5-6:25)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 5
+    dead: 0
+    total lines: 5

--- a/tests/regression/76-memleak/32-no-mem-leak-goblint-check.t
+++ b/tests/regression/76-memleak/32-no-mem-leak-goblint-check.t
@@ -1,5 +1,5 @@
   $ goblint --set ana.activated[+] memLeak --set ana.malloc.unique_address_count 1 32-no-mem-leak-goblint-check.c
-  [Warning][Assert] Assertion "(int )ptr" is unknown. (32-no-mem-leak-goblint-check.c:6:5-6:25)
+  [Error][Assert] Assertion "(unsigned long )ptr == (unsigned long )((int *)0)" will fail. (32-no-mem-leak-goblint-check.c:7:5-7:30)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 5
     dead: 0

--- a/tests/regression/76-memleak/dune
+++ b/tests/regression/76-memleak/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps (glob_files *.c)))


### PR DESCRIPTION
Fixes #1678