### PR TITLE
Handle contradictory relations combination as dead paths

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -431,6 +431,10 @@ struct
     in
     let unify_rel = RD.unify new_rel new_fun_rel in (* TODO: unify_with *)
     if M.tracing then M.tracel "combine-rel" "relation unifying %a %a = %a" RD.pretty new_rel RD.pretty new_fun_rel RD.pretty unify_rel;
+    if RD.is_bot_env unify_rel then begin
+      if M.tracing then M.tracel "combine-rel" "raising Deadcode after bottom unify";
+      raise Deadcode
+    end;
     {fun_st with rel = unify_rel}
 
   let combine_assign man r fe f args fc fun_st (f_ask : Queries.ask) =

--- a/tests/regression/89-apron3/04-combine-dead.c
+++ b/tests/regression/89-apron3/04-combine-dead.c
@@ -1,0 +1,15 @@
+// PARAM: --set ana.activated[+] apron --set ana.path_sens[+] base --set ana.ctx_insens[+] base --set ana.ctx_insens[+] apron --enable ana.int.interval
+// NOCRASH
+#include <goblint.h>
+
+int f(int x) {
+  return x + 1;
+}
+
+int main() {
+  int a = f(1);
+  __goblint_check(a == 2);
+  int b = f(2);
+  __goblint_check(b == 3);
+  return 0;
+}


### PR DESCRIPTION
This fixes one cause of the `IntDomain0.ArithmeticOnIntegerBot` crashes at SV-COMP, found by inspecting the analysis of `recursive/recHanoi02-2.c`.

The crash was caused by propagating a bottom from `relationAnalysis.combine_env`.
In the failing recursive Hanoi case, context-insensitive summary reuse can legitimately pair a caller state with a callee summary whose constraints contradict the actual call arguments. The resulting bottom value is semantically correct and represents an infeasible path. However, `combine_env` continued with `unify_rel` becoming bottom, propagating the bottom value further, eventually leading to the `ArithmeticOnIntegerBot` crash.

The fix is to detect if `RD.is_bot_env unify_rel` and raise `Deadcode` immediately, treating it as an unreachable path instead of propagating bottom. Why this is the right fix:
* context coarsening for recursive functions is intentional and acceptable
* contradictory caller/callee combinations can therefore arise during summary reuse
* the correct semantics for such a contradiction is path infeasibility, not analyzer failure

During debugging, removing setting `relation.no-context` for recursive functions from autotuning made the crash disappear, which helped isolate the issue, showing that the contradiction came from coarse summary reuse. But the real bug was the missing dead-path handling in `combine_env`, not the autotuning itself.

With this fix, we should be now able to solve this task.