### PR TITLE
Experiment with unassume for mutex analysis

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -708,7 +708,7 @@ struct
       Priv.escape man.node (Analyses.ask_of_man man) man.global man.sideg st escaped
     | Assert exp ->
       assert_fn man exp true
-    | Events.Unassume {exp = e; tokens} ->
+    | Events.Unassume {value = Exp e; tokens} ->
       let e_orig = e in
       let ask = Analyses.ask_of_man man in
       let e = replace_deref_exps man.ask e in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -3126,7 +3126,7 @@ struct
       set ~man man.local (eval_lv ~man man.local lval) (Cilfacade.typeOfLval lval) (Thread (ValueDomain.Threads.singleton tid))
     | Events.Assert exp ->
       assert_fn man exp true
-    | Events.Unassume {exp; tokens} ->
+    | Events.Unassume {value = Exp exp; tokens} ->
       Timing.wrap "base unassume" (unassume man exp) tokens
     | Events.Longjmped {lval} ->
       begin match lval with

--- a/src/analyses/mutexAnalysis.ml
+++ b/src/analyses/mutexAnalysis.ml
@@ -359,6 +359,13 @@ struct
              old_access None None *) (* TODO: what about this case? *)
       end;
       man.local
+    | Unassume {value = ProtectedBy {global; mutexes}; tokens} ->
+      let s = GProtecting.make ~write:true ~recovered:false mutexes in
+      WideningTokenLifter.with_side_tokens (WideningTokenLifter.TS.of_list tokens) (fun () ->
+          man.sideg (V.protecting global) (G.create_protecting s);
+        );
+      M.info ~category:Witness "mutex unassumed %a protected_by: %a" CilType.Varinfo.pretty global MustLockset.pretty mutexes;
+      man.local
     | _ ->
       event man e oman (* delegate to must lockset analysis *)
 

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -569,7 +569,7 @@ struct
 
   let event man e oman =
     match e with
-    | Events.Unassume {exp; _} ->
+    | Events.Unassume {value = Exp exp; _} ->
       (* Unassume must forget equalities,
          otherwise var_eq may still have a numeric first iteration equality
          while base has unassumed, causing unnecessary extra evals. *)

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -2726,7 +2726,8 @@
                   "precondition_loop_invariant_certificate",
                   "invariant_set",
                   "violation_sequence",
