### PR TITLE
Fix copy-paste typo in interval set overflow handling

### DIFF
--- a/src/cdomain/value/cdomains/int/intervalSetDomain.ml
+++ b/src/cdomain/value/cdomains/int/intervalSetDomain.ml
@@ -167,7 +167,7 @@ struct
     let res = List.map (norm_interval ~suppress_ovwarn ~cast ik) xs in
     let intvs = List.concat_map fst res in
     let underflow = List.exists (fun (_,{underflow; _}) -> underflow) res in
-    let overflow = List.exists (fun (_,{overflow; _}) -> underflow) res in
+    let overflow = List.exists (fun (_,{overflow; _}) -> overflow) res in
     (canonize intvs,{underflow; overflow})
 
   let binary_op_with_norm op (ik:ikind) (x: t) (y: t) : t*overflow_info = match x, y with

--- a/tests/regression/67-interval-sets-two/59-issue-1798.c
+++ b/tests/regression/67-interval-sets-two/59-issue-1798.c
@@ -1,0 +1,6 @@
+// PARAM: --enable ana.int.interval_set
+int count_int_int;
+void main() {
+  for (;; count_int_int++) // TODO WARN (overflow)
+    ;
+}

--- a/tests/regression/67-interval-sets-two/59-issue-1798.c
+++ b/tests/regression/67-interval-sets-two/59-issue-1798.c
@@ -1,6 +1,6 @@
 // PARAM: --enable ana.int.interval_set
 int count_int_int;
 void main() {
-  for (;; count_int_int++) // TODO WARN (overflow)
+  for (;; count_int_int++) // WARN (overflow)
     ;
 }


### PR DESCRIPTION
Closes #1798.

Maybe we should not be disabling unused variable warnings: they would've caught the issue because previously the argument of the lambda was unused.

### TODO
- [x] Add test.