### PR TITLE
Fix refinement in `baseInvariant` for more complicated lvals

### DIFF
--- a/tests/regression/03-practical/36-struct-ptr.c
+++ b/tests/regression/03-practical/36-struct-ptr.c
@@ -1,21 +1,20 @@
 #include <goblint.h>
 struct aws_al {
 	unsigned long current_size;
-  };
+};
 
-  struct aws_pq {
-	  int pred;
-	  struct aws_al container;
-  };
+struct aws_pq {
+	int pred;
+	struct aws_al container;
+};
 
-  int main() {
+int main() {
 	struct aws_pq queue = { 0, { 0}};
 	struct aws_al *const list = &queue.container;
 
 	if (list->current_size == 0UL) {
-		if (list->current_size == 0UL)
-		{
+		if (list->current_size == 0UL) {
 			__goblint_check(1); //REACHABLE
 		}
 	}
-  }
+}

--- a/tests/regression/03-practical/36-struct-ptr.c
+++ b/tests/regression/03-practical/36-struct-ptr.c
@@ -1,0 +1,21 @@
+#include <goblint.h>
+struct aws_al {
+	unsigned long current_size;
+  };
+
+  struct aws_pq {
+	  int pred;
+	  struct aws_al container;
+  };
+
+  int main() {
+	struct aws_pq queue = { 0, { 0}};
+	struct aws_al *const list = &queue.container;
+
+	if (list->current_size == 0UL) {
+		if (list->current_size == 0UL)
+		{
+			__goblint_check(1); //REACHABLE
+		}
+	}
+  }


### PR DESCRIPTION
This is a follow-up to #1659 which was incorrect as demonstrated by the nightly SV-COMP run.

The offset handling was slightly off there, leading to points-to sets becoming empty when they should not. The correct thing is to:

- From an `Mem (Lval lv), off` pair, take the `Lval lv` part (including any possible offsets it may have), and consider all the values of those separately  by
    - Refining the value for `Lval lv` in base
    - Evaluating `Mem (Lval lv), off` w.r.t. to this new state (for technical reasons computed by appending off to the value of `Lval lv` - queries use stale values).
    - Setting the result to the meet, resp. raise Deadcode if it is `bot`.
    
 I did not test all cases, but the unsoundness is fixed and all the `BothBranchesDead` ones I tested as well, so I would suggest to merge this right away, as the current state is broken.