### PR TITLE
Disable `graphml` witnesses in `svcomp.json`

### DIFF
--- a/conf/svcomp-validate.json
+++ b/conf/svcomp-validate.json
@@ -93,9 +93,6 @@
     }
   },
   "witness": {
-    "graphml": {
-      "enabled": false
-    },
     "yaml": {
       "enabled": false,
       "strict": true,

--- a/conf/svcomp.json
+++ b/conf/svcomp.json
@@ -89,11 +89,6 @@
     }
   },
   "witness": {
-    "graphml": {
-      "enabled": true,
-      "id": "enumerate",
-      "unknown": false
-    },
     "yaml": {
       "enabled": true,
       "format-version": "2.0",


### PR DESCRIPTION
This is the part of #1732 that can be done immediately. I'll leave it to someone more familiar with the ARG which parts of the GraphML facility need to stay.