### PR TITLE
Chages in the error notation

### DIFF
--- a/src/common/util/cilType.ml
+++ b/src/common/util/cilType.ml
@@ -37,14 +37,14 @@ struct
     (* TODO: add special output for locUnknown *)
     x.file ^ ":" ^ string_of_int x.line ^ (
       if x.column >= 0 then
-        ":" ^ string_of_int x.column
+        "." ^ string_of_int x.column
       else
         ""
     ) ^ (
       if x.endByte >= 0 then
         "-" ^ string_of_int x.endLine ^ (
           if x.endColumn >= 0 then
-            ":" ^ string_of_int x.endColumn
+            "." ^ string_of_int x.endColumn
           else
             ""
         )


### PR DESCRIPTION
When using the VS Code terminal, it is possible to click on error messages to go directly to the error range involved. Turns out the error format is slightly different than the one used by Goblint.
Goblint does: `file : line : column - line : column` while VS Code recognise by default `file : line . column - line . column`.
This PR fixes that. 
I tried with a default VS Code configuration without any extensions installed, and it works.