### PR TITLE
Forward Solvers: Split local unknowns by digests 

### DIFF
--- a/src/common/domains/printable.ml
+++ b/src/common/domains/printable.ml
@@ -470,6 +470,63 @@ struct
     | `Lifted2 x -> Base2.to_yojson x
 end
 
+module type Lift3Conf =
+sig
+  include Lift2Conf
+  val expand3: bool
+end
+
+module Lift3Conf (Conf: Lift3Conf) (Base1: S) (Base2: S) (Base3: S) =
+struct
+  open struct
+    module Base1 = PrefixName (struct let expand = Conf.expand1 end) (Base1)
+    module Base2 = PrefixName (struct let expand = Conf.expand2 end) (Base2)
+    module Base3 = PrefixName (struct let expand = Conf.expand3 end) (Base3)
+  end
+
+  type t = [`Bot | `Lifted1 of Base1.t | `Lifted2 of Base2.t | `Lifted3 of Base3.t | `Top] [@@deriving eq, ord, hash]
+  include Std
+  open Conf
+
+  let pretty () (state:t) =
+    match state with
+    | `Lifted1 n ->  Base1.pretty () n
+    | `Lifted2 n ->  Base2.pretty () n
+    | `Lifted3 n ->  Base3.pretty () n
+    | `Bot -> text bot_name
+    | `Top -> text top_name
+
+  let show state =
+    match state with
+    | `Lifted1 n ->  Base1.show n
+    | `Lifted2 n ->  Base2.show n
+    | `Lifted3 n ->  Base3.show n
+    | `Bot -> bot_name
+    | `Top -> top_name
+
+  let relift x = match x with
+    | `Lifted1 n -> `Lifted1 (Base1.relift n)
+    | `Lifted2 n -> `Lifted2 (Base2.relift n)
+    | `Lifted3 n -> `Lifted3 (Base3.relift n)
+    | `Bot | `Top -> x
+
+  let name () = "lifted " ^ Base1.name () ^ " and " ^ Base2.name () ^ " and " ^ Base3.name ()
+
+  let printXml f = function
+    | `Bot       -> BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" bot_name
+    | `Top       -> BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" top_name
+    | `Lifted1 x -> Base1.printXml f x
+    | `Lifted2 x -> Base2.printXml f x
+    | `Lifted3 x -> Base3.printXml f x
+
+  let to_yojson = function
+    | `Bot -> `String bot_name
+    | `Top -> `String top_name
+    | `Lifted1 x -> Base1.to_yojson x
+    | `Lifted2 x -> Base2.to_yojson x
+    | `Lifted3 x -> Base3.to_yojson x
+end
+
 module type ProdConfiguration =
 sig
   val expand_fst: bool

--- a/src/common/domains/printable.ml
+++ b/src/common/domains/printable.ml
@@ -634,16 +634,11 @@ struct
   include Std
 
   let show (x,y,z,w) =
-    (* TODO: remove ref *)
-    let first = ref "" in
-    let second= ref "" in
-    let third = ref "" in
-    let fourth = ref "" in
-    first  := Base1.show x;
-    second := Base2.show y;
-    third  := Base3.show z;
-    fourth := Base4.show w;
-    "(" ^ !first ^ ", " ^ !second ^ ", " ^ !third ^ ", " ^ !fourth ^ ")"
+    let first  = Base1.show x in
+    let second = Base2.show y in
+    let third  = Base3.show z in
+    let fourth = Base4.show w in
+    "(" ^ first ^ ", " ^ second ^ ", " ^ third ^ ", " ^ fourth ^ ")"
 
   let pretty () (x,y,z,w) =
     text "("

--- a/src/common/domains/printable.ml
+++ b/src/common/domains/printable.ml
@@ -571,6 +571,61 @@ struct
   let arbitrary () = QCheck.triple (Base1.arbitrary ()) (Base2.arbitrary ()) (Base3.arbitrary ())
 end
 