-                  "ghost_instrumentation"
+                  "ghost_instrumentation",
+                  "protected_by"
                 ]
               },
               "default": [

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -5,7 +5,7 @@ open Pretty
 
 type unassume =
   | Exp of CilType.Exp.t
-  | ProtectedBy of {global: CilType.Varinfo.t; mutex: LockDomain.MustLockset.t}
+  | ProtectedBy of {global: CilType.Varinfo.t; mutexes: LockDomain.MustLockset.t}
 
 type t =
   | Lock of LockDomain.AddrRW.t
@@ -49,5 +49,6 @@ let pretty () = function
   | Assign {lval; exp} -> dprintf "Assign {lval=%a, exp=%a}" CilType.Lval.pretty lval CilType.Exp.pretty exp
   | UpdateExpSplit exp -> dprintf "UpdateExpSplit %a" d_exp exp
   | Assert exp -> dprintf "Assert %a" d_exp exp
-  | Unassume {value = _; tokens} -> dprintf "Unassume {exp=%s; tokens=%a}" "_" (d_list ", " WideningToken.pretty) tokens (* TODO: fix output *)
+  | Unassume {value = Exp exp; tokens} -> dprintf "Unassume {value=Exp %a; tokens=%a}" CilType.Exp.pretty exp (d_list ", " WideningToken.pretty) tokens
+  | Unassume {value = ProtectedBy {global; mutexes}; tokens} -> dprintf "Unassume {value=ProtectedBy {global=%a; mutexes=%a}; tokens=%a}" CilType.Varinfo.pretty global LockDomain.MustLockset.pretty mutexes (d_list ", " WideningToken.pretty) tokens
   | Longjmped {lval} -> dprintf "Longjmped {lval=%a}" (docOpt (CilType.Lval.pretty ())) lval

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -3,6 +3,10 @@
 open GoblintCil
 open Pretty
 
+type unassume =
+  | Exp of CilType.Exp.t
+  | ProtectedBy of {global: CilType.Varinfo.t; mutex: LockDomain.MustLockset.t}
+
 type t =
   | Lock of LockDomain.AddrRW.t
   | Unlock of LockDomain.Addr.t
@@ -14,7 +18,7 @@ type t =
   | Assign of {lval: CilType.Lval.t; exp: CilType.Exp.t} (** Used to simulate old [man.assign]. *) (* TODO: unused *)
   | UpdateExpSplit of exp (** Used by expsplit analysis to evaluate [exp] on post-state. *)
   | Assert of exp
-  | Unassume of {exp: CilType.Exp.t; tokens: WideningToken.t list}
+  | Unassume of {value: unassume; tokens: WideningToken.t list}
   | Longjmped of {lval: CilType.Lval.t option}
 
 (** Should event be emitted after transfer function raises [Deadcode]? *)
@@ -45,5 +49,5 @@ let pretty () = function
   | Assign {lval; exp} -> dprintf "Assign {lval=%a, exp=%a}" CilType.Lval.pretty lval CilType.Exp.pretty exp
   | UpdateExpSplit exp -> dprintf "UpdateExpSplit %a" d_exp exp
   | Assert exp -> dprintf "Assert %a" d_exp exp
-  | Unassume {exp; tokens} -> dprintf "Unassume {exp=%a; tokens=%a}" d_exp exp (d_list ", " WideningToken.pretty) tokens
+  | Unassume {value = _; tokens} -> dprintf "Unassume {exp=%s; tokens=%a}" "_" (d_list ", " WideningToken.pretty) tokens (* TODO: fix output *)
   | Longjmped {lval} -> dprintf "Longjmped {lval=%a}" (docOpt (CilType.Lval.pretty ())) lval

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -177,6 +177,15 @@ struct
       };
     metadata = metadata ~task ();
   }
+
+  (* non-standard extension *)
+  let protected_by ~task ~variable ~(mutex): Entry.t = {
+    entry_type = ProtectedBy {
+        variable;
+        mutex;
+      };
+    metadata = metadata ~task ();
+  }
 end
 
 let yaml_entries_to_file yaml_entries file =
@@ -402,7 +411,7 @@ struct
 
     (* Generate flow-insensitive entries (ghost instrumentation) *)
     let entries =
-      if entry_type_enabled YamlWitnessType.GhostInstrumentation.entry_type then (
+      if entry_type_enabled YamlWitnessType.GhostInstrumentation.entry_type || entry_type_enabled YamlWitnessType.ProtectedBy.entry_type then (
         (* TODO: only at most one ghost_instrumentation entry can ever be produced, so this fold and deduplication is overkill *)
         let module EntrySet = Queries.YS in
         fst @@ GHT.fold (fun g v accs ->

--- a/tests/util/yamlWitnessStripCommon.ml
+++ b/tests/util/yamlWitnessStripCommon.ml
@@ -79,6 +79,8 @@ struct
           ghost_variables = List.sort GhostInstrumentation.Variable.compare x.ghost_variables;
           ghost_updates = List.sort GhostInstrumentation.LocationUpdate.compare (List.map ghost_location_update_strip_file_hash x.ghost_updates);
         }
+      | ProtectedBy x ->
+        ProtectedBy x (* no location to strip *)
     in
     {entry_type}
 


### PR DESCRIPTION
This is a quick proof-of-concept for an idea I had a while ago: unassume for variable protection in mutex analysis.
It is the first example of a non–value-domain unassume operator.

To do so, this also implements the custom `protected_by` YAML witness entry type from our COOP 2023 talk, including generation and validation.
On test 13/01 it reduces evals 23 → 19, so it conceptually seems to work (even in a trivial case!). But this needs more evaluation to see its potential.

### TODO
- [ ] Add (cram?) tests.
- [ ] Experiment on larger (pthread) programs.
- [ ] Add `location_mutex` entry type as well.