### PR TITLE
Add privatization of effectively thread-local globals

### DIFF
--- a/src/analyses/accessAnalysis.ml
+++ b/src/analyses/accessAnalysis.ml
@@ -29,7 +29,7 @@ struct
   let init _ =
     collect_local := get_bool "witness.yaml.enabled" && get_bool "witness.invariant.accessed";
     let activated = get_string_list "ana.activated" in
-    emit_single_threaded := List.mem (ModifiedSinceSetjmp.Spec.name ()) activated || List.mem (PoisonVariables.Spec.name ()) activated || List.mem (UseAfterFree.Spec.name ()) activated (* TODO: some of these don't have access as dependency *)
+    emit_single_threaded := List.mem (ModifiedSinceSetjmp.Spec.name ()) activated || List.mem (PoisonVariables.Spec.name ()) activated || List.mem (UseAfterFree.Spec.name ()) activated || List.mem (ThreadAccess.Spec.name ()) activated (* TODO: some of these don't have access as dependency *)
 
   let do_access (man: (D.t, G.t, C.t, V.t) man) (kind:AccessKind.t) (reach:bool) (e:exp) =
     if M.tracing then M.trace "access" "do_access %a %a %B" d_exp e AccessKind.pretty kind reach;

--- a/src/analyses/threadAccess.ml
+++ b/src/analyses/threadAccess.ml
@@ -1,0 +1,42 @@
+open Analyses
+
+module Spec =
+struct
+  include UnitAnalysis.Spec
+
+  let name () = "threadAccess"
+
+  module V =
+  struct
+    include CilType.Varinfo
+    let is_write_only _ = false
+  end
+
+  module G = ConcDomain.ThreadSet
+
+  let query man (type a) (q: a Queries.t): a Queries.result =
+    match q with
+    | MayBePublic {global; _} ->
+      if G.cardinal (man.global global) = 1 then
+        false
+      else
+        Queries.Result.top q
+    | _ -> Queries.Result.top q
+
+  let event man e oman =
+    match e with
+    | Events.Access {ad; _} ->
+      Queries.AD.iter (function
+          | Queries.AD.Addr.Addr (v, _) when v.vglob ->
+            begin match man.ask CurrentThreadId with
+              | `Lifted tid -> man.sideg v (G.singleton tid)
+              | _ -> () (* TODO: what here? *)
+            end
+          | _ -> ()
+        ) ad
+    | _ ->
+      man.local
+end
+
+let _ =
+  MCP.register_analysis ~dep:["access"] (module Spec : MCPSpec)

--- a/tests/regression/03-practical/39-signal-effectively-local.c
+++ b/tests/regression/03-practical/39-signal-effectively-local.c
@@ -1,0 +1,19 @@
+// PARAM: --set ana.activated[+] threadAccess
+#include <signal.h>
+#include <goblint.h>
+
+int g = 0;
+
+void handler(int sig) {
+}
+
+int main() {
+  __goblint_check(g == 0);
+  g = 1;
+  __goblint_check(g == 1);
+  signal(SIGTERM, handler);
+  __goblint_check(g == 1);
+  g = 2;
+  __goblint_check(g == 2);
+  return 0;
+}


### PR DESCRIPTION
This is currently on top of #1965.

Inspired by the analysis of signal handlers as threads, it occurred to me that it is very imprecise to make the analysis go into multi-threaded mode if even one signal handler is installed, because the analysis of all globals becomes flow-insensitive.
At least with signal handlers, they are (supposed to be) small and usually read/write very few global variables. So if the rest of the program is single-threaded, it's quite crude to analyze all globals flow-insensitively.

It would be much more precise to only analyze those globals flow-insensitively which are read/written by a signal handler. All other global variables could be analyzed flow-sensitively still.
In fact, this could also be done in actual multi-threaded programs for globals which are effectively thread-local, i.e. only used by one thread.

It's kind of difficult to achieve this right now (to apply privatizations selectively) but this is a dirty attempt. The threadAccess analysis computes for each global the set of threads accessing it. If it's a singleton, then it answers the `MayBePublic` query negatively, which should improve precision of some protection-based privatizations.

Some privatizations with TIDs might be able to do this out of the box anyway (?), but this kind of thing should be possible also for others, thus some extra analysis.
It isn't currently as generic as it could be though: with `none` privatization (as used by large-program conf), the query isn't used and this cannot help, although the same selective flow-(in)sensitivity should still be possible.

### TODO
- [ ] Probably should also require the thread to be unique, which #1965 would give for signals.
- [ ] Consider effectively thread-local variable becoming truly global. Probably broken right now and might require escaping-like support.
- [ ] Need escape-like events for when this changes? Also support in `sync` for branched cases?