### PR TITLE
Make `sem.malloc.*` explicit in svcomp confs

### DIFF
--- a/conf/svcomp-ghost.json
+++ b/conf/svcomp-ghost.json
@@ -109,6 +109,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   },
   "witness": {

--- a/conf/svcomp-yaml-validate.json
+++ b/conf/svcomp-yaml-validate.json
@@ -89,6 +89,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   }
 }

--- a/conf/svcomp-yaml.json
+++ b/conf/svcomp-yaml.json
@@ -106,6 +106,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   }
 }

--- a/conf/svcomp21.json
+++ b/conf/svcomp21.json
@@ -61,6 +61,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   }
 }

--- a/conf/svcomp22.json
+++ b/conf/svcomp22.json
@@ -64,6 +64,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   }
 }

--- a/conf/svcomp23.json
+++ b/conf/svcomp23.json
@@ -87,6 +87,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   }
 }

--- a/conf/svcomp24-validate.json
+++ b/conf/svcomp24-validate.json
@@ -109,6 +109,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   },
   "witness": {

--- a/conf/svcomp24.json
+++ b/conf/svcomp24.json
@@ -105,6 +105,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   },
   "witness": {

--- a/conf/svcomp25-validate.json
+++ b/conf/svcomp25-validate.json
@@ -90,6 +90,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   },
   "witness": {

--- a/conf/svcomp25.json
+++ b/conf/svcomp25.json
@@ -86,6 +86,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   },
   "witness": {

--- a/conf/svcomp26/common.json
+++ b/conf/svcomp26/common.json
@@ -36,6 +36,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "either"
     }
   },
   "witness": {

--- a/conf/svcomp2var.json
+++ b/conf/svcomp2var.json
@@ -104,6 +104,10 @@
     },
     "null-pointer": {
       "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "pointer"
     }
   },
   "witness": {


### PR DESCRIPTION
This is likely to change in the future, so it's better for the old reference confs to be explicit about it.

More importantly, PR #1777 changed the default behavior of `malloc(0)` which accidentally affected svcomp26. We made the default sound (unlike `sem.malloc.fail`) but didn't override it for svcomp26. Hopefully this oversight doesn't cost us too many points...