### PR TITLE
Avoid collecting TD3 `dep` when non-incremental

### DIFF
--- a/src/solver/td3.ml
+++ b/src/solver/td3.ml
@@ -279,6 +279,9 @@ module Base =
 
       let var_messages = data.var_messages in
       let rho_write = data.rho_write in
+
+      (* dep is only needed for some incremental pruning. *)
+      let collect_dep = GobConfig.get_bool "incremental.load" || GobConfig.get_bool "incremental.save" in
       let dep = data.dep in
       let weak_dep = data.weak_dep in
 
@@ -303,7 +306,8 @@ module Base =
       let add_infl y x =
         if tracing then trace "sol2" "add_infl %a %a" S.Var.pretty_trace y S.Var.pretty_trace x;
         HM.replace infl y (VS.add x (try HM.find infl y with Not_found -> VS.empty));
-        HM.replace dep x (VS.add y (HM.find_default dep x VS.empty));
+        if collect_dep then
+          HM.replace dep x (VS.add y (HM.find_default dep x VS.empty));
       in
       let add_sides y x = HM.replace sides y (VS.add x (try HM.find sides y with Not_found -> VS.empty)) in
 
@@ -369,7 +373,8 @@ module Base =
               d
             | _ ->
               (* The RHS is re-evaluated, all deps are re-trigerred *)
-              HM.replace dep x VS.empty;
+              if collect_dep then
+                HM.replace dep x VS.empty;
               eq_wrapper x (fun side -> eq x (eval l x) side (demand l x))
           in
           HM.remove called x;


### PR DESCRIPTION
Closes #1566.

I'm wondering if this makes any difference for large programs like rsync.
The biggest hashtables in TD3 (and probably Goblint overall) are `rho`, `infl` and `dep` because they contain most encountered unknowns. So keeping one empty could make quite a difference.

Obviously we should have this anyway, but I'm interested in doing some benchmarking on sv-benchmarks and rsync to find out if this is one of the stupid significant bottlenecks.

### TODO
- [x] sv-benchmarks
- [x] rsync