### PR TITLE
Fix and update lower-bounds CI

### DIFF
--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Downgrade dependencies
         # must specify ocaml-base-compiler again to prevent it from being downgraded
         # prevent num downgrade to avoid dune/jbuilder error: https://github.com/ocaml/dune/issues/5280
-        run: opam install --solver=builtin-0install --criteria="+removed,+count[version-lag,solution]" goblint ocaml-variants.4.14.2+options ocaml-option-flambda num.1.5
+        run: opam install --solver=builtin-0install --criteria="+removed,+count[version-lag,solution]" --with-test goblint apron ocaml-variants.4.14.2+options ocaml-option-flambda num.1.5
 
       - name: Build
         run: ./make.sh nat

--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install dependencies
         run: opam install . --deps-only --with-test
-      
+
       - name: Install os gem for operating system detection
         run: sudo gem install os
 
@@ -86,9 +86,6 @@ jobs:
         run: ruby scripts/update_suite.rb -m
 
   lower-bounds-downgrade:
-    # use external 0install solver to downgrade: https://github.com/ocaml-opam/opam-0install-solver
-    # TODO: will be built in in opam 2.2: https://github.com/ocaml/opam/pull/4909
-
     strategy:
       fail-fast: false
       matrix:
@@ -133,13 +130,10 @@ jobs:
         if: ${{ false }}
         run: ./make.sh nat
 
-      - name: Install opam-0install
-        run: opam install opam-0install
-
       - name: Downgrade dependencies
         # must specify ocaml-base-compiler again to prevent it from being downgraded
         # prevent num downgrade to avoid dune/jbuilder error: https://github.com/ocaml/dune/issues/5280
-        run: opam install $(opam exec -- opam-0install --prefer-oldest goblint ocaml-variants.4.14.2+options ocaml-option-flambda num.1.5)
+        run: opam install --solver=builtin-0install --criteria="+removed,+count[version-lag,solution]" goblint ocaml-variants.4.14.2+options ocaml-option-flambda num.1.5
 
       - name: Build
         run: ./make.sh nat
@@ -265,7 +259,7 @@ jobs:
         os:
           - ubuntu-22.04 # https://github.com/ocaml/setup-ocaml/issues/872
         ocaml-compiler:
-          - ocaml-variants.5.0.0+options,ocaml-option-flambda 
+          - ocaml-variants.5.0.0+options,ocaml-option-flambda
         node-version:
           - 14
 

--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -133,7 +133,9 @@ jobs:
       - name: Downgrade dependencies
         # must specify ocaml-base-compiler again to prevent it from being downgraded
         # prevent num downgrade to avoid dune/jbuilder error: https://github.com/ocaml/dune/issues/5280
-        run: opam install --solver=builtin-0install --criteria="+removed,+count[version-lag,solution]" --with-test goblint apron ocaml-variants.4.14.2+options ocaml-option-flambda num.1.5
+        run: |
+          opam install --solver=builtin-0install --criteria="+removed,+count[version-lag,solution]" . --deps-only --with-test
+          opam install --solver=builtin-0install --criteria="+count[version-lag,solution]" apron mlgmpidl.1.2.15
 
       - name: Build
         run: ./make.sh nat

--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 

--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -93,7 +93,7 @@ jobs:
           - ubuntu-22.04 # https://github.com/ocaml/setup-ocaml/issues/872
           - macos-13
         ocaml-compiler:
-          - ocaml-variants.4.14.2+options,ocaml-option-flambda # matches opam lock file, downgrade deps step
+          - ocaml-variants.4.14.2+options,ocaml-option-flambda # matches opam lock file
 
     name: lower-bounds (${{ matrix.os }}, ${{ matrix.ocaml-compiler }}, downgrade)
 
@@ -128,8 +128,6 @@ jobs:
         run: ./make.sh nat
 
       - name: Downgrade dependencies
-        # must specify ocaml-base-compiler again to prevent it from being downgraded
-        # prevent num downgrade to avoid dune/jbuilder error: https://github.com/ocaml/dune/issues/5280
         run: |
           opam install --solver=builtin-0install --criteria="+removed,+count[version-lag,solution]" . --deps-only --with-test
           opam install --solver=builtin-0install --criteria="+count[version-lag,solution]" apron mlgmpidl.1.2.15

--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -129,8 +129,7 @@ jobs:
 
       - name: Downgrade dependencies
         run: |
-          opam install --solver=builtin-0install --criteria="+removed,+count[version-lag,solution]" . --deps-only --with-test
-          opam install --solver=builtin-0install --criteria="+count[version-lag,solution]" apron mlgmpidl.1.2.15
+          opam install --solver=builtin-0install --criteria="+count[version-lag,solution]" . --deps-only --with-test
 
       - name: Build
         run: ./make.sh nat

--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -123,13 +123,9 @@ jobs:
           opam depext apron
           opam install apron mlgmpidl.1.2.15
 
-      - name: Build
-        if: ${{ false }}
-        run: ./make.sh nat
-
       - name: Downgrade dependencies
-        run: |
-          opam install --solver=builtin-0install --criteria="+count[version-lag,solution]" . --deps-only --with-test
+        # without "+removed" in criteria, because it also removes optional apron
+        run: opam install --solver=builtin-0install --criteria="+count[version-lag,solution]" . --deps-only --with-test
 
       - name: Build
         run: ./make.sh nat
@@ -142,41 +138,6 @@ jobs:
 
       - name: Test marshal regression # not part of @runtest due to time
         run: ruby scripts/update_suite.rb -m
-
-  lower-bounds-docker:
-    # use builtin-0install solver to remove and downgrade, opam normally compiled without, Docker images have it compiled
-
-    if: ${{ false }}
-
-    name: lower-bounds (docker)
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3 # needed for GitHub Actions Cache in build-push-action
-
-      - name: Build dev Docker image
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          target: dev
-          load: true # load into docker instead of immediately pushing
-          tags: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max # max mode caches all layers for multi-stage image
-
-      - name: Run opam downgrade and tests in dev Docker image
-        uses: addnab/docker-run-action@v3
-        with:
-          image: dev
-          run: |
-            OPAMCRITERIA=+removed,+count[version-lag,solution] OPAMEXTERNALSOLVER=builtin-0install opam-2.1 install . --deps-only --with-test --confirm-level=unsafe-yes
-            opam exec -- dune runtest
 
   opam-install:
     strategy:

--- a/.github/workflows/unlocked.yml
+++ b/.github/workflows/unlocked.yml
@@ -99,9 +99,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    env:
-      OPAMCONFIRMLEVEL: unsafe-yes # allow opam depext to yes package manager prompts
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
The lower-bounds CI job is now failing since the release of opam 2.4.0: https://github.com/ocaml-opam/opam-0install-solver/pull/63.

However, there's no need to rely on opam-0install anymore because the 0install solver that can do lower-bounds in built in since opam 2.2.
This completes the TODO that has been standing there ever since I added the lower-bounds job I think, but at the time setup-ocaml didn't install opam 2.2.