### PR TITLE
Fix C2PO witness invariant generation

### DIFF
--- a/src/cdomains/c2poDomain.ml
+++ b/src/cdomains/c2poDomain.ml
@@ -292,8 +292,12 @@ module D = struct
   let remove_vars_not_in_scope scope cc =
     let not_in_scope t =
       let var = T.get_var t in
-      let var = Var.to_varinfo var in
-      InvariantCil.var_is_tmp var || not (InvariantCil.var_is_in_scope scope  var)
+      (* let var = Var.to_varinfo var in *)
+      (* TODO: why Var.to_varinfo doesn't work? *)
+      match var with
+      | NormalVar var ->
+        InvariantCil.var_is_tmp var || not (InvariantCil.var_is_in_scope scope  var)
+      | _ -> true
     in
     remove_terms not_in_scope cc
 end

--- a/tests/regression/84-c2po/16-loops.t
+++ b/tests/regression/84-c2po/16-loops.t
@@ -6,11 +6,227 @@
     dead: 0
     total lines: 15
   [Info][Witness] witness generation summary:
-    location invariants: 0
-    loop invariants: 0
+    location invariants: 22
+    loop invariants: 2
     flow-insensitive invariants: 0
     total generation entries: 1
 
   $ yamlWitnessStrip < witness.yml
   - entry_type: invariant_set
-    content: []
+    content:
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 13
+          column: 3
+          function: main
+        value: x2 == x
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 15
+          column: 3
+          function: main
+        value: x2 == x
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 16
+          column: 3
+          function: main
+        value: x2 == x
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 16
+          column: 3
+          function: main
+        value: y == *x
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 19
+          column: 5
+          function: main
+        value: '*x == *(z + 1)'
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 19
+          column: 5
+          function: main
+        value: z == x + -1
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 20
+          column: 5
+          function: main
+        value: x != z
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 20
+          column: 5
+          function: main
+        value: x2 != z
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 20
+          column: 5
+          function: main
+        value: z != *x
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 21
+          column: 5
+          function: main
+        value: x != z
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 21
+          column: 5
+          function: main
+        value: x2 != z
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 21
+          column: 5
+          function: main
+        value: z != *(x + -1)
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 22
+          column: 5
+          function: main
+        value: '*(x + -1) == *z'
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 22
+          column: 5
+          function: main
+        value: z == x + -1
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 23
+          column: 5
+          function: main
+        value: '*(x + -1) == *z'
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 23
+          column: 5
+          function: main
+        value: z == x + -1
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 26
+          column: 3
+          function: main
+        value: '*x == *(z + 1)'
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 26
+          column: 3
+          function: main
+        value: z == x + -1
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 27
+          column: 3
+          function: main
+        value: '*x == *(z + 1)'
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 27
+          column: 3
+          function: main
+        value: z == x + -1
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 29
+          column: 3
+          function: main
+        value: '*x == *(z + 1)'
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 16-loops.c
+          line: 29
+          column: 3
+          function: main
+        value: z == x + -1
+        format: c_expression
+    - invariant:
+        type: loop_invariant
+        location:
+          file_name: 16-loops.c
+          line: 18
+          column: 3
+          function: main
+        value: '*x == *(z + 1)'
+        format: c_expression
+    - invariant:
+        type: loop_invariant
+        location:
+          file_name: 16-loops.c
+          line: 18
+          column: 3
+          function: main
+        value: z == x + -1
+        format: c_expression

--- a/tests/regression/84-c2po/16-loops.t
+++ b/tests/regression/84-c2po/16-loops.t
@@ -1,0 +1,16 @@
+  $ goblint --set ana.activated[+] c2po --set ana.activated[+] startState --set ana.activated[+] taintPartialContexts --set ana.c2po.askbase false --enable witness.yaml.enabled --disable ana.base.invariant.enabled 16-loops.c
+  [Success][Assert] Assertion "(unsigned long )z == (unsigned long )(x + -1)" will succeed (16-loops.c:26:3-26:31)
+  [Warning][Assert] Assertion "y == *x2" is unknown. (16-loops.c:27:3-27:28)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 15
+    dead: 0
+    total lines: 15
+  [Info][Witness] witness generation summary:
+    location invariants: 0
+    loop invariants: 0
+    flow-insensitive invariants: 0
+    total generation entries: 1
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: invariant_set
+    content: []

--- a/tests/regression/84-c2po/dune
+++ b/tests/regression/84-c2po/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps (glob_files *.c) (glob_files ??-*.yml)))


### PR DESCRIPTION
Inspired by https://github.com/goblint/analyzer/issues/1710#issuecomment-2717951685, I wondered what invariants C2PO analysis even generates. Turns out, none! Which is surprising, because it does implement the `Invariant` query.

I have no idea what's happening in the C2PO domain, but its pseudo-variable handling logic somehow even messes up normal program variables: `Var.to_varinfo (NormalVar var)` returns something different from `var`. And that variable is such that the temp-ness and in-scope checks cause everything to be filtered out.
I'm not sure why it does things the way it does and what should happen with non-`NormalVar`.

It then outputs some _interesting_ invariants:
1. On line 19: `z == x + -1` (which makes sense) and `*x == *(z + 1)` (which I guess is somehow derived from the former). The latter seems redundant.
2. On line 20: `z != *x` (where both `x` and `z` are of type `long*`). The comparison of `long*` and `long` is strange. But I'm also not sure if it's even true: `z` is just freshly allocated, so it's pointer value (cast to `long`) may equal an arbitrary integer.