### PR TITLE
Add weak dependencies to TD3 (rebased)

### DIFF
--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -2632,6 +2632,19 @@
               "description": "Maximal number of Domains that the solver can use in parallel. Only applies, when a solver of the 'td_parallel_*' family is used. If left at -1, the value of jobs will be used.",
               "type": "integer",
               "default": -1
+            },
+            "wk_deps": {
+              "title": "solvers.td3.wk_deps",
+              "type": "object",
+              "properties": {
+                "eager": {
+                  "title": "solvers.td3.wk_deps.eager",
+                  "description": "Should weak dependencies be solved immediately when first added to wk_deps",
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/src/constraint/constrSys.ml
+++ b/src/constraint/constrSys.ml
@@ -122,8 +122,8 @@ sig
 end
 
 
-(** [EqConstrSys] where [current_var] indicates the variable whose right-hand side is currently being evaluated. *)
-module CurrentVarEqConstrSys (S: EqConstrSys) =
+(** {!DemandEqConstrSys} where [current_var] indicates the variable whose right-hand side is currently being evaluated. *)
+module CurrentVarDemandEqConstrSys (S: DemandEqConstrSys) =
 struct
   let current_var = ref None
 
@@ -135,13 +135,13 @@ struct
       match S.system x with
       | None -> None
       | Some f ->
-        let f' get set =
+        let f' get set demand =
           let old_current_var = !current_var in
           current_var := Some x;
           Fun.protect ~finally:(fun () ->
               current_var := old_current_var
             ) (fun () ->
-              f get set
+              f get set demand
             )
         in
         Some f'

--- a/src/solver/td3.ml
+++ b/src/solver/td3.ml
@@ -76,6 +76,7 @@ module Base =
       var_messages: Message.t HM.t; (** Messages from right-hand sides of variables. Used for incremental postsolving. *)
       rho_write: S.Dom.t HM.t HM.t; (** Side effects from variables to write-only variables with values. Used for fast incremental restarting of write-only variables. *)
       dep: VS.t HM.t; (** Dependencies of variables. Inverse of [infl]. Used for fast pre-reachable pruning in incremental postsolving. *)
+      weak_dep: VS.t HM.t; (** Map of weak dependencies. "caller" -> "end of function" **)
     }
 
     type marshal = solver_data
@@ -93,6 +94,7 @@ module Base =
       var_messages = HM.create 10;
       rho_write = HM.create 10;
       dep = HM.create 10;
+      weak_dep = HM.create 10;
     }
 
     let print_data data =
@@ -140,6 +142,7 @@ module Base =
         var_messages = HM.copy data.var_messages;
         rho_write = HM.map (fun x w -> HM.copy w) data.rho_write; (* map copies outer HM *)
         dep = HM.copy data.dep;
+        weak_dep = HM.copy data.weak_dep;
       }
 
     (* The following hack is for fixing hashconsing.
@@ -205,7 +208,12 @@ module Base =
       HM.iter (fun k v ->
           HM.replace dep (S.Var.relift k) (VS.map S.Var.relift v)
         ) data.dep;
-      {st; infl; sides; update_rule_data; rho; wpoint_gas; stable; side_dep; side_infl; var_messages; rho_write; dep}
+      let weak_dep = HM.create (HM.length data.weak_dep) in
+      HM.iter (fun k v ->
+          HM.replace weak_dep (S.Var.relift k) (VS.map S.Var.relift v)
+        ) data.weak_dep;
+
+      {st; infl; sides; update_rule_data; rho; wpoint_gas; stable; side_dep; side_infl; var_messages; rho_write; dep; weak_dep}
 
     type phase = Widen | Narrow [@@deriving show] (* used in inner solve *)
 
@@ -270,6 +278,7 @@ module Base =
       let var_messages = data.var_messages in
       let rho_write = data.rho_write in
       let dep = data.dep in
+      let weak_dep = data.weak_dep in
 
       let (module WPS) = SideWPointSelect.choose_impl () in
       let module WPS = struct
@@ -507,7 +516,9 @@ module Base =
           if not vetoed_widen then reduce_gas y;
         )
       and demand l x y =
