### PR TITLE
Upgrade GobView to OCaml 5

### DIFF
--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -105,6 +105,7 @@ depends: [
   "stdlib-shims" {= "0.3.0"}
   "stdune" {= "3.16.0"}
   "stringext" {= "1.6.0"}
+  "thread-table" {= "1.0.0"}
   "topkg" {= "1.0.7"}
   "tyxml" {= "4.6.0" & with-doc}
   "uri" {= "4.4.0"}


### PR DESCRIPTION
This should fix GobView being uninstallable after #1708.

### TODO
- [ ] Merge https://github.com/goblint/gobview/pull/52.