### PR TITLE
Add option `witness.yaml.sv-comp-true-only`

### DIFF
--- a/conf/svcomp-ghost.json
+++ b/conf/svcomp-ghost.json
@@ -114,6 +114,7 @@
   "witness": {
     "yaml": {
       "enabled": true,
+      "sv-comp-true-only": false,
       "format-version": "2.1",
       "entry-types": [
         "flow_insensitive_invariant",

--- a/conf/svcomp.json
+++ b/conf/svcomp.json
@@ -91,6 +91,7 @@
   "witness": {
     "yaml": {
       "enabled": true,
+      "sv-comp-true-only": false,
       "format-version": "2.0",
       "entry-types": [
         "invariant_set"

--- a/conf/svcomp24.json
+++ b/conf/svcomp24.json
@@ -110,6 +110,7 @@
   "witness": {
     "yaml": {
       "enabled": true,
+      "sv-comp-true-only": false,
       "format-version": "2.0",
       "entry-types": [
         "invariant_set"

--- a/conf/svcomp25.json
+++ b/conf/svcomp25.json
@@ -91,6 +91,7 @@
   "witness": {
     "yaml": {
       "enabled": true,
+      "sv-comp-true-only": false,
       "format-version": "2.0",
       "entry-types": [
         "invariant_set"

--- a/conf/svcomp2var.json
+++ b/conf/svcomp2var.json
@@ -109,6 +109,7 @@
   "witness": {
     "yaml": {
       "enabled": true,
+      "sv-comp-true-only": false,
       "format-version": "2.0",
       "entry-types": [
         "invariant_set"

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -2785,6 +2785,12 @@
               "type": "boolean",
               "default": false
             },
+            "sv-comp-true-only": {
+              "title": "witness.yaml.sv-comp-true-only",
+              "description": "Only output YAML witness when SV-COMP result is \"true\".",
+              "type": "boolean",
+              "default": false
+            },
             "format-version": {
               "title": "witness.yaml.format-version",
               "description": "YAML witness format version",

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -803,7 +803,7 @@ struct
         None
     in
 
-    let _svcomp_result =
+    let svcomp_result =
       if get_bool "ana.sv-comp.enabled" then (
         (* SV-COMP and witness generation *)
         let module WResult = Witness.Result (R) in
@@ -815,7 +815,7 @@ struct
 
     if get_bool "witness.yaml.enabled" then (
       let module YWitness = YamlWitness.Make (R) in
-      YWitness.write ()
+      YWitness.write ~svcomp_result
     );
 
     let marshal = Spec.finalize () in

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -803,11 +803,15 @@ struct
         None
     in
 
-    if get_bool "ana.sv-comp.enabled" then (
-      (* SV-COMP and witness generation *)
-      let module WResult = Witness.Result (R) in
-      WResult.write yaml_validate_result entrystates
-    );
+    let _svcomp_result =
+      if get_bool "ana.sv-comp.enabled" then (
+        (* SV-COMP and witness generation *)
+        let module WResult = Witness.Result (R) in
+        Some (WResult.write yaml_validate_result entrystates)
+      )
+      else
+        None
+    in
 
     if get_bool "witness.yaml.enabled" then (
       let module YWitness = YamlWitness.Make (R) in

--- a/src/witness/yamlWitness.ml
+++ b/src/witness/yamlWitness.ml
@@ -641,6 +641,15 @@ struct
 
   let write () =
     Timing.wrap "yaml witness" write ()
+
+  let write ~svcomp_result =
+    if GobConfig.get_bool "witness.yaml.sv-comp-true-only" then (
+      match svcomp_result with
+      | Some (Ok Svcomp.Result.True) -> write ()
+      | _ -> ()
+    )
+    else
+      write ()
 end
 
 let init () =


### PR DESCRIPTION
We used to have the option `witness.graphml.unknown` for whether to output GraphML correctness witnesses for "unknown" SV-COMP results. This was removed in #1738 along with GraphML witnesses entirely.

At some point I thought that we still had the option and it applied to YAML witnesses. Turns out that's not the case: YAML correctness witnesses are currently just invariant sets (not necessarily tied to correctness). And our implementation of YAML witnesses is also completely independent from SV-COMP support. This has allowed us to use YAML witnesses in various CRAM tests without needing to configure `ana.specification` to a single SV-COMP property file.

This PR adds the analogous option for YAML witnesses, giving us the possibility to not create too many large YAML witnesses in SV-COMP when they'd be useless anyway.

### TODO
- [ ] Decide value for `svcomp`  conf going forward.
