### PR TITLE
Reduce var_eq witness invariants from quadratic to linear

### DIFF
--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -21,18 +21,23 @@ struct
       fold (fun s a ->
           if B.mem MyCFG.unknown_exp s then
             a
-          else
-            let module B_prod = BatSet.Make2 (Exp) (Exp) in
-            let s_prod = B_prod.cartesian_product s s in
-            let i = B_prod.Product.fold (fun (x, y) a ->
-                if Exp.compare x y < 0 && not (InvariantCil.exp_contains_tmp x) && not (InvariantCil.exp_contains_tmp y) && InvariantCil.exp_is_in_scope scope x && InvariantCil.exp_is_in_scope scope y then (* each equality only one way, no self-equalities *)
-                  let eq = BinOp (Eq, x, y, intType) in
+          else (
+            let s' = B.filter (fun x -> not (InvariantCil.exp_contains_tmp x) && InvariantCil.exp_is_in_scope scope x) s in
+            if B.cardinal s' >= 2 then (
+              (* instead of returning quadratically many pairwise equalities from a cluster,
+                 output linear number of equalities with just one expression *)
+              let lhs = B.choose s' in (* choose arbitrary expression for lhs *)
+              let rhss = B.remove lhs s' in (* and exclude it from rhs-s (no point in reflexive equality) *)
+              let i = B.fold (fun rhs a ->
+                  let eq = BinOp (Eq, lhs, rhs, intType) in
                   Invariant.(a && of_exp eq)
-                else
-                  a
-              ) s_prod (Invariant.top ())
-            in
-            Invariant.(a && i)
+                ) rhss (Invariant.top ())
+              in
+              Invariant.(a && i)
+            )
+            else (* cannot output any equalities between just 0 or 1 usable expressions *)
+              a
+          )
         ) ss (Invariant.top ())
   end
 

--- a/tests/regression/56-witness/71-var_eq-invariants.c
+++ b/tests/regression/56-witness/71-var_eq-invariants.c
@@ -1,0 +1,7 @@
+// CRAM
+
+int main() {
+  int a, b, c, d;
+  a = b = c = d;
+  return 0;
+}

--- a/tests/regression/56-witness/71-var_eq-invariants.t
+++ b/tests/regression/56-witness/71-var_eq-invariants.t
@@ -4,7 +4,7 @@
     dead: 0
     total lines: 3
   [Info][Witness] witness generation summary:
-    location invariants: 6
+    location invariants: 3
     loop invariants: 0
     flow-insensitive invariants: 0
     total generation entries: 1
@@ -40,31 +40,4 @@ With 4 equal variables, there should be just 3 var_eq invariants, not 6.
           column: 3
           function: main
         value: a == d
-        format: c_expression
-    - invariant:
-        type: location_invariant
-        location:
-          file_name: 71-var_eq-invariants.c
-          line: 6
-          column: 3
-          function: main
-        value: b == c
-        format: c_expression
-    - invariant:
-        type: location_invariant
-        location:
-          file_name: 71-var_eq-invariants.c
-          line: 6
-          column: 3
-          function: main
-        value: b == d
-        format: c_expression
-    - invariant:
-        type: location_invariant
-        location:
-          file_name: 71-var_eq-invariants.c
-          line: 6
-          column: 3
-          function: main
-        value: c == d
         format: c_expression

--- a/tests/regression/56-witness/71-var_eq-invariants.t
+++ b/tests/regression/56-witness/71-var_eq-invariants.t
@@ -1,0 +1,70 @@
+  $ goblint --set ana.activated[+] var_eq --enable witness.yaml.enabled 71-var_eq-invariants.c
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 3
+    dead: 0
+    total lines: 3
+  [Info][Witness] witness generation summary:
+    location invariants: 6
+    loop invariants: 0
+    flow-insensitive invariants: 0
+    total generation entries: 1
+
+With 4 equal variables, there should be just 3 var_eq invariants, not 6.
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: invariant_set
+    content:
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 71-var_eq-invariants.c
+          line: 6
+          column: 3
+          function: main
+        value: a == b
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 71-var_eq-invariants.c
+          line: 6
+          column: 3
+          function: main
+        value: a == c
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 71-var_eq-invariants.c
+          line: 6
+          column: 3
+          function: main
+        value: a == d
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 71-var_eq-invariants.c
+          line: 6
+          column: 3
+          function: main
+        value: b == c
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 71-var_eq-invariants.c
+          line: 6
+          column: 3
+          function: main
+        value: b == d
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 71-var_eq-invariants.c
+          line: 6
+          column: 3
+          function: main
+        value: c == d
+        format: c_expression


### PR DESCRIPTION
@karoliineh found that for ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--block--paride--on26.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out in sv-benchmarks we output tens of thousands of invariants into the YAML witness. As of current `master`, 43083 loop invariants to be exact.

Most of them seemed to be equalities between `__cil_tmp` variables which are actually in the program (because it is cilled), not introduced by us, so it's not the filtering of temporaries at fault.
Instead, these equalities come from large `var_eq` equality clusters because there are many of those variables pulled up to function level, so all of the equalities are in scope in many points in large functions.

The current `var_eq` invariant generation is not that great: it outputs a quadratic number of pairwise equalities from a cluster (only deduplicating by reflexivity and symmetry). Arguably, this is very redundant: we shouldn't have to make transitivity explicit.
Therefore, this PR changes `var_eq` invariant generation to output a linear number of equalities with a single element from the cluster, the rest follow by transitivity implicitly.

For the SV-COMP task above, we now only output 859 loop invariants!
We no longer OOM when trying to validate our own witness to this task. However, we also don't confirm it yet because of #1710.