### PR TITLE
Introduce demand in constraint system

### DIFF
--- a/src/constraint/constrSys.ml
+++ b/src/constraint/constrSys.ml
@@ -86,6 +86,13 @@ sig
   val postmortem: v -> v list
 end
 
+(** A side-effecting system that supports [demand] calls *)
+module type DemandEqConstrSys =
+sig
+  include EqConstrSys
+  val system: v -> ((v -> d) -> (v -> d -> unit) -> (v -> unit) -> d) option
+end
+
 (** A side-effecting system with globals. *)
 module type GlobConstrSys =
 sig
@@ -99,6 +106,14 @@ sig
   val sys_change: (LVar.t -> D.t) -> (GVar.t -> G.t) -> [`L of LVar.t | `G of GVar.t] sys_change_info
   val postmortem: LVar.t -> LVar.t list
 end
+
+(** A side-effecting system with globals that supports [demand] calls *)
+module type DemandGlobConstrSys =
+sig
+  include GlobConstrSys
+  val system: LVar.t -> ((LVar.t -> D.t) -> (LVar.t -> D.t -> unit) -> (GVar.t -> G.t) -> (GVar.t -> G.t -> unit) -> (LVar.t -> unit) -> D.t) option
+end
+
 
 (** [EqConstrSys] where [current_var] indicates the variable whose right-hand side is currently being evaluated. *)
 module CurrentVarEqConstrSys (S: EqConstrSys) =

--- a/src/constraint/constrSys.ml
+++ b/src/constraint/constrSys.ml
@@ -110,8 +110,15 @@ end
 (** A side-effecting system with globals that supports [demand] calls *)
 module type DemandGlobConstrSys =
 sig
-  include GlobConstrSys
-  val system: LVar.t -> ((LVar.t -> D.t) -> (LVar.t -> D.t -> unit) -> (GVar.t -> G.t) -> (GVar.t -> G.t -> unit) -> (LVar.t -> unit) -> D.t) option
+  module LVar : VarType
+  module GVar : VarType
+
+  module D : Lattice.S
+  module G : Lattice.S
+  val system: LVar.t -> ((LVar.t -> D.t) -> (LVar.t -> D.t -> unit) -> (LVar.t -> unit) -> (GVar.t -> G.t) -> (GVar.t -> G.t -> unit) -> D.t) option
+  val iter_vars: (LVar.t -> D.t) -> (GVar.t -> G.t) -> VarQuery.t -> LVar.t VarQuery.f -> GVar.t VarQuery.f -> unit
+  val sys_change: (LVar.t -> D.t) -> (GVar.t -> G.t) -> [`L of LVar.t | `G of GVar.t] sys_change_info
+  val postmortem: LVar.t -> LVar.t list
 end
 
 

--- a/src/constraint/solverTypes.ml
+++ b/src/constraint/solverTypes.ml
@@ -14,6 +14,17 @@ module type GenericEqSolver =
   end
 
 (** A solver is something that can translate a system into a solution (hash-table).
+    These solver can handle [DemandEqConstrSys] *)
+module type DemandEqSolver =
+  functor (S:DemandEqConstrSys) ->
+  functor (H:Hashtbl.S with type key=S.v) ->
+  sig
+    (** The hash-map that is the first component of [solve xs vs] is a local solution for interesting variables [vs],
+        reached from starting values [xs]. *)
+    val solve : (S.v*S.d) list -> S.v list -> S.d H.t
+  end
+
+(** A solver is something that can translate a system into a solution (hash-table).
     Incremental solver has data to be marshaled. *)
 module type GenericEqIncrSolverBase =
   functor (S:EqConstrSys) ->
@@ -43,6 +54,25 @@ end
 module type GenericEqIncrSolver =
   functor (Arg: IncrSolverArg) ->
     GenericEqIncrSolverBase
