### PR TITLE
Relational & VarEq: Invalidate LHS on `Longjmpd` event

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -763,6 +763,8 @@ struct
       if M.tracing then M.traceu "apron" "unassume join";
       M.info ~category:Witness "relation unassumed invariant: %a" d_exp e_orig;
       st
+    | Events.Longjmped {lval} ->
+      Option.map_default (invalidate_one ask man st) st lval
     | _ ->
       st
 

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -587,6 +587,11 @@ struct
           remove ask (Cil.var v) st
         in
         List.fold_left remove_var man.local (EscapeDomain.EscapedVars.elements vars)
+    | Events.Longjmped {lval} ->
+      BatOption.map_default (fun lv ->
+          let ask = Analyses.ask_of_man man in
+          man.local|> remove_reachable ~deep:false ask [mkAddrOf lv])
+        man.local lval
     | _ ->
       man.local
 end

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -590,7 +590,7 @@ struct
     | Events.Longjmped {lval} ->
       BatOption.map_default (fun lv ->
           let ask = Analyses.ask_of_man man in
-          man.local|> remove_reachable ~deep:false ask [mkAddrOf lv])
+          remove ask lv man.local)
         man.local lval
     | _ ->
       man.local

--- a/tests/regression/24-octagon/19-sjlj.c
+++ b/tests/regression/24-octagon/19-sjlj.c
@@ -1,0 +1,27 @@
+//SKIP PARAM: --enable ana.int.interval --set ana.activated[+] apron
+// See https://github.com/goblint/analyzer/issues/1774
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <goblint.h>
+
+jmp_buf env_buffer;
+
+int fun() {
+   longjmp(env_buffer, 2);
+}
+
+
+int main () {
+   int val;
+
+   val = setjmp(env_buffer);
+   if(val) {
+      __goblint_check(1); // Reachable
+   } else {
+      fun();
+   }
+
+   __goblint_check(1); // Reachable
+   return(0);
+}

--- a/tests/regression/68-longjmp/57-vareq.c
+++ b/tests/regression/68-longjmp/57-vareq.c
@@ -1,0 +1,32 @@
+//SKIP PARAM: --enable ana.int.interval --set ana.activated[+] var_eq
+// See https://github.com/goblint/analyzer/issues/1774
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <goblint.h>
+
+jmp_buf env_buffer;
+
+int fun() {
+   longjmp(env_buffer, 2);
+}
+
+
+int main () {
+   int val;
+
+   val = setjmp(env_buffer);
+   if(val) {
+      // With var_eq not doing proper invalidation, the check below was unknown (due to the internal state being inconsistent), instead of failing as expected
+      __goblint_check(val == 0); //FAIL
+      __goblint_check(1); // Reachable
+   } else {
+      if(val == 0) {
+         val = 0;
+         fun();
+      }
+   }
+
+   __goblint_check(1); // Reachable
+   return(0);
+}


### PR DESCRIPTION
This is necessary as (via the query system) information about the return value of `setjmp` upon first call is propagated into the relational analysis, despite handling `setjmp` as an unknown function.
A similar problem arises for `VarEq` as well, which is also fixed in this PR.

@leunam99: Can you check if this fixes the issue you saw?

Closes #1774.