### PR TITLE
Turn `malloc_null` into an analysis serving as path-sens hint only & Fix enter

### DIFF
--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -1,4 +1,4 @@
-(** Path-sensitive analysis of failed dynamic memory allocations ([malloc_null]). *)
+(** Helper analysis to be path-sensitive in failed dynamic memory allocations ([malloc_null]). *)
 
 module AD = ValueDomain.AD
 module IdxDom = ValueDomain.IndexDomain
@@ -20,61 +20,6 @@ struct
     Addr set functions:
   *)
   let is_prefix_of m1 m2 = Option.is_some (Addr.Mval.prefix m1 m2)
-
-  (* We just had to dereference an lval --- warn if it was null *)
-  let warn_lval (st:D.t) (v :Addr.Mval.t) : unit =
-    try
-      if D.exists (fun x -> GobOption.exists (fun x -> is_prefix_of x v) (Addr.to_mval x)) st
-      then
-        let var = Addr.of_mval v in
-        Messages.warn ~category:Messages.Category.Behavior.Undefined.nullpointer_dereference "Possible dereferencing of null on variable '%a'." Addr.pretty var
-    with SetDomain.Unsupported _ -> ()
-
-  (* Warn null-lval dereferences, but not normal (null-) lvals*)
-  let rec warn_deref_exp (a: Queries.ask) (st:D.t) (e:exp): unit =
-    let warn_lval_mem e offs =
-      (*      begin try List.iter (warn_lval st) (AD.to_mval (BS.eval_lv gl s (Mem e, offs)))
-              with SetDomain.Unsupported _ -> () end;*)
-      match e with
-      | Lval (Var v, offs) ->
-        begin match a.f (Queries.MayPointTo (mkAddrOf (Var v,offs))) with
-          | ad when not (Queries.AD.is_top ad) ->
-            Queries.AD.iter (function
-                | Queries.AD.Addr.Addr mval -> warn_lval st mval
-                | _ -> ()
-              ) ad
-          | _ -> ()
-        end
-      | _ -> ()
-    in
-    match e with
-    | Const _
-    | SizeOf _
-    | SizeOfStr _
-    | AlignOf _
-    | AddrOfLabel _
-    | Lval (Var _, _) -> ()
-    | AddrOf (Var _, _)
-    | StartOf (Var _, _) ->  warn_lval_mem e NoOffset
-    | AddrOf (Mem e, offs)
-    | StartOf (Mem e, offs)
-    | Lval (Mem e, offs) ->
-      warn_deref_exp a st e;
-      warn_lval_mem e offs
-    | BinOp (_,e1,e2,_) ->
-      warn_deref_exp a st e1;
-      warn_deref_exp a st e2
-    | UnOp (_,e,_)
-    | Real e
-    | Imag e
-    | SizeOfE e
-    | AlignOfE e
-    | CastE  (_,e) ->
-      warn_deref_exp a st e
-    | Question (b, t, f, _) ->
-      warn_deref_exp a st b;
-      warn_deref_exp a st t;
-      warn_deref_exp a st f
 
   (* Generate addresses to all points in an given varinfo. (Depends on type) *)
   let to_addrs (v:varinfo) : Addr.t list =
@@ -146,15 +91,12 @@ struct
 
   (* One step tf-s *)
   let assign man (lval:lval) (rval:exp) : D.t =
-    warn_deref_exp (Analyses.ask_of_man man) man.local (Lval lval) ;
-    warn_deref_exp (Analyses.ask_of_man man) man.local rval;
     match get_concrete_exp rval man.global man.local, get_concrete_lval (Analyses.ask_of_man man) lval with
     | Some rv, Some mval when might_be_null (Analyses.ask_of_man man) rv man.global man.local ->
       D.add (Addr.of_mval mval) man.local
     | _ -> man.local
 
   let branch man (exp:exp) (tv:bool) : D.t =
-    warn_deref_exp (Analyses.ask_of_man man) man.local exp;
     man.local
 
   let body man (f:fundec) : D.t =
@@ -168,7 +110,6 @@ struct
     let nst = List.fold_left remove_var man.local (f.slocals @ f.sformals) in
     match exp with
     | Some ret ->
-      warn_deref_exp (Analyses.ask_of_man man) man.local ret;
       begin match get_concrete_exp ret man.global man.local with
         | Some ev when might_be_null (Analyses.ask_of_man man) ev man.global man.local ->
           D.add (return_addr ()) nst
@@ -179,8 +120,6 @@ struct
 
   let enter man (lval: lval option) (f:fundec) (args:exp list) : (D.t * D.t) list =
     let nst = remove_unreachable (Analyses.ask_of_man man) args man.local in
-    Option.iter (fun x -> warn_deref_exp (Analyses.ask_of_man man) man.local (Lval x)) lval;
-    List.iter (warn_deref_exp (Analyses.ask_of_man man) man.local) args;
     [man.local,nst]
 
   let combine_env man lval fexp f args fc au f_ask =