+module Prod4 (Base1: S) (Base2: S) (Base3: S) (Base4: S) =
+struct
+  type t = Base1.t * Base2.t * Base3.t * Base4.t [@@deriving eq, ord, hash, relift]
+  include Std
+
+  let show (x,y,z,w) =
+    (* TODO: remove ref *)
+    let first = ref "" in
+    let second= ref "" in
+    let third = ref "" in
+    let fourth = ref "" in
+    first  := Base1.show x;
+    second := Base2.show y;
+    third  := Base3.show z;
+    fourth := Base4.show w;
+    "(" ^ !first ^ ", " ^ !second ^ ", " ^ !third ^ ", " ^ !fourth ^ ")"
+
+  let pretty () (x,y,z,w) =
+    text "("
+    ++ text (Base1.name ())
+    ++ text ":"
+    ++ align
+    ++ Base1.pretty () x
+    ++ unalign
+    ++ text ", "
+    ++ text (Base2.name ())
+    ++ text ":"
+    ++ align
+    ++ Base2.pretty () y
+    ++ unalign
+    ++ text ", "
+    ++ text (Base3.name ())
+    ++ text ":"
+    ++ align
+    ++ Base3.pretty () z
+    ++ unalign
+    ++ text ", "
+    ++ text (Base4.name ())
+    ++ text ":"
+    ++ align
+    ++ Base4.pretty () w
+    ++ unalign
+    ++ text ")"
+
+  let printXml f (x,y,z,w) =
+    BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (XmlUtil.escape (Base1.name ())) Base1.printXml x (XmlUtil.escape (Base2.name ())) Base2.printXml y (XmlUtil.escape (Base3.name ())) Base3.printXml z (XmlUtil.escape (Base4.name ())) Base4.printXml w
+
+  let to_yojson (x, y, z, w) =
+    `Assoc [ (Base1.name (), Base1.to_yojson x); (Base2.name (), Base2.to_yojson y); (Base3.name (), Base3.to_yojson z); (Base4.name (), Base4.to_yojson w) ]
+
+  let name () = Base1.name () ^ " * " ^ Base2.name () ^ " * " ^ Base3.name () ^ " * " ^ Base4.name ()
+
+  let arbitrary () = QCheck.tup4 (Base1.arbitrary ()) (Base2.arbitrary ()) (Base3.arbitrary ()) (Base4.arbitrary ())
+end
+
 module PQueue (Base: S) =
 struct
   type t = Base.t BatDeque.dq

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -2497,6 +2497,12 @@
               "description": "How often a contribution should simply overwrite the old one when incomparible instead of widening",
               "type": "integer",
               "default": 0
+            },
+            "digests": {
+              "title": "solvers.fwd.digests",
+              "description": "Whether the constraint system to be solved should use digests to realize path-sensitivity.",
+              "type": "boolean",
+              "default": false
             }
           },
           "additionalProperties": false

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -2502,7 +2502,7 @@
               "title": "solvers.fwd.digests",
               "description": "Whether the constraint system to be solved should use digests to realize path-sensitivity.",
               "type": "boolean",
-              "default": false
+              "default": true
             }
           },
           "additionalProperties": false

--- a/src/domain/lattice.ml
+++ b/src/domain/lattice.ml
@@ -381,6 +381,95 @@ end
 
 module Lift2 = Lift2Conf (Printable.DefaultConf)
 
+module Lift3Conf (Conf: Printable.Lift3Conf) (Base1: PO) (Base2: PO) (Base3: PO) =
+struct
+  include Printable.Lift3Conf (Conf) (Base1) (Base2) (Base3)
+
+  let bot () = `Bot
+  let is_bot x = x = `Bot
+  let top () = `Top
+  let is_top x = x = `Top
+
+  let leq x y =
+    match (x,y) with
+    | (_, `Top) -> true
+    | (`Top, _) -> false
+    | (`Bot, _) -> true
+    | (_, `Bot) -> false
+    | (`Lifted1 x, `Lifted1 y) -> Base1.leq x y
+    | (`Lifted2 x, `Lifted2 y) -> Base2.leq x y
+    | (`Lifted3 x, `Lifted3 y) -> Base3.leq x y
+    | _ -> false
+
+  let pretty_diff () ((x:t),(y:t)): Pretty.doc =
+    match x, y with
+    | `Lifted1 x, `Lifted1 y -> Base1.pretty_diff () (x, y)
+    | `Lifted2 x, `Lifted2 y -> Base2.pretty_diff () (x, y)
+    | `Lifted3 x, `Lifted3 y -> Base3.pretty_diff () (x, y)
+    | _ when leq x y -> Pretty.text "No Changes"
+    | _ -> Pretty.dprintf "%a instead of %a" pretty x pretty y
+
+  let join x y =
+    match (x,y) with
+    | (`Top, _) -> `Top
+    | (_, `Top) -> `Top
+    | (`Bot, x) -> x
+    | (x, `Bot) -> x
+    | (`Lifted1 x, `Lifted1 y) -> begin
+        try `Lifted1 (Base1.join x y)
+        with TopValue -> `Top
+      end
+    | (`Lifted2 x, `Lifted2 y) -> begin
+        try `Lifted2 (Base2.join x y)
+        with TopValue -> `Top
+      end
+    | (`Lifted3 x, `Lifted3 y) -> begin
+        try `Lifted3 (Base3.join x y)
+        with TopValue -> `Top
+      end
+    | _ -> `Top
+
+  let meet x y =
+    match (x,y) with
+    | (`Bot, _) -> `Bot
+    | (_, `Bot) -> `Bot
+    | (`Top, x) -> x
+    | (x, `Top) -> x
+    | (`Lifted1 x, `Lifted1 y) -> begin
+        try `Lifted1 (Base1.meet x y)
+        with BotValue -> `Bot
+      end
+    | (`Lifted2 x, `Lifted2 y) -> begin
+        try `Lifted2 (Base2.meet x y)
+        with BotValue -> `Bot
+      end
+    | (`Lifted3 x, `Lifted3 y) -> begin
+        try `Lifted3 (Base3.meet x y)
+        with BotValue -> `Bot
+      end
+    | _ -> `Bot
+
+  let widen x y =
+    match (x,y) with
+    | (`Lifted1 x, `Lifted1 y) -> `Lifted1 (Base1.widen x y)
+    | (`Lifted2 x, `Lifted2 y) -> `Lifted2 (Base2.widen x y)
+    | (`Lifted3 x, `Lifted3 y) -> `Lifted3 (Base3.widen x y)
+    | _ -> y
+
+  let narrow x y =
+    match (x,y) with
+    | (`Lifted1 x, `Lifted1 y) -> `Lifted1 (Base1.narrow x y)
+    | (`Lifted2 x, `Lifted2 y) -> `Lifted2 (Base2.narrow x y)
+    | (`Lifted3 x, `Lifted3 y) -> `Lifted3 (Base3.narrow x y)
+    | (_, `Bot) -> `Bot
+    | (`Top, y) -> y
+    | _ -> x
+end
+
+module Lift3 = Lift3Conf (Printable.DefaultConf)
+
+
+
 module ProdConf (C: Printable.ProdConfiguration) (Base1: S) (Base2: S) =
 struct
   open struct (* open to avoid leaking P and causing conflicts *)

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -49,27 +49,28 @@ end
 (** Functor for locals with digests. *)
 module VarDigestF (C: Printable.S) (P : Printable.S) =
 struct
-  type t = Node.t * C.t * P.t [@@deriving eq, ord, hash]
-  let relift (n,x,p) = n, C.relift x, P.relift p
+  type t = {node: Node.t; context: C.t; original_digest: P.t; current_digest: P.t} [@@deriving eq, ord, hash]
+  let relift {node; context; original_digest; current_digest} = {node; context = C.relift context; original_digest = P.relift original_digest; current_digest = P.relift current_digest}
 
-  let getLocation (n,d,p) = Node.location n
+  let getLocation {node; context; original_digest; current_digest} = Node.location node
 
-  let pretty_trace () ((n,c,p) as x) =
+  let pretty_trace () x =
     if get_bool "dbg.trace.context" then (* Print context and digest *)
-      dprintf "(%a, %a, %a) on %a" Node.pretty_trace n C.pretty c P.pretty p CilType.Location.pretty (getLocation x)
+      dprintf "(%a, %a, %a) on %a" Node.pretty_trace x.node C.pretty x.context P.pretty x.original_digest CilType.Location.pretty (getLocation x)
     else
-      dprintf "%a on %a" Node.pretty_trace n CilType.Location.pretty (getLocation x)
+      dprintf "%a on %a" Node.pretty_trace x.node CilType.Location.pretty (getLocation x)
 
-  let printXml f (n,c,p) =
-    Var.printXml f n;
+  let printXml f x =
+    Var.printXml f x.node;
     BatPrintf.fprintf f "<context>\n";
-    C.printXml f c;
-    (* Print digest, for now as part of <context>; not sure how this is parsed. *)
-    P.printXml f p;
+    C.printXml f x.context;
+    (* Print original digest and current digest, for now as part of <context>; not sure how this is parsed. *)
+    P.printXml f x.original_digest;
+    P.printXml f x.current_digest;
     BatPrintf.fprintf f "</context>\n"
 
-  let var_id (n,_,_) = Var.var_id n
-  let node (n,_,_) = n
+  let var_id x = Var.var_id x.node
+  let node x = x.node
   let is_write_only _ = false
 end
 

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -49,7 +49,21 @@ end
 (** Functor for locals with digests. *)
 module VarDigestF (C: Printable.S) (P : Printable.S) =
 struct
+  include Printable.Std
+
   type t = {node: Node.t; context: C.t; original_digest: P.t; current_digest: P.t} [@@deriving eq, ord, hash]
+
+  let name () = "VarDigestF"
+
+  let show x =
+    Printf.sprintf "(%s, %s, %s, %s)" (Node.show_id x.node) (C.show x.context) (P.show x.original_digest) (P.show x.current_digest)
+
+  module Show = struct
+    type nonrec t = t
+    let show = show
+  end
+  include Printable.SimpleShow (Show)
+
   let relift {node; context; original_digest; current_digest} = {node; context = C.relift context; original_digest = P.relift original_digest; current_digest = P.relift current_digest}
 
   let getLocation {node; context; original_digest; current_digest} = Node.location node
@@ -145,12 +159,13 @@ struct
     | `Right _ -> false
 end
 
-module GVarFCNW (V:SpecSysVar) (C:Printable.S) =
+module GVarFCNW (V:SpecSysVar) (C:Printable.S) (P: Printable.S) =
 struct
-  include Printable.EitherConf (struct let expand1 = false let expand2 = true end) (V) (Printable.Prod (CilType.Fundec) (C))
+  module ReturnVars = Printable.Prod3 (CilType.Fundec) (C) (P)
+  include Printable.EitherConf (struct let expand1 = false let expand2 = true end) (V) (ReturnVars)
   let name () = "FromSpec"
   let spec x = `Left x
-  let return (x, c) = `Right (x, c)
+  let return (x, c, p) = `Right (x, c, p)
 
   (* from Basetype.Variables *)
   let var_id = show
@@ -360,6 +375,17 @@ sig
   val event : (D.t, G.t, C.t, V.t) man -> Events.t -> (D.t, G.t, C.t, V.t) man -> D.t
 end
 
+module type Spec' = sig
+  include Spec
+  module LVarDMap : MapDomain.S with type key = VarDigestF (C) (P).t and type value = D.t
+end
+
+module Spec2Spec' (S: Spec) =
+struct
+  include S
+  module LVarDMap = MapDomain.MapBot (VarDigestF (C) (P)) (D)
+end
+
 module type Spec2Spec = functor (S: Spec) -> Spec
 
 module type MCPA =
@@ -537,18 +563,18 @@ end
 
 module type FwdSpecSys =
 sig
-  module Spec: Spec
+  module Spec: Spec'
   module EQSys: Goblint_constraint.ConstrSys.FwdGlobConstrSys with module LVar = VarDigestF (Spec.C) (Spec.P)
-                                                               and module GVar = GVarFCNW (Spec.V) (Spec.C)
+                                                               and module GVar = GVarFCNW (Spec.V) (Spec.C) (Spec.P)
                                                                and module D = Spec.D
-                                                               and module G = GVarL (Spec.G) (Spec.D)
+                                                               and module G = GVarL (Spec.G) (Spec.LVarDMap)
   module LHT: BatHashtbl.S with type key = EQSys.LVar.t
   module GHT: BatHashtbl.S with type key = EQSys.GVar.t
 end
 
 module type SpecSys =
 sig
-  module Spec: Spec
+  module Spec: Spec'
   module EQSys: Goblint_constraint.ConstrSys.DemandGlobConstrSys with module LVar = VarF (Spec.C)
                                                                   and module GVar = GVarF (Spec.V)
                                                                   and module D = Spec.D

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -162,10 +162,12 @@ end
 module GVarFCNW (V:SpecSysVar) (C:Printable.S) (P: Printable.S) =
 struct
 
-  (* For return vars given by function, context, original digest *)
-  module ReturnVars = Printable.Prod3 (CilType.Fundec) (C) (P)
-  (* For return vars given by function, context, original digest and current digest *)
+  (** For return vars given by function, context, original digest and current digest *)
   module SingleReturnVars = VarDigestF (C) (P)
+
+  (** For return vars given by function, context, original digest.
+      These are used for collecting which return unknowns of the type SingleReturnVars.t may not be bottom. *)
+  module ReturnVars = Printable.Prod3 (CilType.Fundec) (C) (P)
 
   module Either3Conf = struct
     let expand1 = false

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -69,8 +69,8 @@ struct
   let getLocation {node; context; original_digest; current_digest} = Node.location node
 
   let pretty_trace () x =
-    if get_bool "dbg.trace.context" then (* Print context and digest *)
-      dprintf "(%a, %a, %a) on %a" Node.pretty_trace x.node C.pretty x.context P.pretty x.original_digest CilType.Location.pretty (getLocation x)
+    if get_bool "dbg.trace.context" then (* Print context and digests *)
+      dprintf "(%a, %a, %a, %a) on %a" Node.pretty_trace x.node C.pretty x.context P.pretty x.original_digest P.pretty x.current_digest CilType.Location.pretty (getLocation x)
     else
       dprintf "%a on %a" Node.pretty_trace x.node CilType.Location.pretty (getLocation x)
 

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -46,6 +46,34 @@ struct
   let is_write_only _ = false
 end
 
+(** Functor for locals with digests. *)
+module VarDigestF (C: Printable.S) (P : Printable.S) =
+struct
+  type t = Node.t * C.t * P.t [@@deriving eq, ord, hash]
+  let relift (n,x,p) = n, C.relift x, P.relift p
+
+  let getLocation (n,d,p) = Node.location n
+
+  let pretty_trace () ((n,c,p) as x) =
+    if get_bool "dbg.trace.context" then (* Print context and digest *)
+      dprintf "(%a, %a, %a) on %a" Node.pretty_trace n C.pretty c P.pretty p CilType.Location.pretty (getLocation x)
+    else
+      dprintf "%a on %a" Node.pretty_trace n CilType.Location.pretty (getLocation x)
+
+  let printXml f (n,c,p) =
+    Var.printXml f n;
+    BatPrintf.fprintf f "<context>\n";
+    C.printXml f c;
+    (* Print digest, for now as part of <context>; not sure how this is parsed. *)
+    P.printXml f p;
+    BatPrintf.fprintf f "</context>\n"
+
+  let var_id (n,_,_) = Var.var_id n
+  let node (n,_,_) = n
+  let is_write_only _ = false
+end
+
+
 module type SpecSysVar =
 sig
   include Printable.S
@@ -497,8 +525,8 @@ end
 module type ComparableSpecSys =
 sig
   module Spec: Spec
-  module EQSys: Goblint_constraint.ConstrSys.BaseGlobConstrSys 
-    with module LVar = VarF (Spec.C)
+  module EQSys: Goblint_constraint.ConstrSys.BaseGlobConstrSys
+    with module LVar = VarDigestF (Spec.C) (Spec.P)
      (* and module GVar = GVarPretty (Spec.V) *)
      and module D = Spec.D
   (* and module G = GVarG (Spec.G) (Spec.C) *)
@@ -509,7 +537,7 @@ end
 module type FwdSpecSys =
 sig
   module Spec: Spec
-  module EQSys: Goblint_constraint.ConstrSys.FwdGlobConstrSys with module LVar = VarF (Spec.C)
+  module EQSys: Goblint_constraint.ConstrSys.FwdGlobConstrSys with module LVar = VarDigestF (Spec.C) (Spec.P)
                                                                and module GVar = GVarFCNW (Spec.V) (Spec.C)
                                                                and module D = Spec.D
                                                                and module G = GVarL (Spec.G) (Spec.D)

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -208,7 +208,7 @@ struct
     | x -> BatPrintf.fprintf f "<analysis name=\"fromspec\">%a</analysis>" printXml x
 end
 
-module GVarL (G: Lattice.S) (L: Lattice.S) =
+module GVar2 (G: Lattice.S) (L: Lattice.S) =
 struct
   include Lattice.Lift2 (G) (L)
 
@@ -226,6 +226,38 @@ struct
   let printXml f = function
     | `Lifted1 x -> G.printXml f x
     | `Lifted2 x -> L.printXml f x
+    | x -> BatPrintf.fprintf f "<analysis name=\"fromspec\">%a</analysis>" printXml x
+end
+
+module GVar3 (G: Lattice.S) (L: Lattice.S) (S: Lattice.S) =
+struct
+  include Lattice.Lift3 (G) (L) (S)
+
+  let spec = function
+    | `Bot -> G.bot ()
+    | `Lifted1 x -> x
+    | _ -> failwith "GVarG.spec"
+
+  let single_return = function
+    | `Bot -> S.bot ()
+    | `Lifted2 x -> x
+    | _ -> failwith "GVarG.single_retunr"
+
+
+  let return = function
+    | `Bot -> L.bot ()
+    | `Lifted3 x -> x
+    | _ -> failwith "GVarG.return"
+
+
+  let create_spec spec = `Lifted1 spec
+  let create_single_return single_return = `Lifted2 single_return
+  let create_return return = `Lifted3 return
+
+  let printXml f = function
+    | `Lifted1 x -> G.printXml f x
+    | `Lifted2 x -> L.printXml f x
+    | `Lifted3 x -> S.printXml f x
     | x -> BatPrintf.fprintf f "<analysis name=\"fromspec\">%a</analysis>" printXml x
 end
 
@@ -567,7 +599,7 @@ sig
   module EQSys: Goblint_constraint.ConstrSys.FwdGlobConstrSys with module LVar = VarDigestF (Spec.C) (Spec.P)
                                                                and module GVar = GVarFCNW (Spec.V) (Spec.C) (Spec.P)
                                                                and module D = Spec.D
-                                                               and module G = GVarL (Spec.G) (Spec.LVarDMap)
+                                                               and module G = GVar2 (Spec.G) (Spec.LVarDMap)
   module LHT: BatHashtbl.S with type key = EQSys.LVar.t
   module GHT: BatHashtbl.S with type key = EQSys.GVar.t
 end

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -161,10 +161,22 @@ end
 
 module GVarFCNW (V:SpecSysVar) (C:Printable.S) (P: Printable.S) =
 struct
+
+  (* For return vars given by function, context, original digest *)
   module ReturnVars = Printable.Prod3 (CilType.Fundec) (C) (P)
-  include Printable.EitherConf (struct let expand1 = false let expand2 = true end) (V) (ReturnVars)
+  (* For return vars given by function, context, original digest and current digest *)
+  module SingleReturnVars = VarDigestF (C) (P)
+
+  module Either3Conf = struct
+    let expand1 = false
+    let expand2 = true
+    let expand3 = true
+  end
+
+  include Printable.Either3Conf (Either3Conf) (V) (SingleReturnVars) (ReturnVars)
   let name () = "FromSpec"
   let spec x = `Left x
+  let single_return x = `Middle x
   let return (x, c, p) = `Right (x, c, p)
 
   (* from Basetype.Variables *)
@@ -173,6 +185,7 @@ struct
   let pretty_trace = pretty
   let is_write_only = function
     | `Left x -> V.is_write_only x
+    | `Middle _ -> false
     | `Right _ -> false
 end
 
@@ -236,19 +249,17 @@ struct
   let spec = function
     | `Bot -> G.bot ()
     | `Lifted1 x -> x
-    | _ -> failwith "GVarG.spec"
+    | _ -> failwith "GVar3.spec"
 
   let single_return = function
-    | `Bot -> S.bot ()
+    | `Bot -> L.bot ()
     | `Lifted2 x -> x
-    | _ -> failwith "GVarG.single_retunr"
-
+    | _ -> failwith "GVar3.single_return"
 
   let return = function
-    | `Bot -> L.bot ()
+    | `Bot -> S.bot ()
     | `Lifted3 x -> x
-    | _ -> failwith "GVarG.return"
-
+    | _ -> failwith "GVar3.return"
 
   let create_spec spec = `Lifted1 spec
   let create_single_return single_return = `Lifted2 single_return
@@ -409,13 +420,13 @@ end
 
 module type Spec' = sig
   include Spec
-  module LVarDMap : MapDomain.S with type key = VarDigestF (C) (P).t and type value = D.t
+  module LVarSet : SetDomain.S with type elt = VarDigestF (C) (P).t
 end
 
 module Spec2Spec' (S: Spec) =
 struct
   include S
-  module LVarDMap = MapDomain.MapBot (VarDigestF (C) (P)) (D)
+  module LVarSet = SetDomain.Make (VarDigestF (C) (P))
 end
 
 module type Spec2Spec = functor (S: Spec) -> Spec
@@ -599,7 +610,7 @@ sig
   module EQSys: Goblint_constraint.ConstrSys.FwdGlobConstrSys with module LVar = VarDigestF (Spec.C) (Spec.P)
                                                                and module GVar = GVarFCNW (Spec.V) (Spec.C) (Spec.P)
                                                                and module D = Spec.D
-                                                               and module G = GVar2 (Spec.G) (Spec.LVarDMap)
+                                                               and module G = GVar3 (Spec.G) (Spec.D) (Spec.LVarSet)
   module LHT: BatHashtbl.S with type key = EQSys.LVar.t
   module GHT: BatHashtbl.S with type key = EQSys.GVar.t
 end

--- a/src/framework/analysisResult.ml
+++ b/src/framework/analysisResult.ml
@@ -55,7 +55,7 @@ struct
   let show (es,x,f:t) = D.show x
   let pretty () (_,x,_) = D.pretty () x
   let printXml f (c,d,fd) =
-    BatPrintf.fprintf f "<context>\n%a</context>\n%a" C.printXml c D.printXml d
+    BatPrintf.fprintf f "<tuple>\n<context>\n%a</context>\n<abstract_state>\n%a</abstract_state>\n</tuple>" C.printXml c D.printXml d
 end
 
 module ResultType2Digest (S: Analyses.Spec) =

--- a/src/framework/analysisResult.ml
+++ b/src/framework/analysisResult.ml
@@ -61,11 +61,11 @@ end
 module ResultType2Digest (S: Analyses.Spec) =
 struct
   open S
-  include Printable.Prod4 (C) (P) (D) (CilType.Fundec)
-  let show (es,current_diget,x,f:t) = D.show x
-  let pretty () (_,current_digest,x,_) = D.pretty () x
-  let printXml f (c,current_digest,d,fd) =
-    BatPrintf.fprintf f "<tuple>\n<context>\n%a</context><current_digest>\n%a</current_digest>\n<path>\n%a</path>\n</tuple>" C.printXml c P.printXml current_digest D.printXml d
+  include Printable.Prod4 (C) (P) (P) (D)
+  let show (es,original_digst, current_diget,x) = D.show x
+  let pretty () (_,original_digst,current_diget, x) = D.pretty () x
+  let printXml f (c,original_digst,current_digest,d) =
+    BatPrintf.fprintf f "<tuple>\n<context>\n%a</context>\n<original_digest>\n%a</original_digest>\n<current_digest>\n%a</current_digest>\n<abstract_state>\n%a</abstract_state>\n</tuple>" C.printXml c P.printXml original_digst P.printXml current_digest D.printXml d
 end
 
 

--- a/src/framework/analysisResult.ml
+++ b/src/framework/analysisResult.ml
@@ -57,3 +57,16 @@ struct
   let printXml f (c,d,fd) =
     BatPrintf.fprintf f "<context>\n%a</context>\n%a" C.printXml c D.printXml d
 end
+
+module ResultType2Digest (S: Analyses.Spec) =
+struct
+  open S
+  include Printable.Prod4 (C) (P) (D) (CilType.Fundec)
+  let show (es,current_diget,x,f:t) = D.show x
+  let pretty () (_,current_digest,x,_) = D.pretty () x
+  let printXml f (c,current_digest,d,fd) =
+    BatPrintf.fprintf f "<tuple>\n<context>\n%a</context><current_digest>\n%a</current_digest>\n<path>\n%a</path>\n</tuple>" C.printXml c P.printXml current_digest D.printXml d
+end
+
+
+

--- a/src/framework/compareConstraints.ml
+++ b/src/framework/compareConstraints.ml
@@ -48,7 +48,7 @@ struct
     Logs.info "globals:\tequal = %d\tleft = %d\tright = %d\tincomparable = %d" !eq !le !gr !uk
 
   let compare_locals l1 l2 =
-    let one_ctx (node,_) v h =
+    let one_ctx (node,_,_) v h =
       PP.replace h node (try D.join v (PP.find h node) with Not_found -> v);
       h
     in

--- a/src/framework/compareConstraints.ml
+++ b/src/framework/compareConstraints.ml
@@ -48,8 +48,8 @@ struct
     Logs.info "globals:\tequal = %d\tleft = %d\tright = %d\tincomparable = %d" !eq !le !gr !uk
 
   let compare_locals l1 l2 =
-    let one_ctx (node,_,_) v h =
-      PP.replace h node (try D.join v (PP.find h node) with Not_found -> v);
+    let one_ctx (x : Sys.LVar.t) v h =
+      PP.replace h x.node (try D.join v (PP.find h x.node) with Not_found -> v);
       h
     in
     (* these contain results where the contexts per node have been joined *)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -16,7 +16,7 @@ open SpecLifters
 module type S2S = Spec2Spec
 
 (* spec is lazy, so HConsed table in Hashcons lifters is preserved between analyses in server mode *)
-let spec_module: (module Spec) Lazy.t = lazy (
+let spec_module: (module Spec') Lazy.t = lazy (
   GobConfig.building_spec := true;
   let arg_enabled = get_bool "exp.arg.enabled" in
   let termination_enabled = List.mem "termination" (get_string_list "ana.activated") in (* check if loop termination analysis is enabled*)
@@ -49,11 +49,12 @@ let spec_module: (module Spec) Lazy.t = lazy (
   in
   GobConfig.building_spec := false;
   ControlSpecC.control_spec_c := (module S1.C);
+  let module S1 = Spec2Spec' (S1) in
   (module S1)
 )
 
 (** gets Spec for current options *)
-let get_spec (): (module Spec) =
+let get_spec (): (module Spec') =
   Lazy.force spec_module
 
 let current_node_state_json : (Node.t -> Yojson.Safe.t option) ref = ref (fun _ -> None)
@@ -61,7 +62,7 @@ let current_node_state_json : (Node.t -> Yojson.Safe.t option) ref = ref (fun _ 
 let current_varquery_global_state_json: (Goblint_constraint.VarQuery.t option -> Yojson.Safe.t) ref = ref (fun _ -> `Null)
 
 (** Given a [Cfg], a [Spec], and an [Inc], computes the solution to [MCP.Path] *)
-module AnalyzeCFG (Cfg:CfgBidirSkip) (Spec:Spec) (Inc:Increment) =
+module AnalyzeCFG (Cfg:CfgBidirSkip) (Spec:Spec') (Inc:Increment) =
 struct
 
   module SpecSys: SpecSys with module Spec = Spec =
@@ -77,6 +78,8 @@ struct
     (* Hashtbl for globals *)
     module GHT   = BatHashtbl.Make (EQSys.GVar)
   end
+
+
 
   module FwdSpecSys: FwdSpecSys with module Spec = Spec =
   struct

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -120,7 +120,7 @@ struct
 
   module Slvr = (GlobSolverFromEqSolver (Goblint_solver.Selector.Make (PostSolverArg))) (EQSys) (LHT) (GHT)
   (* The comparator *)
-  (* module CompareGlobSys = CompareConstraints.CompareGlobSys (SpecSys) *)
+  module CompareGlobSys = CompareConstraints.CompareGlobSys (SpecSys)
 
   (* Triple of the function, context, and the local value. *)
   module RT = AnalysisResult.ResultType2 (Spec)
@@ -555,8 +555,7 @@ struct
                 (Splitter.split_solution vh', vh')
               ) (d1, d2)
             in
-            (* TODO: Fix the implementation of CompareConstraints below *)
-(*
+
             if get_bool "dbg.compare_runs.globsys" then
               CompareGlobSys.compare (d1, d2) r1 r2;
 
@@ -570,7 +569,7 @@ struct
 
             let module CompareNode = CompareConstraints.CompareNode (Spec.C) (EQSys.D) (LHT) in
             if get_bool "dbg.compare_runs.node" then
-              CompareNode.compare (d1, d2) (fst r1) (fst r2); *)
+              CompareNode.compare (d1, d2) (fst r1) (fst r2);
 
             r1 (* return the result of the first run for further options -- maybe better to exit early since compare_runs is its own mode. Only excluded verify below since it's on by default. *)
           | _ -> failwith "Currently only two runs can be compared!";
@@ -625,21 +624,19 @@ struct
       in
 
       if get_string "comparesolver" <> "" then (
-        failwith "Comparison not implemented for backward constraint systems."
-        (** TODO: Fix implementation below *)
-        (* let compare_with (module S2 : DemandEqIncrSolver) =
-           let module PostSolverArg2 =
-           struct
+        let compare_with (module S2 : DemandEqIncrSolver) =
+          let module PostSolverArg2 =
+          struct
             include PostSolverArg
             let should_warn = false (* we already warn from main solver *)
             let should_save_run = false (* we already save main solver *)
-           end
-           in
-           let module S2' = (GlobSolverFromEqSolver (S2 (PostSolverArg2))) (EQSys) (LHT) (GHT) in
-           let (r2, _) = S2'.solve entrystates entrystates_global startvars' None in (* TODO: has incremental data? *)
-           CompareGlobSys.compare (get_string "solver", get_string "comparesolver") (lh,gh) (r2)
-           in
-           compare_with (Goblint_solver.Selector.choose_solver (get_string "comparesolver")) *)
+          end
+          in
+          let module S2' = (GlobSolverFromEqSolver (S2 (PostSolverArg2))) (EQSys) (LHT) (GHT) in
+          let (r2, _) = S2'.solve entrystates entrystates_global startvars' None in (* TODO: has incremental data? *)
+          CompareGlobSys.compare (get_string "solver", get_string "comparesolver") (lh,gh) (r2)
+        in
+        compare_with (Goblint_solver.Selector.choose_solver (get_string "comparesolver"))
       );
 
       (* Most warnings happen before during postsolver, but some happen later (e.g. in finalize), so enable this for the rest (if required by option). *)

--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -117,7 +117,7 @@ struct
 
   module Slvr = (GlobSolverFromEqSolver (Goblint_solver.Selector.Make (PostSolverArg))) (EQSys) (LHT) (GHT)
   (* The comparator *)
-  module CompareGlobSys = CompareConstraints.CompareGlobSys (SpecSys)
+  (* module CompareGlobSys = CompareConstraints.CompareGlobSys (SpecSys) *)
 
   (* Triple of the function, context, and the local value. *)
   module RT = AnalysisResult.ResultType2 (Spec)
@@ -552,7 +552,8 @@ struct
                 (Splitter.split_solution vh', vh')
               ) (d1, d2)
             in
-
+            (* TODO: Fix the implementation of CompareConstraints below *)
+(*
             if get_bool "dbg.compare_runs.globsys" then
               CompareGlobSys.compare (d1, d2) r1 r2;
 
@@ -566,7 +567,7 @@ struct
 
             let module CompareNode = CompareConstraints.CompareNode (Spec.C) (EQSys.D) (LHT) in
             if get_bool "dbg.compare_runs.node" then
-              CompareNode.compare (d1, d2) (fst r1) (fst r2);
+              CompareNode.compare (d1, d2) (fst r1) (fst r2); *)
 
             r1 (* return the result of the first run for further options -- maybe better to exit early since compare_runs is its own mode. Only excluded verify below since it's on by default. *)
           | _ -> failwith "Currently only two runs can be compared!";
@@ -621,19 +622,21 @@ struct
       in
 
       if get_string "comparesolver" <> "" then (
-        let compare_with (module S2 : DemandEqIncrSolver) =
-          let module PostSolverArg2 =
-          struct
+        failwith "Comparison not implemented for backward constraint systems."
+        (** TODO: Fix implementation below *)
+        (* let compare_with (module S2 : DemandEqIncrSolver) =
+           let module PostSolverArg2 =
+           struct
             include PostSolverArg
             let should_warn = false (* we already warn from main solver *)
             let should_save_run = false (* we already save main solver *)
-          end
-          in
-          let module S2' = (GlobSolverFromEqSolver (S2 (PostSolverArg2))) (EQSys) (LHT) (GHT) in
-          let (r2, _) = S2'.solve entrystates entrystates_global startvars' None in (* TODO: has incremental data? *)
-          CompareGlobSys.compare (get_string "solver", get_string "comparesolver") (lh,gh) (r2)
-        in
-        compare_with (Goblint_solver.Selector.choose_solver (get_string "comparesolver"))
+           end
+           in
+           let module S2' = (GlobSolverFromEqSolver (S2 (PostSolverArg2))) (EQSys) (LHT) (GHT) in
+           let (r2, _) = S2'.solve entrystates entrystates_global startvars' None in (* TODO: has incremental data? *)
+           CompareGlobSys.compare (get_string "solver", get_string "comparesolver") (lh,gh) (r2)
+           in
+           compare_with (Goblint_solver.Selector.choose_solver (get_string "comparesolver")) *)
       );
 
       (* Most warnings happen before during postsolver, but some happen later (e.g. in finalize), so enable this for the rest (if required by option). *)

--- a/src/framework/fwdCompareConstraints.ml
+++ b/src/framework/fwdCompareConstraints.ml
@@ -4,7 +4,7 @@ open Goblint_constraint.ConstrSys
 open GobConfig
 
 
-module CompareGlobSys (SpecSys: SpecSys) =
+module CompareGlobSys (SpecSys: ComparableSpecSys) =
 struct
   open SpecSys
   module Sys = EQSys
@@ -47,7 +47,17 @@ struct
     GH.iter f g1;
     Logs.info "globals:\tequal = %d\tleft = %d\tright = %d\tincomparable = %d" !eq !le !gr !uk
 
-  let compare_locals h1 h2 =
+  let compare_locals l1 l2 =
+    let one_ctx (x : Sys.LVar.t) v h =
+      PP.replace h x.node (try D.join v (PP.find h x.node) with Not_found -> v);
+      h
+    in
+    (* these contain results where the contexts per node have been joined *)
+    let h1 = PP.create 113 in
+    let h2 = PP.create 113 in
+    let _  = LH.fold one_ctx l1 h1 in
+    let _  = LH.fold one_ctx l2 h2 in
+
     let eq, le, gr, uk = ref 0, ref 0, ref 0, ref 0 in
     let f k v1 =
       if PP.mem h2 k then
@@ -121,19 +131,10 @@ struct
     Logs.info "locals_ctx:\tequal = %d\tleft = %d\tright = %d\tincomparable = %d\tno_ctx_in_right = %d\tno_ctx_in_left = %d" !eq !le !gr !uk !no2 !no1
 
   let compare (name1,name2) (l1,g1) (l2,g2) =
-    let one_ctx (n,_) v h =
-      PP.replace h n (try D.join v (PP.find h n) with Not_found -> v);
-      h
-    in
-    (* these contain results where the contexts per node have been joined *)
-    let h1 = PP.create 113 in
-    let h2 = PP.create 113 in
-    let _  = LH.fold one_ctx l1 h1 in
-    let _  = LH.fold one_ctx l2 h2 in
     Logs.newline ();
     Logs.info "Comparing GlobConstrSys precision of %s (left) with %s (right):" name1 name2;
     compare_globals g1 g2;
-    compare_locals h1 h2;
+    compare_locals l1 l2;
     compare_locals_ctx l1 l2;
     Logs.newline ();
 end

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -393,13 +393,13 @@ struct
         sidel_target_unknowns r
       | Ret (r,fd)     ->
         let r = tf_ret x edge target_node r fd getl sidel getg sideg d in
-        let sideg_target_unkonwn d =
+        let sideg_target_unknown d =
           let target_unknown = target_unknown d in
           let target_unknown_g = GVar.single_return target_unknown  in
           sideg target_unknown_g (G.create_single_return d)
         in
 
-        List.iter sideg_target_unkonwn r;
+        List.iter sideg_target_unknown r;
         (* TODO: Remove need to also propagate to locals for returns *)
         sidel_target_unknowns r;
 

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -374,54 +374,54 @@ struct
       let target_unknown = target_unknown d in
       sidel target_unknown d
     in
-    let sidel_target_unknowns ds =
+    (** Takes a list of values and propagates them to the appropriate successor local unknowns . *)
+    let propagate ds =
       List.iter sidel_target_unkonwn ds
     in
     begin match edge with
       | Assign (lv,rv) ->
         let r = tf_assign x edge target_node lv rv getl sidel getg sideg d in
-        sidel_target_unknowns r
+        propagate r
       | VDecl (v)      ->
         let r = tf_vdecl x edge target_node v getl sidel getg sideg d in
-        sidel_target_unknowns r
+        propagate r
       | Proc (r,f,ars) ->
         let r = tf_proc x edge target_node r f ars getl sidel getg sideg d in
-        sidel_target_unknowns r
+        propagate r
       | Entry f        ->
         let r = tf_entry x edge target_node f getl sidel getg sideg d in
-        sidel_target_unknowns r
+        propagate r
       | Ret (r,fd)     ->
         let r = tf_ret x edge target_node r fd getl sidel getg sideg d in
-        let sideg_target_unknown d =
+        let propagate_to_return_global d =
           let target_unknown = target_unknown d in
           let target_unknown_g = GVar.single_return target_unknown  in
           sideg target_unknown_g (G.create_single_return d)
         in
-
-        List.iter sideg_target_unknown r;
+        List.iter propagate_to_return_global r;
 
         (* Propagate to locals for returns. Currently only needed for the result view at return nodes.
            The analysis will look up the return state at the global for the return. *)
         (* TODO: Adapt generation of result view so that this can be avoided. *)
-        sidel_target_unknowns r;
+        propagate r;
 
         let set = S.LVarSet.bot () in
         let add_entry set d =
           let return_unknown = return_unknown d in
           S.LVarSet.add return_unknown set
         in
-        let g = GVar.return (fd, x.context, x.original_digest) in
-        let contrib = List.fold add_entry set r |> G.create_return in
-        sideg g contrib
+        let return_collector = GVar.return (fd, x.context, x.original_digest) in
+        let return_set = List.fold add_entry set r |> G.create_return in
+        sideg return_collector return_set
       | Test (e,b)     ->
         let r = tf_test x edge target_node e b getl sidel getg sideg d in
-        sidel_target_unknowns r
+        propagate r
       | ASM (_, _, _)  ->
         let r = tf_asm x edge target_node getl sidel getg sideg d in
-        sidel_target_unknowns r
+        propagate r
       | Skip           ->
         let r = tf_skip x edge target_node getl sidel getg sideg d in
-        sidel_target_unknowns r
+        propagate r
     end
 
   type Goblint_backtrace.mark += TfLocation of location

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -244,16 +244,16 @@ struct
         let end_paths =
           if S.D.is_bot v then [S.D.bot ()]
           else
-            let return_nodes = G.return @@ getg endvar |> S.LVarSet.elements in
+            let return_nodes = G.return @@ getg endvar |> S.LVarSet.to_seq in
             let return_value x =
               G.single_return @@ getg (GVar.single_return x)
             in
-            let s = List.map return_value return_nodes in
-            if List.is_empty s then
+            let s = Seq.map return_value return_nodes in
+            if Seq.is_empty s then
               (* In case the callee does not return, create one bottom return path for LongjmpLifter to do its work *)
               [S.D.bot ()]
             else
-              s
+              List.of_seq s
         in
         (c, fc, end_paths)) paths
     in

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -125,7 +125,7 @@ struct
       in
       bigsqcup (List.map one_spawn spawns)
 
-  (** Handle *)
+  (** Handle thread spawns for the provided state and the list of splits *)
   let map_thread_spawns man d splits spawns =
     let ds = d :: splits in
     List.map (fun d -> thread_spawns man d spawns) ds

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -246,14 +246,19 @@ struct
     let paths = List.map (fun (c,fc,v) ->
         let p = S.P.of_elt v in
         let endvar = (GVar.return (f,fc,p)) in
-        let end_paths = if S.D.is_bot v then [v]
+        let end_paths =
+          if S.D.is_bot v then [S.D.bot ()]
           else
             let return_nodes = G.return @@ getg endvar |> S.LVarSet.to_seq in
             let return_value x =
               G.single_return @@ getg (GVar.single_return x)
             in
             let s = Seq.map return_value return_nodes in
-            List.of_seq s
+            if Seq.is_empty s then
+              (* In case the calle does not return, create one bottom return path for LongjmpLifter to do its work *)
+              [S.D.bot ()]
+            else
+              List.of_seq s
         in
         (c, fc, end_paths)) paths
     in

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -26,11 +26,11 @@ module FromSpec (S:Spec) (Cfg:CfgForward) (I: Increment)
   end
 =
 struct
-  type lv = MyCFG.node * S.C.t * S.P.t
+  module LVar = VarDigestF (S.C) (S.P)
+  type lv = LVar.t
   (* type gv = varinfo *)
   type ld = S.D.t
   (* type gd = S.G.t *)
-  module LVar = VarDigestF (S.C) (S.P)
   module GVar = GVarFCNW (S.V)(S.C)
   module D = S.D
   module G = GVarL (S.G) (S.D)
@@ -45,7 +45,7 @@ struct
       S.sync man (`JoinCall f)
     | _ -> S.sync man `Join
 
-  let common_man' (var: node * Obj.t * Obj.t) edge target_node pval (getl:lv -> ld) sidel getg sideg : (D.t, S.G.t, S.C.t, S.V.t) man * D.t list ref * (lval option * varinfo * exp list * D.t * bool) list ref =
+  let common_man' (var : LVar.t) edge target_node pval (getl:lv -> ld) (sidel : lv -> ld -> unit) getg sideg : (D.t, S.G.t, S.C.t, S.V.t) man * D.t list ref * (lval option * varinfo * exp list * D.t * bool) list ref =
     let r = ref [] in
     let spawns = ref [] in
     (* now watch this ... *)
@@ -53,9 +53,9 @@ struct
       { ask     = (fun (type a) (q: a Queries.t) -> S.query man q)
       ; emit    = (fun _ -> failwith "emit outside MCP")
       ; node    = target_node
-      ; prev_node = Tuple3.first var
-      ; control_context = (fun () -> Tuple3.second var |> Obj.obj)
-      ; context = (fun () -> Tuple3.second var |> Obj.obj)
+      ; prev_node = var.node
+      ; control_context = (fun () -> Obj.magic var.context) (** TODO: Just for testing *)
+      ; context = (fun () -> Obj.magic var.context)
       ; edge    = edge
       ; local   = pval
       ; global  = (fun g -> G.spec (getg (GVar.spec g)))
@@ -74,7 +74,8 @@ struct
             let c = S.context man fd d in
             (* Derive digest from abstract state *)
             let p = S.P.of_elt d in
-            sidel (FunctionEntry fd, c, p) d
+            let target_unknown  : lv = {node = FunctionEntry fd; context = c; original_digest = p; current_digest = p} in
+            sidel target_unknown d
           | exception Not_found ->
             (* unknown function *)
             M.error ~category:Imprecise ~tags:[Category Unsound] "Created a thread from unknown function %s" f.vname;
@@ -227,7 +228,8 @@ struct
     let sidel_entries (c,fc,v) =
       if not (S.D.is_bot v) then begin
         let p = S.P.of_elt v in
-        sidel (FunctionEntry f, fc, p) v
+        let target_unknown : lv = {node = FunctionEntry f; context = fc; original_digest = p; current_digest = p}  in
+        sidel target_unknown v
       end
     in
     List.iter sidel_entries paths;
@@ -331,33 +333,37 @@ struct
     let d = S.skip man in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join man d !r !spawns
 
-  let tf ((n,c,p) as var) getl sidel getg sideg target_node edge d =
+  let tf (x : lv) getl sidel getg sideg target_node edge d =
+    let target_unknown d : lv =
+      let current_digest = S.P.of_elt d in
+      {node = target_node; context = x.context; original_digest = x.original_digest; current_digest }
+    in
     begin match edge with
       | Assign (lv,rv) ->
-        let r = tf_assign var edge target_node lv rv getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c, Obj.obj p) r
+        let r = tf_assign x edge target_node lv rv getl sidel getg sideg d in
+        sidel (target_unknown r) r
       | VDecl (v)      ->
-        let r = tf_vdecl var edge target_node v getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c, Obj.obj p) r
+        let r = tf_vdecl x edge target_node v getl sidel getg sideg d in
+        sidel (target_unknown r) r
       | Proc (r,f,ars) ->
-        let r = tf_proc var edge target_node r f ars getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c, Obj.obj p) r
+        let r = tf_proc x edge target_node r f ars getl sidel getg sideg d in
+        sidel (target_unknown r) r
       | Entry f        ->
-        let r = tf_entry var edge target_node f getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c, Obj.obj p) r
+        let r = tf_entry x edge target_node f getl sidel getg sideg d in
+        sidel (target_unknown r) r
       | Ret (r,fd)     ->
-        let r = tf_ret var edge target_node r fd getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c, Obj.obj p) r;
-        sideg (GVar.return (fd,Obj.obj c)) (G.create_return r)
+        let r = tf_ret x edge target_node r fd getl sidel getg sideg d in
+        sidel (target_unknown r) r;
+        sideg (GVar.return (fd, x.context)) (G.create_return r)
       | Test (e,b)     ->
-        let r = tf_test var edge target_node e b getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c, Obj.obj p) r
+        let r = tf_test x edge target_node e b getl sidel getg sideg d in
+        sidel (target_unknown r) r
       | ASM (_, _, _)  ->
-        let r = tf_asm var edge target_node getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c, Obj.obj p) r
+        let r = tf_asm x edge target_node getl sidel getg sideg d in
+        sidel (target_unknown r) r
       | Skip           ->
-        let r = tf_skip var edge target_node getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c, Obj.obj p) r
+        let r = tf_skip x edge target_node getl sidel getg sideg d in
+        sidel (target_unknown r) r
     end
 
   type Goblint_backtrace.mark += TfLocation of location
@@ -368,7 +374,7 @@ struct
       | _ -> None (* for other marks *)
     )
 
-  let tf var getl sidel getg sideg target_node (_,edge) d (f,t):unit =
+  let tf x getl sidel getg sideg target_node (_,edge) d (f,t):unit =
     let old_loc  = !Goblint_tracing.current_loc in
     let old_loc2 = !Goblint_tracing.next_loc in
     Goblint_tracing.current_loc := f;
@@ -377,37 +383,37 @@ struct
         Goblint_tracing.current_loc := old_loc;
         Goblint_tracing.next_loc := old_loc2
       ) (fun () ->
-        tf var getl sidel getg sideg target_node edge d
+        tf x getl sidel getg sideg target_node edge d
       )
 
-  let tf_fwd value (v,c,p) (edges, u) getl sidel getg sideg:unit =
+  let tf_fwd value (x : lv) (edges, u) getl sidel getg sideg:unit =
     let pval = value in
-    let _, locs = List.fold_right (fun (f,e) (t,xs) -> f, (f,t)::xs) edges (Node.location v,[]) in
-    let es = List.map (tf (v,Obj.repr c, Obj.repr p) getl sidel getg sideg u) edges in
+    let _, locs = List.fold_right (fun (f,e) (t,xs) -> f, (f,t)::xs) edges (Node.location x.node,[]) in
+    let es = List.map (tf x getl sidel getg sideg u) edges in
     List.iter2 (fun e l -> e pval l) es locs
 
-  let tf value (v,c,p) (e,u) getl sidel getg sideg =
+  let tf value (x : lv) (e,u) getl sidel getg sideg =
     let old_node = !current_node in
     let old_fd = Option.map Node.find_fundec old_node |? Cil.dummyFunDec in
-    let new_fd = Node.find_fundec v in
+    let new_fd = Node.find_fundec x.node in
     if not (CilType.Fundec.equal old_fd new_fd) then
       Timing.Program.enter new_fd.svar.vname;
     let old_context = !M.current_context in
-    current_node := Some v;
-    M.current_context := Some (Obj.magic c); (* magic is fine because Spec is top-level Control Spec *)
+    current_node := Some x.node;
+    M.current_context := Some (Obj.magic x.context); (* magic is fine because Spec is top-level Control Spec *)
     Fun.protect ~finally:(fun () ->
         current_node := old_node;
         M.current_context := old_context;
         if not (CilType.Fundec.equal old_fd new_fd) then
           Timing.Program.exit new_fd.svar.vname
       ) (fun () ->
-        tf_fwd value (v,c,p) (e,u) getl sidel getg sideg
+        tf_fwd value x (e,u) getl sidel getg sideg
       )
 
-  let system (v,c,p) =
+  let system (x : lv) =
     let tf value getl sidel getg sideg =
-      let tf' eu = tf value (v,c,p) eu getl sidel getg sideg in
-      let xs = Cfg.next v in
+      let tf' eu = tf value x eu getl sidel getg sideg in
+      let xs = Cfg.next x.node in
       List.iter (fun eu -> tf' eu) xs
     in
     Some tf

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -249,16 +249,16 @@ struct
         let end_paths =
           if S.D.is_bot v then [S.D.bot ()]
           else
-            let return_nodes = G.return @@ getg endvar |> S.LVarSet.to_seq in
+            let return_nodes = G.return @@ getg endvar |> S.LVarSet.elements in
             let return_value x =
               G.single_return @@ getg (GVar.single_return x)
             in
-            let s = Seq.map return_value return_nodes in
-            if Seq.is_empty s then
+            let s = List.map return_value return_nodes in
+            if List.is_empty s then
               (* In case the callee does not return, create one bottom return path for LongjmpLifter to do its work *)
               [S.D.bot ()]
             else
-              List.of_seq s
+              s
         in
         (c, fc, end_paths)) paths
     in

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -125,22 +125,20 @@ struct
       in
       bigsqcup (List.map one_spawn spawns)
 
-  let common_join man d splits spawns =
-    thread_spawns man (bigsqcup (d :: splits)) spawns
-
-  let common_split man d splits spawns =
+  (** Handle *)
+  let map_thread_spawns man d splits spawns =
     let ds = d :: splits in
-    List.map (fun d -> common_join man d [] spawns) ds
+    List.map (fun d -> thread_spawns man d spawns) ds
 
   let tf_assign var edge target_node lv e getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.assign man lv e in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_split man d !r !spawns
+    map_thread_spawns man d !r !spawns
 
   let tf_vdecl var edge target_node v getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.vdecl man v in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_split man d !r !spawns
+    map_thread_spawns man d !r !spawns
 
   let normal_return r fd man sideg =
     let spawning_return = S.return man r fd in
@@ -162,17 +160,17 @@ struct
       then toplevel_kernel_return ret fd man sideg
       else normal_return ret fd man sideg
     in
-    common_split man d !r !spawns
+    map_thread_spawns man d !r !spawns
 
   let tf_entry var edge target_node fd getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.body man fd in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_split man d !r !spawns
+    map_thread_spawns man d !r !spawns
 
   let tf_test var edge target_node e tv getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.branch man e tv in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_split man d !r !spawns
+    map_thread_spawns man d !r !spawns
 
   let tf_normal_call man lv e (f:fundec) args getl (sidel : lv -> ld -> unit) getg sideg =
     let combine (cd, fc, fd) =
@@ -344,18 +342,18 @@ struct
       [d]
     end else
       let funs = List.flatten funs in
-      let ds = List.map (fun f -> common_split man f !r !spawns) funs in
+      let ds = List.map (fun f -> map_thread_spawns man f !r !spawns) funs in
       List.flatten ds
 
   let tf_asm var edge target_node getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.asm man in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_split man d !r !spawns
+    map_thread_spawns man d !r !spawns
 
   let tf_skip var edge target_node getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.skip man in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_split man d !r !spawns
+    map_thread_spawns man d !r !spawns
 
   let tf (x : lv) getl sidel getg sideg target_node edge d =
     let target_unknown d : lv =

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -399,7 +399,10 @@ struct
         in
 
         List.iter sideg_target_unknown r;
-        (* TODO: Remove need to also propagate to locals for returns *)
+
+        (* Propagate to locals for returns. Currently only needed for the result view at return nodes.
+           The analysis will look up the return state at the global for the return. *)
+        (* TODO: Adapt generation of result view so that this can be avoided. *)
         sidel_target_unknowns r;
 
         let set = S.LVarSet.bot () in

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -17,23 +17,25 @@ end
 
 
 (** The main point of this file---generating a [FwdGlobConstrSys] from a [Spec]. *)
-module FromSpec (S:Spec) (Cfg:CfgForward) (I: Increment)
+module FromSpec (S:Spec') (Cfg:CfgForward) (I: Increment)
   : sig
     include FwdGlobConstrSys with module LVar = VarDigestF (S.C) (S.P)
-                              and module GVar = GVarFCNW (S.V)(S.C)
+                              and module GVar = GVarFCNW (S.V) (S.C) (S.P)
                               and module D = S.D
-                              and module G = GVarL (S.G) (S.D)
+                              and module G = GVarL (S.G) (S.LVarDMap)
   end
 =
 struct
+
   module LVar = VarDigestF (S.C) (S.P)
+
   type lv = LVar.t
   (* type gv = varinfo *)
   type ld = S.D.t
   (* type gd = S.G.t *)
-  module GVar = GVarFCNW (S.V)(S.C)
+  module GVar = GVarFCNW (S.V) (S.C) (S.P)
   module D = S.D
-  module G = GVarL (S.G) (S.D)
+  module G = GVarL (S.G) (S.LVarDMap)
 
   (* Two global invariants:
      1. S.V -> S.G  --  used for Spec
@@ -163,7 +165,7 @@ struct
       then toplevel_kernel_return ret fd man sideg
       else normal_return ret fd man sideg
     in
-    common_join man d !r !spawns (*TODO: common_split? *)
+    common_split man d !r !spawns (*TODO: common_split? *)
 
   let tf_entry var edge target_node fd getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
@@ -228,6 +230,9 @@ struct
       if M.tracing then M.traceu "combine" "combined local: %a" S.D.pretty r;
       r
     in
+    let combine_each (cd, fc, fd_list) =
+      List.map (fun fd -> combine (cd, fc, fd)) fd_list
+    in
     let paths = S.enter man lv f args in
     let paths = List.map (fun (c,v) -> (c, S.context man f v, v)) paths in
     let sidel_entries (c,fc,v) =
@@ -239,16 +244,22 @@ struct
     in
     List.iter sidel_entries paths;
     let paths = List.map (fun (c,fc,v) ->
-        let endvar = (GVar.return (f,fc)) in
-        (c, fc, if S.D.is_bot v then v else G.return @@ getg endvar)) paths in
+        let p = S.P.of_elt v in
+        let endvar = (GVar.return (f,fc,p)) in
+        let end_paths = if S.D.is_bot v then [v]
+          else
+            let return_nodes = G.return @@ getg endvar in
+            S.LVarDMap.bindings return_nodes |> List.map snd
+        in
+        (c, fc, end_paths)) paths
+    in
     (* Don't filter bot paths, otherwise LongjmpLifter is not called. *)
     (* let paths = List.filter (fun (c,fc,v) -> not (D.is_bot v)) paths in *)
     let paths = List.map (Tuple3.map2 Option.some) paths in
     if M.tracing then M.traceli "combine" "combining";
-    let paths = List.map combine paths in
-    let r = List.fold_left D.join (D.bot ()) paths in
-    if M.tracing then M.traceu "combine" "combined: %a" S.D.pretty r;
-    r
+    let paths = List.map combine_each paths in
+    let paths = List.flatten paths in
+    paths
 
 
   let rec tf_proc var edge target_node lv e args getl sidel getg sideg d =
@@ -309,7 +320,7 @@ struct
                tf_special_call man f
              | fd ->
                (* TODO: Handle this properly by handling splitting also here. *)
-               [tf_normal_call man lv e fd args getl sidel getg sideg]
+               tf_normal_call man lv e fd args getl sidel getg sideg
              | exception Not_found ->
                tf_special_call man f)
           in
@@ -370,8 +381,15 @@ struct
         sidel_target_unknowns r
       | Ret (r,fd)     ->
         let r = tf_ret x edge target_node r fd getl sidel getg sideg d in
-        sidel (target_unknown r) r;
-        sideg (GVar.return (fd, x.context)) (G.create_return r)
+        sidel_target_unknowns r;
+        let map = S.LVarDMap.bot () in
+        let add_entry map d =
+          let target_unknown = target_unknown d in
+          S.LVarDMap.add target_unknown d map
+        in
+        let g = GVar.return (fd, x.context, x.original_digest) in
+        let contrib = List.fold add_entry map r |> G.create_return in
+        sideg g contrib
       | Test (e,b)     ->
         let r = tf_test x edge target_node e b getl sidel getg sideg d in
         sidel_target_unknowns r

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -326,7 +326,6 @@ struct
                M.info ~category:Analyzer "Using special for defined function %s" f.vname;
                tf_special_call man f
              | fd ->
-               (* TODO: Handle this properly by handling splitting also here. *)
                tf_normal_call man lv e fd args getl sidel getg sideg
              | exception Not_found ->
                tf_special_call man f)

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -22,7 +22,7 @@ module FromSpec (S:Spec') (Cfg:CfgForward) (I: Increment)
     include FwdGlobConstrSys with module LVar = VarDigestF (S.C) (S.P)
                               and module GVar = GVarFCNW (S.V) (S.C) (S.P)
                               and module D = S.D
-                              and module G = GVar2 (S.G) (S.LVarDMap)
+                              and module G = GVar3 (S.G) (S.D) (S.LVarSet)
   end
 =
 struct
@@ -35,7 +35,7 @@ struct
   (* type gd = S.G.t *)
   module GVar = GVarFCNW (S.V) (S.C) (S.P)
   module D = S.D
-  module G = GVar2 (S.G) (S.LVarDMap)
+  module G = GVar3 (S.G) (S.D) (S.LVarSet)
 
   (* Two global invariants:
      1. S.V -> S.G  --  used for Spec
@@ -248,8 +248,12 @@ struct
         let endvar = (GVar.return (f,fc,p)) in
         let end_paths = if S.D.is_bot v then [v]
           else
-            let return_nodes = G.return @@ getg endvar in
-            S.LVarDMap.bindings return_nodes |> List.map snd
+            let return_nodes = G.return @@ getg endvar |> S.LVarSet.to_seq in
+            let return_value x =
+              G.single_return @@ getg (GVar.single_return x)
+            in
+            let s = Seq.map return_value return_nodes in
+            List.of_seq s
         in
         (c, fc, end_paths)) paths
     in
@@ -359,6 +363,11 @@ struct
       let current_digest = S.P.of_elt d in
       {node = target_node; context = x.context; original_digest = x.original_digest; current_digest }
     in
+    let return_unknown d =
+      let target_unknown = target_unknown d in
+      (* GVar.single_return *)
+      target_unknown
+    in
     let sidel_target_unkonwn d =
       let target_unknown = target_unknown d in
       sidel target_unknown d
@@ -381,14 +390,23 @@ struct
         sidel_target_unknowns r
       | Ret (r,fd)     ->
         let r = tf_ret x edge target_node r fd getl sidel getg sideg d in
-        sidel_target_unknowns r;
-        let map = S.LVarDMap.bot () in
-        let add_entry map d =
+        let sideg_target_unkonwn d =
           let target_unknown = target_unknown d in
-          S.LVarDMap.add target_unknown d map
+          let target_unknown_g = GVar.single_return target_unknown  in
+          sideg target_unknown_g (G.create_single_return d)
+        in
+
+        List.iter sideg_target_unkonwn r;
+        (* TODO: Remove need to also propagate to locals for returns *)
+        sidel_target_unknowns r;
+
+        let set = S.LVarSet.bot () in
+        let add_entry set d =
+          let return_unknown = return_unknown d in
+          S.LVarSet.add return_unknown set
         in
         let g = GVar.return (fd, x.context, x.original_digest) in
-        let contrib = List.fold add_entry map r |> G.create_return in
+        let contrib = List.fold add_entry set r |> G.create_return in
         sideg g contrib
       | Test (e,b)     ->
         let r = tf_test x edge target_node e b getl sidel getg sideg d in

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -126,17 +126,22 @@ struct
   let common_join man d splits spawns =
     thread_spawns man (bigsqcup (d :: splits)) spawns
 
-  let common_joins man ds splits spawns = common_join man (bigsqcup ds) splits spawns
+  let common_split man d splits spawns =
+    let ds = d :: splits in
+    List.map (fun d -> common_join man d [] spawns) ds
+
+  let common_joins man ds splits spawns =
+    common_split man (bigsqcup ds) splits spawns
 
   let tf_assign var edge target_node lv e getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.assign man lv e in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_join man d !r !spawns
+    common_split man d !r !spawns
 
   let tf_vdecl var edge target_node v getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.vdecl man v in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_join man d !r !spawns
+    common_split man d !r !spawns
 
   let normal_return r fd man sideg =
     let spawning_return = S.return man r fd in
@@ -158,17 +163,17 @@ struct
       then toplevel_kernel_return ret fd man sideg
       else normal_return ret fd man sideg
     in
-    common_join man d !r !spawns
+    common_join man d !r !spawns (*TODO: common_split? *)
 
   let tf_entry var edge target_node fd getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.body man fd in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_join man d !r !spawns
+    common_split man d !r !spawns
 
   let tf_test var edge target_node e tv getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.branch man e tv in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_join man d !r !spawns
+    common_split man d !r !spawns
 
   let tf_normal_call man lv e (f:fundec) args getl (sidel : lv -> ld -> unit) getg sideg =
     let combine (cd, fc, fd) =
@@ -267,13 +272,15 @@ struct
           tf_proc var edge target_node None init_routine [] getl sidel getg sideg d'
         in
         let later_call = S.event man (Events.EnterOnce { once_control;  ran = true }) man in
-        D.join (leave_once first_call) (leave_once later_call)
+        let first_calls = List.map leave_once first_call in
+        let later_call = leave_once later_call in
+        List.map (D.join later_call) first_calls
       in
       let is_once = LibraryFunctions.find ~nowarn:true f in
       (* If the prototpye for a library function is wrong, this will throw an exception. Such exceptions are usually unrelated to pthread_once, it is just that the call to `is_once.special` raises here *)
       match is_once.special args with
       | Once { once_control; init_routine } -> once once_control init_routine
-      | _  -> S.special man lv f args
+      | _  -> [S.special man lv f args]
     in
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let functions =
@@ -301,7 +308,8 @@ struct
                M.info ~category:Analyzer "Using special for defined function %s" f.vname;
                tf_special_call man f
              | fd ->
-               tf_normal_call man lv e fd args getl sidel getg sideg
+               (* TODO: Handle this properly by handling splitting also here. *)
+               [tf_normal_call man lv e fd args getl sidel getg sideg]
              | exception Not_found ->
                tf_special_call man f)
           in
@@ -316,54 +324,63 @@ struct
         None
     in
     let funs = List.filter_map one_function functions in
+    let funs = List.flatten funs in
     if [] = funs && not (S.D.is_bot man.local) then begin
       M.msg_final Warning ~category:Unsound ~tags:[Category Call] "No suitable function to call";
       M.warn ~category:Unsound ~tags:[Category Call] "No suitable function to be called at call site. Continuing with state before call.";
-      d (* because LevelSliceLifter *)
+      [d]
     end else
-      common_joins man funs !r !spawns
+      let ds = List.map (fun f -> common_split man f !r !spawns) funs in
+      List.flatten ds
 
   let tf_asm var edge target_node getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.asm man in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_join man d !r !spawns
+    common_split man d !r !spawns
 
   let tf_skip var edge target_node getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.skip man in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
-    common_join man d !r !spawns
+    common_split man d !r !spawns
 
   let tf (x : lv) getl sidel getg sideg target_node edge d =
     let target_unknown d : lv =
       let current_digest = S.P.of_elt d in
       {node = target_node; context = x.context; original_digest = x.original_digest; current_digest }
     in
+    let sidel_target_unkonwn d =
+      let target_unknown = target_unknown d in
+      sidel target_unknown d
+    in
+    let sidel_target_unknowns ds =
+      List.iter sidel_target_unkonwn ds
+    in
     begin match edge with
       | Assign (lv,rv) ->
         let r = tf_assign x edge target_node lv rv getl sidel getg sideg d in
-        sidel (target_unknown r) r
+        sidel_target_unknowns r
       | VDecl (v)      ->
         let r = tf_vdecl x edge target_node v getl sidel getg sideg d in
-        sidel (target_unknown r) r
+        sidel_target_unknowns r
       | Proc (r,f,ars) ->
         let r = tf_proc x edge target_node r f ars getl sidel getg sideg d in
-        sidel (target_unknown r) r
+        sidel_target_unknowns r
       | Entry f        ->
         let r = tf_entry x edge target_node f getl sidel getg sideg d in
-        sidel (target_unknown r) r
+        sidel_target_unknowns r
       | Ret (r,fd)     ->
         let r = tf_ret x edge target_node r fd getl sidel getg sideg d in
         sidel (target_unknown r) r;
         sideg (GVar.return (fd, x.context)) (G.create_return r)
       | Test (e,b)     ->
         let r = tf_test x edge target_node e b getl sidel getg sideg d in
-        sidel (target_unknown r) r
+        sidel_target_unknowns r
       | ASM (_, _, _)  ->
         let r = tf_asm x edge target_node getl sidel getg sideg d in
-        sidel (target_unknown r) r
+        sidel_target_unknowns r
       | Skip           ->
         let r = tf_skip x edge target_node getl sidel getg sideg d in
-        sidel (target_unknown r) r
+        sidel_target_unknowns r
     end
 
   type Goblint_backtrace.mark += TfLocation of location

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -400,8 +400,11 @@ struct
           let return_unknown = target_unknown d in
           S.LVarSet.add return_unknown set
         in
-        let return_collector = GVar.return (fd, x.context, x.original_digest) in
+
+        (* Set of return unkonwns, split by current digest, that this transfer function contributes to. *)
         let return_set = List.fold add_entry set r |> G.create_return in
+        (* Unknown, consisting of function, context and original (calling) digest, where the possible unknowns, split by current digest, are collected *)
+        let return_collector = GVar.return (fd, x.context, x.original_digest) in
         sideg return_collector return_set
       | Test (e,b)     ->
         let r = tf_test x edge target_node e b getl sidel getg sideg d in

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -260,7 +260,6 @@ struct
     (* Don't filter bot paths, otherwise LongjmpLifter is not called. *)
     (* let paths = List.filter (fun (c,fc,v) -> not (D.is_bot v)) paths in *)
     let paths = List.map (Tuple3.map2 Option.some) paths in
-    if M.tracing then M.traceli "combine" "combining";
     let paths = List.map combine_each paths in
     let paths = List.flatten paths in
     paths
@@ -339,12 +338,12 @@ struct
         None
     in
     let funs = List.filter_map one_function functions in
-    let funs = List.flatten funs in
     if [] = funs && not (S.D.is_bot man.local) then begin
       M.msg_final Warning ~category:Unsound ~tags:[Category Call] "No suitable function to call";
       M.warn ~category:Unsound ~tags:[Category Call] "No suitable function to be called at call site. Continuing with state before call.";
       [d]
     end else
+      let funs = List.flatten funs in
       let ds = List.map (fun f -> common_split man f !r !spawns) funs in
       List.flatten ds
 

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -255,7 +255,7 @@ struct
             in
             let s = Seq.map return_value return_nodes in
             if Seq.is_empty s then
-              (* In case the calle does not return, create one bottom return path for LongjmpLifter to do its work *)
+              (* In case the callee does not return, create one bottom return path for LongjmpLifter to do its work *)
               [S.D.bot ()]
             else
               List.of_seq s

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -56,7 +56,7 @@ struct
       ; emit    = (fun _ -> failwith "emit outside MCP")
       ; node    = target_node
       ; prev_node = var.node
-      ; control_context = (fun () -> Obj.magic var.context) (** TODO: Just for testing *)
+      ; control_context = (fun () -> Obj.magic var.context)
       ; context = (fun () -> Obj.magic var.context)
       ; edge    = edge
       ; local   = pval

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -286,9 +286,8 @@ struct
           tf_proc var edge target_node None init_routine [] getl sidel getg sideg d'
         in
         let later_call = S.event man (Events.EnterOnce { once_control;  ran = true }) man in
-        let first_calls = List.map leave_once first_call in
-        let later_call = leave_once later_call in
-        List.map (D.join later_call) first_calls
+        let first_call = List.fold D.join (D.bot ()) first_call in
+        [D.join (leave_once first_call) (leave_once later_call)]
       in
       let is_once = LibraryFunctions.find ~nowarn:true f in
       (* If the prototpye for a library function is wrong, this will throw an exception. Such exceptions are usually unrelated to pthread_once, it is just that the call to `is_once.special` raises here *)

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -132,9 +132,6 @@ struct
     let ds = d :: splits in
     List.map (fun d -> common_join man d [] spawns) ds
 
-  let common_joins man ds splits spawns =
-    common_split man (bigsqcup ds) splits spawns
-
   let tf_assign var edge target_node lv e getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in
     let d = S.assign man lv e in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -22,7 +22,7 @@ module FromSpec (S:Spec') (Cfg:CfgForward) (I: Increment)
     include FwdGlobConstrSys with module LVar = VarDigestF (S.C) (S.P)
                               and module GVar = GVarFCNW (S.V) (S.C) (S.P)
                               and module D = S.D
-                              and module G = GVarL (S.G) (S.LVarDMap)
+                              and module G = GVar2 (S.G) (S.LVarDMap)
   end
 =
 struct
@@ -35,7 +35,7 @@ struct
   (* type gd = S.G.t *)
   module GVar = GVarFCNW (S.V) (S.C) (S.P)
   module D = S.D
-  module G = GVarL (S.G) (S.LVarDMap)
+  module G = GVar2 (S.G) (S.LVarDMap)
 
   (* Two global invariants:
      1. S.V -> S.G  --  used for Spec

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -365,11 +365,6 @@ struct
       let current_digest = S.P.of_elt d in
       {node = target_node; context = x.context; original_digest = x.original_digest; current_digest }
     in
-    let return_unknown d =
-      let target_unknown = target_unknown d in
-      (* GVar.single_return *)
-      target_unknown
-    in
     let sidel_target_unkonwn d =
       let target_unknown = target_unknown d in
       sidel target_unknown d
@@ -407,7 +402,7 @@ struct
 
         let set = S.LVarSet.bot () in
         let add_entry set d =
-          let return_unknown = return_unknown d in
+          let return_unknown = target_unknown d in
           S.LVarSet.add return_unknown set
         in
         let return_collector = GVar.return (fd, x.context, x.original_digest) in

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -165,7 +165,7 @@ struct
       then toplevel_kernel_return ret fd man sideg
       else normal_return ret fd man sideg
     in
-    common_split man d !r !spawns (*TODO: common_split? *)
+    common_split man d !r !spawns
 
   let tf_entry var edge target_node fd getl sidel getg sideg d =
     let man, r, spawns = common_man' var edge target_node d getl sidel getg sideg in

--- a/src/framework/fwdConstraints.ml
+++ b/src/framework/fwdConstraints.ml
@@ -19,18 +19,18 @@ end
 (** The main point of this file---generating a [FwdGlobConstrSys] from a [Spec]. *)
 module FromSpec (S:Spec) (Cfg:CfgForward) (I: Increment)
   : sig
-    include FwdGlobConstrSys with module LVar = VarF (S.C)
+    include FwdGlobConstrSys with module LVar = VarDigestF (S.C) (S.P)
                               and module GVar = GVarFCNW (S.V)(S.C)
                               and module D = S.D
                               and module G = GVarL (S.G) (S.D)
   end
 =
 struct
-  type lv = MyCFG.node * S.C.t
+  type lv = MyCFG.node * S.C.t * S.P.t
   (* type gv = varinfo *)
   type ld = S.D.t
   (* type gd = S.G.t *)
-  module LVar = VarF (S.C)
+  module LVar = VarDigestF (S.C) (S.P)
   module GVar = GVarFCNW (S.V)(S.C)
   module D = S.D
   module G = GVarL (S.G) (S.D)
@@ -45,7 +45,7 @@ struct
       S.sync man (`JoinCall f)
     | _ -> S.sync man `Join
 
-  let common_man' var edge target_node pval (getl:lv -> ld) sidel getg sideg : (D.t, S.G.t, S.C.t, S.V.t) man * D.t list ref * (lval option * varinfo * exp list * D.t * bool) list ref =
+  let common_man' (var: node * Obj.t * Obj.t) edge target_node pval (getl:lv -> ld) sidel getg sideg : (D.t, S.G.t, S.C.t, S.V.t) man * D.t list ref * (lval option * varinfo * exp list * D.t * bool) list ref =
     let r = ref [] in
     let spawns = ref [] in
     (* now watch this ... *)
@@ -53,9 +53,9 @@ struct
       { ask     = (fun (type a) (q: a Queries.t) -> S.query man q)
       ; emit    = (fun _ -> failwith "emit outside MCP")
       ; node    = target_node
-      ; prev_node = fst var
-      ; control_context = (fun () -> snd var |> Obj.obj)
-      ; context = (fun () -> snd var |> Obj.obj)
+      ; prev_node = Tuple3.first var
+      ; control_context = (fun () -> Tuple3.second var |> Obj.obj)
+      ; context = (fun () -> Tuple3.second var |> Obj.obj)
       ; edge    = edge
       ; local   = pval
       ; global  = (fun g -> G.spec (getg (GVar.spec g)))
@@ -72,7 +72,9 @@ struct
           match Cilfacade.find_varinfo_fundec f with
           | fd ->
             let c = S.context man fd d in
-            sidel (FunctionEntry fd, c) d
+            (* Derive digest from abstract state *)
+            let p = S.P.of_elt d in
+            sidel (FunctionEntry fd, c, p) d
           | exception Not_found ->
             (* unknown function *)
             M.error ~category:Imprecise ~tags:[Category Unsound] "Created a thread from unknown function %s" f.vname;
@@ -167,7 +169,7 @@ struct
     let d = S.branch man e tv in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join man d !r !spawns
 
-  let tf_normal_call man lv e (f:fundec) args getl sidel getg sideg =
+  let tf_normal_call man lv e (f:fundec) args getl (sidel : lv -> ld -> unit) getg sideg =
     let combine (cd, fc, fd) =
       if M.tracing then M.traceli "combine" "local: %a" S.D.pretty cd;
       if M.tracing then M.trace "combine" "function: %a" S.D.pretty fd;
@@ -222,7 +224,13 @@ struct
     in
     let paths = S.enter man lv f args in
     let paths = List.map (fun (c,v) -> (c, S.context man f v, v)) paths in
-    List.iter (fun (c,fc,v) -> if not (S.D.is_bot v) then sidel (FunctionEntry f, fc) v) paths;
+    let sidel_entries (c,fc,v) =
+      if not (S.D.is_bot v) then begin
+        let p = S.P.of_elt v in
+        sidel (FunctionEntry f, fc, p) v
+      end
+    in
+    List.iter sidel_entries paths;
     let paths = List.map (fun (c,fc,v) ->
         let endvar = (GVar.return (f,fc)) in
         (c, fc, if S.D.is_bot v then v else G.return @@ getg endvar)) paths in
@@ -323,33 +331,33 @@ struct
     let d = S.skip man in (* Force transfer function to be evaluated before dereferencing in common_join argument. *)
     common_join man d !r !spawns
 
-  let tf ((n,c) as var) getl sidel getg sideg target_node edge d =
+  let tf ((n,c,p) as var) getl sidel getg sideg target_node edge d =
     begin match edge with
       | Assign (lv,rv) ->
         let r = tf_assign var edge target_node lv rv getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c) r
+        sidel (target_node, Obj.obj c, Obj.obj p) r
       | VDecl (v)      ->
         let r = tf_vdecl var edge target_node v getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c) r
+        sidel (target_node, Obj.obj c, Obj.obj p) r
       | Proc (r,f,ars) ->
         let r = tf_proc var edge target_node r f ars getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c) r
+        sidel (target_node, Obj.obj c, Obj.obj p) r
       | Entry f        ->
         let r = tf_entry var edge target_node f getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c) r
+        sidel (target_node, Obj.obj c, Obj.obj p) r
       | Ret (r,fd)     ->
         let r = tf_ret var edge target_node r fd getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c) r;
+        sidel (target_node, Obj.obj c, Obj.obj p) r;
         sideg (GVar.return (fd,Obj.obj c)) (G.create_return r)
-      | Test (p,b)     ->
-        let r = tf_test var edge target_node p b getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c) r
+      | Test (e,b)     ->
+        let r = tf_test var edge target_node e b getl sidel getg sideg d in
+        sidel (target_node, Obj.obj c, Obj.obj p) r
       | ASM (_, _, _)  ->
         let r = tf_asm var edge target_node getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c) r
+        sidel (target_node, Obj.obj c, Obj.obj p) r
       | Skip           ->
         let r = tf_skip var edge target_node getl sidel getg sideg d in
-        sidel (target_node, Obj.obj c) r
+        sidel (target_node, Obj.obj c, Obj.obj p) r
     end
 
   type Goblint_backtrace.mark += TfLocation of location
@@ -372,13 +380,13 @@ struct
         tf var getl sidel getg sideg target_node edge d
       )
 
-  let tf_fwd value (v,c) (edges, u) getl sidel getg sideg:unit =
+  let tf_fwd value (v,c,p) (edges, u) getl sidel getg sideg:unit =
     let pval = value in
     let _, locs = List.fold_right (fun (f,e) (t,xs) -> f, (f,t)::xs) edges (Node.location v,[]) in
-    let es = List.map (tf (v,Obj.repr c) getl sidel getg sideg u) edges in
+    let es = List.map (tf (v,Obj.repr c, Obj.repr p) getl sidel getg sideg u) edges in
     List.iter2 (fun e l -> e pval l) es locs
 
-  let tf value (v,c) (e,u) getl sidel getg sideg =
+  let tf value (v,c,p) (e,u) getl sidel getg sideg =
     let old_node = !current_node in
     let old_fd = Option.map Node.find_fundec old_node |? Cil.dummyFunDec in
     let new_fd = Node.find_fundec v in
@@ -393,12 +401,12 @@ struct
         if not (CilType.Fundec.equal old_fd new_fd) then
           Timing.Program.exit new_fd.svar.vname
       ) (fun () ->
-        tf_fwd value (v,c) (e,u) getl sidel getg sideg
+        tf_fwd value (v,c,p) (e,u) getl sidel getg sideg
       )
 
-  let system (v,c) =
+  let system (v,c,p) =
     let tf value getl sidel getg sideg =
-      let tf' eu = tf value (v,c) eu getl sidel getg sideg in
+      let tf' eu = tf value (v,c,p) eu getl sidel getg sideg in
       let xs = Cfg.next v in
       List.iter (fun eu -> tf' eu) xs
     in

--- a/src/framework/fwdControl.ml
+++ b/src/framework/fwdControl.ml
@@ -33,7 +33,7 @@ let spec_module: (module Spec') Lazy.t = lazy (
       |> lift (get_bool "ana.opt.hashcached") (module HashCachedContextLifter)
       |> lift arg_enabled (module HashconsLifter)
       |> lift arg_enabled (module ArgConstraints.PathSensitive3)
-      (* |> lift (not arg_enabled) (module PathSensitive2) *)
+      |> lift (not arg_enabled && not (get_bool "solvers.fwd.digests")) (module PathSensitive2)
       |> lift (get_bool "ana.dead-code.branches") (module DeadBranchLifter)
       |> lift true (module DeadCodeLifter)
       |> lift (get_bool "dbg.slice.on") (module LevelSliceLifter)
@@ -45,6 +45,7 @@ let spec_module: (module Spec') Lazy.t = lazy (
       |> lift true (module LongjmpLifter.Lifter)
       |> lift termination_enabled (module RecursionTermLifter.Lifter) (* Always activate the recursion termination analysis, when the loop termination analysis is activated*)
       |> lift (get_int "ana.widen.delay.global" > 0) (module WideningDelay.GLifter)
+      |> lift (not (get_bool "solvers.fwd.digests")) (module NoDigestLifter.Lifter) (* Exposes only unit to be used as digest *)
     )
   in
   GobConfig.building_spec := false;

--- a/src/framework/fwdControl.ml
+++ b/src/framework/fwdControl.ml
@@ -33,7 +33,7 @@ let spec_module: (module Spec) Lazy.t = lazy (
       |> lift (get_bool "ana.opt.hashcached") (module HashCachedContextLifter)
       |> lift arg_enabled (module HashconsLifter)
       |> lift arg_enabled (module ArgConstraints.PathSensitive3)
-      |> lift (not arg_enabled) (module PathSensitive2)
+      (* |> lift (not arg_enabled) (module PathSensitive2) *)
       |> lift (get_bool "ana.dead-code.branches") (module DeadBranchLifter)
       |> lift true (module DeadCodeLifter)
       |> lift (get_bool "dbg.slice.on") (module LevelSliceLifter)
@@ -106,7 +106,7 @@ struct
 
 
   (* Triple of the function, context, and the local value. *)
-  module RT = AnalysisResult.ResultType2 (Spec)
+  module RT = AnalysisResult.ResultType2Digest (Spec)
   (* Set of triples [RT] *)
   module LT = SetDomain.HeadlessSet (RT)
   (* Analysis result structure---a hashtable from program points to [LT] *)
@@ -138,7 +138,7 @@ struct
         FunSet.replace live_funs f ();
         let add_fun  = BatISet.add l.line in
         let add_file = StringMap.modify_def BatISet.empty f.svar.vname add_fun in
-        let is_dead = LT.for_all (fun (_,x,f) -> Spec.D.is_bot x) v in
+        let is_dead = LT.for_all (fun (_,_,x,f) -> Spec.D.is_bot x) v in
         if is_dead then (
           dead_lines := StringMap.modify_def StringMap.empty l.file add_file !dead_lines
         ) else (
@@ -236,9 +236,9 @@ struct
             (* If this source location has been added before, we look it up
               * and add another node to it information to it. *)
             let prev = Result.find res x.node in
-            Result.replace res x.node (LT.add (x.context,state,fundec) prev)
+            Result.replace res x.node (LT.add (x.context,x.current_digest,state,fundec) prev)
           else
-            Result.add res x.node (LT.singleton (x.context,state,fundec))
+            Result.add res x.node (LT.singleton (x.context,x.current_digest,state,fundec))
         (* If the function is not defined, and yet has been included to the
           * analysis result, we generate a warning. *)
         with Not_found ->

--- a/src/framework/fwdControl.ml
+++ b/src/framework/fwdControl.ml
@@ -225,7 +225,8 @@ struct
     let res = Result.create 113 in
 
     (* Adding the state at each system variable to the final result *)
-    let add_local_var (n,es) state =
+    (* TODO: Consider digest in result? *)
+    let add_local_var (n,es,_) state =
       (* Not using Node.location here to have updated locations in incremental analysis.
           See: https://github.com/goblint/analyzer/issues/290#issuecomment-881258091. *)
       let loc = UpdateCil.getLoc n in
@@ -445,8 +446,8 @@ struct
     in
     let prestartstate = Spec.startstate MyCFG.dummy_func.svar in (* like in do_extern_inits *)
     let othervars = List.map (enter_with (otherstate prestartstate)) otherfuns in
-    let startvars = List.concat (startvars @ exitvars @ othervars) in
-    if startvars = [] then
+    let startfuns = List.concat (startvars @ exitvars @ othervars) in
+    if startfuns = [] then
       failwith "BUG: Empty set of start variables; may happen if enter_func of any analysis returns an empty list.";
 
     AnalysisState.global_initialization := false;
@@ -466,9 +467,21 @@ struct
       ; sideg   = (fun g d -> sideg (EQSys.GVar.spec g) (EQSys.G.create_spec d))
       }
     in
-    let startvars' = List.map (fun (n,e) -> (MyCFG.FunctionEntry n, Spec.context (man e) n e)) startvars in
+    let startvars' =
+      let to_startvar (n,e) =
+        let context = Spec.context (man e) n e in
+        let digest = Spec.P.of_elt e in
+        (MyCFG.FunctionEntry n, context, digest)
+      in
+      List.map to_startvar startfuns in
 
-    let entrystates = List.map (fun (n,e) -> (MyCFG.FunctionEntry n, Spec.context (man e) n e), e) startvars in
+    let entrystates =
+      let to_entrystate (n,e) =
+        let context = Spec.context (man e) n e in
+        let digest = Spec.P.of_elt e in
+        ((MyCFG.FunctionEntry n, context, digest), e)
+      in
+      List.map to_entrystate startfuns in
     let entrystates_global = GHT.to_list gh in
 
     let uncalled_dead = ref 0 in
@@ -481,9 +494,9 @@ struct
       let gobview = get_bool "gobview" in
       let save_run_str = let o = get_string "save_run" in if o = "" then (if gobview then "run" else "") else o in
       let solve = if (get_string "solver" = "bu") then BuSolver.solve else
-        if (get_string "solver" = "wbu") then WBuSolver.solve else FwdSolver.solve in 
-      let check = if (get_string "solver" = "bu") then BuSolver.check else 
-        if (get_string "solver" = "wbu") then WBuSolver.check else FwdSolver.check in 
+        if (get_string "solver" = "wbu") then WBuSolver.solve else FwdSolver.solve in
+      let check = if (get_string "solver" = "bu") then BuSolver.check else
+        if (get_string "solver" = "wbu") then WBuSolver.check else FwdSolver.check in
       let _ = solve entrystates entrystates_global startvars' in
 
       AnalysisState.should_warn := true; (* reset for postsolver *)
@@ -496,7 +509,7 @@ struct
       (* Most warnings happen before during postsolver, but some happen later (e.g. in finalize), so enable this for the rest (if required by option). *)
       AnalysisState.should_warn := PostSolverArg.should_warn;
       let insrt k _ s = match k with
-        | (MyCFG.FunctionEntry fn,_) -> Set.Int.add fn.svar.vid s
+        | (MyCFG.FunctionEntry fn,_,_) -> Set.Int.add fn.svar.vid s
         | _ -> s
       in
       (* set of ids of called functions *)
@@ -541,10 +554,10 @@ struct
           let lh2, gh2 = LHT.of_seq rho, GHT.of_seq tau in
           CompareGlobSys.compare (get_string "solver", get_string "comparesolver") (lh,gh) (lh2, gh2)
         in
-        let solve = if (get_string "comparesolver" = "bu") then BuSolver.solve else 
+        let solve = if (get_string "comparesolver" = "bu") then BuSolver.solve else
             (if (get_string "comparesolver" = "fwd") then FwdSolver.solve else WBuSolver.solve) in
 
-        let check = if (get_string "comparesolver" = "bu") then BuSolver.check else 
+        let check = if (get_string "comparesolver" = "bu") then BuSolver.check else
             (if (get_string "comparesolver" = "fwd") then FwdSolver.check else WBuSolver.check) in
         compare_with solve check;
       );

--- a/src/framework/fwdControl.ml
+++ b/src/framework/fwdControl.ml
@@ -619,7 +619,8 @@ struct
       match g with
       | `Left g -> (* Spec global *)
         Query.ask_global gh (WarnGlobal (Obj.repr g))
-      | `Right _ -> (* contexts global *)
+      | `Middle _ (* return global *)
+      | `Right _ ->
         ()
     in
     Timing.wrap "warn_global" (GHT.iter warn_global) gh;

--- a/src/framework/fwdControl.ml
+++ b/src/framework/fwdControl.ml
@@ -101,7 +101,7 @@ struct
   module WBuSolver = Wbu.FwdWBuSolver (Sys)
   (* module Slvr2 = BuSlvr *)
 
-  module CompareGlobSys = CompareConstraints.CompareGlobSys (SpecSys)
+  module CompareGlobSys = FwdCompareConstraints.CompareGlobSys (SpecSys)
   (* TODO remove those witnesses once the mismatch is solved *)
   let _ : EQSys.G.t -> EQSys.G.t = fun x -> x
   let _ : 'a CompareGlobSys.GH.t -> 'a GHT.t = fun x -> x

--- a/src/framework/fwdControl.ml
+++ b/src/framework/fwdControl.ml
@@ -140,7 +140,7 @@ struct
         FunSet.replace live_funs f ();
         let add_fun  = BatISet.add l.line in
         let add_file = StringMap.modify_def BatISet.empty f.svar.vname add_fun in
-        let is_dead = LT.for_all (fun (_,_,x,f) -> Spec.D.is_bot x) v in
+        let is_dead = LT.for_all (fun (_,_,_,x) -> Spec.D.is_bot x) v in
         if is_dead then (
           dead_lines := StringMap.modify_def StringMap.empty l.file add_file !dead_lines
         ) else (
@@ -233,14 +233,13 @@ struct
           See: https://github.com/goblint/analyzer/issues/290#issuecomment-881258091. *)
       let loc = UpdateCil.getLoc x.node in
       if loc <> locUnknown then try
-          let fundec = Node.find_fundec x.node in
           if Result.mem res x.node then
             (* If this source location has been added before, we look it up
               * and add another node to it information to it. *)
             let prev = Result.find res x.node in
-            Result.replace res x.node (LT.add (x.context,x.current_digest,state,fundec) prev)
+            Result.replace res x.node (LT.add (x.context,x.original_digest, x.current_digest,state) prev)
           else
-            Result.add res x.node (LT.singleton (x.context,x.current_digest,state,fundec))
+            Result.add res x.node (LT.singleton (x.context,x.original_digest, x.current_digest,state))
         (* If the function is not defined, and yet has been included to the
           * analysis result, we generate a warning. *)
         with Not_found ->

--- a/src/framework/fwdControl.ml
+++ b/src/framework/fwdControl.ml
@@ -64,7 +64,7 @@ let current_varquery_global_state_json: (Goblint_constraint.VarQuery.t option ->
 module AnalyzeCFG (Cfg:CfgBidirSkip) (Spec:Spec) (Inc:Increment) =
 struct
 
- module SpecSys: FwdSpecSys with module Spec = Spec =
+  module SpecSys: FwdSpecSys with module Spec = Spec =
   struct
     (* Must be created in module, because cannot be wrapped in a module later. *)
     module Spec = Spec
@@ -226,23 +226,23 @@ struct
 
     (* Adding the state at each system variable to the final result *)
     (* TODO: Consider digest in result? *)
-    let add_local_var (n,es,_) state =
+    let add_local_var (x : LHT.key) state =
       (* Not using Node.location here to have updated locations in incremental analysis.
           See: https://github.com/goblint/analyzer/issues/290#issuecomment-881258091. *)
-      let loc = UpdateCil.getLoc n in
+      let loc = UpdateCil.getLoc x.node in
       if loc <> locUnknown then try
-          let fundec = Node.find_fundec n in
-          if Result.mem res n then
+          let fundec = Node.find_fundec x.node in
+          if Result.mem res x.node then
             (* If this source location has been added before, we look it up
               * and add another node to it information to it. *)
-            let prev = Result.find res n in
-            Result.replace res n (LT.add (es,state,fundec) prev)
+            let prev = Result.find res x.node in
+            Result.replace res x.node (LT.add (x.context,state,fundec) prev)
           else
-            Result.add res n (LT.singleton (es,state,fundec))
+            Result.add res x.node (LT.singleton (x.context,state,fundec))
         (* If the function is not defined, and yet has been included to the
           * analysis result, we generate a warning. *)
         with Not_found ->
-          Messages.debug ~category:Analyzer ~loc:(CilLocation loc) "Calculated state for undefined function: unexpected node %a" Node.pretty_trace n
+          Messages.debug ~category:Analyzer ~loc:(CilLocation loc) "Calculated state for undefined function: unexpected node %a" Node.pretty_trace x.node
     in
     LHT.iter add_local_var h;
     res
@@ -467,19 +467,19 @@ struct
       ; sideg   = (fun g d -> sideg (EQSys.GVar.spec g) (EQSys.G.create_spec d))
       }
     in
+    let to_startvar (n,e) =
+      let context = Spec.context (man e) n e in
+      let digest = Spec.P.of_elt e in
+      let startvar : LHT.key = {node = MyCFG.FunctionEntry n; context; original_digest = digest; current_digest = digest} in
+      startvar
+    in
     let startvars' =
-      let to_startvar (n,e) =
-        let context = Spec.context (man e) n e in
-        let digest = Spec.P.of_elt e in
-        (MyCFG.FunctionEntry n, context, digest)
-      in
       List.map to_startvar startfuns in
 
     let entrystates =
       let to_entrystate (n,e) =
-        let context = Spec.context (man e) n e in
-        let digest = Spec.P.of_elt e in
-        ((MyCFG.FunctionEntry n, context, digest), e)
+        let startvar = to_startvar (n,e) in
+        (startvar, e)
       in
       List.map to_entrystate startfuns in
     let entrystates_global = GHT.to_list gh in
@@ -508,8 +508,8 @@ struct
 
       (* Most warnings happen before during postsolver, but some happen later (e.g. in finalize), so enable this for the rest (if required by option). *)
       AnalysisState.should_warn := PostSolverArg.should_warn;
-      let insrt k _ s = match k with
-        | (MyCFG.FunctionEntry fn,_,_) -> Set.Int.add fn.svar.vid s
+      let insrt (k : LHT.key) _ s = match k.node with
+        | MyCFG.FunctionEntry fn -> Set.Int.add fn.svar.vid s
         | _ -> s
       in
       (* set of ids of called functions *)

--- a/src/framework/fwdControl.ml
+++ b/src/framework/fwdControl.ml
@@ -16,7 +16,7 @@ open SpecLifters
 module type S2S = Spec2Spec
 
 (* spec is lazy, so HConsed table in Hashcons lifters is preserved between analyses in server mode *)
-let spec_module: (module Spec) Lazy.t = lazy (
+let spec_module: (module Spec') Lazy.t = lazy (
   GobConfig.building_spec := true;
   let arg_enabled = get_bool "exp.arg.enabled" in
   let termination_enabled = List.mem "termination" (get_string_list "ana.activated") in (* check if loop termination analysis is enabled*)
@@ -49,11 +49,12 @@ let spec_module: (module Spec) Lazy.t = lazy (
   in
   GobConfig.building_spec := false;
   ControlSpecC.control_spec_c := (module S1.C);
+  let module S1 = Spec2Spec' (S1) in
   (module S1)
 )
 
 (** gets Spec for current options *)
-let get_spec (): (module Spec) =
+let get_spec (): (module Spec') =
   Lazy.force spec_module
 
 let current_node_state_json : (Node.t -> Yojson.Safe.t option) ref = ref (fun _ -> None)
@@ -61,7 +62,7 @@ let current_node_state_json : (Node.t -> Yojson.Safe.t option) ref = ref (fun _ 
 let current_varquery_global_state_json: (Goblint_constraint.VarQuery.t option -> Yojson.Safe.t) ref = ref (fun _ -> `Null)
 
 (** Given a [Cfg], a [Spec], and an [Inc], computes the solution to [MCP.Path] *)
-module AnalyzeCFG (Cfg:CfgBidirSkip) (Spec:Spec) (Inc:Increment) =
+module AnalyzeCFG (Cfg:CfgBidirSkip) (Spec:Spec') (Inc:Increment) =
 struct
 
   module SpecSys: FwdSpecSys with module Spec = Spec =

--- a/src/lifters/longjmpLifter.ml
+++ b/src/lifters/longjmpLifter.ml
@@ -11,7 +11,6 @@ struct
 
   module V =
   struct
-    (* TODO: Consider splitting unknowns by digest for constraint system in [FwdConstraints] *)
     include Printable.Either3Conf (struct let expand1 = false let expand2 = true let expand3 = true end) (S.V) (Printable.Prod (Node) (C)) (Printable.Prod (CilType.Fundec) (C))
     let name () = "longjmp"
     let s x = `Left x

--- a/src/lifters/longjmpLifter.ml
+++ b/src/lifters/longjmpLifter.ml
@@ -188,7 +188,9 @@ struct
           }
         in
         let longjmped = S.event jmp_man (Events.Longjmped {lval=lv}) jmp_man in
-        S.D.join normal_return longjmped
+        man.split normal_return [];
+        man.split longjmped [];
+        D.bot ()
       )
     | Longjmp {env; value} ->
       let current_fundec = Node.find_fundec man.node in

--- a/src/lifters/longjmpLifter.ml
+++ b/src/lifters/longjmpLifter.ml
@@ -188,9 +188,8 @@ struct
           }
         in
         let longjmped = S.event jmp_man (Events.Longjmped {lval=lv}) jmp_man in
-        man.split normal_return [];
         man.split longjmped [];
-        D.bot ()
+        normal_return
       )
     | Longjmp {env; value} ->
       let current_fundec = Node.find_fundec man.node in

--- a/src/lifters/longjmpLifter.ml
+++ b/src/lifters/longjmpLifter.ml
@@ -11,6 +11,7 @@ struct
 
   module V =
   struct
+    (* TODO: Consider splitting unknowns by digest for constraint system in [FwdConstraints] *)
     include Printable.Either3Conf (struct let expand1 = false let expand2 = true let expand3 = true end) (S.V) (Printable.Prod (Node) (C)) (Printable.Prod (CilType.Fundec) (C))
     let name () = "longjmp"
     let s x = `Left x

--- a/src/lifters/noDigestLifter.ml
+++ b/src/lifters/noDigestLifter.ml
@@ -1,0 +1,14 @@
+open Analyses
+
+module Lifter (S:Spec)
+  : Spec with module D = S.D
+          and module C = S.C
+          and module G = S.G
+=
+struct
+  include S
+  module P = struct
+    include Printable.Unit
+    let of_elt _ = ()
+  end
+end

--- a/src/lifters/noDigestLifter.ml
+++ b/src/lifters/noDigestLifter.ml
@@ -10,5 +10,6 @@ struct
   module P = struct
     include Printable.Unit
     let of_elt _ = ()
+    let printXml _ _ = ()
   end
 end

--- a/src/solver/td_simplified_ref_improved.ml
+++ b/src/solver/td_simplified_ref_improved.ml
@@ -38,7 +38,7 @@ module Base : GenericEqSolver =
     let source = S.Var.node
 
     type origin = {
-      init: S.Dom.t; 
+      init: S.Dom.t;
       from: (S.Dom.t * int * int * bool * VS.t) OM.t;
       last: S.Dom.t HM.t
     }
@@ -46,12 +46,12 @@ module Base : GenericEqSolver =
     let gas_default = ref (10,3)
     let abs_GC = ref true
 
-    let warrow (a,delay,gas,narrow) b = 
+    let warrow (a,delay,gas,narrow) b =
       let (delay0,_) = !gas_default in
       if S.Dom.equal a b then (a,delay,gas,narrow)
-      else if S.Dom.leq b a then 
+      else if S.Dom.leq b a then
         if narrow then (S.Dom.narrow a b,delay,gas,true)
-        else if gas<=0 then (a,delay,gas,false) 
+        else if gas<=0 then (a,delay,gas,false)
         else (S.Dom.narrow a b, delay,gas-1,true)
       else if narrow then (S.Dom.join a b,delay0,gas,false)
       else if delay <= 0 then (S.Dom.widen a (S.Dom.join a b),0,gas,false)
@@ -83,13 +83,13 @@ module Base : GenericEqSolver =
           begin
             new_var_event x;
             if tracing then trace "init" "init %a" S.Var.pretty_trace x;
-            let data_x = ref { 
+            let data_x = ref {
                 infl = VS.empty;
                 value = S.Dom.bot ();
                 wpoint = false;
                 stable = false;
                 called = false;
-                contrib = VS.empty 
+                contrib = VS.empty
               } in
             HM.replace data x data_x;
             let orig_x = {
@@ -108,7 +108,7 @@ module Base : GenericEqSolver =
               match S.system x with
               | None -> S.Dom.bot ()
               | Some f -> f get set
-            in 
+            in
       *)
 
 (*
@@ -125,7 +125,7 @@ alternatively, distinguish contribs by session number?
             if tracing then trace "destab" "stable remove %a" S.Var.pretty_trace y;
             let y_ref = HM.find data y in
             y_ref := { !y_ref with stable = false };
-            if !y_ref.called then () 
+            if !y_ref.called then ()
             else destabilize y
           ) w
       in
@@ -157,8 +157,8 @@ alternatively, distinguish contribs by session number?
         let y_ref = init y in
         if tracing then trace "side" "side to %a (wpx: %b) from %a ## value: %a" S.Var.pretty_trace y (!y_ref.wpoint) S.Var.pretty_trace x S.Dom.pretty d;
         let {init;last;from} = HM.find origin y in
-        let (old_xy,delay,gas,narrow,set) = try OM.find from sx 
-          with _ -> 
+        let (old_xy,delay,gas,narrow,set) = try OM.find from sx
+          with _ ->
             let (delay,gas) = !gas_default in
             let tuple = (S.Dom.bot (),delay,gas,false,VS.empty) in
             let () = OM.add from sx tuple in
@@ -166,7 +166,7 @@ alternatively, distinguish contribs by session number?
         let () = HM.add last x d in
         let set = VS.add x set in
         let d = VS.fold (fun x d -> S.Dom.join d (HM.find last x)) set d in
-        let (new_xy,delay,gas,narrow) = 
+        let (new_xy,delay,gas,narrow) =
           if M.tracing then M.trace "wpoint" "side widen %a" S.Var.pretty_trace y;
           warrow (old_xy,delay,gas,narrow) d in
         OM.replace from sx (new_xy,delay,gas,narrow,set);
@@ -182,10 +182,10 @@ alternatively, distinguish contribs by session number?
           )
         )
 
-      and wrap_eq x = 
+      and wrap_eq x =
         match S.system x with
         | None -> S.Dom.bot ()
-        | Some f -> 
+        | Some f ->
           let sigma = HM.create 10 in
           let new_set = ref VS.empty in
           let add_sigma y d =
@@ -196,8 +196,8 @@ alternatively, distinguish contribs by session number?
           let d = f (query x) add_sigma in
           let x_ref = init x in
           let old_set = !x_ref.contrib in
-          let _ = x_ref := {!x_ref with contrib = !new_set} in    
-          let _ = if !abs_GC then 
+          let _ = x_ref := {!x_ref with contrib = !new_set} in
+          let _ = if !abs_GC then
               let rem_set = VS.filter (fun g -> not (VS.mem g !new_set)) old_set in
               VS.iter (fun g -> side x g (S.Dom.bot ())) rem_set in
           d
@@ -211,7 +211,7 @@ alternatively, distinguish contribs by session number?
         if not (!x_ref.stable) then (
           x_ref := { !x_ref with stable = true };
           let wp = !x_ref.wpoint in (* if x becomes a wpoint during eq, checking this will delay widening until next iterate *)
-          let eqd = 
+          let eqd =
             wrap_eq x in
                 (*
                 eq x (query x) (side x) in (* d from equation/rhs *)
@@ -223,7 +223,7 @@ alternatively, distinguish contribs by session number?
               if M.tracing then M.trace "wpoint" "widen %a" S.Var.pretty_trace x;
               box old eqd)
           in
-          if not (Timing.wrap "S.Dom.equal" (fun () -> S.Dom.equal old wpd) ()) then ( 
+          if not (Timing.wrap "S.Dom.equal" (fun () -> S.Dom.equal old wpd) ()) then (
             (* old != wpd *)
             if tracing && not (S.Dom.is_bot old) && !x_ref.wpoint then trace "solchange" "%a (wpx: %b): %a" S.Var.pretty_trace x (!x_ref.wpoint) S.Dom.pretty_diff (wpd, old);
             update_var_event x old wpd;
@@ -233,7 +233,7 @@ alternatively, distinguish contribs by session number?
             (iterate[@tailcall]) x
           ) else (
             (* old == wpd *)
-            if not (!x_ref.stable) then ( 
+            if not (!x_ref.stable) then (
               (* value unchanged, but not stable, i.e. destabilized itself during rhs *)
               if tracing then trace "iter" "iterate still unstable %a" S.Var.pretty_trace x;
               (iterate[@tailcall]) x
@@ -271,12 +271,12 @@ alternatively, distinguish contribs by session number?
             Logs.newline ();
             flush_all ();
           );
-          List.iter (fun x -> 
+          List.iter (fun x ->
               let x_ref = HM.find data x in
               x_ref := { !x_ref with called = true };
               if tracing then trace "multivar" "solving for %a" S.Var.pretty_trace x;
-              iterate x; 
-              x_ref := { !x_ref with called = false } 
+              iterate x;
+              x_ref := { !x_ref with called = false }
             ) unstable_vs;
           solver ();
         )

--- a/tests/regression/90-digests/01-function-call.c
+++ b/tests/regression/90-digests/01-function-call.c
@@ -1,0 +1,31 @@
+//PARAM: --set "solver" "bu"
+// Test that function calls are handled properly when the digest changes during the function call
+
+#include <pthread.h>
+#include <goblint.h>
+
+pthread_mutex_t m1;
+
+void my_lock(pthread_mutex_t* m) {
+	pthread_mutex_lock(m);
+}
+
+
+int main(int argc, char const *argv[])
+{
+	int top;
+	pthread_mutex_t* ptr;
+	ptr = &m1;
+
+
+	my_lock(ptr);
+
+	if(top) {
+		// possible double-locking error
+		pthread_mutex_lock(ptr); //WARN
+	}
+
+	pthread_mutex_unlock(ptr); //NOWARN
+
+	return 0;
+}

--- a/tests/regression/90-digests/02-function-call-split.c
+++ b/tests/regression/90-digests/02-function-call-split.c
@@ -1,0 +1,30 @@
+//PARAM: --set "solver" "bu"
+// Test that function calls are handled properly when the digest changes during the function call
+
+#include <pthread.h>
+#include <goblint.h>
+
+pthread_mutex_t m1;
+pthread_mutex_t m2;
+
+void my_lock(pthread_mutex_t* m) {
+	pthread_mutex_lock(m);
+}
+
+
+int main(int argc, char const *argv[])
+{
+	int top;
+	pthread_mutex_t* ptr;
+	ptr = &m1;
+
+	if(top){
+		ptr = &m2;
+	}
+
+	pthread_mutex_lock(ptr);
+
+	pthread_mutex_unlock(ptr); //NOWARN
+
+	return 0;
+}

--- a/tests/regression/90-digests/02-mutex-lock-split.c
+++ b/tests/regression/90-digests/02-mutex-lock-split.c
@@ -7,10 +7,6 @@
 pthread_mutex_t m1;
 pthread_mutex_t m2;
 
-void my_lock(pthread_mutex_t* m) {
-	pthread_mutex_lock(m);
-}
-
 
 int main(int argc, char const *argv[])
 {

--- a/tests/regression/90-digests/03-function-call-split.c
+++ b/tests/regression/90-digests/03-function-call-split.c
@@ -1,0 +1,32 @@
+//PARAM: --set "solver" "bu"
+// Test that function calls are handled properly when the digest changes during the function call
+
+#include <pthread.h>
+#include <goblint.h>
+
+pthread_mutex_t m1;
+pthread_mutex_t m2;
+
+pthread_mutex_t* ptr;
+
+void my_lock() {
+	pthread_mutex_lock(ptr);
+}
+
+
+int main(int argc, char const *argv[])
+{
+	int top;
+
+	ptr = &m1;
+
+	if(top){
+		ptr = &m2;
+	}
+
+	my_lock();
+
+	pthread_mutex_unlock(ptr); //NOWARN
+
+	return 0;
+}

--- a/tests/regression/90-digests/04-garbage-digest.c
+++ b/tests/regression/90-digests/04-garbage-digest.c
@@ -18,7 +18,7 @@ int main(){
 		z = 7;
 	}
 
-	__goblint_check(z == 0);
+	__goblint_check(z == 0); //TODO
 	pthread_mutex_unlock(&m1);
 	return 0;
 }

--- a/tests/regression/90-digests/04-garbage-digest.c
+++ b/tests/regression/90-digests/04-garbage-digest.c
@@ -1,0 +1,23 @@
+//PARAM: --set solver bu --enable ana.int.interval
+#include <pthread.h>
+#include <stdio.h>
+#include <goblint.h>
+pthread_mutex_t m1 = PTHREAD_MUTEX_INITIALIZER;
+
+int main(){
+	int z = 0;
+
+	pthread_mutex_lock(&m1);
+	int i;
+
+	for(i = 0; i < 10; i++){
+		printf("Iteration %d\n", i);
+	}
+	if (i == 11){
+		// This is not reachable, but introduces a garbage value for z that should be garbage collected, so that the check below is not unknown.
+		z = 7;
+	}
+
+	__goblint_check(z == 0);
+	pthread_mutex_unlock(&m1);
+}

--- a/tests/regression/90-digests/04-garbage-digest.c
+++ b/tests/regression/90-digests/04-garbage-digest.c
@@ -20,4 +20,5 @@ int main(){
 
 	__goblint_check(z == 0);
 	pthread_mutex_unlock(&m1);
+	return 0;
 }

--- a/tests/regression/90-digests/05-garbage-call.c
+++ b/tests/regression/90-digests/05-garbage-call.c
@@ -26,4 +26,5 @@ int main(){
 	int h = foo(ptr, i);
 	int x = identity(0);
 	__goblint_check(x < 11); //TODO
+	return 0;
 }

--- a/tests/regression/90-digests/05-garbage-call.c
+++ b/tests/regression/90-digests/05-garbage-call.c
@@ -2,15 +2,15 @@
 #include <stdio.h>
 #include <goblint.h>
 
+int identity(int z){
+	return z;
+}
+
 int foo(int* ptr, int z){
 	__goblint_check(z < 11); // TODO
 	int r = identity(z);
 	__goblint_check(z < 11); // TODO
 	return r;
-}
-
-int identity(int z){
-	return z;
 }
 
 int main(){

--- a/tests/regression/90-digests/05-garbage-call.c
+++ b/tests/regression/90-digests/05-garbage-call.c
@@ -1,0 +1,29 @@
+//PARAM: --set solver bu --enable ana.int.interval --disable ana.base.context.int
+#include <stdio.h>
+#include <goblint.h>
+
+int foo(int* ptr, int z){
+	__goblint_check(z < 11); // TODO
+	int r = identity(z);
+	__goblint_check(z < 11); // TODO
+	return r;
+}
+
+int identity(int z){
+	return z;
+}
+
+int main(){
+	int a = 0;
+	int i;
+	for(i = 0; i < 10; i++){
+		printf("Iteration %d\n", i);
+	}
+	int *ptr = &i;
+	if (i == 34){
+		ptr = & a;
+	}
+	int h = foo(ptr, i);
+	int x = identity(0);
+	__goblint_check(x < 11); //TODO
+}

--- a/tests/regression/90-digests/06-longjmp-return.c
+++ b/tests/regression/90-digests/06-longjmp-return.c
@@ -1,0 +1,25 @@
+// PARAM: --set solver "bu" --enable ana.int.interval --enable ana.int.enums --disable exp.volatiles_are_top --set solvers.td3.side_widen never
+#include <goblint.h>
+#include <setjmp.h>
+
+jmp_buf my_jump_buffer;
+
+void foo(int count)
+{
+    __goblint_check(count >= 0 && count <= 5);
+    longjmp(my_jump_buffer, 1);
+    __goblint_check(0); // NOWARN
+}
+
+int main(void)
+{
+    volatile int count = 0;
+    setjmp(my_jump_buffer);
+    __goblint_check(count == 0); // UNKNOWN!
+    if (count < 5) {
+        count++;
+        foo(count);
+        __goblint_check(0); // NOWARN
+    }
+    __goblint_check(count == 5);
+}

--- a/xslt/node.xsl
+++ b/xslt/node.xsl
@@ -124,6 +124,12 @@
                 </div>
               </div>
               <div class="toggle off">
+                <span>Calling Digest</span>
+                <div>
+                  <xsl:apply-templates select="original_digest"/>
+                </div>
+              </div>
+              <div class="toggle off">
                 <span>Current Digest</span>
                 <div>
                   <xsl:apply-templates select="current_digest"/>

--- a/xslt/node.xsl
+++ b/xslt/node.xsl
@@ -123,18 +123,22 @@
                   <xsl:apply-templates select="context"/>
                 </div>
               </div>
-              <div class="toggle off">
-                <span>Calling Digest</span>
-                <div>
-                  <xsl:apply-templates select="original_digest"/>
+              <xsl:if test="normalize-space(original_digest) != ''">
+                <div class="toggle off">
+                  <span>Calling Digest</span>
+                  <div>
+                    <xsl:apply-templates select="original_digest"/>
+                  </div>
                 </div>
-              </div>
-              <div class="toggle off">
-                <span>Current Digest</span>
-                <div>
-                  <xsl:apply-templates select="current_digest"/>
+              </xsl:if>
+              <xsl:if test="normalize-space(current_digest) != ''">
+                <div class="toggle off">
+                  <span>Current Digest</span>
+                  <div>
+                    <xsl:apply-templates select="current_digest"/>
+                  </div>
                 </div>
-              </div>
+              </xsl:if>
               <div class="toggle off">
                 <span>Abstract State</span>
                 <div>

--- a/xslt/node.xsl
+++ b/xslt/node.xsl
@@ -111,13 +111,34 @@
         @<xsl:value-of select="@file" />:<xsl:value-of select="@line" />:<xsl:value-of select="@column" />-<xsl:value-of select="@endLine" />:<xsl:value-of select="@endColumn" /> (synthetic: <xsl:value-of select="@synthetic" />)
       </div>
     </a>
-    <div class="toggle off">
-      <span>context:</span>
+    <div>
+      <span>Analysis Results:</span>
       <div>
-        <xsl:apply-templates select="context" />
+        <xsl:for-each select="tuple">
+          <div class="tuple">
+            <strong>Result entry <xsl:value-of select="position()"/>:</strong>
+              <div class="toggle off">
+                <span>Context</span>
+                <div>
+                  <xsl:apply-templates select="context"/>
+                </div>
+              </div>
+              <div class="toggle off">
+                <span>Current Digest</span>
+                <div>
+                  <xsl:apply-templates select="current_digest"/>
+                </div>
+              </div>
+              <div class="toggle off">
+                <span>Path</span>
+                <div>
+                  <xsl:apply-templates select="path"/>
+                </div>
+              </div>
+          </div>
+        </xsl:for-each>
       </div>
     </div>
-    <xsl:apply-templates select="path" />
   </xsl:template>
 
 

--- a/xslt/node.xsl
+++ b/xslt/node.xsl
@@ -130,9 +130,9 @@
                 </div>
               </div>
               <div class="toggle off">
-                <span>Path</span>
+                <span>Abstract State</span>
                 <div>
-                  <xsl:apply-templates select="path"/>
+                  <xsl:apply-templates select="abstract_state"/>
                 </div>
               </div>
           </div>


### PR DESCRIPTION
This PR splits the local unknowns by digests for the forward constraint systems. It uses the module `P` of the analysis specifications that was previously used for pathsensitivity.  

Local unknowns now are four-tuples, consisting of the node, the calling context, the calling digest (called original_digest in the implementation) and the current digest.
 
After the application of a transfer function, when the new abstract state is computed, the new current digest is derived from the abstract state via the function `P.of_elt`. In case a transfer function should introduce some splitting, it can use `man.split`, which is the same mechanism as for pathsensitivity. 

The pathsensitivity (without splitting of unknowns) is used when `solvers.fwd.digests` is `false`, and the digests are used otherwise. 

Additionally, there are changes to the XSLT-output, now grouping result entries consisting of context, calling digest, current digest and abstract state together. 