### PR TITLE
Relational: Assert type bounds after `branch`

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -272,6 +272,8 @@ struct
         RD.assert_inv ask rel' e' (not b) (no_overflow ask e)
       )
     in
+    let vars = Basetype.CilExp.get_vars e |> List.unique ~eq:CilType.Varinfo.equal |> List.filter RD.Tracked.varinfo_tracked in
+    let res = List.fold_left (assert_type_bounds ask) res vars in
     if RD.is_bot_env res then raise Deadcode;
     {st with rel = res}
 

--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -269,11 +269,11 @@ struct
     let ask = Analyses.ask_of_man man in
     let res = assign_from_globals_wrapper ask man.global st e (fun rel' e' ->
         (* not an assign, but must remove g#in-s still *)
-        RD.assert_inv ask rel' e' (not b) (no_overflow ask e)
+        let r = RD.assert_inv ask rel' e' (not b) (no_overflow ask e) in
+        let vars = Basetype.CilExp.get_vars e' |> List.unique ~eq:CilType.Varinfo.equal |> List.filter (fun v -> RD.Tracked.varinfo_tracked v)  in
+        List.fold_left (assert_type_bounds ask) r vars
       )
     in
-    let vars = Basetype.CilExp.get_vars e |> List.unique ~eq:CilType.Varinfo.equal |> List.filter RD.Tracked.varinfo_tracked in
-    let res = List.fold_left (assert_type_bounds ask) res vars in
     if RD.is_bot_env res then raise Deadcode;
     {st with rel = res}
 

--- a/tests/regression/24-octagon/18-dead.c
+++ b/tests/regression/24-octagon/18-dead.c
@@ -1,0 +1,23 @@
+//SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
+// NOCRASH (was arithmetic on bottom)
+int main(void)
+{
+    int a;
+    unsigned short b;
+    int tmp;
+
+    b = (unsigned short )a;
+
+    if ((int )b + (int )b < (int )b) {
+
+        tmp = (int )b;
+        b += 1;
+
+        if (! tmp) {
+           tmp = 1;
+        }
+
+    }
+
+    return 0;
+}


### PR DESCRIPTION
After branches, it pays off to check that computed constraints remain consistent with type-bounds. 

This closes #1697 where this issue manifested as a `both branches dead` message. The test is for an equivalent `arithmetic on integer bot` case.