### PR TITLE
Add workaround for `__goblint_assume_join` on newer GCC

### DIFF
--- a/lib/goblint/runtime/src/dune
+++ b/lib/goblint/runtime/src/dune
@@ -2,4 +2,5 @@
  (archive_name goblint)
  (language c)
  (names goblint)
+ (flags :standard -std=c11) ; workaround for https://github.com/goblint/analyzer/issues/1779
  (include_dirs ../include))


### PR DESCRIPTION
Issue #1779.