### PR TITLE
Replace camlidl pin with released 1.13

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -72,6 +72,7 @@ Goblint includes analyses for assertions, overflows, deadlocks, etc and can be e
   )
   (depopts
     (apron (>= v0.9.15))
+    (camlidl (>= 1.13)) ; for stability (https://github.com/goblint/analyzer/issues/1520)
     z3
     domainslib
   )

--- a/goblint.opam
+++ b/goblint.opam
@@ -72,6 +72,7 @@ depends: [
 ]
 depopts: [
   "apron" {>= "v0.9.15"}
+  "camlidl" {>= "1.13"}
   "z3"
   "domainslib"
 ]
@@ -102,8 +103,6 @@ available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" |
 pin-depends: [
   # published goblint-cil 2.0.6 is currently up-to-date, but pinned for reproducibility
   [ "goblint-cil.2.0.6" "git+https://github.com/goblint/cil.git#8385ab315bc7461f6801af57673c64731bfa036a" ]
-  # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new camlidl release
-  [ "camlidl.1.12" "git+https://github.com/xavierleroy/camlidl.git#1c1e87e3f56c2c6b3226dd0af3510ef414b462d0" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
   [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]
 ]

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -35,7 +35,7 @@ depends: [
   "bigarray-compat" {= "1.1.0"}
   "bigstringaf" {= "0.9.1"}
   "bos" {= "0.2.1"}
-  "camlidl" {= "1.12"}
+  "camlidl" {= "1.13"}
   "camlp-streams" {= "5.0.1"}
   "catapult" {= "0.2"}
   "catapult-file" {= "0.2"}
@@ -144,10 +144,6 @@ pin-depends: [
   [
     "goblint-cil.2.0.6"
     "git+https://github.com/goblint/cil.git#8385ab315bc7461f6801af57673c64731bfa036a"
-  ]
-  [
-    "camlidl.1.12"
-    "git+https://github.com/xavierleroy/camlidl.git#1c1e87e3f56c2c6b3226dd0af3510ef414b462d0"
   ]
   [
     "apron.v0.9.15"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -4,8 +4,6 @@ available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" |
 pin-depends: [
   # published goblint-cil 2.0.6 is currently up-to-date, but pinned for reproducibility
   [ "goblint-cil.2.0.6" "git+https://github.com/goblint/cil.git#8385ab315bc7461f6801af57673c64731bfa036a" ]
-  # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new camlidl release
-  [ "camlidl.1.12" "git+https://github.com/xavierleroy/camlidl.git#1c1e87e3f56c2c6b3226dd0af3510ef414b462d0" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
   [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]
 ]


### PR DESCRIPTION
The released version finally includes the necessary fix for #1520.