### PR TITLE
Generalize def_exc ranges to not include 0

### DIFF
--- a/src/cdomain/value/cdomains/int/defExcDomain.ml
+++ b/src/cdomain/value/cdomains/int/defExcDomain.ml
@@ -110,10 +110,11 @@ struct
     | `Bot -> None
 
   let in_range r i =
-    if Z.compare i Z.zero < 0 then
+    (* if Z.compare i Z.zero < 0 then *)
       let lowerb = Exclusion.min_of_range r in
       Z.compare lowerb i <= 0
-    else
+      &&
+    (* else *)
       let upperb = Exclusion.max_of_range r in
       Z.compare i upperb <= 0
 
@@ -269,6 +270,9 @@ struct
      * just DeMorgans Law *)
     | `Excluded (x,r1), `Excluded (y,r2) ->
       let r' = R.meet r1 r2 in
+      if R.is_bot r' then
+        `Bot
+      else
       let s' = S.union x y |> S.filter (in_range r') in
       `Excluded (s', r')
 

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -471,6 +471,10 @@ module Size = struct (* size in bits as int, range as int64 *)
     in
     if sign x = `Signed then
       size (min_for x)
+    else if Z.compare x Z.zero > 0 then (
+      let n = Int64.of_int (Z.numbits x) in
+      (Int64.pred n, n)
+    )
     else
       let a, b = size (min_for x) in
       if b <= 64L then
@@ -487,7 +491,7 @@ module Size = struct (* size in bits as int, range as int64 *)
   let max_from_bit_range pos_bits = Z.(pred @@ shift_left Z.one (to_int (Z.of_int64 pos_bits)))
 
   (* From the number of bits used to represent a non-positive value, determines the minimal representable value *)
-  let min_from_bit_range neg_bits = Z.(if neg_bits = 0L then Z.zero else neg @@ shift_left Z.one (to_int (neg (Z.of_int64 neg_bits))))
+  let min_from_bit_range neg_bits = Z.(if neg_bits = 0L then Z.zero else if neg_bits < 0L then neg @@ shift_left Z.one (to_int (neg (Z.of_int64 neg_bits))) else max_from_bit_range neg_bits)
 
 end
 

--- a/tests/regression/13-privatized/04-priv_multi.t
+++ b/tests/regression/13-privatized/04-priv_multi.t
@@ -191,7 +191,7 @@
       format: C
   - entry_type: flow_insensitive_invariant
     flow_insensitive_invariant:
-      string: '! multithreaded || ((0 <= B && B <= 127) && B != 0)'
+      string: '! multithreaded || (3 <= B && B <= 7)'
       type: assertion
       format: C
 
@@ -266,7 +266,7 @@ Location invariant at `for` loop in `main` should be on column 3, not 7.
   >     column: 3
   >     function: main
   >   location_invariant:
-  >     string: '! multithreaded || ((0 <= B && B <= 127) && B != 0)'
+  >     string: '! multithreaded || (3 <= B && B <= 7)'
   >     type: assertion
   >     format: C
   > - entry_type: location_invariant
@@ -299,7 +299,7 @@ Location invariant at `for` loop in `main` should be on column 3, not 7.
   >     column: 3
   >     function: main
   >   location_invariant:
-  >     string: '! multithreaded || ((0 <= B && B <= 127) && B != 0)'
+  >     string: '! multithreaded || (3 <= B && B <= 7)'
   >     type: assertion
   >     format: C
   > - entry_type: location_invariant

--- a/tests/regression/29-svcomp/16-atomic_priv.t
+++ b/tests/regression/29-svcomp/16-atomic_priv.t
@@ -105,7 +105,6 @@ Non-atomic privatization:
       format: C
   - entry_type: flow_insensitive_invariant
     flow_insensitive_invariant:
-      string: '! multithreaded || ((0 <= myglobal && myglobal <= 127) && myglobal !=
-        0)'
+      string: '! multithreaded || (3 <= myglobal && myglobal <= 7)'
       type: assertion
       format: C


### PR DESCRIPTION
In relation to a thesis I'm supervising, the matter came up whether def_exc exclusion range (in bits) may be something like [4, 6], i.e. 15..63. Such things could arise from joining definite 15 and 63, for example. My intuition about the domain is that conceptually this should be fine.

Turns out that our implementation does not handle such things, but always requires the range to include 0. But this assumption doesn't seem to be documented anywhere, nor is it even `assert`ed anywhere.
It was even difficult to find out that we have such implicit assumption. The reason we do is in how we construct exclusion ranges: always based on some `ikind` boundaries, i.e. in multiples of 8 and always including 0.

So in this PR I quickly tried to change that, but only for positive ranges for now by modifying `IntDomain0.Size.min_range_sign_agnostic`. Although it should be generalizable to negative ones as well.
A few things break immediately, but they seem to be also easily fixed. Although it's far from clear whether some abstract operations still make the implicit assumption.

Of course this begs the question whether we should have this. At some point I thought about removing the exclusion ranges entirely because all `IntDomain` operations now get `ikind`s, but I think the counterargument was that we can still find out slightly more precise things than the type with these ranges, particularly about booleans. So if we have the ranges, we should use them to their full potential like this.