+
+module type DemandEqIncrSolverBase =
+  functor (S: DemandEqConstrSys) ->
+  functor (H:Hashtbl.S with type key=S.v) ->
+  sig
+    type marshal
+
+    val copy_marshal: marshal -> marshal
+    val relift_marshal: marshal -> marshal
+
+    (** The hash-map that is the first component of [solve xs vs] is a local solution for interesting variables [vs],
+        reached from starting values [xs].
+        As a second component the solver returns data structures for incremental serialization. *)
+    val solve : (S.v*S.d) list -> S.v list -> marshal option -> S.d H.t * marshal
+  end
+
+module type DemandEqIncrSolver =
+  functor (Arg: IncrSolverArg) ->
+    DemandEqIncrSolverBase
 
 (** A solver is something that can translate a system into a solution (hash-table)
 

--- a/src/constraint/solverTypes.ml
+++ b/src/constraint/solverTypes.ml
@@ -77,8 +77,8 @@ module type DemandEqIncrSolver =
 (** A solver is something that can translate a system into a solution (hash-table)
 
 *)
-module type GenericGlobIncrSolver =
-  functor (S:GlobConstrSys) ->
+module type DemandGlobIncrSolver =
+  functor (S:DemandGlobConstrSys) ->
   functor (LH:Hashtbl.S with type key=S.LVar.t) ->
   functor (GH:Hashtbl.S with type key=S.GVar.t) ->
   sig

--- a/src/constraint/translators.ml
+++ b/src/constraint/translators.ml
@@ -26,12 +26,12 @@ struct
   let postmortem = S.postmortem
 end
 
-(** Translate a [GlobConstrSys] into a [EqConstrSys] *)
-module EqConstrSysFromGlobConstrSys (S:GlobConstrSys)
-  : EqConstrSys   with type v = Var2(S.LVar)(S.GVar).t
-                   and type d = Lattice.Lift2(S.G)(S.D).t
-                   and module Var = Var2(S.LVar)(S.GVar)
-                   and module Dom = Lattice.Lift2(S.G)(S.D)
+(** Translate a [DemandGlobConstrSys] into a [DemandEqConstrSys] *)
+module EqConstrSysFromGlobConstrSys (S:DemandGlobConstrSys)
+  : DemandEqConstrSys   with type v = Var2(S.LVar)(S.GVar).t
+                         and type d = Lattice.Lift2(S.G)(S.D).t
+                         and module Var = Var2(S.LVar)(S.GVar)
+                         and module Dom = Lattice.Lift2(S.G)(S.D)
 =
 struct
   module Var = Var2(S.LVar)(S.GVar)
@@ -61,8 +61,8 @@ struct
   let l, g = (fun x -> `L x), (fun x -> `G x)
   let lD, gD = (fun x -> `Lifted2 x), (fun x -> `Lifted1 x)
 
-  let conv f get set =
-    f (getL % get % l) (fun x v -> set (l x) (lD v))
+  let conv f get set demand =
+    f (getL % get % l) (fun x v -> set (l x) (lD v)) (fun x -> ignore @@ getL @@ get @@ l x)
       (getG % get % g) (fun x v -> set (g x) (gD v))
     |> lD
 
@@ -79,7 +79,7 @@ struct
 end
 
 (** Splits a [EqConstrSys] solution into a [GlobConstrSys] solution with given [Hashtbl.S] for the [EqConstrSys]. *)
-module GlobConstrSolFromEqConstrSolBase (S: GlobConstrSys) (LH: Hashtbl.S with type key = S.LVar.t) (GH: Hashtbl.S with type key = S.GVar.t) (VH: Hashtbl.S with type key = Var2 (S.LVar) (S.GVar).t) =
+module GlobConstrSolFromEqConstrSolBase (S: DemandGlobConstrSys) (LH: Hashtbl.S with type key = S.LVar.t) (GH: Hashtbl.S with type key = S.GVar.t) (VH: Hashtbl.S with type key = Var2 (S.LVar) (S.GVar).t) =
 struct
   let split_solution hm =
     let l' = LH.create 113 in
@@ -108,7 +108,7 @@ struct
 end
 
 (** Splits a [EqConstrSys] solution into a [GlobConstrSys] solution. *)
-module GlobConstrSolFromEqConstrSol (S: GlobConstrSys) (LH: Hashtbl.S with type key = S.LVar.t) (GH: Hashtbl.S with type key = S.GVar.t) =
+module GlobConstrSolFromEqConstrSol (S: DemandGlobConstrSys) (LH: Hashtbl.S with type key = S.LVar.t) (GH: Hashtbl.S with type key = S.GVar.t) =
 struct
   module S2 = EqConstrSysFromGlobConstrSys (S)
   module VH = Hashtbl.Make (S2.Var)
@@ -117,23 +117,16 @@ struct
 end
 
 
-module DemandEqIncrSolverFromGenericEqIncrSolver (Sol: GenericEqIncrSolverBase) =
+module DemandEqIncrSolverFromGenericEqIncrSolver (Sol: GenericEqIncrSolver): DemandEqIncrSolver =
+  functor (Arg: IncrSolverArg) ->
   functor (S: DemandEqConstrSys) ->
   functor (H: Hashtbl.S with type key = S.v) ->
-  struct
-    module EqSys = EqConstrSysFromDemandConstrSys (S)
-    module Sol' = Sol (EqSys) (H)
-
-    type marshal = Sol'.marshal
-    let copy_marshal = Sol'.copy_marshal
-    let relift_marshal = Sol'.relift_marshal
-    let solve = Sol'.solve
-  end
+    Sol (Arg) (EqConstrSysFromDemandConstrSys  (S)) (H)
 
 
-(** Transforms a [GenericEqIncrSolver] into a [GenericGlobIncrSolver]. *)
-module GlobSolverFromEqSolver (Sol:GenericEqIncrSolverBase)
-  = functor (S:GlobConstrSys) ->
+(** Transforms a [DemandEqIncrSolver] into a [DemandGlobIncrSolver]. *)
+module GlobSolverFromEqSolver (Sol:DemandEqIncrSolverBase)
+  = functor (S:DemandGlobConstrSys) ->
     functor (LH:Hashtbl.S with type key=S.LVar.t) ->
     functor (GH:Hashtbl.S with type key=S.GVar.t) ->
     struct

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -424,7 +424,7 @@ end
 module type SpecSys =
 sig
   module Spec: Spec
-  module EQSys: Goblint_constraint.ConstrSys.GlobConstrSys with module LVar = VarF (Spec.C)
+  module EQSys: Goblint_constraint.ConstrSys.DemandGlobConstrSys with module LVar = VarF (Spec.C)
                                and module GVar = GVarF (Spec.V)
                                and module D = Spec.D
                                and module G = GVarG (Spec.G) (Spec.C)

--- a/src/framework/compareConstraints.ml
+++ b/src/framework/compareConstraints.ml
@@ -158,7 +158,7 @@ struct
   include PrecCompare.MakeHashtbl (Var) (Dom) (VH)
 end
 
-module CompareEqSys (Sys: EqConstrSys) (VH: Hashtbl.S with type key = Sys.Var.t) =
+module CompareEqSys (Sys: DemandEqConstrSys) (VH: Hashtbl.S with type key = Sys.Var.t) =
 struct
   module Compare = CompareHashtbl (Sys.Var) (Sys.Dom) (VH)
 

--- a/src/framework/compareConstraints.ml
+++ b/src/framework/compareConstraints.ml
@@ -158,7 +158,7 @@ struct
   include PrecCompare.MakeHashtbl (Var) (Dom) (VH)
 end
 
-module CompareEqSys (Sys: DemandEqConstrSys) (VH: Hashtbl.S with type key = Sys.Var.t) =
+module CompareEqSys (Sys: EqConstrSys) (VH: Hashtbl.S with type key = Sys.Var.t) =
 struct
   module Compare = CompareHashtbl (Sys.Var) (Sys.Dom) (VH)
 

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -19,9 +19,9 @@ end
 module FromSpec (S:Spec) (Cfg:CfgBackward) (I: Increment)
   : sig
     include DemandGlobConstrSys with module LVar = VarF (S.C)
-                           and module GVar = GVarF (S.V)
-                           and module D = S.D
-                           and module G = GVarG (S.G) (S.C)
+                                 and module GVar = GVarF (S.V)
+                                 and module D = S.D
+                                 and module G = GVarG (S.G) (S.C)
   end
 =
 struct

--- a/src/framework/constraints.ml
+++ b/src/framework/constraints.ml
@@ -15,10 +15,10 @@ sig
 end
 
 
-(** The main point of this file---generating a [GlobConstrSys] from a [Spec]. *)
+(** The main point of this file---generating a [DemandGlobConstrSys] from a [Spec]. *)
 module FromSpec (S:Spec) (Cfg:CfgBackward) (I: Increment)
   : sig
-    include GlobConstrSys with module LVar = VarF (S.C)
+    include DemandGlobConstrSys with module LVar = VarF (S.C)
                            and module GVar = GVarF (S.V)
                            and module D = S.D
                            and module G = GVarG (S.G) (S.C)
@@ -50,7 +50,7 @@ struct
     if !AnalysisState.postsolving then
       sideg (GVar.contexts f) (G.create_contexts (G.CSet.singleton c))
 
-  let common_man var edge prev_node pval (getl:lv -> ld) sidel getg sideg : (D.t, S.G.t, S.C.t, S.V.t) man * D.t list ref * (lval option * varinfo * exp list * D.t * bool) list ref =
+  let common_man var edge prev_node pval (getl:lv -> ld) sidel demandl getg sideg : (D.t, S.G.t, S.C.t, S.V.t) man * D.t list ref * (lval option * varinfo * exp list * D.t * bool) list ref =
     let r = ref [] in
     let spawns = ref [] in
     (* now watch this ... *)
@@ -78,7 +78,7 @@ struct
           | fd ->
             let c = S.context man fd d in
             sidel (FunctionEntry fd, c) d;
-            ignore (getl (Function fd, c))
+            demandl (Function fd, c)
           | exception Not_found ->
             (* unknown function *)
             M.error ~category:Imprecise ~tags:[Category Unsound] "Created a thread from unknown function %s" f.vname;
@@ -131,13 +131,13 @@ struct
 
   let common_joins man ds splits spawns = common_join man (bigsqcup ds) splits spawns
 
-  let tf_assign var edge prev_node lv e getl sidel getg sideg d =
-    let man, r, spawns = common_man var edge prev_node d getl sidel getg sideg in
+  let tf_assign var edge prev_node lv e getl sidel demandl getg sideg d =
+    let man, r, spawns = common_man var edge prev_node d getl sidel demandl getg sideg in
     let d = S.assign man lv e in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join man d !r !spawns
 
-  let tf_vdecl var edge prev_node v getl sidel getg sideg d =
-    let man, r, spawns = common_man var edge prev_node d getl sidel getg sideg in
+  let tf_vdecl var edge prev_node v getl sidel demandl getg sideg d =
+    let man, r, spawns = common_man var edge prev_node d getl sidel demandl getg sideg in
     let d = S.vdecl man v in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join man d !r !spawns
 
@@ -152,8 +152,8 @@ struct
     let nval = S.sync { man with local = spawning_return } `Return in
     nval
 
-  let tf_ret var edge prev_node ret fd getl sidel getg sideg d =
-    let man, r, spawns = common_man var edge prev_node d getl sidel getg sideg in
+  let tf_ret var edge prev_node ret fd getl sidel demandl getg sideg d =
+    let man, r, spawns = common_man var edge prev_node d getl sidel demandl getg sideg in
     let d = (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
       if (CilType.Fundec.equal fd MyCFG.dummy_func ||
           List.mem fd.svar.vname (get_string_list "mainfun")) &&
@@ -163,21 +163,21 @@ struct
     in
     common_join man d !r !spawns
 
-  let tf_entry var edge prev_node fd getl sidel getg sideg d =
+  let tf_entry var edge prev_node fd getl sidel demandl getg sideg d =
     (* Side effect function context here instead of at sidel to FunctionEntry,
        because otherwise context for main functions (entrystates) will be missing or pruned during postsolving. *)
     let c: unit -> S.C.t = snd var |> Obj.obj in
     side_context sideg fd (c ());
-    let man, r, spawns = common_man var edge prev_node d getl sidel getg sideg in
+    let man, r, spawns = common_man var edge prev_node d getl sidel demandl getg sideg in
     let d = S.body man fd in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join man d !r !spawns
 
-  let tf_test var edge prev_node e tv getl sidel getg sideg d =
-    let man, r, spawns = common_man var edge prev_node d getl sidel getg sideg in
+  let tf_test var edge prev_node e tv getl sidel demandl getg sideg d =
+    let man, r, spawns = common_man var edge prev_node d getl sidel demandl getg sideg in
     let d = S.branch man e tv in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join man d !r !spawns
 
-  let tf_normal_call man lv e (f:fundec) args getl sidel getg sideg =
+  let tf_normal_call man lv e (f:fundec) args getl sidel demandl getg sideg =
     let combine (cd, fc, fd) =
       if M.tracing then M.traceli "combine" "local: %a" S.D.pretty cd;
       if M.tracing then M.trace "combine" "function: %a" S.D.pretty fd;
@@ -245,8 +245,8 @@ struct
 
   let tf_special_call man lv f args = S.special man lv f args
 
-  let tf_proc var edge prev_node lv e args getl sidel getg sideg d =
-    let man, r, spawns = common_man var edge prev_node d getl sidel getg sideg in
+  let tf_proc var edge prev_node lv e args getl sidel demandl getg sideg d =
+    let man, r, spawns = common_man var edge prev_node d getl sidel demandl getg sideg in
     let functions =
       match e with
       | Lval (Var v, NoOffset) ->
@@ -271,7 +271,7 @@ struct
                 M.info ~category:Analyzer "Using special for defined function %s" f.vname;
                 tf_special_call man lv f args
               | fd ->
-                tf_normal_call man lv e fd args getl sidel getg sideg
+                tf_normal_call man lv e fd args getl sidel demandl getg sideg
               | exception Not_found ->
                 tf_special_call man lv f args)
           end
@@ -292,17 +292,17 @@ struct
     end else
       common_joins man funs !r !spawns
 
-  let tf_asm var edge prev_node getl sidel getg sideg d =
-    let man, r, spawns = common_man var edge prev_node d getl sidel getg sideg in
+  let tf_asm var edge prev_node getl sidel demandl getg sideg d =
+    let man, r, spawns = common_man var edge prev_node d getl sidel demandl getg sideg in
     let d = S.asm man in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join man d !r !spawns
 
-  let tf_skip var edge prev_node getl sidel getg sideg d =
-    let man, r, spawns = common_man var edge prev_node d getl sidel getg sideg in
+  let tf_skip var edge prev_node getl sidel demandl getg sideg d =
+    let man, r, spawns = common_man var edge prev_node d getl sidel demandl getg sideg in
     let d = S.skip man in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join man d !r !spawns
 
-  let tf var getl sidel getg sideg prev_node edge d =
+  let tf var getl sidel demandl getg sideg prev_node edge d =
     begin match edge with
       | Assign (lv,rv) -> tf_assign var edge prev_node lv rv
       | VDecl (v)      -> tf_vdecl var edge prev_node v
@@ -312,7 +312,7 @@ struct
       | Test (p,b)     -> tf_test var edge prev_node p b
       | ASM (_, _, _)  -> tf_asm var edge prev_node (* TODO: use ASM fields for something? *)
       | Skip           -> tf_skip var edge prev_node
-    end getl sidel getg sideg d
+    end getl sidel demandl getg sideg d
 
   type Goblint_backtrace.mark += TfLocation of location
 
@@ -322,7 +322,7 @@ struct
       | _ -> None (* for other marks *)
     )
 
-  let tf var getl sidel getg sideg prev_node (_,edge) d (f,t) =
+  let tf var getl sidel demandl getg sideg prev_node (_,edge) d (f,t) =
     let old_loc  = !Goblint_tracing.current_loc in
     let old_loc2 = !Goblint_tracing.next_loc in
     Goblint_tracing.current_loc := f;
@@ -331,16 +331,16 @@ struct
         Goblint_tracing.current_loc := old_loc;
         Goblint_tracing.next_loc := old_loc2
       ) (fun () ->
-        let d       = tf var getl sidel getg sideg prev_node edge d in
+        let d       = tf var getl sidel demandl getg sideg prev_node edge d in
         d
       )
 
-  let tf (v,c) (edges, u) getl sidel getg sideg =
+  let tf (v,c) (edges, u) getl sidel demandl getg sideg =
     let pval = getl (u,c) in
     let _, locs = List.fold_right (fun (f,e) (t,xs) -> f, (f,t)::xs) edges (Node.location v,[]) in
-    List.fold_left2 (|>) pval (List.map (tf (v,Obj.repr (fun () -> c)) getl sidel getg sideg u) edges) locs
+    List.fold_left2 (|>) pval (List.map (tf (v,Obj.repr (fun () -> c)) getl sidel demandl getg sideg u) edges) locs
 
-  let tf (v,c) (e,u) getl sidel getg sideg =
+  let tf (v,c) (e,u) getl sidel demandl getg sideg =
     let old_node = !current_node in
     let old_fd = Option.map Node.find_fundec old_node |? Cil.dummyFunDec in
     let new_fd = Node.find_fundec v in
@@ -355,7 +355,7 @@ struct
         if not (CilType.Fundec.equal old_fd new_fd) then
           Timing.Program.exit new_fd.svar.vname
       ) (fun () ->
-        let d       = tf (v,c) (e,u) getl sidel getg sideg in
+        let d       = tf (v,c) (e,u) getl sidel demandl getg sideg in
         d
       )
 
@@ -364,8 +364,8 @@ struct
     | FunctionEntry _ ->
       None
     | _ ->
-      let tf getl sidel getg sideg =
-        let tf' eu = tf (v,c) eu getl sidel getg sideg in
+      let tf getl sidel demandl getg sideg =
+        let tf' eu = tf (v,c) eu getl sidel demandl getg sideg in
 
         match NodeH.find_option CfgTools.node_scc_global v with
         | Some scc when NodeH.mem scc.prev v && NodeH.length scc.prev = 1 ->

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -507,7 +507,7 @@ struct
           match compare_runs with
           | d1::d2::[] -> (* the directories of the runs *)
             if d1 = d2 then Logs.warn "Beware that you are comparing a run with itself! There should be no differences.";
-            (* instead of rewriting Compare for EqConstrSys, just transform unmarshaled EqConstrSys solutions to GlobConstrSys soltuions *)
+            (* instead of rewriting Compare for EqConstrSys, just transform unmarshaled EqConstrSys solutions to GlobConstrSys solutions *)
             let module Splitter = GlobConstrSolFromEqConstrSol (EQSys: DemandGlobConstrSys) (LHT) (GHT) in
             let module S2 = Splitter.S2 in
             let module VH = Splitter.VH in

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -6,6 +6,7 @@ open Batteries
 open GoblintCil
 open MyCFG
 open Analyses
+open Goblint_constraint.ConstrSys
 open Goblint_constraint.Translators
 open Goblint_constraint.SolverTypes
 open GobConfig
@@ -507,7 +508,7 @@ struct
           | d1::d2::[] -> (* the directories of the runs *)
             if d1 = d2 then Logs.warn "Beware that you are comparing a run with itself! There should be no differences.";
             (* instead of rewriting Compare for EqConstrSys, just transform unmarshaled EqConstrSys solutions to GlobConstrSys soltuions *)
-            let module Splitter = GlobConstrSolFromEqConstrSol (EQSys) (LHT) (GHT) in
+            let module Splitter = GlobConstrSolFromEqConstrSol (EQSys: DemandGlobConstrSys) (LHT) (GHT) in
             let module S2 = Splitter.S2 in
             let module VH = Splitter.VH in
             let (r1, r1'), (r2, r2') = Tuple2.mapn (fun d ->
@@ -588,7 +589,7 @@ struct
       in
 
       if get_string "comparesolver" <> "" then (
-        let compare_with (module S2 : GenericEqIncrSolver) =
+        let compare_with (module S2 : DemandEqIncrSolver) =
           let module PostSolverArg2 =
           struct
             include PostSolverArg

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -526,7 +526,7 @@ struct
             if get_bool "dbg.compare_runs.globsys" then
               CompareGlobSys.compare (d1, d2) r1 r2;
 
-            let module CompareEqSys = CompareConstraints.CompareEqSys (S2) (VH) in
+            let module CompareEqSys = CompareConstraints.CompareEqSys (EqConstrSysFromDemandConstrSys (S2) ) (VH) in
             if get_bool "dbg.compare_runs.eqsys" then
               CompareEqSys.compare (d1, d2) r1' r2';
 

--- a/src/solver/effectWConEq.ml
+++ b/src/solver/effectWConEq.ml
@@ -87,4 +87,4 @@ module Make =
   end
 
 let _ =
-  Selector.add_solver ("effectWConDemandEq", (module PostSolver.DemandEqIncrSolverFromEqSolver (Make)));
+  Selector.add_solver ("effectWConEq", (module PostSolver.DemandEqIncrSolverFromEqSolver (Make)));

--- a/src/solver/effectWConEq.ml
+++ b/src/solver/effectWConEq.ml
@@ -87,4 +87,4 @@ module Make =
   end
 
 let _ =
-  Selector.add_solver ("effectWConEq", (module PostSolver.EqIncrSolverFromEqSolver (Make)));
+  Selector.add_solver ("effectWConDemandEq", (module PostSolver.DemandEqIncrSolverFromEqSolver (Make)));

--- a/src/solver/generic.ml
+++ b/src/solver/generic.ml
@@ -28,8 +28,8 @@ module LoadRunSolver: GenericEqSolver =
         vh
   end
 
-module LoadRunIncrSolver: GenericEqIncrSolver =
-  PostSolver.EqIncrSolverFromEqSolver (LoadRunSolver)
+module LoadRunIncrSolver: DemandEqIncrSolver =
+  PostSolver.DemandEqIncrSolverFromEqSolver (LoadRunSolver)
 
 module SolverStats (S:EqConstrSys) (HM:Hashtbl.S with type key = S.v) =
 struct

--- a/src/solver/postSolver.ml
+++ b/src/solver/postSolver.ml
@@ -338,8 +338,9 @@ module EqIncrSolverFromEqSolver (Sol: GenericEqSolver): GenericEqIncrSolver =
 module DemandEqIncrSolverFromEqSolver (Sol: GenericEqSolver): DemandEqIncrSolver =
   functor (Arg: IncrSolverArg) (S: DemandEqConstrSys) (VH: Hashtbl.S with type key = S.v) ->
   struct
-    module Sol' = Sol (EqConstrSysFromDemandConstrSys (S)) (VH)
-    module Post = MakeList (ListArgFromStdArg (EqConstrSysFromDemandConstrSys (S)) (VH) (Arg))
+    module Sys = EqConstrSysFromDemandConstrSys (S)
+    module Sol' = Sol (Sys) (VH)
+    module Post = MakeList (ListArgFromStdArg (Sys) (VH) (Arg))
     type marshal = unit
     let copy_marshal () = ()
     let relift_marshal () = ()

--- a/src/solver/postSolver.ml
+++ b/src/solver/postSolver.ml
@@ -3,6 +3,7 @@
 open Batteries
 open Goblint_constraint.ConstrSys
 open Goblint_constraint.SolverTypes
+open Goblint_constraint.Translators
 open GobConfig
 module Pretty = GoblintCil.Pretty
 module M  = Messages
@@ -329,6 +330,21 @@ module EqIncrSolverFromEqSolver (Sol: GenericEqSolver): GenericEqIncrSolver =
 
     let solve xs vs _ =
       let vh = Sol.solve xs vs in
+      Post.post xs vs vh;
+      (vh, ())
+  end
+
+
+module DemandEqIncrSolverFromEqSolver (Sol: GenericEqSolver): DemandEqIncrSolver =
+  functor (Arg: IncrSolverArg) (S: DemandEqConstrSys) (VH: Hashtbl.S with type key = S.v) ->
+  struct
+    module Sol' = Sol (EqConstrSysFromDemandConstrSys (S)) (VH)
+    module Post = MakeList (ListArgFromStdArg (EqConstrSysFromDemandConstrSys (S)) (VH) (Arg))
+    type marshal = unit
+    let copy_marshal () = ()
+    let relift_marshal () = ()
+    let solve xs vs old_data =
+      let vh = Sol'.solve xs vs in
       Post.post xs vs vh;
       (vh, ())
   end

--- a/src/solver/sLR.ml
+++ b/src/solver/sLR.ml
@@ -523,29 +523,29 @@ let _ =
   let module W1 = JustWiden (struct let ver = 1 end) in
   let module W2 = JustWiden (struct let ver = 2 end) in
   let module W3 = JustWiden (struct let ver = 3 end) in
-  Selector.add_solver ("widen1",  (module PostSolver.EqIncrSolverFromEqSolver (W1)));
-  Selector.add_solver ("widen2",  (module PostSolver.EqIncrSolverFromEqSolver (W2)));
-  Selector.add_solver ("widen3",  (module PostSolver.EqIncrSolverFromEqSolver (W3)));
+  Selector.add_solver ("widen1",  (module PostSolver.DemandEqIncrSolverFromEqSolver (W1)));
+  Selector.add_solver ("widen2",  (module PostSolver.DemandEqIncrSolverFromEqSolver (W2)));
+  Selector.add_solver ("widen3",  (module PostSolver.DemandEqIncrSolverFromEqSolver (W3)));
   let module S2 = TwoPhased (struct let ver = 1 end) in
   (* Selector.add_solver ("two",  (module PostSolver.EqIncrSolverFromEqSolver (S2))); (* TODO: broken even on 00-sanity/01-assert *) *)
   let module S1 = Make (struct let ver = 1 end) in
-  Selector.add_solver ("new",  (module PostSolver.EqIncrSolverFromEqSolver (S1)));
-  Selector.add_solver ("slr+", (module PostSolver.EqIncrSolverFromEqSolver (S1)))
+  Selector.add_solver ("new",  (module PostSolver.DemandEqIncrSolverFromEqSolver (S1)));
+  Selector.add_solver ("slr+", (module PostSolver.DemandEqIncrSolverFromEqSolver (S1)))
 
 let _ =
   let module S1 = Make (struct let ver = 1 end) in
   let module S2 = Make (struct let ver = 2 end) in
   let module S3 = SLR3 in
   let module S4 = Make (struct let ver = 4 end) in
-  Selector.add_solver ("slr1", (module PostSolver.EqIncrSolverFromEqSolver (S1))); (* W&N at every program point *)
-  Selector.add_solver ("slr2", (module PostSolver.EqIncrSolverFromEqSolver (S2))); (* W&N dynamic at certain points, growing number of W-points *)
-  Selector.add_solver ("slr3", (module PostSolver.EqIncrSolverFromEqSolver (S3))); (* same as S2 but number of W-points may also shrink *)
-  Selector.add_solver ("slr4", (module PostSolver.EqIncrSolverFromEqSolver (S4))); (* restarting: set influenced variables to bot and start up-iteration instead of narrowing *)
+  Selector.add_solver ("slr1", (module PostSolver.DemandEqIncrSolverFromEqSolver (S1))); (* W&N at every program point *)
+  Selector.add_solver ("slr2", (module PostSolver.DemandEqIncrSolverFromEqSolver (S2))); (* W&N dynamic at certain points, growing number of W-points *)
+  Selector.add_solver ("slr3", (module PostSolver.DemandEqIncrSolverFromEqSolver (S3))); (* same as S2 but number of W-points may also shrink *)
+  Selector.add_solver ("slr4", (module PostSolver.DemandEqIncrSolverFromEqSolver (S4))); (* restarting: set influenced variables to bot and start up-iteration instead of narrowing *)
   let module S1p = PrintInfluence (Make (struct let ver = 1 end)) in
   let module S2p = PrintInfluence (Make (struct let ver = 2 end)) in
   let module S3p = PrintInfluence (Make (struct let ver = 3 end)) in
   let module S4p = PrintInfluence (Make (struct let ver = 4 end)) in
-  Selector.add_solver ("slr1p", (module PostSolver.EqIncrSolverFromEqSolver (S1p))); (* same as S1-4 above but with side-effects *)
-  Selector.add_solver ("slr2p", (module PostSolver.EqIncrSolverFromEqSolver (S2p)));
-  Selector.add_solver ("slr3p", (module PostSolver.EqIncrSolverFromEqSolver (S3p)));
-  Selector.add_solver ("slr4p", (module PostSolver.EqIncrSolverFromEqSolver (S4p)));
+  Selector.add_solver ("slr1p", (module PostSolver.DemandEqIncrSolverFromEqSolver (S1p))); (* same as S1-4 above but with side-effects *)
+  Selector.add_solver ("slr2p", (module PostSolver.DemandEqIncrSolverFromEqSolver (S2p)));
+  Selector.add_solver ("slr3p", (module PostSolver.DemandEqIncrSolverFromEqSolver (S3p)));
+  Selector.add_solver ("slr4p", (module PostSolver.DemandEqIncrSolverFromEqSolver (S4p)));

--- a/src/solver/sLRphased.ml
+++ b/src/solver/sLRphased.ml
@@ -205,4 +205,4 @@ module Make =
   end
 
 let _ =
-  Selector.add_solver ("slr3tp", (module PostSolver.EqIncrSolverFromEqSolver (Make))); (* two-phased slr3t *)
+  Selector.add_solver ("slr3tp", (module PostSolver.DemandEqIncrSolverFromEqSolver (Make))); (* two-phased slr3t *)

--- a/src/solver/sLRterm.ml
+++ b/src/solver/sLRterm.ml
@@ -224,4 +224,4 @@ module SLR3term =
   end
 
 let _ =
-  Selector.add_solver ("slr3t", (module PostSolver.EqIncrSolverFromEqSolver (SLR3term))); (* same as S2 but number of W-points may also shrink + terminating? *)
+  Selector.add_solver ("slr3t", (module PostSolver.DemandEqIncrSolverFromEqSolver (SLR3term))); (* same as S2 but number of W-points may also shrink + terminating? *)

--- a/src/solver/selector.ml
+++ b/src/solver/selector.ml
@@ -9,7 +9,7 @@ open GobConfig
 let solvers = ref []
 
 (** Register your solvers here!!! *)
-let add_solver x = solvers := x::!solvers
+let add_solver (x : string * (module DemandEqIncrSolver)) = solvers := x::!solvers
 
 (** Dynamically choose the solver. *)
 let choose_solver solver =
@@ -20,28 +20,28 @@ let choose_solver solver =
 (** The solver that actually uses the implementation based of [GobConfig.get_string "solver"]. *)
 module Make =
   functor (Arg: IncrSolverArg) ->
-  functor (S:EqConstrSys) ->
+  functor (S:DemandEqConstrSys) ->
   functor (VH:Hashtbl.S with type key = S.v) ->
   struct
     type marshal = Obj.t (* cannot use Sol.marshal because cannot unpack first-class module in applicative functor *)
 
     let copy_marshal (marshal: marshal) =
-      let module Sol = (val choose_solver (get_string "solver") : GenericEqIncrSolver) in
+      let module Sol = (val choose_solver (get_string "solver") : DemandEqIncrSolver) in
       let module F = Sol (Arg) (S) (VH) in
       Obj.repr (F.copy_marshal (Obj.obj marshal))
 
     let relift_marshal (marshal: marshal) =
-      let module Sol = (val choose_solver (get_string "solver") : GenericEqIncrSolver) in
+      let module Sol = (val choose_solver (get_string "solver") : DemandEqIncrSolver) in
       let module F = Sol (Arg) (S) (VH) in
       Obj.repr (F.relift_marshal (Obj.obj marshal))
 
     let solve xs vs (old_data: marshal option) =
-      let module Sol = (val choose_solver (get_string "solver") : GenericEqIncrSolver) in
+      let module Sol = (val choose_solver (get_string "solver") : DemandEqIncrSolver) in
       let module F = Sol (Arg) (S) (VH) in
       let (vh, marshal) = F.solve xs vs (Option.map Obj.obj old_data) in
       (vh, Obj.repr marshal)
   end
 
 let _ =
-  let module T1 : GenericEqIncrSolver = Make in
+  let module T1 : DemandEqIncrSolver = Make in
   ()

--- a/src/solver/td3.ml
+++ b/src/solver/td3.ml
@@ -16,6 +16,7 @@
 open Batteries
 open Goblint_constraint.ConstrSys
 open Goblint_constraint.SolverTypes
+open Goblint_constraint.Translators
 open Messages
 
 module M = Messages
@@ -1224,13 +1225,16 @@ let after_config () =
     if restart_sided || restart_wpoint || restart_once then (
       M.warn "restarting active, ignoring solvers.td3.skip-unchanged-rhs";
       (* TODO: fix DepVals with restarting, https://github.com/goblint/analyzer/pull/738#discussion_r876005821 *)
-      Selector.add_solver ("td3", (module Basic(UpdateRule): GenericEqIncrSolver))
+      Selector.add_solver ("td3", (module DemandEqIncrSolverFromGenericEqIncrSolver
+            (Basic(UpdateRule): GenericEqIncrSolver): DemandEqIncrSolver))
     )
     else
-      Selector.add_solver ("td3", (module DepVals(UpdateRule): GenericEqIncrSolver))
+      Selector.add_solver ("td3", (module DemandEqIncrSolverFromGenericEqIncrSolver
+            (DepVals(UpdateRule): GenericEqIncrSolver): DemandEqIncrSolver))
   )
   else
-    Selector.add_solver ("td3", (module Basic(UpdateRule): GenericEqIncrSolver))
+    Selector.add_solver ("td3", (module DemandEqIncrSolverFromGenericEqIncrSolver
+          (Basic(UpdateRule): GenericEqIncrSolver): DemandEqIncrSolver))
 
 let () =
   AfterConfig.register after_config

--- a/src/solver/td_simplified.ml
+++ b/src/solver/td_simplified.ml
@@ -203,4 +203,4 @@ module Base : GenericEqSolver =
   end
 
 let () =
-  Selector.add_solver ("td_simplified", (module PostSolver.EqIncrSolverFromEqSolver (Base)));
+  Selector.add_solver ("td_simplified", (module PostSolver.DemandEqIncrSolverFromEqSolver (Base)));

--- a/src/solver/topDown.ml
+++ b/src/solver/topDown.ml
@@ -154,4 +154,4 @@ module WP =
   end
 
 let _ =
-  Selector.add_solver ("topdown", (module PostSolver.EqIncrSolverFromEqSolver (WP)));
+  Selector.add_solver ("topdown", (module PostSolver.DemandEqIncrSolverFromEqSolver (WP)));

--- a/src/solver/topDown_deprecated.ml
+++ b/src/solver/topDown_deprecated.ml
@@ -161,4 +161,4 @@ module TD3 =
   end
 
 let _ =
-  Selector.add_solver ("topdown_deprecated", (module PostSolver.EqIncrSolverFromEqSolver (TD3)));
+  Selector.add_solver ("topdown_deprecated", (module PostSolver.DemandEqIncrSolverFromEqSolver (TD3)));

--- a/src/solver/topDown_space_cache_term.ml
+++ b/src/solver/topDown_space_cache_term.ml
@@ -195,4 +195,4 @@ module WP =
   end
 
 let _ =
-  Selector.add_solver ("topdown_space_cache_term", (module PostSolver.EqIncrSolverFromEqSolver (WP)));
+  Selector.add_solver ("topdown_space_cache_term", (module PostSolver.DemandEqIncrSolverFromEqSolver (WP)));

--- a/src/solver/topDown_term.ml
+++ b/src/solver/topDown_term.ml
@@ -133,4 +133,4 @@ module WP =
   end
 
 let _ =
-  Selector.add_solver ("topdown_term", (module PostSolver.EqIncrSolverFromEqSolver (WP)));
+  Selector.add_solver ("topdown_term", (module PostSolver.DemandEqIncrSolverFromEqSolver (WP)));

--- a/src/solver/worklist.ml
+++ b/src/solver/worklist.ml
@@ -62,4 +62,4 @@ module Make =
 
 
 let _ =
-  Selector.add_solver ("WL",  (module PostSolver.EqIncrSolverFromEqSolver (Make)));
+  Selector.add_solver ("WL",  (module PostSolver.DemandEqIncrSolverFromEqSolver (Make)));

--- a/tests/unit/solver/solverTest.ml
+++ b/tests/unit/solver/solverTest.ml
@@ -38,11 +38,11 @@ module ConstrSys = struct
     3. z := y
     4. w := w + 1 [also g := 42; _ := z]
     *)
-  let system : LVar.t -> ((LVar.t -> D.t) -> (LVar.t -> D.t -> unit) -> (GVar.t -> G.t) -> (GVar.t -> G.t -> unit) -> D.t) option = function
-    | "x" -> Some (fun loc _ glob gside -> glob "g")
-    | "y" -> Some (fun loc _ glob gside -> (ignore (loc "x"); Int.of_int (Z.of_int64 8L)))
-    | "z" -> Some (fun loc _ glob gside -> (ignore (loc "y"); loc "y"))
-    | "w" -> Some (fun loc _ glob gside -> (gside "g" (Int.of_int (Z.of_int64 42L)); ignore (loc "z"); try Int.add (loc "w") (Int.of_int (Z.of_int64 1L)) with IntDomain.ArithmeticOnIntegerBot _ -> Int.top ()))
+  let system : LVar.t -> ((LVar.t -> D.t) -> (LVar.t -> D.t -> unit) -> (LVar.t -> unit) -> (GVar.t -> G.t) -> (GVar.t -> G.t -> unit) -> D.t) option = function
+    | "x" -> Some (fun loc _ _ glob gside -> glob "g")
+    | "y" -> Some (fun loc _ _ glob gside -> (ignore (loc "x"); Int.of_int (Z.of_int64 8L)))
+    | "z" -> Some (fun loc _ _ glob gside -> (ignore (loc "y"); loc "y"))
+    | "w" -> Some (fun loc _ _ glob gside -> (gside "g" (Int.of_int (Z.of_int64 42L)); ignore (loc "z"); try Int.add (loc "w") (Int.of_int (Z.of_int64 1L)) with IntDomain.ArithmeticOnIntegerBot _ -> Int.top ()))
     | _   -> None
 
   let iter_vars _ _ _ _ _ = ()
@@ -59,7 +59,7 @@ struct
   let should_warn = false
   let should_save_run = false
 end
-module Solver = GlobSolverFromEqSolver (PostSolver.EqIncrSolverFromEqSolver (EffectWConEq.Make) (PostSolverArg)) (ConstrSys) (LH) (GH)
+module Solver = GlobSolverFromEqSolver (PostSolver.DemandEqIncrSolverFromEqSolver (EffectWConEq.Make) (PostSolverArg)) (ConstrSys) (LH) (GH)
 
 let test1 _ =
   let id x = x in


### PR DESCRIPTION
This implements #1743 following #1745 .

The focus is on the constraint systems here. Another PR should follow for renaming and possibly simplifying the lifters. When td3 is able to handle `demand`, some lifters can be removed.