### PR TITLE
Fix spurious unary - overflow check in `abs` implementation

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2662,7 +2662,8 @@ struct
              | _, None
              | None, _ -> ID.top_of ik
              | Some mx, Some mm when Z.equal mx mm -> ID.top_of ik
-             | _, _ ->
+             | _, _ -> (* ID.neg will not overflow *)
+               let@ () = GobRef.wrap AnalysisState.executing_speculative_computations true in (* ID.neg is our internal implementation of abs *)
                let x1 = ID.neg (ID.meet (ID.ending ik Z.zero) xcast) in
                let x2 = ID.meet (ID.starting ik Z.zero) xcast in
                ID.join x1 x2


### PR DESCRIPTION
Due to preconditions, this cannot overflow.
But we also don't want the successful check from our internal implementation in the dashboard.