### PR TITLE
Remove `IntDomain.Size.top_typ`

### DIFF
--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -233,7 +233,6 @@ module Size = struct (* size in bits as int, range as int64 *)
   open Cil
   let sign x = if Z.compare x Z.zero < 0 then `Signed else `Unsigned
 
-  let top_typ = TInt (ILongLong, [])
   let min_for x = intKindForValue x (sign x = `Unsigned)
   let bit = function (* bits needed for representation *)
     | IBool -> 1

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -387,8 +387,6 @@ sig
 
 
   module Size : sig
-    (** The biggest type we support for integers. *)
-    val top_typ         : Cil.typ
     val range           : Cil.ikind -> Z.t * Z.t
     val is_cast_injective : from_type:Cil.typ -> to_type:Cil.typ -> bool
     val bits            : Cil.ikind -> int * int

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -702,7 +702,7 @@ struct
     | (x, Top) -> x
     | (Int x, Int y) -> Int (ID.meet x y)
     | (Float x, Float y) -> Float (FD.meet x y)
-    | (Int _, Address _) -> meet x (cast (TInt(Cilfacade.ptr_ikind (),[])) y)
+    | (Int _, Address _) -> meet x (cast !GoblintCil.upointType y)
     | (Address x, Int y) -> Address (AD.meet x (AD.of_int y))
     | (Address x, Address y) -> Address (AD.meet x y)
     | (Struct x, Struct y) -> Struct (Structs.meet x y)
@@ -727,7 +727,7 @@ struct
     match (x,y) with
     | (Int x, Int y) -> Int (ID.narrow x y)
     | (Float x, Float y) -> Float (FD.narrow x y)
-    | (Int _, Address _) -> narrow x (cast (TInt(Cilfacade.ptr_ikind (),[])) y)
+    | (Int _, Address _) -> narrow x (cast !GoblintCil.upointType y)
     | (Address x, Int y) -> Address (AD.narrow x (AD.of_int y))
     | (Address x, Address y) -> Address (AD.narrow x y)
     | (Struct x, Struct y) -> Struct (Structs.narrow x y)

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -727,7 +727,7 @@ struct
     match (x,y) with
     | (Int x, Int y) -> Int (ID.narrow x y)
     | (Float x, Float y) -> Float (FD.narrow x y)
-    | (Int _, Address _) -> narrow x (cast IntDomain.Size.top_typ y)
+    | (Int _, Address _) -> narrow x (cast (TInt(Cilfacade.ptr_ikind (),[])) y)
     | (Address x, Int y) -> Address (AD.narrow x (AD.of_int y))
     | (Address x, Address y) -> Address (AD.narrow x y)
     | (Struct x, Struct y) -> Struct (Structs.narrow x y)


### PR DESCRIPTION
This is on top of #1741.

It's out of date now that we have 128bit integers.
Moreover, it's only usage in `ValueDomain` should just use the right type for pointers.

Also using use `GoblintCil.upointType` directly to avoid reconstructing type from which the ikind was extracted to begin with.