### PR TITLE
Add OCaml 5.5 compatibility

### DIFF
--- a/src/framework/control.ml
+++ b/src/framework/control.ml
@@ -860,7 +860,7 @@ let rec analyze_loop (module CFG : CfgBidirSkip) file fs change_info =
         Whoever raised the exception should've modified some global state
         to do a more precise analysis next time. *)
     (* TODO: do some more incremental refinement and reuse parts of solution *)
-    analyze_loop (module CFG) file fs change_info
+    analyze_loop (module CFG: CfgBidirSkip) file fs change_info (* explicit module type needed for OCaml 5.5: https://github.com/goblint/analyzer/issues/2006 *)
 
 (** The main function to perform the selected analyses. *)
 let analyze change_info (file: file) fs =


### PR DESCRIPTION
Closes #2006.

This currently requires pinning https://github.com/ocaml-batteries-team/batteries-included/pull/1146 to be installable on 5.5.