### PR TITLE
Update 56-witness/*-tm-inv-tranfer* tests

### DIFF
--- a/tests/regression/56-witness/60-tm-inv-transfer-protection.c
+++ b/tests/regression/56-witness/60-tm-inv-transfer-protection.c
@@ -4,24 +4,17 @@
 
 int g = 40; // matches expected precise read
 pthread_mutex_t B = PTHREAD_MUTEX_INITIALIZER;
-pthread_mutex_t C = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&B);
-  pthread_mutex_lock(&C);
   g = 42;
-  pthread_mutex_unlock(&C);
-  pthread_mutex_lock(&C);
   g = 41;
-  pthread_mutex_unlock(&C);
   pthread_mutex_unlock(&B);
   return NULL;
 }
 
 void *t_fun2(void *arg) {
-  pthread_mutex_lock(&C);
   g = 41;
-  pthread_mutex_unlock(&C);
   return NULL;
 }
 
@@ -31,16 +24,12 @@ int main(void) {
   pthread_create(&id2, NULL, t_fun2, NULL);
 
   pthread_mutex_lock(&B);
-  pthread_mutex_lock(&C);
   __goblint_check(g >= 40);
   __goblint_check(g <= 41); // UNKNOWN (lacks expressivity)
-  pthread_mutex_unlock(&C);
   pthread_mutex_unlock(&B);
 
-  pthread_mutex_lock(&C);
   __goblint_check(g >= 40);
   __goblint_check(g <= 42); // unknown with widening
-  pthread_mutex_unlock(&C);
 
   return 0;
 }

--- a/tests/regression/56-witness/60-tm-inv-transfer-protection.c
+++ b/tests/regression/56-witness/60-tm-inv-transfer-protection.c
@@ -1,4 +1,4 @@
-// PARAM: --set solvers.td3.side_widen always --set solvers.td3.side_widen_gas 0 --enable ana.int.interval --set ana.base.privatization protection
+// PARAM: --set solvers.td3.side_widen never --enable ana.int.interval --set ana.base.privatization protection
 #include <pthread.h>
 #include <goblint.h>
 
@@ -39,7 +39,7 @@ int main(void) {
 
   pthread_mutex_lock(&C);
   __goblint_check(g >= 40);
-  __goblint_check(g <= 42); // UNKNOWN (widen)
+  __goblint_check(g <= 42); // unknown with widening
   pthread_mutex_unlock(&C);
 
   return 0;

--- a/tests/regression/56-witness/61-tm-inv-transfer-mine.c
+++ b/tests/regression/56-witness/61-tm-inv-transfer-mine.c
@@ -4,24 +4,17 @@
 
 int g = 40; // matches expected precise read
 pthread_mutex_t B = PTHREAD_MUTEX_INITIALIZER;
-pthread_mutex_t C = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&B);
-  pthread_mutex_lock(&C);
   g = 42;
-  pthread_mutex_unlock(&C);
-  pthread_mutex_lock(&C);
   g = 41;
-  pthread_mutex_unlock(&C);
   pthread_mutex_unlock(&B);
   return NULL;
 }
 
 void *t_fun2(void *arg) {
-  pthread_mutex_lock(&C);
   g = 41;
-  pthread_mutex_unlock(&C);
   return NULL;
 }
 
@@ -31,16 +24,12 @@ int main(void) {
   pthread_create(&id2, NULL, t_fun2, NULL);
 
   pthread_mutex_lock(&B);
-  pthread_mutex_lock(&C);
   __goblint_check(g >= 40);
   __goblint_check(g <= 41);
-  pthread_mutex_unlock(&C);
   pthread_mutex_unlock(&B);
 
-  pthread_mutex_lock(&C);
   __goblint_check(g >= 40); // unknown with widening
   __goblint_check(g <= 42);
-  pthread_mutex_unlock(&C);
 
   return 0;
 }

--- a/tests/regression/56-witness/61-tm-inv-transfer-mine.c
+++ b/tests/regression/56-witness/61-tm-inv-transfer-mine.c
@@ -1,4 +1,4 @@
-// PARAM: --set solvers.td3.side_widen always --enable ana.int.interval --set ana.base.privatization mine
+// PARAM: --set solvers.td3.side_widen never --enable ana.int.interval --set ana.base.privatization mine
 #include <pthread.h>
 #include <goblint.h>
 
@@ -38,7 +38,7 @@ int main(void) {
   pthread_mutex_unlock(&B);
 
   pthread_mutex_lock(&C);
-  __goblint_check(g >= 40); // TODO why?
+  __goblint_check(g >= 40); // unknown with widening
   __goblint_check(g <= 42);
   pthread_mutex_unlock(&C);
 

--- a/tests/regression/56-witness/62-tm-inv-transfer-protection-witness-manual.yml
+++ b/tests/regression/56-witness/62-tm-inv-transfer-protection-witness-manual.yml
@@ -1,0 +1,34 @@
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: a3819e93-2ad6-42fd-aee8-f25aac0eb212
+    creation_time: 2025-03-07T15:04:22Z
+    producer:
+      name: Vesal Vojdani
+      version: n/a
+    task:
+      input_files:
+      - 62-tm-inv-transfer-protection-witness.c
+      input_file_hashes:
+        62-tm-inv-transfer-protection-witness.c: 139627d4167e48c2399f0a6359e533d8ac7597e9b4155c58ddcb2b7bfe780088
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 27
+        column: 3
+        function: main
+      value: 40 <= g && g <= 41
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 31
+        column: 3
+        function: main
+      value: 40 <= g && g <= 42
+      format: c_expression

--- a/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.c
+++ b/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.c
@@ -1,4 +1,4 @@
-// PARAM: --set solvers.td3.side_widen always --enable ana.int.interval --set ana.base.privatization protection --set "ana.activated[+]" unassume --set witness.yaml.unassume 62-tm-inv-transfer-protection-witness.yml --enable ana.widen.tokens
+// PARAM: --set solvers.td3.side_widen never --enable ana.int.interval --set ana.base.privatization protection --set "ana.activated[+]" unassume --set witness.yaml.unassume 62-tm-inv-transfer-protection-witness.yml --enable ana.widen.tokens
 #include <pthread.h>
 #include <goblint.h>
 

--- a/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.c
+++ b/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.c
@@ -4,24 +4,17 @@
 
 int g = 40; // matches expected precise read
 pthread_mutex_t B = PTHREAD_MUTEX_INITIALIZER;
-pthread_mutex_t C = PTHREAD_MUTEX_INITIALIZER;
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&B);
-  pthread_mutex_lock(&C);
   g = 42;
-  pthread_mutex_unlock(&C);
-  pthread_mutex_lock(&C);
   g = 41;
-  pthread_mutex_unlock(&C);
   pthread_mutex_unlock(&B);
   return NULL;
 }
 
 void *t_fun2(void *arg) {
-  pthread_mutex_lock(&C);
   g = 41;
-  pthread_mutex_unlock(&C);
   return NULL;
 }
 
@@ -31,16 +24,12 @@ int main(void) {
   pthread_create(&id2, NULL, t_fun2, NULL);
 
   pthread_mutex_lock(&B);
-  pthread_mutex_lock(&C);
   __goblint_check(g >= 40);
   __goblint_check(g <= 41); // UNKNOWN (lacks expressivity)
-  pthread_mutex_unlock(&C);
   pthread_mutex_unlock(&B);
 
-  pthread_mutex_lock(&C);
   __goblint_check(g >= 40);
   __goblint_check(g <= 42);
-  pthread_mutex_unlock(&C);
 
   return 0;
 }

--- a/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.t
+++ b/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.t
@@ -1,0 +1,27 @@
+Same as regression test, but with manually written witness from Simmo's PhD thesis:
+
+  $ goblint --set solvers.td3.side_widen never --enable ana.int.interval --set ana.base.privatization protection --set "ana.activated[+]" unassume --set witness.yaml.unassume 62-tm-inv-transfer-protection-witness-manual.yml --enable ana.widen.tokens 62-tm-inv-transfer-protection-witness.c
+  [Info][Witness] unassume invariant: 40 <= g && g <= 41 (62-tm-inv-transfer-protection-witness.c:26:3-26:25)
+  [Success][Assert] Assertion "g >= 40" will succeed (62-tm-inv-transfer-protection-witness.c:27:3-27:27)
+  [Warning][Assert] Assertion "g <= 41" is unknown. (62-tm-inv-transfer-protection-witness.c:28:3-28:27)
+  [Info][Witness] unassume invariant: 40 <= g && g <= 42 (62-tm-inv-transfer-protection-witness.c:29:3-29:27)
+  [Success][Assert] Assertion "g >= 40" will succeed (62-tm-inv-transfer-protection-witness.c:31:3-31:27)
+  [Success][Assert] Assertion "g <= 42" will succeed (62-tm-inv-transfer-protection-witness.c:32:3-32:27)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 19
+    dead: 0
+    total lines: 19
+  [Warning][Race] Memory location g (race with conf. 110): (62-tm-inv-transfer-protection-witness.c:5:5-5:11)
+    write with [lock:{B}, thread:[main, t_fun@62-tm-inv-transfer-protection-witness.c:23:3-23:40]] (conf. 110)  (exp: & g) (62-tm-inv-transfer-protection-witness.c:10:3-10:9)
+    write with [lock:{B}, thread:[main, t_fun@62-tm-inv-transfer-protection-witness.c:23:3-23:40]] (conf. 110)  (exp: & g) (62-tm-inv-transfer-protection-witness.c:11:3-11:9)
+    write with thread:[main, t_fun2@62-tm-inv-transfer-protection-witness.c:24:3-24:42] (conf. 110)  (exp: & g) (62-tm-inv-transfer-protection-witness.c:17:3-17:9)
+    read with [mhp:{created={[main, t_fun@62-tm-inv-transfer-protection-witness.c:23:3-23:40], [main, t_fun2@62-tm-inv-transfer-protection-witness.c:24:3-24:42]}}, lock:{B}, thread:[main]] (conf. 110)  (exp: & g) (62-tm-inv-transfer-protection-witness.c:27:3-27:27)
+    read with [mhp:{created={[main, t_fun@62-tm-inv-transfer-protection-witness.c:23:3-23:40], [main, t_fun2@62-tm-inv-transfer-protection-witness.c:24:3-24:42]}}, lock:{B}, thread:[main]] (conf. 110)  (exp: & g) (62-tm-inv-transfer-protection-witness.c:28:3-28:27)
+    read with [mhp:{created={[main, t_fun@62-tm-inv-transfer-protection-witness.c:23:3-23:40], [main, t_fun2@62-tm-inv-transfer-protection-witness.c:24:3-24:42]}}, thread:[main]] (conf. 110)  (exp: & g) (62-tm-inv-transfer-protection-witness.c:31:3-31:27)
+    read with [mhp:{created={[main, t_fun@62-tm-inv-transfer-protection-witness.c:23:3-23:40], [main, t_fun2@62-tm-inv-transfer-protection-witness.c:24:3-24:42]}}, thread:[main]] (conf. 110)  (exp: & g) (62-tm-inv-transfer-protection-witness.c:32:3-32:27)
+  [Info][Race] Memory locations race summary:
+    safe: 0
+    vulnerable: 0
+    unsafe: 1
+    total memory locations: 1
+

--- a/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.yml
+++ b/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.yml
@@ -1,15 +1,16 @@
-- entry_type: location_invariant
+- entry_type: invariant_set
   metadata:
-    format_version: "0.1"
-    uuid: 9ee02271-d3f1-4821-bee6-ac57700e48eb
-    creation_time: 2025-03-07T11:06:06Z
+    format_version: "2.0"
+    uuid: c999d11f-cb5e-4e7a-b63b-6b4600eefe0a
+    creation_time: 2025-03-07T11:44:35Z
     producer:
       name: Goblint
       version: heads/arg-complete-array-0-gf35516955-dirty
       command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
         ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
         ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''invariant_set'' ''--set'' ''witness.yaml.format-version''
+        ''2.0'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
@@ -17,564 +18,184 @@
         62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 35
-    column: 3
-    function: main
-  location_invariant:
-    string: 40 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: dd40f553-4e46-4b3c-9923-89dde4438ec7
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 35
-    column: 3
-    function: main
-  location_invariant:
-    string: g <= 41
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: be1365a2-a839-4a76-b838-3b3110e25dd0
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 11
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: 40 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 81af500d-afe5-4780-a7c0-94c21e473c21
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 11
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: g <= 41
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: abaa4c8c-0169-4c6e-b79a-84c9aad7b1f5
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 11
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: (unsigned long )arg == 0UL
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: fd0c4661-7b9d-4830-9d6f-067f55bf1f98
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 34
-    column: 3
-    function: main
-  location_invariant:
-    string: 40 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 8e190cf5-96ab-4296-98d7-6033e2327465
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 34
-    column: 3
-    function: main
-  location_invariant:
-    string: g <= 41
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 84ab7fb3-c742-4b61-af5d-858d85ac8e9e
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 15
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: 41 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 747fa085-e015-481c-86f3-ba4d576c9e26
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 15
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: g <= 42
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: e23a506a-ae1c-49a1-8500-dd4238b774ca
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 15
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: (unsigned long )arg == 0UL
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: b2bab27b-4228-495e-a465-6040948433b8
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 12
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: 40 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 4ed60272-e037-429f-b761-4a77df14d540
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 12
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: g <= 41
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: fed861d4-6752-4925-8cba-3475bca4d2a9
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 12
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: (unsigned long )arg == 0UL
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 27791833-54b9-471d-9300-7e916d67e655
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 23
-    column: 3
-    function: t_fun2
-  location_invariant:
-    string: 0 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 264e2e7a-2e86-4d18-9fa1-aafa11026d78
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 23
-    column: 3
-    function: t_fun2
-  location_invariant:
-    string: g <= 42
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 5dd1ca6c-3cb9-4ddf-a048-a17dabb4fc2d
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 23
-    column: 3
-    function: t_fun2
-  location_invariant:
-    string: (unsigned long )arg == 0UL
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 65d7492f-3650-42b9-86b1-2ecbba1f4d2c
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 23
-    column: 3
-    function: t_fun2
-  location_invariant:
-    string: g != 0
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: c4d1cf3a-6dae-400c-bab8-98d7437df344
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 41
-    column: 3
-    function: main
-  location_invariant:
-    string: 0 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 6fec3abc-a0a4-454a-98c5-d7be3fe1f95a
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 41
-    column: 3
-    function: main
-  location_invariant:
-    string: g <= 42
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 4829dfc0-592e-4452-9e47-746c57ea2494
-    creation_time: 2025-03-07T11:06:06Z
-    producer:
-      name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
-        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
-        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
-        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
-    line: 41
-    column: 3
-    function: main
-  location_invariant:
-    string: g != 0
-    type: assertion
-    format: C
+  content:
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 35
+        column: 3
+        function: main
+      value: 40 <= g
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 35
+        column: 3
+        function: main
+      value: g <= 41
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 11
+        column: 3
+        function: t_fun
+      value: 40 <= g
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 11
+        column: 3
+        function: t_fun
+      value: g <= 41
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 11
+        column: 3
+        function: t_fun
+      value: (unsigned long )arg == 0UL
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 34
+        column: 3
+        function: main
+      value: 40 <= g
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 34
+        column: 3
+        function: main
+      value: g <= 41
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 15
+        column: 3
+        function: t_fun
+      value: 41 <= g
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 15
+        column: 3
+        function: t_fun
+      value: g <= 42
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 15
+        column: 3
+        function: t_fun
+      value: (unsigned long )arg == 0UL
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 12
+        column: 3
+        function: t_fun
+      value: 40 <= g
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 12
+        column: 3
+        function: t_fun
+      value: g <= 41
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 12
+        column: 3
+        function: t_fun
+      value: (unsigned long )arg == 0UL
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 23
+        column: 3
+        function: t_fun2
+      value: 0 <= g
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 23
+        column: 3
+        function: t_fun2
+      value: g <= 42
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 23
+        column: 3
+        function: t_fun2
+      value: (unsigned long )arg == 0UL
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 23
+        column: 3
+        function: t_fun2
+      value: g != 0
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 41
+        column: 3
+        function: main
+      value: 0 <= g
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 41
+        column: 3
+        function: main
+      value: g <= 42
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 62-tm-inv-transfer-protection-witness.c
+        line: 41
+        column: 3
+        function: main
+      value: g != 0
+      format: c_expression

--- a/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.yml
+++ b/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.yml
@@ -1,8 +1,8 @@
 - entry_type: invariant_set
   metadata:
     format_version: "2.0"
-    uuid: 198dd98d-49a8-4e2a-a516-bebbe4ddc11f
-    creation_time: 2025-03-07T15:01:05Z
+    uuid: 616f1f47-6b4f-42b4-a6d0-5b0e96c46d04
+    creation_time: 2025-03-10T08:52:01Z
     producer:
       name: Goblint
       version: heads/tm-inv-transfer-0-g2297ee03e-dirty
@@ -15,7 +15,7 @@
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: 139627d4167e48c2399f0a6359e533d8ac7597e9b4155c58ddcb2b7bfe780088
+        62-tm-inv-transfer-protection-witness.c: 092126836eb79039199015ac90bff562d5e53fcd1c9d793373dec577edd4c71b
       data_model: LP64
       language: C
   content:

--- a/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.yml
+++ b/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.yml
@@ -1,54 +1,83 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 133c6e4e-142e-431f-a3ff-e15e10e1deba
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 9ee02271-d3f1-4821-bee6-ac57700e48eb
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 11
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+    line: 35
     column: 3
-    function: t_fun
+    function: main
   location_invariant:
-    string: 0 <= g
+    string: 40 <= g
     type: assertion
     format: C
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 61a293a5-2bdc-4c18-bbba-f1c518da1b02
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: dd40f553-4e46-4b3c-9923-89dde4438ec7
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+    line: 35
+    column: 3
+    function: main
+  location_invariant:
+    string: g <= 41
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: be1365a2-a839-4a76-b838-3b3110e25dd0
+    creation_time: 2025-03-07T11:06:06Z
+    producer:
+      name: Goblint
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
+    task:
+      input_files:
+      - 62-tm-inv-transfer-protection-witness.c
+      input_file_hashes:
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+      data_model: LP64
+      language: C
+  location:
+    file_name: 62-tm-inv-transfer-protection-witness.c
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 11
     column: 3
     function: t_fun
@@ -59,25 +88,25 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 8e43be9d-94a6-45c7-9587-bccfa0e42bd3
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 81af500d-afe5-4780-a7c0-94c21e473c21
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 11
     column: 3
     function: t_fun
@@ -88,54 +117,25 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 13bf2d94-bee2-499a-a75e-ef3027f8b24a
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: abaa4c8c-0169-4c6e-b79a-84c9aad7b1f5
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 11
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: g <= 127
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 706fb27a-7e48-42b3-acdd-335094a1554d
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 11
     column: 3
     function: t_fun
@@ -146,86 +146,28 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 6f35861f-61a1-457c-b6a6-d149f319c7a0
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: fd0c4661-7b9d-4830-9d6f-067f55bf1f98
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 11
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+    line: 34
     column: 3
-    function: t_fun
-  location_invariant:
-    string: g != 0
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 86bfbad5-b128-4332-b97e-859baaa1bd6b
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 12
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: 0 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 1c5bb61a-ae4f-486c-9845-eb4e9c16ce0d
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 12
-    column: 3
-    function: t_fun
+    function: main
   location_invariant:
     string: 40 <= g
     type: assertion
@@ -233,28 +175,28 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: f84cb86c-9e50-4ea2-84de-53dd49f524db
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 8e190cf5-96ab-4296-98d7-6033e2327465
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 12
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+    line: 34
     column: 3
-    function: t_fun
+    function: main
   location_invariant:
     string: g <= 41
     type: assertion
@@ -262,141 +204,25 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: c0d744a9-44b4-410f-9a62-5dfd6feb9872
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 84ab7fb3-c742-4b61-af5d-858d85ac8e9e
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 12
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: g <= 127
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 95667fee-53ff-4e19-ad4c-25ba5677d89d
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 12
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: (unsigned long )arg == 0UL
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 5f89e9b6-49b4-412d-9960-83d0b6b218ae
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 12
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: g != 0
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 2c43a931-eb96-4eda-bf6b-1a0d975fa4ac
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 15
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: 0 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 43af07b3-ef5c-42e7-be35-0c42e6cf7c6f
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 15
     column: 3
     function: t_fun
@@ -407,25 +233,25 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: e2cc7d90-0b9b-45f5-b6fc-3fd0054c9c94
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 747fa085-e015-481c-86f3-ba4d576c9e26
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 15
     column: 3
     function: t_fun
@@ -436,54 +262,25 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 844ae533-568d-484e-ad22-e86ef6fe53bd
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: e23a506a-ae1c-49a1-8500-dd4238b774ca
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 15
-    column: 3
-    function: t_fun
-  location_invariant:
-    string: g <= 127
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 10a8179a-c720-4455-85fa-d05c3f3f88f7
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 15
     column: 3
     function: t_fun
@@ -494,54 +291,112 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 5e5d8433-3b12-4ce4-bbc7-39b00a258522
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: b2bab27b-4228-495e-a465-6040948433b8
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 15
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+    line: 12
     column: 3
     function: t_fun
   location_invariant:
-    string: g != 0
+    string: 40 <= g
     type: assertion
     format: C
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 2a09193a-f1f8-4391-b730-82250831e6a4
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 4ed60272-e037-429f-b761-4a77df14d540
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+    line: 12
+    column: 3
+    function: t_fun
+  location_invariant:
+    string: g <= 41
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: fed861d4-6752-4925-8cba-3475bca4d2a9
+    creation_time: 2025-03-07T11:06:06Z
+    producer:
+      name: Goblint
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
+    task:
+      input_files:
+      - 62-tm-inv-transfer-protection-witness.c
+      input_file_hashes:
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+      data_model: LP64
+      language: C
+  location:
+    file_name: 62-tm-inv-transfer-protection-witness.c
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+    line: 12
+    column: 3
+    function: t_fun
+  location_invariant:
+    string: (unsigned long )arg == 0UL
+    type: assertion
+    format: C
+- entry_type: location_invariant
+  metadata:
+    format_version: "0.1"
+    uuid: 27791833-54b9-471d-9300-7e916d67e655
+    creation_time: 2025-03-07T11:06:06Z
+    producer:
+      name: Goblint
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
+    task:
+      input_files:
+      - 62-tm-inv-transfer-protection-witness.c
+      input_file_hashes:
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+      data_model: LP64
+      language: C
+  location:
+    file_name: 62-tm-inv-transfer-protection-witness.c
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 23
     column: 3
     function: t_fun2
@@ -552,25 +407,25 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 99f930ae-4d58-4053-b6ce-b0bb7f0174c1
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 264e2e7a-2e86-4d18-9fa1-aafa11026d78
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 23
     column: 3
     function: t_fun2
@@ -581,54 +436,25 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 4747768b-1132-4f92-8f6d-f8f26c2b5f78
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 5dd1ca6c-3cb9-4ddf-a048-a17dabb4fc2d
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 23
-    column: 3
-    function: t_fun2
-  location_invariant:
-    string: g <= 127
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 2efbed6d-9ee4-4d42-95a2-b2f7785f4694
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 23
     column: 3
     function: t_fun2
@@ -639,25 +465,25 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 964650c6-f1cb-4fbb-9d27-a42bb1835fed
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 65d7492f-3650-42b9-86b1-2ecbba1f4d2c
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 23
     column: 3
     function: t_fun2
@@ -668,315 +494,25 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: a93a369c-481b-41f8-bba6-2cfa5e995eb7
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: c4d1cf3a-6dae-400c-bab8-98d7437df344
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 34
-    column: 3
-    function: main
-  location_invariant:
-    string: 0 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: d7d103d4-f875-4632-8227-05d516529b77
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 34
-    column: 3
-    function: main
-  location_invariant:
-    string: 40 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: e2712d23-05cc-469c-a64a-9823d4fc4614
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 34
-    column: 3
-    function: main
-  location_invariant:
-    string: g <= 41
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: f70be86e-9d03-44e3-ad33-1a0464f7422a
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 34
-    column: 3
-    function: main
-  location_invariant:
-    string: g <= 127
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 7e20f5c6-c20e-42c4-a398-b59fe1f18c70
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 34
-    column: 3
-    function: main
-  location_invariant:
-    string: g != 0
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: a5f14cc3-8162-4cbf-9bb9-057032c9b6d3
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 35
-    column: 3
-    function: main
-  location_invariant:
-    string: 0 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 7ff6bae4-2b2f-4a26-9879-9d19af5dee03
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 35
-    column: 3
-    function: main
-  location_invariant:
-    string: 40 <= g
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: dfb0ce8d-1f5c-401c-bdc7-26e4a6063ed8
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 35
-    column: 3
-    function: main
-  location_invariant:
-    string: g <= 41
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: edbed876-835f-42b8-b672-c485b7c36a4c
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 35
-    column: 3
-    function: main
-  location_invariant:
-    string: g <= 127
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 760f5e5a-aacc-46b6-a93f-b6e0ac795ef8
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 35
-    column: 3
-    function: main
-  location_invariant:
-    string: g != 0
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: d870e247-12c1-4e7b-9fea-b2e64939e2ce
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 41
     column: 3
     function: main
@@ -987,112 +523,54 @@
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 2eab2231-3a68-4da8-b728-8fa1189fc1e9
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 6fec3abc-a0a4-454a-98c5-d7be3fe1f95a
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 41
     column: 3
     function: main
   location_invariant:
-    string: 40 <= g
+    string: g <= 42
     type: assertion
     format: C
 - entry_type: location_invariant
   metadata:
     format_version: "0.1"
-    uuid: 8da58356-ef30-4417-9c53-34fd8fefad26
-    creation_time: 2023-01-29T12:06:58Z
+    uuid: 4829dfc0-592e-4452-9e47-746c57ea2494
+    creation_time: 2025-03-07T11:06:06Z
     producer:
       name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
+      version: heads/arg-complete-array-0-gf35516955-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+        ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
+        ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
+        ''--set'' ''witness.yaml.entry-types[*]'' ''location_invariant'' ''62-tm-inv-transfer-protection-witness.c'''
     task:
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
       data_model: LP64
       language: C
   location:
     file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 41
-    column: 3
-    function: main
-  location_invariant:
-    string: g <= 41
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: e175760f-b69a-471c-966a-f4549b232abb
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-    line: 41
-    column: 3
-    function: main
-  location_invariant:
-    string: g <= 127
-    type: assertion
-    format: C
-- entry_type: location_invariant
-  metadata:
-    format_version: "0.1"
-    uuid: 31e43c51-5cdc-4d6b-8fb7-79b8d6bbe2e1
-    creation_time: 2023-01-29T12:06:58Z
-    producer:
-      name: Goblint
-      version: heads/master-0-g29ef47bce-dirty
-      command_line: '''goblint'' ''--set'' ''solvers.td3.side_widen'' ''always'' ''--enable''
-        ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine'' ''--enable''
-        ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.accessed'' ''--disable''
-        ''witness.invariant.other'' ''62-tm-inv-transfer-protection-witness.c'''
-    task:
-      input_files:
-      - 62-tm-inv-transfer-protection-witness.c
-      input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
-      data_model: LP64
-      language: C
-  location:
-    file_name: 62-tm-inv-transfer-protection-witness.c
-    file_hash: f3fd475486e1259fbd3c64c1b66b2ded22ee682bc9120914578ac370a630548b
+    file_hash: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
     line: 41
     column: 3
     function: main

--- a/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.yml
+++ b/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.yml
@@ -1,8 +1,8 @@
 - entry_type: invariant_set
   metadata:
     format_version: "2.0"
-    uuid: 1dfbece3-f0f2-4c72-986c-fd8b9563764b
-    creation_time: 2025-03-07T14:55:47Z
+    uuid: 198dd98d-49a8-4e2a-a516-bebbe4ddc11f
+    creation_time: 2025-03-07T15:01:05Z
     producer:
       name: Goblint
       version: heads/tm-inv-transfer-0-g2297ee03e-dirty
@@ -15,7 +15,7 @@
       input_files:
       - 62-tm-inv-transfer-protection-witness.c
       input_file_hashes:
-        62-tm-inv-transfer-protection-witness.c: bcb3785ef06661495164be10f538f9d169301aaacdc22573b2db89c8f8c8b178
+        62-tm-inv-transfer-protection-witness.c: 139627d4167e48c2399f0a6359e533d8ac7597e9b4155c58ddcb2b7bfe780088
       data_model: LP64
       language: C
   content:
@@ -23,7 +23,7 @@
       type: location_invariant
       location:
         file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 35
+        line: 27
         column: 3
         function: main
       value: 40 <= g
@@ -32,52 +32,7 @@
       type: location_invariant
       location:
         file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 35
-        column: 3
-        function: main
-      value: g <= 41
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 11
-        column: 3
-        function: t_fun
-      value: 40 <= g
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 11
-        column: 3
-        function: t_fun
-      value: g <= 41
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 11
-        column: 3
-        function: t_fun
-      value: (unsigned long )arg == 0UL
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 34
-        column: 3
-        function: main
-      value: 40 <= g
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 34
+        line: 27
         column: 3
         function: main
       value: g <= 41
@@ -86,34 +41,7 @@
       type: location_invariant
       location:
         file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 15
-        column: 3
-        function: t_fun
-      value: 41 <= g
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 15
-        column: 3
-        function: t_fun
-      value: g <= 42
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 15
-        column: 3
-        function: t_fun
-      value: (unsigned long )arg == 0UL
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 12
+        line: 10
         column: 3
         function: t_fun
       value: 40 <= g
@@ -122,7 +50,7 @@
       type: location_invariant
       location:
         file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 12
+        line: 10
         column: 3
         function: t_fun
       value: g <= 41
@@ -131,53 +59,8 @@
       type: location_invariant
       location:
         file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 12
+        line: 10
         column: 3
         function: t_fun
       value: (unsigned long )arg == 0UL
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 23
-        column: 3
-        function: t_fun2
-      value: 40 <= g
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 23
-        column: 3
-        function: t_fun2
-      value: g <= 42
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 23
-        column: 3
-        function: t_fun2
-      value: (unsigned long )arg == 0UL
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 41
-        column: 3
-        function: main
-      value: 40 <= g
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 41
-        column: 3
-        function: main
-      value: g <= 42
       format: c_expression

--- a/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.yml
+++ b/tests/regression/56-witness/62-tm-inv-transfer-protection-witness.yml
@@ -1,12 +1,12 @@
 - entry_type: invariant_set
   metadata:
     format_version: "2.0"
-    uuid: c999d11f-cb5e-4e7a-b63b-6b4600eefe0a
-    creation_time: 2025-03-07T11:44:35Z
+    uuid: 1dfbece3-f0f2-4c72-986c-fd8b9563764b
+    creation_time: 2025-03-07T14:55:47Z
     producer:
       name: Goblint
-      version: heads/arg-complete-array-0-gf35516955-dirty
-      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''always''
+      version: heads/tm-inv-transfer-0-g2297ee03e-dirty
+      command_line: '''../../../goblint'' ''--set'' ''solvers.td3.side_widen'' ''never''
         ''--enable'' ''ana.int.interval'' ''--set'' ''ana.base.privatization'' ''mine''
         ''--enable'' ''witness.yaml.enabled'' ''--disable'' ''witness.invariant.other''
         ''--set'' ''witness.yaml.entry-types[*]'' ''invariant_set'' ''--set'' ''witness.yaml.format-version''
@@ -143,7 +143,7 @@
         line: 23
         column: 3
         function: t_fun2
-      value: 0 <= g
+      value: 40 <= g
       format: c_expression
   - invariant:
       type: location_invariant
@@ -167,19 +167,10 @@
       type: location_invariant
       location:
         file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 23
-        column: 3
-        function: t_fun2
-      value: g != 0
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
         line: 41
         column: 3
         function: main
-      value: 0 <= g
+      value: 40 <= g
       format: c_expression
   - invariant:
       type: location_invariant
@@ -189,13 +180,4 @@
         column: 3
         function: main
       value: g <= 42
-      format: c_expression
-  - invariant:
-      type: location_invariant
-      location:
-        file_name: 62-tm-inv-transfer-protection-witness.c
-        line: 41
-        column: 3
-        function: main
-      value: g != 0
       format: c_expression


### PR DESCRIPTION
These tests correspond to an old thread-modular invariant transfer example (by @vesalvojdani) that was excluded from the unassume paper but is restored for my PhD thesis.

### Changes
1. Remove mutex `C` which is an explicit version of $$m_{\texttt{g}}$$.
2. Disable side widening. This unnecessarily obscures precision differences.
3. Regenerates the witness in 2.0 format.
4. Adds hand-written witness used in the paper/thesis.