### PR TITLE
Add error for non-path-sensitive analysis in `ana.path_sens`

### DIFF
--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -322,6 +322,12 @@ struct
   let should_print _ = false
 end
 
+module EmptyP =
+struct
+  include Printable.Empty
+  let of_elt _ = failwith "EmptyP.of_elt: analysis cannot be path-sensitive"
+end
+
 module UnitP =
 struct
   include Printable.Unit
@@ -339,7 +345,7 @@ module DefaultSpec =
 struct
   module G = Lattice.Unit
   module V = EmptyV
-  module P = UnitP
+  module P = EmptyP
 
   type marshal = unit
   let init _ = ()


### PR DESCRIPTION
This occurred to me while looking at PR #1791.
Currently any analysis can be added to `ana.path_sens`, even if it provides no path-sensitivity whatsoever. There is no error, so it might appear like it's supposed to do something, while it actually doesn't.

Thus, this PR changes the default path-sensitivity module to error instead if a non-path-sensitive analysis is added to `ana.path_sens`, making it explicit that this is pointless.