### PR TITLE
Add upper bound to yojson

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -40,7 +40,7 @@ Goblint includes analyses for assertions, overflows, deadlocks, etc and can be e
     (goblint-cil (>= 2.0.5)) ; TODO no way to define as pin-depends? Used goblint.opam.template to add it for now. https://github.com/ocaml/dune/issues/3231. Alternatively, removing this line and adding cil as a git submodule and `(vendored_dirs cil)` as ./dune also works. This way, no more need to reinstall the pinned cil opam package on changes. However, then cil is cleaned and has to be rebuild together with goblint.
     (batteries (>= 3.5.1))
     (zarith (>= 1.10))
-    (yojson (>= 2.0.0))
+    (yojson (and (>= 2.0.0) (< 3))) ; json-data-encoding has incompatible yojson representation for yojson 3
     (qcheck-core (>= 0.19))
     (ppx_deriving (>= 6.0.2))
     (ppx_deriving_hash (>= 0.1.2))

--- a/goblint.opam
+++ b/goblint.opam
@@ -40,7 +40,7 @@ depends: [
   "goblint-cil" {>= "2.0.5"}
   "batteries" {>= "3.5.1"}
   "zarith" {>= "1.10"}
-  "yojson" {>= "2.0.0"}
+  "yojson" {>= "2.0.0" & < "3"}
   "qcheck-core" {>= "0.19"}
   "ppx_deriving" {>= "6.0.2"}
   "ppx_deriving_hash" {>= "0.1.2"}


### PR DESCRIPTION
The recently released Yojson 3 is incompatible with json-data-encoding, which we use for JSON schema validation. This causes _all_ jobs in the unlocked CI to fail.

It took me a while to notice this, because the unlocked CI currently is still failing for Gobview for some other reasons.