### PR TITLE
Deduplicate TID and lockset in access output with creationLockset

### DIFF
--- a/src/analyses/creationLockset.ml
+++ b/src/analyses/creationLockset.ml
@@ -143,7 +143,7 @@ module Spec = struct
     let to_yojson (_, _, cl) = G.to_yojson cl
     let printXml f (_, _, cl) = G.printXml f cl
 
-    let should_print (_t, _ls, cl) = not @@ G.is_empty cl
+    let should_print (_t, _ls, cl) = G.exists (fun _ ls -> not @@ Lockset.is_empty ls) cl
   end
 
   let access man _ =


### PR DESCRIPTION
While reviewing #1928 I inspected the current access output of the creationLockset analysis to understand why it wasn't precise enough.
While doing so, I noticed that the TID and lockset are printed twice in access output because they are queried from other analyses which are already responsible for outputting those parts.

On a side note, I'm wondering if `should_print` could be refined further. For example,
```
creationLockset:{
                [main] -> {}
              }
```
is a non-empty map, but only containing empty locksets. That can't really rule out any races, can it?