### PR TITLE
Add weak dependencies to TD3

### DIFF
--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -2417,6 +2417,19 @@
               "description": "Check TD3 data structure invariants",
               "type": "boolean",
               "default": false
+            },
+            "wk_deps": {
+              "title": "solvers.td3.wk_deps",
+              "type": "object",
+              "properties": {
+                "eager": {
+                  "title": "solvers.td3.wk_deps.eager",
+                  "description": "Should weak dependencies be solved immediately when first added to wk_deps",
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/src/constraint/constrSys.ml
+++ b/src/constraint/constrSys.ml
@@ -285,13 +285,13 @@ struct
       match S.system x with
       | None -> None
       | Some f ->
-        let f' get set =
+        let f' get set demand =
           let old_current_var = !current_var in
           current_var := Some x;
           Fun.protect ~finally:(fun () ->
               current_var := old_current_var
             ) (fun () ->
-              f get set
+              f get set demand
             )
         in
         Some f'

--- a/src/constraint/constrSys.ml
+++ b/src/constraint/constrSys.ml
@@ -195,8 +195,8 @@ struct
   let lD, gD = (fun x -> `Lifted2 x), (fun x -> `Lifted1 x)
 
   let conv f get set demand  =
-    f (getL % get % l) (fun x v -> set (l x) (lD v)) (ignore )
-      (getG % get % g) (fun x v -> set (g x) (gD v)) (ignore )
+    f (getL % get % l) (fun x v -> set (l x) (lD v)) (demand % l)
+      (getG % get % g) (fun x v -> set (g x) (gD v)) (demand % g)
     |> lD
 
   let system = function

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -50,7 +50,7 @@ struct
     if !AnalysisState.postsolving then
       sideg (GVar.contexts f) (G.create_contexts (G.CSet.singleton c))
 
-  let common_ctx var edge prev_node pval (getl:lv -> ld) sidel demandl getg sideg demandg : (D.t, S.G.t, S.C.t, S.V.t) ctx * D.t list ref * (lval option * varinfo * exp list * D.t * bool) list ref =
+  let common_ctx var edge prev_node pval (getl:lv -> ld) sidel (demandl: lv -> unit) getg sideg demandg : (D.t, S.G.t, S.C.t, S.V.t) ctx * D.t list ref * (lval option * varinfo * exp list * D.t * bool) list ref =
     let r = ref [] in
     let spawns = ref [] in
     (* now watch this ... *)
@@ -78,7 +78,8 @@ struct
           | fd ->
             let c = S.context ctx fd d in
             sidel (FunctionEntry fd, c) d;
-            ignore (getl (Function fd, c))
+            demandl (Function fd, c);
+
           | exception Not_found ->
             (* unknown function *)
             M.error ~category:Imprecise ~tags:[Category Unsound] "Created a thread from unknown function %s" f.vname

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -50,7 +50,7 @@ struct
     if !AnalysisState.postsolving then
       sideg (GVar.contexts f) (G.create_contexts (G.CSet.singleton c))
 
-  let common_ctx var edge prev_node pval (getl:lv -> ld) sidel getg sideg : (D.t, S.G.t, S.C.t, S.V.t) ctx * D.t list ref * (lval option * varinfo * exp list * D.t * bool) list ref =
+  let common_ctx var edge prev_node pval (getl:lv -> ld) sidel demandl getg sideg demandg : (D.t, S.G.t, S.C.t, S.V.t) ctx * D.t list ref * (lval option * varinfo * exp list * D.t * bool) list ref =
     let r = ref [] in
     let spawns = ref [] in
     (* now watch this ... *)
@@ -121,13 +121,13 @@ struct
 
   let common_joins ctx ds splits spawns = common_join ctx (bigsqcup ds) splits spawns
 
-  let tf_assign var edge prev_node lv e getl sidel getg sideg d =
-    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
+  let tf_assign var edge prev_node lv e getl sidel demandl getg sideg demandg d =
+    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel demandl getg sideg demandg in
     let d = S.assign ctx lv e in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join ctx d !r !spawns
 
-  let tf_vdecl var edge prev_node v getl sidel getg sideg d =
-    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
+  let tf_vdecl var edge prev_node v getl sidel demandl getg sideg demandg d =
+    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel demandl getg sideg demandg in
     let d = S.vdecl ctx v in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join ctx d !r !spawns
 
@@ -142,8 +142,8 @@ struct
     let nval = S.sync { ctx with local = spawning_return } `Return in
     nval
 
-  let tf_ret var edge prev_node ret fd getl sidel getg sideg d =
-    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
+  let tf_ret var edge prev_node ret fd getl sidel demandl getg sideg demandg d =
+    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel demandl getg sideg demandg in
     let d = (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
       if (CilType.Fundec.equal fd MyCFG.dummy_func ||
           List.mem fd.svar.vname (get_string_list "mainfun")) &&
@@ -153,21 +153,21 @@ struct
     in
     common_join ctx d !r !spawns
 
-  let tf_entry var edge prev_node fd getl sidel getg sideg d =
+  let tf_entry var edge prev_node fd getl sidel demandl getg sideg demandg d =
     (* Side effect function context here instead of at sidel to FunctionEntry,
        because otherwise context for main functions (entrystates) will be missing or pruned during postsolving. *)
     let c: unit -> S.C.t = snd var |> Obj.obj in
     side_context sideg fd (c ());
-    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
+    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel demandl getg sideg demandg in
     let d = S.body ctx fd in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join ctx d !r !spawns
 
-  let tf_test var edge prev_node e tv getl sidel getg sideg d =
-    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
+  let tf_test var edge prev_node e tv getl sidel demandl getg sideg demandg d =
+    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel demandl getg sideg demandg in
     let d = S.branch ctx e tv in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join ctx d !r !spawns
 
-  let tf_normal_call ctx lv e (f:fundec) args getl sidel getg sideg =
+  let tf_normal_call ctx lv e (f:fundec) args getl sidel demandl getg sideg demandg =
     let combine (cd, fc, fd) =
       if M.tracing then M.traceli "combine" "local: %a" S.D.pretty cd;
       if M.tracing then M.trace "combine" "function: %a" S.D.pretty fd;
@@ -235,8 +235,8 @@ struct
 
   let tf_special_call ctx lv f args = S.special ctx lv f args
 
-  let tf_proc var edge prev_node lv e args getl sidel getg sideg d =
-    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
+  let tf_proc var edge prev_node lv e args getl sidel demandl getg sideg demandg d =
+    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel demandl getg sideg demandg in
     let functions =
       match e with
       | Lval (Var v, NoOffset) ->
@@ -261,7 +261,7 @@ struct
                 M.info ~category:Analyzer "Using special for defined function %s" f.vname;
                 tf_special_call ctx lv f args
               | fd ->
-                tf_normal_call ctx lv e fd args getl sidel getg sideg
+                tf_normal_call ctx lv e fd args getl sidel demandl getg sideg demandg
               | exception Not_found ->
                 tf_special_call ctx lv f args)
           end
@@ -282,17 +282,17 @@ struct
     end else
       common_joins ctx funs !r !spawns
 
-  let tf_asm var edge prev_node getl sidel getg sideg d =
-    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
+  let tf_asm var edge prev_node getl sidel demandl getg sideg demandg d =
+    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel demandl getg sideg demandg in
     let d = S.asm ctx in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join ctx d !r !spawns
 
-  let tf_skip var edge prev_node getl sidel getg sideg d =
-    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel getg sideg in
+  let tf_skip var edge prev_node getl sidel demandl getg sideg demandg d =
+    let ctx, r, spawns = common_ctx var edge prev_node d getl sidel demandl getg sideg demandg in
     let d = S.skip ctx in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join ctx d !r !spawns
 
-  let tf var getl sidel getg sideg prev_node edge d =
+  let tf var getl sidel demandl getg sideg demandg prev_node edge d =
     begin match edge with
       | Assign (lv,rv) -> tf_assign var edge prev_node lv rv
       | VDecl (v)      -> tf_vdecl var edge prev_node v
@@ -302,7 +302,7 @@ struct
       | Test (p,b)     -> tf_test var edge prev_node p b
       | ASM (_, _, _)  -> tf_asm var edge prev_node (* TODO: use ASM fields for something? *)
       | Skip           -> tf_skip var edge prev_node
-    end getl sidel getg sideg d
+    end getl sidel demandl getg sideg demandg d
 
   type Goblint_backtrace.mark += TfLocation of location
 
@@ -312,7 +312,7 @@ struct
       | _ -> None (* for other marks *)
     )
 
-  let tf var getl sidel getg sideg prev_node (_,edge) d (f,t) =
+  let tf var getl sidel demandl getg sideg demandg prev_node (_,edge) d (f,t) =
     let old_loc  = !Goblint_tracing.current_loc in
     let old_loc2 = !Goblint_tracing.next_loc in
     Goblint_tracing.current_loc := f;
@@ -321,16 +321,16 @@ struct
         Goblint_tracing.current_loc := old_loc;
         Goblint_tracing.next_loc := old_loc2
       ) (fun () ->
-        let d       = tf var getl sidel getg sideg prev_node edge d in
+        let d       = tf var getl sidel demandl getg sideg demandg prev_node edge d in
         d
       )
 
-  let tf (v,c) (edges, u) getl sidel getg sideg =
+  let tf (v,c) (edges, u) getl sidel demandl getg sideg demandg =
     let pval = getl (u,c) in
     let _, locs = List.fold_right (fun (f,e) (t,xs) -> f, (f,t)::xs) edges (Node.location v,[]) in
-    List.fold_left2 (|>) pval (List.map (tf (v,Obj.repr (fun () -> c)) getl sidel getg sideg u) edges) locs
+    List.fold_left2 (|>) pval (List.map (tf (v,Obj.repr (fun () -> c)) getl sidel demandl getg sideg demandg u) edges) locs
 
-  let tf (v,c) (e,u) getl sidel getg sideg =
+  let tf (v,c) (e,u) getl sidel demandl getg sideg demandg =
     let old_node = !current_node in
     let old_fd = Option.map Node.find_fundec old_node |? Cil.dummyFunDec in
     let new_fd = Node.find_fundec v in
@@ -345,7 +345,7 @@ struct
         if not (CilType.Fundec.equal old_fd new_fd) then
           Timing.Program.exit new_fd.svar.vname
       ) (fun () ->
-        let d       = tf (v,c) (e,u) getl sidel getg sideg in
+        let d       = tf (v,c) (e,u) getl sidel demandl getg sideg demandg in
         d
       )
 
@@ -354,8 +354,8 @@ struct
     | FunctionEntry _ ->
       None
     | _ ->
-      let tf getl sidel getg sideg =
-        let tf' eu = tf (v,c) eu getl sidel getg sideg in
+      let tf getl sidel demandl getg sideg demandg =
+        let tf' eu = tf (v,c) eu getl sidel demandl getg sideg demandg in
 
         match NodeH.find_option CfgTools.node_scc_global v with
         | Some scc when NodeH.mem scc.prev v && NodeH.length scc.prev = 1 ->

--- a/src/solver/effectWConEq.ml
+++ b/src/solver/effectWConEq.ml
@@ -42,13 +42,13 @@ module Make =
           HM.replace infl x VS.empty
         end;
         HM.replace stable x ();
-        set x (eq x (eval x) set)
+        set x (eq x (eval x) set (ignore ))
 
-      and eq x get set =
+      and eq x get set demand =
         eval_rhs_event x;
         match S.system x with
         | None  -> S.Dom.bot ()
-        | Some f -> f get set
+        | Some f -> f get set demand
 
       and eval x y =
         get_var_event y;

--- a/src/solver/generic.ml
+++ b/src/solver/generic.ml
@@ -173,7 +173,7 @@ module DirtyBoxSolver : GenericEqSolver =
           H.replace stbl x ();
           (* set the new value for [x] *)
           eval_rhs_event x;
-          Option.may (fun f -> set x (f (eval x) set)) (S.system x)
+          Option.may (fun f -> set x (f (eval x) set demand)) (S.system x)
         end
 
       (* return the value for [y] and mark its influence on [x] *)
@@ -204,6 +204,7 @@ module DirtyBoxSolver : GenericEqSolver =
           (* solve all dependencies *)
           solve_all deps
         end
+      and demand x = ()
 
       (* solve all elements of the list *)
       and solve_all xs =
@@ -255,7 +256,7 @@ module SoundBoxSolverImpl =
           (* set the new value for [x] *)
           eval_rhs_event x;
           let set_x d = if H.mem called x then set x d in
-          Option.may (fun f -> set_x (f (eval x) side)) (S.system x);
+          Option.may (fun f -> set_x (f (eval x) side demand)) (S.system x);
           (* remove [x] from called *)
           H.remove called x
         end
@@ -269,6 +270,8 @@ module SoundBoxSolverImpl =
         H.replace infl y (x :: h_find_default infl y []);
         (* return the value for [y] *)
         H.find sol y
+
+      and demand x = ()
 
       (* this is the function we give to [S.system] *)
       and side x d =
@@ -363,10 +366,11 @@ module PreciseSideEffectBoxSolver : GenericEqSolver =
           H.remove sols x;
           (* set the new value for [x] *)
           eval_rhs_event x;
-          Option.may (fun f -> set x (f (eval x) (side x))) (S.system x);
+          Option.may (fun f -> set x (f (eval x) (side x) demand )) (S.system x);
           (* remove [x] from called *)
           H.remove called x
         end
+      and demand x = ()
 
       (* return the value for [y] and mark its influence on [x] *)
       and eval x y =

--- a/src/solver/postSolver.ml
+++ b/src/solver/postSolver.ml
@@ -207,8 +207,7 @@ struct
         one_var y
       in
       let demand y =
-        (* TODO: Implementation for demand *)
-        ()
+        one_var y;
       in
       let rhs = f get set demand in
       if M.tracing then M.trace "postsolver" "one_constraint %a %a" S.Var.pretty_trace x S.Dom.pretty rhs;

--- a/src/solver/postSolver.ml
+++ b/src/solver/postSolver.ml
@@ -157,8 +157,8 @@ struct
   let system x =
     match S.system x, VH.find_option starth x with
     | f_opt, None -> f_opt
-    | None, Some d -> Some (fun _ _ -> d)
-    | Some f, Some d -> Some (fun get set -> S.Dom.join (f get set) d)
+    | None, Some d -> Some (fun _ _ _ -> d)
+    | Some f, Some d -> Some (fun get set demand -> S.Dom.join (f get set demand) d)
 end
 
 (** Postsolver for incremental. *)
@@ -206,7 +206,11 @@ struct
         (* check before recursing *)
         one_var y
       in
-      let rhs = f get set in
+      let demand y =
+        (* TODO: Implementation for demand *)
+        ()
+      in
+      let rhs = f get set demand in
       if M.tracing then M.trace "postsolver" "one_constraint %a %a" S.Var.pretty_trace x S.Dom.pretty rhs;
       PS.one_constraint ~vh ~x ~rhs
     in

--- a/src/solver/sLR.ml
+++ b/src/solver/sLR.ml
@@ -60,7 +60,7 @@ module SLR3 =
           HM.remove wpoint x;
           HM.replace stable x ();
           let old = HM.find rho x in
-          let tmp = eq x (eval x) (side x) in
+          let tmp = eq x (eval x) (side x) (ignore % eval x) in
           let tmp = S.Dom.join tmp (sides x) in
           if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
           if tracing then trace "sol" "Contrib:%a" S.Dom.pretty tmp;
@@ -85,7 +85,7 @@ module SLR3 =
           done;
         end;
         assert (HM.mem stable x)
-      and eq x get set =
+      and eq x get set demand =
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
@@ -98,7 +98,7 @@ module SLR3 =
             );
             set y d
           in
-          f get sidef
+          f get sidef demand
       and eval x y =
         get_var_event y;
         if not (HM.mem rho y) then init y;
@@ -308,7 +308,7 @@ module Make0 =
       let _ = List.iter (fun (x,v) -> XY.set_value (x,x) v; T.update T.set x (P.single x)) st in
       let _ = work := H.merge (H.from_list list) !work in
 
-      let eq x get set =
+      let eq x get set demand =
         match S.system x with
         | None -> S.Dom.bot ()
         | Some f ->
@@ -317,7 +317,7 @@ module Make0 =
             let _ = X.get_key x in (* set priority immediately! *)
             h_find_default sides x (S.Dom.bot ()) |> S.Dom.join v |> HM.replace sides x
           in
-          let d = f get collect_set in
+          let d = f get collect_set demand in
           HM.iter set sides;
           d
       in
@@ -397,7 +397,7 @@ module Make0 =
           let _ = P.insert stable x in
           let old = X.get_value x in
 
-          let tmp = do_side x (eq x (eval x) (side x)) in
+          let tmp = do_side x (eq x (eval x) (side x) (ignore )) in
           let use_box = (not (V.ver>1)) || HM.mem wpoint x in
           let restart_mode_x = h_find_default restart_mode x (2*GobConfig.get_int "solvers.slr4.restart_count") in
           let rstrt = use_box && (V.ver>3) && D.leq tmp old && restart_mode_x <> 0 in

--- a/src/solver/sLR.ml
+++ b/src/solver/sLR.ml
@@ -397,7 +397,7 @@ module Make0 =
           let _ = P.insert stable x in
           let old = X.get_value x in
 
-          let tmp = do_side x (eq x (eval x) (side x) (ignore )) in
+          let tmp = do_side x (eq x (eval x) (side x) (ignore % eval x)) in
           let use_box = (not (V.ver>1)) || HM.mem wpoint x in
           let restart_mode_x = h_find_default restart_mode x (2*GobConfig.get_int "solvers.slr4.restart_count") in
           let rstrt = use_box && (V.ver>3) && D.leq tmp old && restart_mode_x <> 0 in

--- a/src/solver/sLRphased.ml
+++ b/src/solver/sLRphased.ml
@@ -98,7 +98,7 @@ module Make =
           );
           HM.replace wpoint y ()
         in
-        let tmp = eq x eval side in
+        let tmp = eq x eval side (ignore % eval) in
         let tmp = S.Dom.join tmp (sides x) in
         (* if (b && not (S.Dom.leq old tmp)) then ( *)
         (*   trace "sol" "Var: %a\nOld: %a\nTmp: %a" S.Var.pretty_trace x S.Dom.pretty old S.Dom.pretty tmp; *)
@@ -163,11 +163,11 @@ module Make =
         let w = try HM.find set x with Not_found -> VS.empty in
         let v = Enum.fold (fun d z -> try S.Dom.join d (HPM.find rho' (z,x)) with Not_found -> d) (S.Dom.bot ()) (VS.enum w)
         in if tracing then trace "sol" "SIDES: Var: %a\nVal: %a" S.Var.pretty_trace x S.Dom.pretty v; v
-      and eq x get set =
+      and eq x get set demand =
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
-        | Some f -> f get set
+        | Some f -> f get set demand
       in
 
       let set_start (x,d) =

--- a/src/solver/sLRterm.ml
+++ b/src/solver/sLRterm.ml
@@ -149,7 +149,7 @@ module SLR3term =
           );
           HM.replace wpoint y ()
         in
-        let tmp = eq x eval side in
+        let tmp = eq x eval side (ignore % eval) in
         let tmp = S.Dom.join tmp (sides x) in
         let val_new, b_new =
           if wpx then
@@ -184,11 +184,11 @@ module SLR3term =
           HM.replace infl x VS.empty
         end;
         b_new
-      and eq x get set =
+      and eq x get set demand =
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
-        | Some f -> f get set
+        | Some f -> f get set demand
       in
 
       let set_start (x,d) =

--- a/src/solver/td3.ml
+++ b/src/solver/td3.ml
@@ -238,6 +238,7 @@ module Base =
 
       let narrow_reuse = GobConfig.get_bool "solvers.td3.narrow-reuse" in
       let remove_wpoint = GobConfig.get_bool "solvers.td3.remove-wpoint" in
+      let eager_solve_wk_deps = GobConfig.get_bool "solvers.td3.wk_deps.eager" in
 
       let side_dep = data.side_dep in
       let side_infl = data.side_infl in
@@ -395,6 +396,10 @@ module Base =
       and demand_thr x y =
         if tracing then trace "sol2" "demand weak dep %a from %a" S.Var.pretty_trace y S.Var.pretty_trace x;
         HM.replace weak_dep x (VS.add y (try HM.find weak_dep x with Not_found -> VS.empty));
+        (* TODO: should we check if it is already added? and solve if it is not*)
+        if eager_solve_wk_deps then (
+          solve y Widen;
+        );
         
       and eval l x y =
         if tracing then trace "sol2" "eval %a ## %a" S.Var.pretty_trace x S.Var.pretty_trace y;

--- a/src/solver/td3.ml
+++ b/src/solver/td3.ml
@@ -808,10 +808,9 @@ module Base =
         ) else (
           if tracing then trace "sol2" "unstable_wk_deps length %i" (List.length unstable_wk_dps);
         );
-        List.iter (fun x -> solve x Widen) unstable_wk_dps;
-      
-        
-        let unstable_vs = List.filter (neg (HM.mem stable)) vs in
+
+        let interesting_vs = List.append (List.append List.([]) unstable_wk_dps ) vs in
+        let unstable_vs = List.filter (neg (HM.mem stable)) (interesting_vs) in
         if unstable_vs <> [] then (
           if Logs.Level.should_log Debug then (
             if !i = 1 then Logs.newline ();

--- a/src/solver/topDown.ml
+++ b/src/solver/topDown.ml
@@ -57,7 +57,7 @@ module WP =
           let wpx = HM.mem wpoint x in
           init x;
           let old = HM.find rho x in
-          let tmp' = eq x (eval x) (side x) in
+          let tmp' = eq x (eval x) (side x) (ignore % eval x) in
           let tmp = S.Dom.join tmp' (sides x) in
           if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
           if tracing then trace "sol" "Contrib:%a" S.Dom.pretty tmp;
@@ -73,7 +73,7 @@ module WP =
           );
           (solve[@tailcall]) x
         )
-      and eq x get set =
+      and eq x get set demand =
         if tracing then trace "sol2" "eq %a" S.Var.pretty_trace x;
         eval_rhs_event x;
         match S.system x with
@@ -87,7 +87,7 @@ module WP =
             );
             set y d
           in
-          f get sidef
+          f get sidef demand
       and eval x y =
         if tracing then trace "sol2" "eval %a ## %a" S.Var.pretty_trace x S.Var.pretty_trace y;
         get_var_event y;

--- a/src/solver/topDown_deprecated.ml
+++ b/src/solver/topDown_deprecated.ml
@@ -52,7 +52,7 @@ module TD3 =
           HM.remove wpoint x;
           HM.replace stable x ();
           let old = HM.find rho x in
-          let tmp = eq x (eval x) (side x) in
+          let tmp = eq x (eval x) (side x) (ignore % (eval x)) in
           let tmp = S.Dom.join tmp (sides x) in
           if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
           if tracing then trace "sol" "Contrib:%a" S.Dom.pretty tmp;
@@ -67,7 +67,7 @@ module TD3 =
             (solve[@tailcall]) x;
           end;
         end;
-      and eq x get set =
+      and eq x get set demand =
         if tracing then trace "sol2" "eq %a" S.Var.pretty_trace x;
         eval_rhs_event x;
         match S.system x with
@@ -81,7 +81,7 @@ module TD3 =
             );
             set y d
           in
-          f get sidef
+          f get sidef demand
       and eval x y =
         if tracing then trace "sol2" "eval %a ## %a" S.Var.pretty_trace x S.Var.pretty_trace y;
         get_var_event y;

--- a/src/solver/topDown_term.ml
+++ b/src/solver/topDown_term.ml
@@ -48,7 +48,7 @@ module WP =
           let wpx = HM.mem wpoint x in
           init x;
           let old = HM.find rho x in
-          let tmp = eq x (eval x) side in
+          let tmp = eq x (eval x) side demand in
           let tmp = S.Dom.join tmp (try HM.find rho' x with Not_found -> S.Dom.bot ()) in
           if tracing then trace "sol" "Var: %a" S.Var.pretty_trace x ;
           if tracing then trace "sol" "Contrib:%a" S.Dom.pretty tmp;
@@ -69,12 +69,12 @@ module WP =
             (solve[@tailcall]) x Narrow;
           );
         )
-      and eq x get set =
+      and eq x get set demand =
         if tracing then trace "sol2" "eq %a" S.Var.pretty_trace x;
         eval_rhs_event x;
         match S.system x with
         | None -> S.Dom.bot ()
-        | Some f -> f get set
+        | Some f -> f get set demand
       and eval x y =
         if tracing then trace "sol2" "eval %a ## %a" S.Var.pretty_trace x S.Var.pretty_trace y;
         get_var_event y;
@@ -90,6 +90,7 @@ module WP =
           init y;
           solve y Widen;
         )
+      and demand y = ()
       and init x =
         if tracing then trace "sol2" "init %a" S.Var.pretty_trace x;
         if not (HM.mem rho x) then (

--- a/src/solver/worklist.ml
+++ b/src/solver/worklist.ml
@@ -13,12 +13,12 @@ module Make =
 
     open S.Dom
 
-    let eq x get set =
+    let eq x get set demand =
       match S.system x with
       | None -> bot ()
       | Some f ->
         eval_rhs_event x;
-        f get set
+        f get set demand
 
     let solve st vs =
       let infl = HM.create 10 in
@@ -54,7 +54,7 @@ module Make =
       while not (VS.is_empty !vs) do
         let x, vs' = VS.pop !vs in
         let _ = vs := vs' in
-        set x (eq x (eval x) set)
+        set x (eq x (eval x) set (ignore % (eval x)))
       done;
       stop_event ();
       rho

--- a/tests/regression/82-weak-deps/01-basic_weak_dep.c
+++ b/tests/regression/82-weak-deps/01-basic_weak_dep.c
@@ -1,0 +1,38 @@
+// PARAM: --set "ana.activated[+]" signs
+// Fully context-insensitive
+#include <goblint.h>
+#include <pthread.h>
+
+int g = 0;
+int y = 0;
+
+void *t_foo(void *arg) {
+  if (g == 1) {
+     y = 1;
+  }
+
+}
+
+int main() {
+  int x;
+  int k = 1;
+  int l = 2;
+  int m = 3;
+  int n = 4;
+  
+  pthread_t id;
+  pthread_create(&id, NULL, t_foo, NULL);
+  int a = 1; // should not be re-evaluated 
+  int b = 2; // should not be re-evaluated 
+  int c = 3; // should not be re-evaluated 
+  int d = 4; // should not be re-evaluated 
+  g = 1;
+  x = y;
+  int d = 4;
+
+  __goblint_check(y < 2); // SUCCESS
+  __goblint_check(y == 1); // UNKNOWN!
+  __goblint_check(x < 2); // SUCCESS
+  __goblint_check(x == 1); // UNKNOWN!
+  return 0;
+}

--- a/tests/unit/solver/solverTest.ml
+++ b/tests/unit/solver/solverTest.ml
@@ -37,11 +37,11 @@ module ConstrSys = struct
     3. z := y
     4. w := w + 1 [also g := 42; _ := z]
     *)
-  let system : LVar.t -> ((LVar.t -> D.t) -> (LVar.t -> D.t -> unit) -> (GVar.t -> G.t) -> (GVar.t -> G.t -> unit) -> D.t) option = function
-    | "x" -> Some (fun loc _ glob gside -> glob "g")
-    | "y" -> Some (fun loc _ glob gside -> (ignore (loc "x"); Int.of_int (Z.of_int64 8L)))
-    | "z" -> Some (fun loc _ glob gside -> (ignore (loc "y"); loc "y"))
-    | "w" -> Some (fun loc _ glob gside -> (gside "g" (Int.of_int (Z.of_int64 42L)); ignore (loc "z"); try Int.add (loc "w") (Int.of_int (Z.of_int64 1L)) with IntDomain.ArithmeticOnIntegerBot _ -> Int.top ()))
+  let system : LVar.t -> ((LVar.t -> D.t) -> (LVar.t -> D.t -> unit) -> (LVar.t -> unit) -> (GVar.t -> G.t) -> (GVar.t -> G.t -> unit) -> (GVar.t -> unit) -> D.t) option = function
+    | "x" -> Some (fun loc _ _ glob gside gdemand -> glob "g")
+    | "y" -> Some (fun loc _ _ glob gside gdemand -> (ignore (loc "x"); Int.of_int (Z.of_int64 8L)))
+    | "z" -> Some (fun loc _ _ glob gside gdemand -> (ignore (loc "y"); loc "y"))
+    | "w" -> Some (fun loc _ _ glob gside gdemand -> (gside "g" (Int.of_int (Z.of_int64 42L)); ignore (loc "z"); try Int.add (loc "w") (Int.of_int (Z.of_int64 1L)) with IntDomain.ArithmeticOnIntegerBot _ -> Int.top ()))
     | _   -> None
 
   let iter_vars _ _ _ _ _ = ()


### PR DESCRIPTION
Added a new function to the right-hand side of an unknown - **demand**.

The new constraint system functional form definition is _val system : v -> ((v -> d) -> (v -> d -> unit) -> (v -> unit) -> d) m_, where the added  _(v -> unit)_ represents **demand**.
Thread spawning now uses `demandl (Function fd, c);` inplace of `ignore (getl (Function fd, c))`.

TD3 implements _demand_ as `demand_thr`  and adds a new hashmap `weak_dep`.
TD3 with weak dependencies can be run in two "modes" - eager and lazy.

**Eager**. 
Can be toggled with `--enable solvers.td3.wk_deps.eager`
1. If `demand` is called the demanded unknown `y` is added to the hashmap `weak_dep` and solved immediately. 
2. If at the end of the iteration any unknown in `weak_dep` or in `vs` is unstable, they are solved again until all unknowns in both are stable.

**Lazy**:
Default behavior currently.
Same as eager, but without solving immediately when calling `demand`.

Part of the bachelor's thesis "Weak Dependencies for Side-Effecting Constraint Systems".