### PR TITLE
Pin CIL with global state removed from `Pretty`

### DIFF
--- a/goblint.opam
+++ b/goblint.opam
@@ -102,7 +102,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 pin-depends: [
   # published goblint-cil 2.0.6 is currently up-to-date, but pinned for reproducibility
-  [ "goblint-cil.2.0.6" "git+https://github.com/goblint/cil.git#e4bf34970c80dad2810680507effee9a983f9d30" ]
+  [ "goblint-cil.2.0.6" "git+https://github.com/goblint/cil.git#4b8b06eb39801a87d195f81d830a686578bd8b8b" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
   [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]
 ]

--- a/goblint.opam
+++ b/goblint.opam
@@ -102,7 +102,7 @@ dev-repo: "git+https://github.com/goblint/analyzer.git"
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 pin-depends: [
   # published goblint-cil 2.0.6 is currently up-to-date, but pinned for reproducibility
-  [ "goblint-cil.2.0.6" "git+https://github.com/goblint/cil.git#c0b10d1848223a67de45ef608f4e05c082977ac1" ]
+  [ "goblint-cil.2.0.6" "git+https://github.com/goblint/cil.git#e4bf34970c80dad2810680507effee9a983f9d30" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
   [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]
 ]

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -143,7 +143,7 @@ post-messages: [
 pin-depends: [
   [
     "goblint-cil.2.0.6"
-    "git+https://github.com/goblint/cil.git#c0b10d1848223a67de45ef608f4e05c082977ac1"
+    "git+https://github.com/goblint/cil.git#e4bf34970c80dad2810680507effee9a983f9d30"
   ]
   [
     "apron.v0.9.15"

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -143,7 +143,7 @@ post-messages: [
 pin-depends: [
   [
     "goblint-cil.2.0.6"
-    "git+https://github.com/goblint/cil.git#e4bf34970c80dad2810680507effee9a983f9d30"
+    "git+https://github.com/goblint/cil.git#4b8b06eb39801a87d195f81d830a686578bd8b8b"
   ]
   [
     "apron.v0.9.15"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -2,8 +2,7 @@
 # also remember to generate/adjust goblint.opam.locked!
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 pin-depends: [
-  # published goblint-cil 2.0.6 is currently up-to-date, but pinned for reproducibility
-  [ "goblint-cil.2.0.6" "git+https://github.com/goblint/cil.git#e4bf34970c80dad2810680507effee9a983f9d30" ]
+  [ "goblint-cil.2.0.6" "git+https://github.com/goblint/cil.git#4b8b06eb39801a87d195f81d830a686578bd8b8b" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
   [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]
 ]

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -3,7 +3,7 @@
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 pin-depends: [
   # published goblint-cil 2.0.6 is currently up-to-date, but pinned for reproducibility
-  [ "goblint-cil.2.0.6" "git+https://github.com/goblint/cil.git#c0b10d1848223a67de45ef608f4e05c082977ac1" ]
+  [ "goblint-cil.2.0.6" "git+https://github.com/goblint/cil.git#e4bf34970c80dad2810680507effee9a983f9d30" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
   [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]
 ]


### PR DESCRIPTION
Updates CIL pin with https://github.com/goblint/cil/pull/187.

### TODO
- [x] Merge https://github.com/goblint/cil/pull/187.