### PR TITLE
Adjust `test_FI_div_zero_result_top` QCheck test property to account for the 0/0 case

### DIFF
--- a/src/cdomain/value/cdomains/floatDomain.ml
+++ b/src/cdomain/value/cdomains/floatDomain.ml
@@ -220,7 +220,9 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
     | _ -> Top
 
   (**for QCheck: should describe how to generate random values and shrink possible counter examples *)
-  let arbitrary () = QCheck.map convert_arb (QCheck.option (QCheck.pair QCheck.float QCheck.float))
+  let arbitrary () =
+    let gen = QCheck.map convert_arb (QCheck.option (QCheck.pair QCheck.float QCheck.float)) in
+    QCheck.set_print show gen
 
   let of_interval' interval =
     let x = norm @@ Interval interval

--- a/tests/unit/cdomains/floatDomainTest.ml
+++ b/tests/unit/cdomains/floatDomainTest.ml
@@ -265,7 +265,10 @@ struct
 
   let test_FI_div_zero_result_top =
     QCheck.Test.make ~name:"test_FI_div_zero_result_top" (FI.arbitrary ()) (fun arg ->
-        FI.is_top (FI.div arg (FI.of_const 0.)))
+        let res = FI.div arg (FI.of_const 0.) in
+        if FI.equal arg fi_zero
+        then FI.equal res (FI.nan ())
+        else FI.is_top res)
 
   let test_FI_accurate_neg =
     QCheck.Test.make ~name:"test_FI_accurate_neg" QCheck.float (fun arg ->


### PR DESCRIPTION
The forthcoming QCheck 0.26 release ocaml/opam-repository#28148 changes the distribution of the `float` generator to avoid blind spots: c-cube/qcheck#350. As a consequence, an existing goblint analyzer test now fails to hold, resulting in:
```
File "src/core/QCheck2.ml", line 2005, characters 1-1:
Error: :1:floatDomainTest:1:float_interval_qcheck32:2:test_FI_div_zero_result_top (in the code).


test `test_FI_div_zero_result_top` failed on ≥ 1 cases: <instance>
```

This PR first patches the `arbitrary` generator to use the existing `show` function to print counterexamples:
```
File "src/core/QCheck2.ml", line 2005, characters 1-1:
Error: :1:floatDomainTest:1:float_interval_qcheck32:2:test_FI_div_zero_result_top (in the code).


test `test_FI_div_zero_result_top` failed on ≥ 1 cases: [0.,0.]
```

Second, it patches the property of the mentioned QCheck test to account for the [0.;0.] / [0.;0.] case.
Here, I was guided by the unit test above already exercising this corner case:
https://github.com/goblint/analyzer/blob/f2c4520a3019178659c984a38471533bea9a895d/tests/unit/cdomains/floatDomainTest.ml#L103-L109

In retrospect, I can see the `arbitrary ()` generator produces random intervals by mapping `convert_arb` over a pair of random `float`s. The chance of producing a unit (const) interval with that strategy is close to zero. :thinking: 
I believe the change of distribution (and the ability of emitting `nan`) is the reason why the failure started to trigger with QCheck 0.26: 
```ocaml
# min nan 0.;;
- : float = 0.
# max nan 0.;;
- : float = 0.
```
I therefore encourage you to investigate the distribution of the generator. I just adjusted the output of `collect` stats in QCheck 0.26 https://github.com/c-cube/qcheck/pull/351 which lends itself to a nice "top", "bot", "const", "non-const" classification... :nerd_face: :sweat_smile: 