### PR TITLE
Add bash completion for array element addition and removal

### DIFF
--- a/src/config/options.ml
+++ b/src/config/options.ml
@@ -24,7 +24,7 @@ let rec element_paths (element: element): string list =
   | Number _ ->
     [""]
   | Monomorphic_array _ ->
-    [""; "[+]"; "[-]"]
+    [""; "[+]"; "[-]"; "[*]"]
   | Object object_specs ->
     List.concat_map (fun (name, field_element, _, _) ->
         List.map (fun path -> "." ^ name ^ path) (element_paths field_element)
@@ -56,7 +56,7 @@ let rec element_completions (element: element): (string * string list) list =
       element_completions array_element
       |> List.concat_map (fun (path, cs) ->
           assert (path = ""); (* Arrays of objects/arrays not supported. Currently we only have arrays of strings.*)
-          [("[+]", cs); ("[-]", cs)]
+          [("[+]", cs); ("[-]", cs); ("[*]", cs)]
         )
     in
     default_completion () @ array_element_completions

--- a/src/config/options.ml
+++ b/src/config/options.ml
@@ -21,12 +21,13 @@ let rec element_paths (element: element): string list =
   | String _
   | Boolean
   | Integer _
-  | Number _
-  | Monomorphic_array _ ->
+  | Number _ ->
     [""]
+  | Monomorphic_array _ ->
+    [""; "[+]"; "[-]"]
   | Object object_specs ->
     List.concat_map (fun (name, field_element, _, _) ->
-        List.map (fun path -> name ^ "." ^ path) (element_paths field_element)
+        List.map (fun path -> "." ^ name ^ path) (element_paths field_element)
       ) object_specs.properties
   | _ ->
     Logs.Format.error "%a" Json_schema.pp (create element);
@@ -34,7 +35,7 @@ let rec element_paths (element: element): string list =
 
 let schema_paths (schema: schema): string list =
   element_paths (root schema)
-  |> List.map BatString.rchop (* remove trailing '.' *)
+  |> List.map BatString.lchop (* remove first '.' *)
 
 let paths = schema_paths schema
 
@@ -48,9 +49,17 @@ let rec element_completions (element: element): (string * string list) list =
   in
   match element.kind with
   | Integer _
-  | Number _
-  | Monomorphic_array _ ->
+  | Number _ ->
     default_completion ()
+  | Monomorphic_array (array_element, array_specs) ->
+    let array_element_completions =
+      element_completions array_element
+      |> List.concat_map (fun (path, cs) ->
+          assert (path = ""); (* Arrays of objects/arrays not supported. Currently we only have arrays of strings.*)
+          [("[+]", cs); ("[-]", cs)]
+        )
+    in
+    default_completion () @ array_element_completions
   | Boolean ->
     [("", ["false"; "true"])]
   | String string_specs ->
@@ -68,7 +77,7 @@ let rec element_completions (element: element): (string * string list) list =
     end
   | Object object_specs ->
     List.concat_map (fun (name, field_element, _, _) ->
-        List.map (fun (path, cs) -> (name ^ "." ^ path, cs)) (element_completions field_element)
+        List.map (fun (path, cs) -> ("." ^ name ^ path, cs)) (element_completions field_element)
       ) object_specs.properties
   | _ ->
     Logs.Format.error "%a" Json_schema.pp (create element);
@@ -76,7 +85,7 @@ let rec element_completions (element: element): (string * string list) list =
 
 let schema_completions (schema: schema): (string * string list) list =
   element_completions (root schema)
-  |> List.map (BatTuple.Tuple2.map1 BatString.rchop) (* remove trailing '.' *)
+  |> List.map (BatTuple.Tuple2.map1 BatString.lchop) (* remove first '.' *)
 
 let completions = schema_completions schema
 


### PR DESCRIPTION
This allows bash completing things like `--set witness.yaml.entry-types[+]` to offer a list of valid things to add or remove (with `[-]`) from the list.