@@ -197,8 +136,6 @@ struct
     | _ -> man.local
 
   let special man (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
-    Option.iter (fun x -> warn_deref_exp (Analyses.ask_of_man man) man.local (Lval x)) lval;
-    List.iter (warn_deref_exp (Analyses.ask_of_man man) man.local) arglist;
     let desc = LibraryFunctions.find f in
     match desc.special arglist, lval with
     | Malloc _, Some lv ->

--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -79,7 +79,7 @@ struct
     | ad when not (Queries.AD.is_top ad) ->
       let one_addr_might = function
         | Queries.AD.Addr.Addr mval ->
-          D.exists (fun addr -> GobOption.exists (fun x -> is_prefix_of mval x) (Addr.to_mval addr)) st
+          D.exists (fun addr -> GobOption.exists (is_prefix_of mval) (Addr.to_mval addr)) st
         | _ -> false
       in
       Queries.AD.exists one_addr_might ad

--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -9,7 +9,7 @@ open Analyses
 
 module Spec =
 struct
-  include Analyses.DefaultSpec
+  include Analyses.IdentitySpec
 
   module Addr = ValueDomain.Addr
   module D = ValueDomain.AddrSetDomain
@@ -95,12 +95,6 @@ struct
     | Some rv, Some mval when might_be_null (Analyses.ask_of_man man) rv man.global man.local ->
       D.add (Addr.of_mval mval) man.local
     | _ -> man.local
-
-  let branch man (exp:exp) (tv:bool) : D.t =
-    man.local
-
-  let body man (f:fundec) : D.t =
-    man.local
 
   let return_addr_ = ref Addr.NullPtr
   let return_addr () = !return_addr_

--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -147,7 +147,6 @@ struct
 
   let startstate v = D.empty ()
   let threadenter man ~multiple lval f args = [D.empty ()]
-  let threadspawn man ~multiple lval f args fman = man.local
   let exitstate  v = D.empty ()
 
   let init marshal =

--- a/src/analyses/malloc_null.ml
+++ b/src/analyses/malloc_null.ml
@@ -1,4 +1,4 @@
-(** Helper analysis to be path-sensitive in failed dynamic memory allocations ([malloc_null]). *)
+(** Helper analysis to be path-sensitive in failed dynamic memory allocations ([malloc_null]). It is not soundness critical, it only causes certain paths to be kept separate. *)
 
 module AD = ValueDomain.AD
 module IdxDom = ValueDomain.IndexDomain

--- a/tests/regression/08-malloc_null/01-simple-malloc.c
+++ b/tests/regression/08-malloc_null/01-simple-malloc.c
@@ -19,11 +19,11 @@ void *no_malloc(size_t x){
 int main(void) {
         int *v;
 
-        v = (int*)smalloc(sizeof(*v));
+        v = (int*)smalloc(sizeof(*v)); // NOWARN (v may be NULL, but sizeof does not evaluate)
         *v = 10; // NOWARN
 
 
-        v = (int*)malloc(sizeof(*v));
+        v = (int*)malloc(sizeof(*v)); // NOWARN (v is not NULL and sizeof does not evaluate anyway)
         if (v == 0){
                 __goblint_check(0); // FAIL
   } else {
@@ -31,7 +31,7 @@ int main(void) {
                 *v != 0; // NOWARN
         }
 
-        v = (int*)no_malloc(sizeof(*v));
+        v = (int*)no_malloc(sizeof(*v)); // NOWARN (v may be NULL, but sizeof does not evaluate)
         *v = 10; //WARN
 
         if (v == 0)

--- a/tests/regression/08-malloc_null/02-paths-malloc.c
+++ b/tests/regression/08-malloc_null/02-paths-malloc.c
@@ -6,8 +6,8 @@
 int main(void) {
   int *v, *u, r;
 
-  u = (int*)malloc(sizeof(*u));
-  v = (int*)malloc(sizeof(*v));
+  u = (int*)malloc(sizeof(*u)); // NOWARN (u may be NULL, but sizeof does not evaluate)
+  v = (int*)malloc(sizeof(*v)); // NOWARN (v may be NULL, but sizeof does not evaluate)
 
   *u = 10; // WARN
   *v = 10; // WARN
@@ -25,8 +25,8 @@ int main(void) {
   *v = 20; // NOWARN
 
   if (r){
-    u = (int*)malloc(sizeof(*u));
-    v = (int*)malloc(sizeof(*v));
+    u = (int*)malloc(sizeof(*u)); // NOWARN (u is not NULL and sizeof does not evaluate anyway)
+    v = (int*)malloc(sizeof(*v)); // NOWARN (v is not NULL and sizeof does not evaluate anyway)
   }
 
   *u = 30; // WARN

--- a/tests/regression/08-malloc_null/03-interproc.c
+++ b/tests/regression/08-malloc_null/03-interproc.c
@@ -1,0 +1,25 @@
+// PARAM: --set ana.activated[+] malloc_null --set ana.ctx_sens "['thread']"
+// Making all analyses context-insensitive except an irrelevant one, we want to rely on malloc_null here
+#include <stdlib.h>
+#include <goblint.h>
+
+void fun(int* a, int c) {
+  if(c == 1) {
+    if(a == NULL) { return; }
+  }
+
+  *a = 5; //NOWARN
+}
+
+
+int main(void) {
+  int *x;
+
+  x = malloc(sizeof(int));
+  fun(x,1);
+
+  int y;
+  fun(&y, 2);
+
+  return 0;
+}


### PR DESCRIPTION
- Removes redundant warning facilities from `malloc_null`
- Fixes interprocedural aspect:
   - If a function `f(int x)` is called as `f(y)`, nullness information should be transferred from  `y` in the callee state to `x` in the caller state
   - Adds a test where contexts are disabled, and one relies only on `malloc_null` 
   
Closes #1691.