### PR TITLE
`IsMultiple` in `MallocWrapper`: Check uniqueness of allocating(!) thread

### DIFF
--- a/src/analyses/wrapperFunctionAnalysis.ml
+++ b/src/analyses/wrapperFunctionAnalysis.ml
@@ -171,7 +171,10 @@ module MallocWrapper : MCPSpec = struct
       NodeVarinfoMap.mem_varinfo v
     | Q.IsMultiple v ->
       begin match NodeVarinfoMap.from_varinfo v with
-        | Some (_, _, c) -> UniqueCount.is_top c || not (man.ask Q.MustBeUniqueThread)
+        | Some (t, _, c) -> UniqueCount.is_top c ||
+                            (match t with
+                             | `Lifted tid -> not (Thread.is_unique tid)
+                             | _ -> true)
         | None -> false
       end
     | _ -> Queries.Result.top q

--- a/tests/regression/11-heap/17-unique-mt.c
+++ b/tests/regression/11-heap/17-unique-mt.c
@@ -1,0 +1,26 @@
+// PARAM: --set ana.malloc.unique_address_count 3
+#include<pthread.h>
+static int iRThreads = 1;
+static int data1Value = 0;
+pthread_mutex_t *data1Lock;
+
+void *funcA(void *param) {
+    pthread_mutex_lock(data1Lock);
+    data1Value = 1; //NORACE
+    pthread_mutex_unlock(data1Lock);
+}
+
+int main(int argc, char *argv[]) {
+    data1Lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+
+    pthread_t one;
+    pthread_t other[3];
+
+    pthread_create(&one, ((void *)0), &funcA, ((void *)0));
+
+    for (int i = 0; i < 3; i++) {
+      pthread_create(&other[i], ((void *)0), &funcA, ((void *)0));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
To determine uniqueness of a malloced object, Goblint is supposed to perform the following logic:

- A: Check that is assigned a counter value (numbering mallocs within a thread) other than `top`
- B: Check that the allocating thread is unique

Unfortunately, the logic for (B) is broken: It checks whether the thread **making a uniqueness query** for the blob is unique, instead of the thread which **allocated** the memory in the first place.

The added testcase is a precision issue, but it also is a soundness problem. 

If the querying thread happens to be unique but the allocating one is not, we give the wrong answer here.  Because of various internals (always spawning the unique copy of a thread in a loop too), getting Goblint to actually surface the unsoundness was beyond me, though.

SV-COMP: After this blunder is removed, we might benefit in MemSafety and it may also be interesting to re-check if one should enable the malloc uniqueness for races (CC @karoliineh): With ` --set ana.malloc.unique_address_count 1`, we now succeed on `sv-comp/sv-benchmarks/c/pthread/twostage_3.i`.

Closes #1719 