### PR TITLE
Check cast safety in base `invariant_fallback`

### DIFF
--- a/tests/regression/29-svcomp/37-weaver-invariant-cast.c
+++ b/tests/regression/29-svcomp/37-weaver-invariant-cast.c
@@ -12,6 +12,6 @@ int main() {
   assume_abort_if_not(n_update >= 0);
   assume_abort_if_not(n_update <= ( 4294967295UL /  sizeof (char)));
 
-  __goblint_check(1); // TODO reachable
+  __goblint_check(1); // reachable
   return 0;
 }

--- a/tests/regression/29-svcomp/37-weaver-invariant-cast.c
+++ b/tests/regression/29-svcomp/37-weaver-invariant-cast.c
@@ -1,0 +1,17 @@
+// PARAM: --enable ana.int.interval --set ana.activated[+] abortUnless
+#include <goblint.h>
+
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+
+int main() {
+  int n_update;
+
+  assume_abort_if_not(n_update >= 0);
+  assume_abort_if_not(n_update <= ( 4294967295UL /  sizeof (char)));
+
+  __goblint_check(1); // TODO reachable
+  return 0;
+}


### PR DESCRIPTION
Closes #1782.

In the problematic test, the changed line was casting `4294967295UL` (same after division by `sizeof(char)`) to the type of the lvalue `n_update`, which is `int`. This cast is not safe and caused an incorrect -1 bound to be used.

This PR adds a check with `VD.is_dynamically_safe_cast` before doing the cast.

This is the very base case of `invariant_fallback`, so the change could have quite an impact. Although lvalues are also refined by HC4's `inv_exp` at the non-fallback level. So I'm not sure how often the fallback case actually gets used.