### PR TITLE
Fix duplicate conflicting dead branch warnings due to loop unrolling

### DIFF
--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -870,19 +870,24 @@ struct
   let context man = S.context (conv man)
 
   let branch man exp tv =
+    let prev_node =
+      match man.prev_node with
+      | Statement s -> Node.Statement (LoopUnrolling.find_original s) (* aggregate all unrolled copies under original to avoid conflicting warnings about same source branch *)
+      | n -> n (* never unrolled *)
+    in
     if !AnalysisState.postsolving then (
       try
         let r = branch man exp tv in
         (* branch is live *)
-        man.sideg (V.node man.prev_node) (G.create_node (EM.singleton exp (`Lifted tv))); (* record expression with reached tv *)
+        man.sideg (V.node prev_node) (G.create_node (EM.singleton exp (`Lifted tv))); (* record expression with reached tv *)
         r
       with Deadcode ->
         (* branch is dead *)
-        man.sideg (V.node man.prev_node) (G.create_node (EM.singleton exp `Bot)); (* record expression without reached tv *)
+        man.sideg (V.node prev_node) (G.create_node (EM.singleton exp `Bot)); (* record expression without reached tv *)
         raise Deadcode
     )
     else (
-      man.sideg (V.node man.prev_node) (G.create_node (EM.bot ())); (* create global variable during solving, to allow postsolving leq hack to pass verify *)
+      man.sideg (V.node prev_node) (G.create_node (EM.bot ())); (* create global variable during solving, to allow postsolving leq hack to pass verify *)
       branch man exp tv
     )
 

--- a/tests/regression/55-loop-unrolling/11-unrolled-loop-invariant.t
+++ b/tests/regression/55-loop-unrolling/11-unrolled-loop-invariant.t
@@ -198,26 +198,6 @@
     live: 10
     dead: 0
     total lines: 10
-  [Warning][Deadcode][CWE-570] condition 'k < 100' (possibly inserted by CIL) is always false (11-unrolled-loop-invariant.c:9:12-9:19)
-  [Warning][Deadcode][CWE-571] condition 'j < 10' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:8:10-8:16)
-  [Warning][Deadcode][CWE-570] condition 'k < 100' (possibly inserted by CIL) is always false (11-unrolled-loop-invariant.c:9:12-9:19)
-  [Warning][Deadcode][CWE-570] condition 'k < 100' (possibly inserted by CIL) is always false (11-unrolled-loop-invariant.c:9:12-9:19)
-  [Warning][Deadcode][CWE-571] condition 'j < 10' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:8:10-8:16)
-  [Warning][Deadcode][CWE-570] condition 'k < 100' (possibly inserted by CIL) is always false (11-unrolled-loop-invariant.c:9:12-9:19)
-  [Warning][Deadcode][CWE-571] condition 'i < 10' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:4:10-4:16)
-  [Warning][Deadcode][CWE-571] condition 'i < 10' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:4:10-4:16)
-  [Warning][Deadcode][CWE-571] condition 'i < 10' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:4:10-4:16)
-  [Warning][Deadcode][CWE-571] condition 'i < 10' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:4:10-4:16)
-  [Warning][Deadcode][CWE-571] condition 'i < 10' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:4:10-4:16)
-  [Warning][Deadcode][CWE-571] condition 'j < 10' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:8:10-8:16)
-  [Warning][Deadcode][CWE-570] condition 'k < 100' (possibly inserted by CIL) is always false (11-unrolled-loop-invariant.c:9:12-9:19)
-  [Warning][Deadcode][CWE-571] condition 'j < 10' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:8:10-8:16)
-  [Warning][Deadcode][CWE-571] condition 'k < 100' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:9:12-9:19)
-  [Warning][Deadcode][CWE-571] condition 'k < 100' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:9:12-9:19)
-  [Warning][Deadcode][CWE-571] condition 'k < 100' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:9:12-9:19)
-  [Warning][Deadcode][CWE-571] condition 'k < 100' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:9:12-9:19)
-  [Warning][Deadcode][CWE-571] condition 'k < 100' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:9:12-9:19)
-  [Warning][Deadcode][CWE-571] condition 'j < 10' (possibly inserted by CIL) is always true (11-unrolled-loop-invariant.c:8:10-8:16)
   [Info][Witness] witness generation summary:
     location invariants: 11
     loop invariants: 5

--- a/tests/regression/55-loop-unrolling/14-unrolled-loop-dead-branch.c
+++ b/tests/regression/55-loop-unrolling/14-unrolled-loop-dead-branch.c
@@ -1,7 +1,7 @@
 // PARAM: --enable ana.dead-code.branches --set exp.unrolling-factor 2
 int main() {
-  for (int i = 0; i < 2; i++) { // TODO NOWARN (dead branch)
-    if (i == 1) { // TODO NOWARN (dead branch)
+  for (int i = 0; i < 2; i++) { // NOWARN (dead branch)
+    if (i == 1) { // NOWARN (dead branch)
 
     }
   }


### PR DESCRIPTION
Previously the added test output contained
```
[Warning][Deadcode][CWE-571] condition 'i < 2' (possibly inserted by CIL) is always true (tests/regression/55-loop-unrolling/14-unrolled-loop-dead-branch.c:3:17-3:24)
[Warning][Deadcode][CWE-570] condition 'i == 1' is always false (tests/regression/55-loop-unrolling/14-unrolled-loop-dead-branch.c:4:9-4:15)
[Warning][Deadcode][CWE-571] condition 'i < 2' (possibly inserted by CIL) is always true (tests/regression/55-loop-unrolling/14-unrolled-loop-dead-branch.c:3:17-3:24)
[Warning][Deadcode][CWE-571] condition 'i == 1' is always true (tests/regression/55-loop-unrolling/14-unrolled-loop-dead-branch.c:4:9-4:15)
[Warning][Deadcode][CWE-570] condition 'i < 2' (possibly inserted by CIL) is always false (tests/regression/55-loop-unrolling/14-unrolled-loop-dead-branch.c:3:17-3:24)
```
which is just plain confusing both sides of both conditions are live.
The branches are only dead in the internal unrolling of the loop and that's the point of loop unrolling.
It's strange that activating loop unrolling would previously generate more warnings.