### PR TITLE
Use generic `Spec` lifters for delayed widening

### DIFF
--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -22,6 +22,7 @@ module type LatticeLifter =
 module DomainLifter (N: NameLifter) (F: LatticeLifter) (S:Spec)
   : Spec with module G = S.G
           and module C = S.C
+          and module D = F (S.D)
 =
 struct
   module D = F (S.D)

--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -19,10 +19,14 @@ module type LatticeLifter =
     val unlift: t -> L.t
   end
 
-module DomainLifter (N: NameLifter) (F: LatticeLifter) (S:Spec)
-  : Spec with module G = S.G
-          and module C = S.C
-          and module D = F (S.D)
+module DomainLifter (N: NameLifter) (F: LatticeLifter) (S:Spec):
+sig
+  include Spec with module G = S.G
+                and module C = S.C
+                and module D = F (S.D)
+                and module V = S.V
+  val conv: (D.t, G.t, C.t, V.t) man -> (S.D.t, G.t, C.t, V.t) man
+end
 =
 struct
   module D = F (S.D)
@@ -105,10 +109,14 @@ struct
     D.lift @@ S.event (conv man) e (conv oman)
 end
 
-module GlobalDomainLifter (N: NameLifter) (F: LatticeLifter) (S:Spec)
-  : Spec with module D = S.D
-          and module G = F (S.G)
-          and module C = S.C
+module GlobalDomainLifter (N: NameLifter) (F: LatticeLifter) (S:Spec):
+sig
+  include Spec with module D = S.D
+                and module G = F (S.G)
+                and module C = S.C
+                and module V = S.V
+  val conv: (D.t, G.t, C.t, V.t) man -> (D.t, S.G.t, C.t, V.t) man
+end
 =
 struct
   module D = S.D
@@ -213,10 +221,14 @@ module type PrintableLifter =
     val unlift: t -> P.t
   end
 
-module ContextLifter (N: NameLifter) (F: PrintableLifter) (S:Spec)
-  : Spec with module D = S.D
-          and module G = S.G
-          and module C = F (S.C)
+module ContextLifter (N: NameLifter) (F: PrintableLifter) (S:Spec):
+sig
+  include Spec with module D = S.D
+                and module G = S.G
+                and module C = F (S.C)
+                and module V = S.V
+  val conv: (D.t, G.t, C.t, V.t) man -> (D.t, G.t, S.C.t, V.t) man
+end
 =
 struct
   module D = S.D

--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -105,6 +105,85 @@ struct
     D.lift @@ S.event (conv man) e (conv oman)
 end
 
+module GlobalDomainLifter (N: NameLifter) (F: LatticeLifter) (S:Spec)
+  : Spec with module D = S.D
+          and module G = F (S.G)
+          and module C = S.C
+=
+struct
+  module D = S.D
+  module G = F (S.G)
+  module C = S.C
+  module V = S.V
+  module P = S.P
+
+  let name () = N.lift_name (S.name ())
+
+  type marshal = S.marshal
+  let init = S.init
+  let finalize = S.finalize
+
+  let startstate = S.startstate
+  let exitstate  = S.exitstate
+  let morphstate = S.morphstate
+
+  let conv man =
+    { man with global = (fun v -> G.unlift (man.global v))
+             ; sideg = (fun v g -> man.sideg v (G.lift g))
+    }
+
+  let context man fd = S.context (conv man) fd
+  let startcontext () = S.startcontext ()
+
+  let sync man reason =
+    S.sync (conv man) reason
+
+  let query man =
+    S.query (conv man)
+
+  let assign man lv e =
+    S.assign (conv man) lv e
+
+  let vdecl man v =
+    S.vdecl (conv man) v
+
+  let branch man e tv =
+    S.branch (conv man) e tv
+
+  let body man f =
+    S.body (conv man) f
+
+  let return man r f =
+    S.return (conv man) r f
+
+  let asm man =
+    S.asm (conv man)
+
+  let skip man =
+    S.skip (conv man)
+
+  let enter man r f args =
+    S.enter (conv man) r f args
+
+  let special man r f args =
+    S.special (conv man) r f args
+
+  let combine_env man r fe f args fc es f_ask =
+    S.combine_env (conv man) r fe f args fc es f_ask
+
+  let combine_assign man r fe f args fc es f_ask =
+    S.combine_assign (conv man) r fe f args fc es f_ask
+
+  let threadenter man ~multiple lval f args =
+    S.threadenter (conv man) ~multiple lval f args
+
+  let threadspawn man ~multiple lval f args fman =
+    S.threadspawn (conv man) ~multiple lval f args (conv fman)
+
+  let paths_as_set man = S.paths_as_set (conv man)
+  let event man e oman = S.event (conv man) e (conv oman)
+end
+
 (** Lifts a [Spec] so that the domain is [Hashcons]d *)
 module HashconsLifter (S: Spec) = (* keep functor eta-expanded to look up option when lifter is actually used *)
 struct

--- a/src/lifters/wideningDelay.ml
+++ b/src/lifters/wideningDelay.ml
@@ -24,6 +24,9 @@ struct
   module Chain = Printable.Chain (ChainParams)
   include Printable.Prod (Base) (Chain)
 
+  let lift d = (d, 0)
+  let unlift (d, _) = d
+
   let bot () = (Base.bot (), 0)
   let is_bot (b, _) = Base.is_bot b
   let top () = (Base.top (), ChainParams.n ())
@@ -58,9 +61,6 @@ struct
 
     let printXml f (b, i) =
       BatPrintf.fprintf f "%a<analysis name=\"widen-delay\">%a</analysis>" D.printXml b Chain.printXml i
-
-    let lift d = (d, 0)
-    let unlift (d, _) = d
   end
 
   module NameLifter =
@@ -86,9 +86,6 @@ struct
 
     let printXml f (b, i) =
       BatPrintf.fprintf f "%a<analysis name=\"widen-delay\">%a</analysis>" G.printXml b Chain.printXml i
-
-    let lift d = (d, 0)
-    let unlift (d, _) = d
   end
 
   module NameLifter =

--- a/src/lifters/wideningDelay.ml
+++ b/src/lifters/wideningDelay.ml
@@ -69,12 +69,12 @@ struct
   end
   include SpecLifters.DomainLifter (NameLifter) (DD) (S)
 
+  (* Redefine morphstate and paths_as_set to keep counter instead of resetting to 0. *)
+
   let morphstate v (d, l) = (S.morphstate v d, l)
 
   let paths_as_set man =
-    let liftmap = List.map (fun (x, _) -> (x, snd man.local)) in
-    (* TODO: expose conv from DomainLifter? *)
-    liftmap (paths_as_set man)
+    List.map (fun x -> (x, snd man.local)) @@ S.paths_as_set (conv man)
 end
 
 (** Lift {!S} to use widening delay for global unknowns. *)


### PR DESCRIPTION
This applies #1692 to #1483, which was the original intention of #1692.
Here `SpecLifters.GlobalDomainLifter` is also added.