### PR TITLE
Add dune 3.22.0 conflict due to regression

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -77,6 +77,7 @@ Goblint includes analyses for assertions, overflows, deadlocks, etc and can be e
     memtrace
   )
   (conflicts
+    (dune (>= 3.22.0)) ; TODO: remove if fixed (https://github.com/ocaml/dune/issues/14085)
     (result (< 1.5)) ; transitive dependency, overrides standard Result module and doesn't have map_error, bind
     (apron (< v0.9.15)) ; lower bounds for depopts seem to not properly constrain in builtin-0install lower-bounds job, so upper bounds for conflicts instead
     (camlidl (< 1.13)) ; for stability (https://github.com/goblint/analyzer/issues/1520)

--- a/goblint.opam
+++ b/goblint.opam
@@ -74,6 +74,7 @@ depends: [
 ]
 depopts: ["apron" "z3" "domainslib" "memtrace"]
 conflicts: [
+  "dune" {>= "3.22.0"}
   "result" {< "1.5"}
   "apron" {< "v0.9.15"}
   "camlidl" {< "1.13"}

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -136,6 +136,7 @@ build: [
 dev-repo: "git+https://github.com/goblint/analyzer.git"
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 conflicts: [
+  "dune" {>= "3.22.0"}
   "result" {< "1.5"}
   "apron" {< "v0.9.15"}
   "camlidl" {< "1.13"}


### PR DESCRIPTION
Currently all the unlocked CI jobs fail.
See https://github.com/ocaml/dune/issues/14085.

This makes them work again: https://github.com/goblint/analyzer/actions/runs/24877848737.