### PR TITLE
Relational: Assert type bounds after `assign` & Fix loop tests

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -256,8 +256,9 @@ struct
             if M.tracing then M.traceli "relation" "assign inner %a = %a (%a)" CilType.Varinfo.pretty v d_exp e' d_plainexp e';
             if M.tracing then M.trace "relation" "st: %a" RD.pretty apr';
             let r = RD.assign_exp ask apr' (RV.local v) e' (no_overflow ask simplified_e) in
-            if M.tracing then M.traceu "relation" "-> %a" RD.pretty r;
-            r
+            let r' = assert_type_bounds ask r v in
+            if M.tracing then M.traceu "relation" "-> %a" RD.pretty r';
+            r'
           )
       )
     in

--- a/tests/regression/24-octagon/18-dead.c
+++ b/tests/regression/24-octagon/18-dead.c
@@ -1,0 +1,23 @@
+//SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
+// NOCRASH (was arithmetic on bottom)
+int main(void)
+{
+    int a;
+    unsigned short b;
+    int tmp;
+
+    b = (unsigned short )a;
+
+    if ((int )b + (int )b < (int )b) {
+
+        tmp = (int )b;
+        b += 1;
+
+        if (! tmp) {
+           tmp = 1;
+        }
+
+    }
+
+    return 0;
+}

