### PR TITLE
Deduplicate `IntDomain` module types

### DIFF
--- a/src/cdomain/value/cdomains/intDomain.mli
+++ b/src/cdomain/value/cdomains/intDomain.mli
@@ -1,1 +1,3 @@
+(** Abstract domains for C integers. *)
+
 include IntDomain_intf.IntDomain (** @inline *)

--- a/src/cdomain/value/cdomains/intDomain.mli
+++ b/src/cdomain/value/cdomains/intDomain.mli
@@ -1,0 +1,1 @@
+include IntDomain_intf.IntDomain (** @inline *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -1,7 +1,6 @@
 open GobConfig
 open GoblintCil
 open Pretty
-open PrecisionUtil
 
 include IntDomain_intf
 
@@ -110,28 +109,6 @@ sig
 
 end
 
-module type Y =
-sig
-  include B
-  include Lattice.Top with type t := t
-  include Arith with type t:= t
-  val of_int: Cil.ikind -> int_t -> t
-  val of_bool: Cil.ikind -> bool -> t
-  val of_interval: ?suppress_ovwarn:bool -> Cil.ikind -> int_t * int_t -> t
-  val of_congruence: Cil.ikind -> int_t * int_t -> t
-  val of_bitfield: Cil.ikind -> int_t * int_t -> t
-  val to_bitfield: Cil.ikind -> t -> int_t * int_t
-
-  val starting   : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
-  val ending     : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
-  val is_top_of: Cil.ikind -> t -> bool
-
-  val project: int_precision -> t -> t
-  val invariant: Cil.exp -> t -> Invariant.t
-end
-
-module type Z = Y with type int_t = Z.t
-
 
 module IntDomLifter (I : S) =
 struct
@@ -238,10 +215,6 @@ struct
   let project p v =  { v = I.project v.ikind p v.v; ikind = v.ikind }
 end
 
-module type Ikind =
-sig
-  val ikind: unit -> Cil.ikind
-end
 
 module PtrDiffIkind : Ikind =
 struct

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -2,6 +2,10 @@
 
 open GoblintCil
 
+module type IntDomain =
+sig
+(* TODO: fix indent *)
+
 val should_wrap: Cil.ikind -> bool
 val should_ignore_overflow: Cil.ikind -> bool
 
@@ -448,3 +452,5 @@ module Lift (Base: IkindUnawareS): IkindUnawareS with type t = [ `Bot | `Lifted 
 (* module IncExcInterval : S with type t = [ | `Excluded of Interval.t| `Included of Interval.t ] *)
 (** Inclusive and exclusive intervals. Warning: NOT A LATTICE *)
 module Enums : S with type int_t = Z.t
+
+end

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -1,5 +1,3 @@
-(** Abstract domains for C integers. *)
-
 open GoblintCil
 
 

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -2,14 +2,6 @@
 
 open GoblintCil
 
-module type IntDomain =
-sig
-(* TODO: fix indent *)
-
-val should_wrap: Cil.ikind -> bool
-val should_ignore_overflow: Cil.ikind -> bool
-
-val reset_lazy: unit -> unit
 
 type overflow_info = { overflow: bool; underflow: bool;}
 
@@ -315,6 +307,25 @@ sig
 
 
 end
+
+module type IntDomain =
+sig
+(* TODO: fix indent *)
+
+val should_wrap: Cil.ikind -> bool
+val should_ignore_overflow: Cil.ikind -> bool
+
+val reset_lazy: unit -> unit
+
+type nonrec overflow_info = overflow_info = { overflow: bool; underflow: bool;}
+
+module type Arith = Arith
+module type ArithIkind = ArithIkind
+module type B = B
+module type IkindUnawareS = IkindUnawareS
+module type S = S
+module type SOverflow = SOverflow
+
 
 module SOverflowUnlifter (D : SOverflow) : S with type int_t = D.int_t and type t = D.t
 

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -308,28 +308,6 @@ sig
 
 end
 
-module type IntDomain =
-sig
-(* TODO: fix indent *)
-
-val should_wrap: Cil.ikind -> bool
-val should_ignore_overflow: Cil.ikind -> bool
-
-val reset_lazy: unit -> unit
-
-type nonrec overflow_info = overflow_info = { overflow: bool; underflow: bool;}
-
-module type Arith = Arith
-module type ArithIkind = ArithIkind
-module type B = B
-module type IkindUnawareS = IkindUnawareS
-module type S = S
-module type SOverflow = SOverflow
-
-
-module SOverflowUnlifter (D : SOverflow) : S with type int_t = D.int_t and type t = D.t
-
-
 module type Y =
 sig
   include B
@@ -362,12 +340,38 @@ end
 
 module type Z = Y with type int_t = Z.t
 
-module IntDomLifter (I: S): Y with type int_t = I.int_t
-
 module type Ikind =
 sig
   val ikind: unit -> Cil.ikind
 end
+
+
+module type IntDomain =
+sig
+(* TODO: fix indent *)
+
+val should_wrap: Cil.ikind -> bool
+val should_ignore_overflow: Cil.ikind -> bool
+
+val reset_lazy: unit -> unit
+
+type nonrec overflow_info = overflow_info = { overflow: bool; underflow: bool;}
+
+module type Arith = Arith
+module type ArithIkind = ArithIkind
+module type B = B
+module type IkindUnawareS = IkindUnawareS
+module type S = S
+module type SOverflow = SOverflow
+
+module SOverflowUnlifter (D : SOverflow) : S with type int_t = D.int_t and type t = D.t
+
+module type Y = Y
+module type Z = Z
+
+module IntDomLifter (I: S): Y with type int_t = I.int_t
+
+module type Ikind = Ikind
 
 module PtrDiffIkind : Ikind
 


### PR DESCRIPTION
This applies the `_intf` trick, which we also have in a few other places, to `IntDomain` where it's particularly useful because there are many large module types that currently are duplicated in `intDomain.mli` and `intDomain0.ml`.