-        ignore (eval l x y)
+        (* ignore (eval l x y) *)
+        if tracing then trace "sol2" "demand weak dep %a from %a" S.Var.pretty_trace y S.Var.pretty_trace x;
+        HM.replace weak_dep x (VS.add y (try HM.find weak_dep x with Not_found -> VS.empty));
       and init x =
         if tracing then trace "sol2" "init %a" S.Var.pretty_trace x;
         if not (HM.mem rho x) then (
@@ -812,6 +823,17 @@ module Base =
       let i = ref 0 in
       let rec solver () = (* as while loop in paper *)
         incr i;
+        let to_list (acc: S.v list ) (v: VS.t) = VS.fold (fun el acc -> el :: acc) v acc in
+        let hm_keys (hm: VS.t HM.t) = HM.fold (fun k v acc -> to_list acc v) hm [] in
+        let unstable_wk_dps = List.filter (neg (HM.mem stable)) (hm_keys weak_dep)  in
+        if List.length unstable_wk_dps = 0 then (
+          if tracing then trace "sol2" "unstable_wk_deps is empty";
+        ) else (
+          if tracing then trace "sol2" "unstable_wk_deps length %i" (List.length unstable_wk_dps);
+        );
+        List.iter (fun x -> solve x Widen) unstable_wk_dps;
+
+
         let unstable_vs = List.filter (neg (HM.mem stable)) vs in
         if unstable_vs <> [] then (
           if Logs.Level.should_log Debug then (
@@ -1076,7 +1098,7 @@ module Base =
       print_data_verbose data "Data after postsolve";
 
       verify_data data;
-      (rho, {st; infl; sides; update_rule_data; rho; wpoint_gas; stable; side_dep; side_infl; var_messages; rho_write; dep})
+      (rho, {st; infl; sides; update_rule_data; rho; wpoint_gas; stable; side_dep; side_infl; var_messages; rho_write; dep; weak_dep})
   end
 
 (** TD3 with no hooks. *)

--- a/src/solver/td3.ml
+++ b/src/solver/td3.ml
@@ -831,10 +831,9 @@ module Base =
         ) else (
           if tracing then trace "sol2" "unstable_wk_deps length %i" (List.length unstable_wk_dps);
         );
-        List.iter (fun x -> solve x Widen) unstable_wk_dps;
 
-
-        let unstable_vs = List.filter (neg (HM.mem stable)) vs in
+        let interesting_vs = List.append (List.append List.([]) unstable_wk_dps ) vs in
+        let unstable_vs = List.filter (neg (HM.mem stable)) (interesting_vs) in
         if unstable_vs <> [] then (
           if Logs.Level.should_log Debug then (
             if !i = 1 then Logs.newline ();

--- a/src/solver/td3.ml
+++ b/src/solver/td3.ml
@@ -257,6 +257,7 @@ module Base =
 
       let narrow_reuse = GobConfig.get_bool "solvers.td3.narrow-reuse" in
       let remove_wpoint = GobConfig.get_bool "solvers.td3.remove-wpoint" in
+      let eager_solve_wk_deps = GobConfig.get_bool "solvers.td3.wk_deps.eager" in
 
       let side_dep = data.side_dep in
       let side_infl = data.side_infl in
@@ -519,6 +520,10 @@ module Base =
         (* ignore (eval l x y) *)
         if tracing then trace "sol2" "demand weak dep %a from %a" S.Var.pretty_trace y S.Var.pretty_trace x;
         HM.replace weak_dep x (VS.add y (try HM.find weak_dep x with Not_found -> VS.empty));
+        (* TODO: should we check if it is already added? and solve if it is not*)
+        if eager_solve_wk_deps then (
+          solve y Widen;
+        );
       and init x =
         if tracing then trace "sol2" "init %a" S.Var.pretty_trace x;
         if not (HM.mem rho x) then (

--- a/tests/regression/86-weak-deps/01-basic_weak_dep.c
+++ b/tests/regression/86-weak-deps/01-basic_weak_dep.c
@@ -1,0 +1,38 @@
+// PARAM: --set "ana.activated[+]" signs
+// Fully context-insensitive
+#include <goblint.h>
+#include <pthread.h>
+
+int g = 0;
+int y = 0;
+
+void *t_foo(void *arg) {
+  if (g == 1) {
+     y = 1;
+  }
+
+}
+
+int main() {
+  int x;
+  int k = 1;
+  int l = 2;
+  int m = 3;
+  int n = 4;
+  
+  pthread_t id;
+  pthread_create(&id, NULL, t_foo, NULL);
+  int a = 1; // should not be re-evaluated 
+  int b = 2; // should not be re-evaluated 
+  int c = 3; // should not be re-evaluated 
+  int d = 4; // should not be re-evaluated 
+  g = 1;
+  x = y;
+  int d = 4;
+
+  __goblint_check(y < 2); // SUCCESS
+  __goblint_check(y == 1); // UNKNOWN!
+  __goblint_check(x < 2); // SUCCESS
+  __goblint_check(x == 1); // UNKNOWN!
+  return 0;
+}


### PR DESCRIPTION
This is a rebase of (the relevant parts of) #1743 on top of #1746.
It was easier to cherry-pick the necessary commits from #1743 to avoid conflicts with #1746. Also #1743 includes changes to unrelated solvers which would've needed reverting anyway. So this way we get a cleaner history.

### TODO
- [ ] Fix incremental tests.
- [ ] Allow option to disable weak dependencies altogether.