--- a/tests/regression/78-termination/01-simple-loop-terminating.c
+++ b/tests/regression/78-termination/01-simple-loop-terminating.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int i = 1;
+  unsigned int i = 1;
 
   while (i <= 10)
   {

--- a/tests/regression/78-termination/03-nested-loop-terminating.c
+++ b/tests/regression/78-termination/03-nested-loop-terminating.c
@@ -3,9 +3,9 @@
 
 int main()
 {
-  int rows = 3;
-  int columns = 4;
-  int i = 1;
+  unsigned int rows = 3;
+  unsigned int columns = 4;
+  unsigned int i = 1;
 
   // Outer while loop for rows
   while (i <= rows)

--- a/tests/regression/78-termination/04-nested-loop-nonterminating.c
+++ b/tests/regression/78-termination/04-nested-loop-nonterminating.c
@@ -7,7 +7,7 @@ int main()
 
   while (outerCount <= 3)
   {
-    int innerCount = 1;
+    unsigned int innerCount = 1;
 
     while (1) // NONTERMLOOP termination analysis shall mark beginning of while as non-terminating loop
     {

--- a/tests/regression/78-termination/05-for-loop-terminating.c
+++ b/tests/regression/78-termination/05-for-loop-terminating.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int i;
+  unsigned int i;
 
   for (i = 1; i <= 10; i++)
   {

--- a/tests/regression/78-termination/07-nested-for-loop-terminating.c
+++ b/tests/regression/78-termination/07-nested-for-loop-terminating.c
@@ -3,8 +3,8 @@
 
 int main()
 {
-  int rows = 3;
-  int columns = 4;
+  unsigned int rows = 3;
+  unsigned int columns = 4;
 
   // Nested loop to iterate over rows and columns
   for (int i = 1; i <= rows; i++)

--- a/tests/regression/78-termination/08-nested-for-loop-nonterminating.c
+++ b/tests/regression/78-termination/08-nested-for-loop-nonterminating.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int outerCount, innerCount;
+  unsigned int outerCount, innerCount;
 
   for (outerCount = 1; outerCount <= 3; outerCount++)
   {

--- a/tests/regression/78-termination/09-complex-for-loop-terminating.c
+++ b/tests/regression/78-termination/09-complex-for-loop-terminating.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 int loops0(){
-  int i, j, k;
+  unsigned int i, j, k;
 
   // Outer loop
   for (i = 1; i <= 5; i++)
@@ -36,7 +36,7 @@ int loops0(){
 }
 
 int loops1(){
-  int i, j, k;
+  unsigned int i, j, k;
 
   // Loop with conditions
   for (i = 1; i <= 10; i++)
@@ -81,7 +81,7 @@ int loops1(){
   printf("\n");
 
   // Loop with multiple variables
-  int a, b, c;
+  unsigned int a, b, c;
   for (a = 1, b = 2, c = 3; a <= 10; a++, b += 2, c += 3)
   {
     printf("%d %d %d\n", a, b, c);

--- a/tests/regression/78-termination/10-complex-loop-terminating.c
+++ b/tests/regression/78-termination/10-complex-loop-terminating.c
@@ -3,9 +3,9 @@
 #include <stdio.h>
 
 int loops0(){
-  int i = 1;
-  int j = 1;
-  int k = 5;
+  unsigned int i = 1;
+  unsigned int j = 1;
+  unsigned int k = 5;
 
   // Outer while loop
   while (i <= 5)
@@ -84,9 +84,9 @@ int loops0(){
 
 int loops1()
 {
-  int i = 1;
-  int j = 1;
-  int k = 5;
+  unsigned int i = 1;
+  unsigned int j = 1;
+  unsigned int k = 5;
 
   // Outer while loop
   while (i <= 5)
@@ -145,9 +145,9 @@ int loops1()
 }
 
 int loops2(){
-  int i = 1;
-  int j = 1;
-  int k = 5;
+  unsigned int i = 1;
+  unsigned int j = 1;
+  unsigned int k = 5;
 
   // Loop with nested conditions
   i = 1;
@@ -197,9 +197,9 @@ int loops2(){
   printf("\n");
 
   // Loop with multiple variables
-  int a = 1;
-  int b = 2;
-  int c = 3;
+  unsigned int a = 1;
+  unsigned int b = 2;
+  unsigned int c = 3;
   while (a <= 10)
   {
     printf("%d %d %d\n", a, b, c);

--- a/tests/regression/78-termination/12-do-while-instant-terminating.c
+++ b/tests/regression/78-termination/12-do-while-instant-terminating.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int i = 0;
+  unsigned int i = 0;
 
   do
   {

--- a/tests/regression/78-termination/13-do-while-terminating.c
+++ b/tests/regression/78-termination/13-do-while-terminating.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int i = 1;
+  unsigned int i = 1;
 
   do
   {

--- a/tests/regression/78-termination/14-do-while-nonterminating.c
+++ b/tests/regression/78-termination/14-do-while-nonterminating.c
@@ -3,12 +3,14 @@
 
 int main()
 {
-  int i = 1;
+  unsigned int i = 1;
 
   do
   {
     printf("Inside the do-while loop\n");
     i++;
+
+    if(i ==0) {i = 2;}
   } while (i >= 2); // NONTERMLOOP termination analysis shall mark while as non-terminating loop
 
   printf("Exited the loop\n");

--- a/tests/regression/78-termination/15-complex-loop-combination-terminating.c
+++ b/tests/regression/78-termination/15-complex-loop-combination-terminating.c
@@ -4,7 +4,7 @@
 
 int non_nested_loops(){
   // Non-nested loops
-  int i;
+  unsigned int i;
 
   // for loop
   for (i = 1; i <= 10; i++)
@@ -13,7 +13,7 @@ int non_nested_loops(){
   }
 
   // while loop
-  int j = 1;
+  unsigned int j = 1;
   while (j <= 10)
   {
     printf("While loop iteration: %d\n", j);
@@ -21,7 +21,7 @@ int non_nested_loops(){
   }
 
   // do-while loop
-  int k = 1;
+  unsigned int k = 1;
   do
   {
     printf("Do-While loop iteration: %d\n", k);
@@ -30,9 +30,9 @@ int non_nested_loops(){
   return 0;
 }
 
-int nested_loops(){
+int nested_loops1(){
    // Nested loops
-  int a, b;
+  unsigned int a, b;
 
   // Nested for and while loop
   for (a = 1; a <= 5; a++)
@@ -44,12 +44,14 @@ int nested_loops(){
       c++;
     }
   }
+}
 
+int nested_loops2(){
   // Nested while and do-while loop
-  int x = 1;
+  unsigned int x = 1;
   while (x <= 5)
   {
-    int y = 1;
+    unsigned int y = 1;
     do
     {
       printf("Nested While-Do-While loop: %d\n", y);
@@ -57,9 +59,11 @@ int nested_loops(){
     } while (y <= x);
     x++;
   }
+}
 
+int nested_loops3(){
   // Nested do-while and for loop
-  int p = 1;
+  unsigned int p = 1;
   do
   {
     for (int q = 1; q <= p; q++)
@@ -72,10 +76,10 @@ int nested_loops(){
 }
 
 int nested_while_loop_with_break(){
-  int m;
+  unsigned int m;
 
   // Nested while loop with a break statement
-  int n = 1;
+  unsigned int n = 1;
   while (n <= 5)
   {
     printf("Outer While loop iteration: %d\n", n);
@@ -96,7 +100,7 @@ int nested_while_loop_with_break(){
 
 int nested_loop_with_conditions(){
   // Loop with nested conditions
-  for (int v = 1; v <= 10; v++)
+  for (unsigned int v = 1; v <= 10; v++)
   {
     printf("Loop with Nested Conditions: %d - ", v);
     if (v < 5)
@@ -117,7 +121,9 @@ int nested_loop_with_conditions(){
 int main()
 {
   non_nested_loops();
-  nested_loops();
+  nested_loops1();
+  nested_loops2();
+  nested_loops3();
   // Additional nested loops
   nested_while_loop_with_break();
   nested_loop_with_conditions();

--- a/tests/regression/78-termination/16-nested-loop-nontrivial-nonterminating.c
+++ b/tests/regression/78-termination/16-nested-loop-nontrivial-nonterminating.c
@@ -3,11 +3,11 @@
 
 int main()
 {
-  int outerCount = 1;
+  unsigned int outerCount = 1;
 
   while (outerCount <= 3)
   {
-    int innerCount = 1;
+    unsigned int innerCount = 1;
 
     while (outerCount < 3 || innerCount > 0) // NONTERMLOOP termination analysis shall mark beginning of while as non-terminating loop
     {

--- a/tests/regression/78-termination/17-goto-terminating.c
+++ b/tests/regression/78-termination/17-goto-terminating.c
@@ -4,7 +4,7 @@
 
 int main()
 {
-  int num = 1;
+  unsigned int num = 1;
 
 loop:
   printf("Current number: %d\n", num);

--- a/tests/regression/78-termination/18-goto-nonterminating.c
+++ b/tests/regression/78-termination/18-goto-nonterminating.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int num = 1;
+  unsigned int num = 1;
 
 loop:
   printf("Current number: %d\n", num);

--- a/tests/regression/78-termination/19-rand-terminating.c
+++ b/tests/regression/78-termination/19-rand-terminating.c
@@ -11,7 +11,7 @@ int main()
   if (rand())
   {
     // Loop inside the if part
-    for (int i = 1; i <= 5; i++)
+    for (unsigned int i = 1; i <= 5; i++)
     {
       printf("Loop inside if part: %d\n", i);
     }
@@ -19,7 +19,7 @@ int main()
   else
   {
     // Loop inside the else part
-    int j = 1;
+    unsigned int j = 1;
     while (j <= 5)
     {
       printf("Loop inside else part: %d\n", j);

--- a/tests/regression/78-termination/20-rand-nonterminating.c
+++ b/tests/regression/78-termination/20-rand-nonterminating.c
@@ -11,7 +11,7 @@ int main()
   if (rand())
   {
     // Loop inside the if part
-    for (int i = 1; i >= 0; i++) // NONTERMLOOP termination analysis shall mark beginning of while as non-terminating loop
+    for (unsigned int i = 1; i >= 0; i++) // NONTERMLOOP termination analysis shall mark beginning of while as non-terminating loop
     {
       printf("Loop inside if part: %d\n", i);
     }

--- a/tests/regression/78-termination/21-no-exit-on-rand-unproofable.c
+++ b/tests/regression/78-termination/21-no-exit-on-rand-unproofable.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int forever, i = 0;
+  unsigned int forever, i = 0;
 
   // This loop is not provable, therefore it should throw a warning
   while (i < 4 || forever == 1) // NONTERMLOOP termination analysis shall mark beginning of while as non-terminating loop

--- a/tests/regression/78-termination/22-exit-on-rand-unproofable.c
+++ b/tests/regression/78-termination/22-exit-on-rand-unproofable.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int forever = 1;
+  unsigned int forever = 1;
 
   // This loop is not provable, therefore it should throw a warning
   while (forever == 1) // NONTERMLOOP termination analysis shall mark beginning of while as non-terminating loop

--- a/tests/regression/78-termination/23-exit-on-rand-terminating.c
+++ b/tests/regression/78-termination/23-exit-on-rand-terminating.c
@@ -4,7 +4,7 @@
 
 int main()
 {
-  int short_run, i = 0;
+  unsigned int short_run, i = 0;
   // Currently not able to detect this as terminating due to multiple conditions
   while (i < 90 && short_run != 1)
   {

--- a/tests/regression/78-termination/25-leave-loop-goto-terminating.c
+++ b/tests/regression/78-termination/25-leave-loop-goto-terminating.c
@@ -1,9 +1,9 @@
-// SKIP TERM PARAM: --set "ana.activated[+]" termination --set ana.activated[+] apron --enable ana.int.interval --set ana.apron.domain polyhedra
+// SKIP TODO TERM PARAM: --set "ana.activated[+]" termination --set ana.activated[+] apron --enable ana.int.interval --set ana.apron.domain polyhedra
 #include <stdio.h>
 
 int main()
 {
-  int counter = 0;
+  unsigned int counter = 0;
 
   while (1)
   {

--- a/tests/regression/78-termination/26-enter-loop-goto-terminating.c
+++ b/tests/regression/78-termination/26-enter-loop-goto-terminating.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int counter = 0;
+  unsigned int counter = 0;
 
   goto jump_point;
 
@@ -13,7 +13,7 @@ int main()
 
     // Dummy code
     printf("Iteration %d\n", counter);
-    int result = counter * 2;
+    unsigned int result = counter * 2;
   jump_point:
     printf("Result: %d\n", result);
 

--- a/tests/regression/78-termination/28-do-while-continue-terminating.c
+++ b/tests/regression/78-termination/28-do-while-continue-terminating.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int i = 1;
+  unsigned int i = 1;
 
   do
   {

--- a/tests/regression/78-termination/29-do-while-continue-nonterminating.c
+++ b/tests/regression/78-termination/29-do-while-continue-nonterminating.c
@@ -3,12 +3,14 @@
 
 int main()
 {
-  int i = 1;
+  unsigned int i = 1;
 
   do
   {
     printf("Inside the do-while loop\n");
     i++;
+
+    if(i ==0) {i = 2;}
 
     if (i % 2)
     {

--- a/tests/regression/78-termination/30-goto-out-of-inner-loop-terminating.c
+++ b/tests/regression/78-termination/30-goto-out-of-inner-loop-terminating.c
@@ -3,14 +3,14 @@
 
 int main()
 {
-  int rows = 5;
-  int columns = 5;
+  unsigned int rows = 5;
+  unsigned int columns = 5;
 
   // Outer loop for rows
-  for (int i = 1; i <= rows; i++)
+  for (unsigned int i = 1; i <= rows; i++)
   {
     // Inner loop for columns
-    for (int j = 1; j <= columns; j++)
+    for (unsigned int j = 1; j <= columns; j++)
     {
       if (j == 3)
       {

--- a/tests/regression/78-termination/31-goto-out-of-inner-loop-nonterminating.c
+++ b/tests/regression/78-termination/31-goto-out-of-inner-loop-nonterminating.c
@@ -7,7 +7,7 @@ int main()
   int columns = 5;
 
   // Outer loop for rows
-  for (int i = 1; 1; i++) // NONTERMLOOP termination analysis shall mark beginning of for as non-terminating loop
+  for (unsigned int i = 1; 1; i++) // NONTERMLOOP termination analysis shall mark beginning of for as non-terminating loop
   {
     // Inner loop for columns
     for (int j = 1; j <= columns; j++)

--- a/tests/regression/78-termination/34-nested-for-loop-nonterminating.c
+++ b/tests/regression/78-termination/34-nested-for-loop-nonterminating.c
@@ -3,11 +3,11 @@
 
 int main()
 {
-  int outerCount, innerCount;
+  unsigned int outerCount, innerCount;
 
   for (outerCount = 1; outerCount <= 3; outerCount++)
   {
-    for (innerCount = 1; innerCount > 0; innerCount++) // NONTERMLOOP termination analysis shall mark beginning of for as non-terminating loop
+    for (innerCount = 1; innerCount > 0; innerCount += 4) // NONTERMLOOP termination analysis shall mark beginning of for as non-terminating loop
     {
       printf("(%d, %d) ", outerCount, innerCount);
     }

--- a/tests/regression/78-termination/35-goto-out-of-inner-loop-with-print-terminating.c
+++ b/tests/regression/78-termination/35-goto-out-of-inner-loop-with-print-terminating.c
@@ -3,14 +3,14 @@
 
 int main()
 {
-  int rows = 5;
-  int columns = 5;
+  unsigned int rows = 5;
+  unsigned int columns = 5;
 
   // Outer loop for rows
-  for (int i = 1; i <= rows; i++)
+  for (unsigned int i = 1; i <= rows; i++)
   {
     // Inner loop for columns
-    for (int j = 1; j <= columns; j++)
+    for (unsigned int j = 1; j <= columns; j++)
     {
       if (j == 3)
       {

--- a/tests/regression/78-termination/40-multi-expression-conditions-terminating.c
+++ b/tests/regression/78-termination/40-multi-expression-conditions-terminating.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-  int i;
+  unsigned int i;
 
   // Loop with complex conditions
   for (i = 1; i <= 10; i++)
@@ -28,7 +28,7 @@ int main()
   printf("\n");
 
   // Loop with multiple conditions
-  int s = 1;
+  unsigned int s = 1;
   while (s <= 10 && s % 2 == 0) // CIL defines new jump labels to default location (-1)
   {
     printf("Loop with Multiple Conditions: %d\n", s);
@@ -36,7 +36,7 @@ int main()
   }
 
   // Loop with multiple variables
-  int t, u;
+  unsigned int t, u;
   for (t = 1, u = 10; t <= 5 && u >= 5; t++, u--) // CIL defines new jump labels to default location (-1)
   {
     printf("Loop with Multiple Variables: %d %d\n", t, u);

--- a/tests/regression/78-termination/41-for-continue-terminating.c
+++ b/tests/regression/78-termination/41-for-continue-terminating.c
@@ -4,7 +4,7 @@
 int main()
 {
   // Loop with a continue statement
-  for (int i = 1; i <= 10; i++)
+  for (unsigned int i = 1; i <= 10; i++)
   {
     if (i % 2 == 0)
     {
@@ -16,7 +16,7 @@ int main()
 
 
   // Loop with a continue statement
-  for (int r = 1; r <= 10; r++)
+  for (unsigned int r = 1; r <= 10; r++)
   {
     if (r % 3 == 0)
     {

--- a/tests/regression/78-termination/43-return-from-endless-loop-terminating.c
+++ b/tests/regression/78-termination/43-return-from-endless-loop-terminating.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 
 int main() {
-  int i = 1;
+  unsigned int i = 1;
 
   while (i != 0) {
     printf("%d\n", i);

--- a/tests/regression/78-termination/50-decreasing-signed-int.c
+++ b/tests/regression/78-termination/50-decreasing-signed-int.c
@@ -1,9 +1,9 @@
 // SKIP TERM PARAM: --set "ana.activated[+]" termination --set ana.activated[+] apron --enable ana.int.interval --set ana.apron.domain octagon
 int main()
 {
-	int x;
+	unsigned int x;
 
-	if(x <= 0){
+	if(x == 0){
 		return 0;
 	}
 	while (x > 0) {


### PR DESCRIPTION
**This is an alternative fix to #1697 that we could consider instead of #1698 (I prefer it to #1698 in fact).**

Compared to that one, the difference is that, instead of after an `assert`, type bounds are asserted after an `assign`, which maybe is the more logical place to do it, as the assert should simply not lose the bounds but needn't establish new ones.

This precision improvement then raises the following pre-existing issue: Our termination analysis assumes signed overflows do not happen (this is, e.g., an assumption one can make for `SV-COMP` as programs there contain no UB).

However, this means it is trivial for our analysis to establish that any loop over an `int` which is increased in each iteration terminates.

~~~C
int i = 0; 
while(1) {
 i++;
}
~~~ 

is found to terminate as the inserted iteration counter is established to be equal to `i`, and `i` itself is "bounded" by `MAX_INT`. This issue is already there before this PR.
However, with this PR, most termination regression tests are found to be trivial, and some are incorrect. Thus, most of them are changed to iterate over `unsigned` types here.