### PR TITLE
Extract generic `Spec` domain and context lifters

### DIFF
--- a/src/domain/lattice.ml
+++ b/src/domain/lattice.ml
@@ -145,7 +145,7 @@ struct
 end
 
 (* HAS SIDE-EFFECTS ---- PLEASE INSTANCIATE ONLY ONCE!!! *)
-module HConsed (Base:S) (Arg: sig val assume_idempotent: bool end) =
+module HConsed (Arg: sig val assume_idempotent: bool end) (Base:S) =
 struct
   include Printable.HConsed (Base)
 

--- a/src/domain/mapDomain.ml
+++ b/src/domain/mapDomain.ml
@@ -263,7 +263,7 @@ module HConsed (M: S) : S with
   type key = M.key and
   type value = M.value =
 struct
-  include Lattice.HConsed (M) (struct let assume_idempotent = false end)
+  include Lattice.HConsed (struct let assume_idempotent = false end) (M)
 
   type key = M.key
   type value = M.value

--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -101,7 +101,7 @@ struct
 end
 
 (** Lifts a [Spec] so that the domain is [Hashcons]d *)
-module HashconsLifter (S: Spec) =
+module HashconsLifter (S: Spec) = (* keep functor eta-expanded to look up option when lifter is actually used *)
 struct
   module HConsedArg =
   struct
@@ -109,8 +109,8 @@ struct
     (* see https://github.com/goblint/analyzer/issues/1005 *)
     let assume_idempotent = GobConfig.get_string "ana.int.refinement" = "never"
   end
-  module F (L: Lattice.S) = Lattice.HConsed (L) (HConsedArg)
-  include DomainLifter (F) (S)
+
+  include DomainLifter (Lattice.HConsed (HConsedArg)) (S)
 end
 
 module type PrintableLifter =

--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -36,7 +36,7 @@ struct
 
   let name () = N.lift_name (S.name ())
 
-  type marshal = S.marshal (* TODO: should hashcons table be in here to avoid relift altogether? *)
+  type marshal = S.marshal
   let init = S.init
   let finalize = S.finalize
 
@@ -120,6 +120,8 @@ struct
   end
 
   include DomainLifter (NameLifter) (Lattice.HConsed (HConsedArg)) (S)
+
+  (* TODO: should marshal hashcons table to avoid relift altogether? *)
 end
 
 module type PrintableLifter =
@@ -145,7 +147,7 @@ struct
 
   let name () = N.lift_name (S.name ())
 
-  type marshal = S.marshal (* TODO: should hashcons table be in here to avoid relift altogether? *)
+  type marshal = S.marshal
   let init = S.init
   let finalize = S.finalize
 
@@ -214,6 +216,7 @@ end
 
 (** Lifts a [Spec] so that the context is [Hashcons]d. *)
 module HashconsContextLifter = ContextLifter (struct let lift_name s = s ^ " context hashconsed" end) (Printable.HConsed)
+(* TODO: should marshal hashcons table to avoid relift altogether? *)
 
 (** Lifts a [Spec] so that the context is [HashCached]. *)
 module HashCachedContextLifter = ContextLifter (struct let lift_name s = s ^ " context hashcached" end) (Printable.HashCached)


### PR DESCRIPTION
So far the only lifters of this kind have been for hashconsing, but others have been proposed:
1. #1690
2. #1483
3. #1484

They share a lot of the boilerplate which maybe could be avoided like this.
I'd wait for #1690 to be merged to see if this is actually general enough.