### PR TITLE
Fix file descriptor leak in `GobConfig.merge_file`

### DIFF
--- a/.semgrep/batio.yml
+++ b/.semgrep/batio.yml
@@ -1,0 +1,6 @@
+rules:
+  - id: batio-to_input_channel
+    pattern: BatIO.to_input_channel
+    message: don't use (leaks two file descriptors)
+    languages: [ocaml]
+    severity: ERROR


### PR DESCRIPTION
See https://github.com/ocaml-batteries-team/batteries-included/blob/e28a7d4bf8c6c3aa34ee3adddeabbc91d2dbb79d/src/batIO.ml#L710.

I had a BenchExec run hit the open file limit (https://github.com/sosy-lab/benchexec/issues/1220), so I also looked into if Goblint could be leaking file descriptors and found this. But it seems unlikely that this is the actual cause of that: each process has its own count, so Goblint shouldn't be able to make BenchExec run out.

This was revealed by valgrind:
```console
$ valgrind --leak-check=no --track-fds=yes ./goblint --conf conf/examples/large-program.json tests/regression/00-sanity/01-assert.c

[...]
==3265361== 
==3265361== FILE DESCRIPTORS: 14 open (3 std) at exit.
==3265361== Open file descriptor 5: /tmp/ocaml5cb3b8pipe
==3265361==    at 0x4D1C1A5: open (open64.c:41)
==3265361==    by 0x1A2B3EB: open (fcntl2.h:59)
==3265361==    by 0x1A2B3EB: caml_sys_open (sys.c:217)
==3265361==    by 0x1948299: camlStdlib__open_in_gen_869 (stdlib.ml:405)
==3265361==    by 0x17838F4: camlBatInnerPervasives__$25_200 (batInnerPervasives.ml:77)
==3265361==    by 0x1783631: camlBatInnerPervasives__finally_62 (batInnerPervasives.ml:26)
==3265361==    by 0x167A1A0: camlGobConfig__merge_file_1622 (batFile.ml:167)
==3265361==    by 0x198767A: camlStdlib__Arg__treat_action_703 (arg.ml:206)
==3265361==    by 0x1986D5B: camlStdlib__Arg__parse_and_expand_argv_dynamic_aux_420 (arg.ml:278)
==3265361==    by 0x1988069: camlStdlib__Arg__parse_1276 (arg.ml:290)
==3265361==    by 0x13813C3: camlGoblint_lib__Maingoblint__parse_arguments_2453 (maingoblint.ml:209)
==3265361==    by 0x127C079: camlDune__exe__Goblint__main_2 (goblint.ml:8)
==3265361==    by 0x1948F8A: camlStdlib__new_exit_1413 (stdlib.ml:560)
==3265361== 
==3265361== Open file descriptor 4: /tmp/ocaml5cb3b8pipe
==3265361==    at 0x4D1C1A5: open (open64.c:41)
==3265361==    by 0x1A2B3EB: open (fcntl2.h:59)
==3265361==    by 0x1A2B3EB: caml_sys_open (sys.c:217)
==3265361==    by 0x1947DD9: camlStdlib__open_out_gen_669 (stdlib.ml:331)
==3265361==    by 0x19B0AAF: camlStdlib__Filename__open_temp_file_inner_1759 (filename.ml:357)
==3265361==    by 0x178BA33: camlBatIO__to_input_channel_3450 (batIO.ml:712)
==3265361==    by 0x17838F4: camlBatInnerPervasives__$25_200 (batInnerPervasives.ml:77)
==3265361==    by 0x1783631: camlBatInnerPervasives__finally_62 (batInnerPervasives.ml:26)
==3265361==    by 0x167A1A0: camlGobConfig__merge_file_1622 (batFile.ml:167)
==3265361==    by 0x198767A: camlStdlib__Arg__treat_action_703 (arg.ml:206)
==3265361==    by 0x1986D5B: camlStdlib__Arg__parse_and_expand_argv_dynamic_aux_420 (arg.ml:278)
==3265361==    by 0x1988069: camlStdlib__Arg__parse_1276 (arg.ml:290)
==3265361==    by 0x13813C3: camlGoblint_lib__Maingoblint__parse_arguments_2453 (maingoblint.ml:209)
==3265361== 
[...]
```