### PR TITLE
Treat string function non-address inputs as top values

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2434,7 +2434,7 @@ struct
           | Addr.Addr (v, o) -> Addr.Addr (v, lo o)
           | other -> other in
         AD.map rmLastOffset a
-      | _ -> raise (Failure "String function: not an address")
+      | _ -> AD.top ()
     in
     let string_manipulation s1 s2 lv all op_addr op_array =
       let s1_v = eval_rv ~man st s1 in

--- a/tests/regression/73-strings/11-not-an-address.c
+++ b/tests/regression/73-strings/11-not-an-address.c
@@ -1,0 +1,18 @@
+// NOCRASH
+extern int strcmp(const char *, const char *);
+
+static int hello_read(const char *path) {
+    return strcmp(path, "Hello");
+}
+
+static const struct ops {
+	int (*read)(const char *);
+} hello_oper = {
+	.read = hello_read,
+};
+
+extern int main_real(const struct ops *);
+
+int main() {
+	return main_real(&hello_oper);
+}


### PR DESCRIPTION
Fixes #1934. The same issue also appears in rsync analysis.

The change might be naive, and instead upstream problem that generates non-address strings might need to get fixed. However, I am not sure where that would be, so let me know if that's the case.