### PR TITLE
Use patricia-tree library more

### DIFF
--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -169,7 +169,7 @@ struct
 
   module W =
   struct
-    include MapDomain.MapBot_LiftTop (Basetype.Variables) (MinLocksets)
+    include MapDomain.PatriciaMapBot_LiftTop (Basetype.Variables) (MinLocksets)
     let name () = "W"
   end
 
@@ -178,7 +178,7 @@ struct
     (* Note different Map order! *)
     (* MapTop because default value in P must be top of MinLocksets,
        as opposed to bottom in W. *)
-    include MapDomain.MapTop_LiftBot (Basetype.Variables) (MinLocksets)
+    include MapDomain.PatriciaMapTop_LiftBot (Basetype.Variables) (MinLocksets)
     let name () = "P"
 
     (* TODO: change MinLocksets.exists/top instead? *)

--- a/src/analyses/loopTermination.ml
+++ b/src/analyses/loopTermination.ml
@@ -36,7 +36,7 @@ struct
   end
 
   (** We want to record termination information of loops and use the loop statements for that. *)
-  module G = MapDomain.MapBot (CilType.Stmt) (BoolDomain.MustBool)
+  module G = MapDomain.PatriciaMapBot (CilType.Stmt) (BoolDomain.MustBool)
 
   let startstate _ = ()
   let exitstate = startstate

--- a/src/analyses/startStateAnalysis.ml
+++ b/src/analyses/startStateAnalysis.ml
@@ -12,7 +12,7 @@ module Spec : Analyses.MCPSpec =
 struct
   let name () = "startState"
   module AD = ValueDomain.AD
-  module D = MapDomain.MapBot (Basetype.Variables) (AD)
+  module D = MapDomain.PatriciaMapBot (Basetype.Variables) (AD)
   module C = D
 
   include Analyses.IdentitySpec

--- a/src/cdomains/baseDomain.ml
+++ b/src/cdomains/baseDomain.ml
@@ -20,7 +20,7 @@ end
 module PartDeps =
 struct
   module VarSet = SetDomain.Make(Basetype.Variables)
-  include MapDomain.MapBot_LiftTop(Basetype.Variables)(VarSet)
+  include MapDomain.PatriciaMapBot_LiftTop(Basetype.Variables)(VarSet)
   let name () = "array partitioning deps"
 end
 

--- a/src/common/util/cilType.ml
+++ b/src/common/util/cilType.ml
@@ -390,6 +390,7 @@ struct
   let equal x y = Varinfo.equal x.svar y.svar
   let compare x y = Varinfo.compare x.svar y.svar
   let hash x = Varinfo.hash x.svar
+  let tag x = Varinfo.tag x.svar
 
   (* Output *)
   let pretty () x = Varinfo.pretty () x.svar

--- a/src/common/util/cilType.ml
+++ b/src/common/util/cilType.ml
@@ -512,6 +512,7 @@ struct
   let equal x y = x.sid = y.sid
   let compare x y = Stdlib.compare x.sid y.sid
   let hash x = x.sid
+  let tag x = x.sid
 
   (* Output *)
   let pretty () x = dn_stmt () x

--- a/src/domain/disjointDomain.ml
+++ b/src/domain/disjointDomain.ml
@@ -586,7 +586,6 @@ struct
       | b' ->
         Some b'
     ) m1 m2
-  let merge f m1 m2 = failwith "ProjectiveMap.merge" (* TODO: ? *)
 
   let widen m1 m2 =
     Lattice.assert_valid_widen ~leq ~pretty_diff m1 m2;
@@ -775,7 +774,6 @@ struct
   let idempotent_inter_filter _ _ _ = failwith "PairwiseMap.idempotent_inter_filter" (* TODO: ? *)
   let nonidempotent_inter_filter _ _ _ = failwith "PairwiseMap.nonidempotent_inter_filter" (* TODO: ? *)
   let difference _ _ _ = failwith "PairwiseMap.difference" (* TODO: ? *)
-  let merge f m1 m2 = failwith "PairwiseMap.merge" (* TODO: ? *)
 
   let leq s1 s2 =
     S.for_all (fun b1 ->

--- a/src/domain/disjointDomain.ml
+++ b/src/domain/disjointDomain.ml
@@ -98,19 +98,14 @@ struct
       end
     | None -> m
   let diff m1 m2 =
-    M.merge (fun _ b1 b2 ->
-        match b1, b2 with
-        | Some b1, Some b2 ->
-          begin match B.diff b1 b2 with
-            | b' when B.is_bot b' ->
-              None (* remove bot bucket to preserve invariant *)
-            | exception Lattice.BotValue ->
-              None (* remove bot bucket to preserve invariant *)
-            | b' ->
-              Some b'
-          end
-        | Some _, None -> b1
-        | None, _ -> None
+    M.difference (fun b1 b2 ->
+        match B.diff b1 b2 with
+        | b' when B.is_bot b' ->
+          None (* remove bot bucket to preserve invariant *)
+        | exception Lattice.BotValue ->
+          None (* remove bot bucket to preserve invariant *)
+        | b' ->
+          Some b'
       ) m1 m2
 
   let of_list es = List.fold_left (fun acc e ->
@@ -579,10 +574,19 @@ struct
       B.nonidempotent_union f b1 b2
     ) m1 m2
   let idempotent_inter f m1 m2 = M.idempotent_inter (fun b1 b2 ->
-      B.idempotent_inter f b1 b2
+      B.idempotent_inter f b1 b2 (* TODO: should remove bot bucket to preserve invariant? *)
     ) m1 m2
   let nonidempotent_inter f m1 m2 = M.nonidempotent_inter (fun b1 b2 ->
-      B.nonidempotent_inter f b1 b2
+      B.nonidempotent_inter f b1 b2 (* TODO: should remove bot bucket to preserve invariant? *)
+    ) m1 m2
+  let difference f m1 m2 = M.difference (fun b1 b2 ->
+      match B.difference f b1 b2 with
+      | b' when B.is_bot b' ->
+        None (* remove bot bucket to preserve invariant *)
+      | exception Lattice.BotValue ->
+        None (* remove bot bucket to preserve invariant *)
+      | b' ->
+        Some b'
     ) m1 m2
   let merge f m1 m2 = failwith "ProjectiveMap.merge" (* TODO: ? *)
 
@@ -778,6 +782,7 @@ struct
     in
     snd (S.fold f s2 (s1, S.empty ()))
   let idempotent_inter _ _ _ = failwith "PairwiseMap.idempotent_inter" (* TODO: ? *)
+  let difference _ _ _ = failwith "PairwiseMap.difference" (* TODO: ? *)
   let merge f m1 m2 = failwith "PairwiseMap.merge" (* TODO: ? *)
 
   let leq s1 s2 =

--- a/src/domain/disjointDomain.ml
+++ b/src/domain/disjointDomain.ml
@@ -122,32 +122,24 @@ struct
     M.widen m1 m2
 
   let meet m1 m2 =
-    M.merge (fun _ b1 b2 ->
-        match b1, b2 with
-        | Some b1, Some b2 ->
-          begin match B.meet b1 b2 with
-            | b' when B.is_bot b' ->
-              None (* remove bot bucket to preserve invariant *)
-            | exception Lattice.BotValue ->
-              None (* remove bot bucket to preserve invariant *)
-            | b' ->
-              Some b'
-          end
-        | _, _ -> None
+    M.nonidempotent_inter_filter (fun b1 b2 -> (* TODO: idempotent_inter_filter if not using int domain refinement *)
+        match B.meet b1 b2 with
+        | b' when B.is_bot b' ->
+          None (* remove bot bucket to preserve invariant *)
+        | exception Lattice.BotValue ->
+          None (* remove bot bucket to preserve invariant *)
+        | b' ->
+          Some b'
       ) m1 m2
   let narrow m1 m2 =
-    M.merge (fun _ b1 b2 ->
-        match b1, b2 with
-        | Some b1, Some b2 ->
-          begin match B.narrow b1 b2 with
-            | b' when B.is_bot b' ->
-              None (* remove bot bucket to preserve invariant *)
-            | exception Lattice.BotValue ->
-              None (* remove bot bucket to preserve invariant *)
-            | b' ->
-              Some b'
-          end
-        | _, _ -> None
+    M.nonidempotent_inter_filter (fun b1 b2 -> (* TODO: idempotent_inter_filter if not using int domain refinement *)
+        match B.narrow b1 b2 with
+        | b' when B.is_bot b' ->
+          None (* remove bot bucket to preserve invariant *)
+        | exception Lattice.BotValue ->
+          None (* remove bot bucket to preserve invariant *)
+        | b' ->
+          Some b'
       ) m1 m2
 
   let union = join
@@ -579,6 +571,12 @@ struct
   let nonidempotent_inter f m1 m2 = M.nonidempotent_inter (fun b1 b2 ->
       B.nonidempotent_inter f b1 b2 (* TODO: should remove bot bucket to preserve invariant? *)
     ) m1 m2
+  let idempotent_inter_filter f m1 m2 = M.idempotent_inter (fun b1 b2 ->
+      B.idempotent_inter_filter f b1 b2 (* TODO: should remove bot bucket to preserve invariant? *)
+    ) m1 m2
+  let nonidempotent_inter_filter f m1 m2 = M.nonidempotent_inter (fun b1 b2 ->
+      B.nonidempotent_inter_filter f b1 b2 (* TODO: should remove bot bucket to preserve invariant? *)
+    ) m1 m2
   let difference f m1 m2 = M.difference (fun b1 b2 ->
       match B.difference f b1 b2 with
       | b' when B.is_bot b' ->
@@ -595,32 +593,24 @@ struct
     M.widen m1 m2
 
   let meet m1 m2 =
-    M.merge (fun _ b1 b2 ->
-        match b1, b2 with
-        | Some b1, Some b2 ->
-          begin match B.meet b1 b2 with
-            | b' when B.is_bot b' ->
-              None (* remove bot bucket to preserve invariant *)
-            | exception Lattice.BotValue ->
-              None (* remove bot bucket to preserve invariant *)
-            | b' ->
-              Some b'
-          end
-        | _, _ -> None
+    M.nonidempotent_inter_filter (fun b1 b2 -> (* TODO: idempotent_inter_filter if not using int domain refinement *)
+        match B.meet b1 b2 with
+        | b' when B.is_bot b' ->
+          None (* remove bot bucket to preserve invariant *)
+        | exception Lattice.BotValue ->
+          None (* remove bot bucket to preserve invariant *)
+        | b' ->
+          Some b'
       ) m1 m2
   let narrow m1 m2 =
-    M.merge (fun _ b1 b2 ->
-        match b1, b2 with
-        | Some b1, Some b2 ->
-          begin match B.narrow b1 b2 with
-            | b' when B.is_bot b' ->
-              None (* remove bot bucket to preserve invariant *)
-            | exception Lattice.BotValue ->
-              None (* remove bot bucket to preserve invariant *)
-            | b' ->
-              Some b'
-          end
-        | _, _ -> None
+    M.nonidempotent_inter_filter (fun b1 b2 -> (* TODO: idempotent_inter_filter if not using int domain refinement *)
+        match B.narrow b1 b2 with
+        | b' when B.is_bot b' ->
+          None (* remove bot bucket to preserve invariant *)
+        | exception Lattice.BotValue ->
+          None (* remove bot bucket to preserve invariant *)
+        | b' ->
+          Some b'
       ) m1 m2
 
   include MapDomain.Print (E) (V) (
@@ -782,6 +772,8 @@ struct
     in
     snd (S.fold f s2 (s1, S.empty ()))
   let idempotent_inter _ _ _ = failwith "PairwiseMap.idempotent_inter" (* TODO: ? *)
+  let idempotent_inter_filter _ _ _ = failwith "PairwiseMap.idempotent_inter_filter" (* TODO: ? *)
+  let nonidempotent_inter_filter _ _ _ = failwith "PairwiseMap.nonidempotent_inter_filter" (* TODO: ? *)
   let difference _ _ _ = failwith "PairwiseMap.difference" (* TODO: ? *)
   let merge f m1 m2 = failwith "PairwiseMap.merge" (* TODO: ? *)
 

--- a/src/domain/disjointDomain.ml
+++ b/src/domain/disjointDomain.ml
@@ -565,17 +565,41 @@ struct
   let nonidempotent_union f m1 m2 = M.nonidempotent_union (fun b1 b2 ->
       B.nonidempotent_union f b1 b2
     ) m1 m2
-  let idempotent_inter f m1 m2 = M.idempotent_inter (fun b1 b2 ->
-      B.idempotent_inter f b1 b2 (* TODO: should remove bot bucket to preserve invariant? *)
+  let idempotent_inter f m1 m2 = M.idempotent_inter_filter (fun b1 b2 ->
+      match B.idempotent_inter f b1 b2 with
+      | b' when B.is_bot b' ->
+        None (* remove bot bucket to preserve invariant *)
+      | exception Lattice.BotValue ->
+        None (* remove bot bucket to preserve invariant *)
+      | b' ->
+        Some b'
     ) m1 m2
-  let nonidempotent_inter f m1 m2 = M.nonidempotent_inter (fun b1 b2 ->
-      B.nonidempotent_inter f b1 b2 (* TODO: should remove bot bucket to preserve invariant? *)
+  let nonidempotent_inter f m1 m2 = M.nonidempotent_inter_filter (fun b1 b2 ->
+      match B.nonidempotent_inter f b1 b2 with
+      | b' when B.is_bot b' ->
+        None (* remove bot bucket to preserve invariant *)
+      | exception Lattice.BotValue ->
+        None (* remove bot bucket to preserve invariant *)
+      | b' ->
+        Some b'
     ) m1 m2
-  let idempotent_inter_filter f m1 m2 = M.idempotent_inter (fun b1 b2 ->
-      B.idempotent_inter_filter f b1 b2 (* TODO: should remove bot bucket to preserve invariant? *)
+  let idempotent_inter_filter f m1 m2 = M.idempotent_inter_filter (fun b1 b2 ->
+      match B.idempotent_inter_filter f b1 b2 with
+      | b' when B.is_bot b' ->
+        None (* remove bot bucket to preserve invariant *)
+      | exception Lattice.BotValue ->
+        None (* remove bot bucket to preserve invariant *)
+      | b' ->
+        Some b'
     ) m1 m2
-  let nonidempotent_inter_filter f m1 m2 = M.nonidempotent_inter (fun b1 b2 ->
-      B.nonidempotent_inter_filter f b1 b2 (* TODO: should remove bot bucket to preserve invariant? *)
+  let nonidempotent_inter_filter f m1 m2 = M.nonidempotent_inter_filter (fun b1 b2 ->
+      match B.nonidempotent_inter_filter f b1 b2 with
+      | b' when B.is_bot b' ->
+        None (* remove bot bucket to preserve invariant *)
+      | exception Lattice.BotValue ->
+        None (* remove bot bucket to preserve invariant *)
+      | b' ->
+        Some b'
     ) m1 m2
   let difference f m1 m2 = M.difference (fun b1 b2 ->
       match B.difference f b1 b2 with

--- a/src/domain/mapDomain.ml
+++ b/src/domain/mapDomain.ml
@@ -33,7 +33,8 @@ sig
   val nonidempotent_inter: (value -> value -> value) -> t -> t -> t
   val idempotent_union: (value -> value -> value) -> t -> t -> t
   val nonidempotent_union: (value -> value -> value) -> t -> t -> t
-  val merge : (key -> value option -> value option -> value option) -> t -> t -> t (* TODO: unused, remove? *)
+  val difference: (value -> value -> value option) -> t -> t -> t
+  val merge : (key -> value option -> value option -> value option) -> t -> t -> t (* TODO: remove? *)
 
   val cardinal: t -> int
   val choose: t -> key * value
@@ -153,6 +154,7 @@ sig
   val nonidempotent_union: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
   val idempotent_inter: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
   val nonidempotent_inter: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val difference: ('a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
   val reflexive_compare: ('a -> 'a -> int) -> 'a t -> 'a t -> int
   val reflexive_equal: ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
   val reflexive_subset_domain_for_all2: ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
@@ -209,6 +211,14 @@ struct
 
   let idempotent_inter f m1 m2 =
     if m1 == m2 then m1 else nonidempotent_inter f m1 m2
+
+  let difference f =
+    merge (fun _ v1 v2 ->
+        match v1, v2 with
+        | Some v1, Some v2 -> f v1 v2
+        | Some _, None -> v1
+        | None, _ -> None
+      )
 end
 
 module PatriciaMap (K: PatriciaTree.KEY): MapS with type key = K.t =
@@ -220,6 +230,7 @@ struct
   let nonidempotent_union f = nonidempotent_union (fun _ v v' -> f v v')
   let idempotent_inter f = idempotent_inter (fun _ v v' -> f v v')
   let nonidempotent_inter f = nonidempotent_inter_no_share (fun _ v v' -> f v v')
+  let difference f = difference (fun _ v v' -> f v v')
   let reflexive_subset_domain_for_all2 f = reflexive_subset_domain_for_all2 (fun _ v v' -> f v v')
   let exists f m = not (for_all (fun k v -> not (f k v)) m)
   let bindings = to_list
@@ -319,6 +330,8 @@ struct
   let idempotent_inter op = lift_f2' (M.idempotent_inter op)
   let nonidempotent_inter op = lift_f2' (M.nonidempotent_inter op)
 
+  let difference op = lift_f2' (M.difference op)
+
   let reflexive_subset_domain_for_all2 f = lift_f2 (M.reflexive_subset_domain_for_all2 f)
   let leq_with_fct f = lift_f2 (M.leq_with_fct f)
   let join_with_fct f = lift_f2' (M.join_with_fct f)
@@ -374,6 +387,8 @@ struct
 
   let idempotent_inter op = lift_f2' (M.idempotent_inter op)
   let nonidempotent_inter op = lift_f2' (M.nonidempotent_inter op)
+
+  let difference op = lift_f2' (M.difference op)
 
   let reflexive_subset_domain_for_all2 f = lift_f2 (M.reflexive_subset_domain_for_all2 f)
   let leq_with_fct f = lift_f2 (M.leq_with_fct f)
@@ -449,6 +464,8 @@ struct
 
   let idempotent_inter f x y = time "idempotent_inter" (M.idempotent_inter f x) y
   let nonidempotent_inter f x y = time "nonidempotent_inter" (M.nonidempotent_inter f x) y
+
+  let difference f x y = time "difference" (M.difference f x) y
 
   let reflexive_subset_domain_for_all2 f x y = time "reflexive_subset_domain_for_all2" (M.reflexive_subset_domain_for_all2 f x) y
   let leq_with_fct f x y = time "leq_with_fct" (M.leq_with_fct f x) y
@@ -616,6 +633,11 @@ struct
     | `Lifted x, `Lifted y -> `Lifted (M.nonidempotent_union f x y)
     | _ -> raise (Fn_over_All "nonidempotent_union")
 
+  let difference f x y =
+    match x, y with
+    | `Lifted x, `Lifted y -> `Lifted (M.difference f x y)
+    | _ -> raise (Fn_over_All "difference")
+
   let for_all f = function
     | `Top -> raise (Fn_over_All "for_all")
     | `Lifted x -> M.for_all f x
@@ -760,6 +782,11 @@ struct
     | `Lifted x, `Lifted y -> `Lifted (M.nonidempotent_union f x y)
     | _ -> raise (Fn_over_All "nonidempotent_union")
 
+  let difference f x y =
+    match x, y with
+    | `Lifted x, `Lifted y -> `Lifted (M.difference f x y)
+    | _ -> raise (Fn_over_All "difference")
+
   let for_all f = function
     | `Bot -> raise (Fn_over_All "for_all")
     | `Lifted x -> M.for_all f x
@@ -862,6 +889,7 @@ struct
   let nonidempotent_inter f (e, r) (e', r') = (E.meet e e', f r r') (* TODO: does this make sense? *)
   let idempotent_union f (e, r) (e', r') = (E.join e e', f r r') (* TODO: does this make sense? *)
   let nonidempotent_union f (e, r) (e', r') = (E.join e e', f r r') (* TODO: does this make sense? *)
+  let difference f m1 m2 = failwith "MapDomain.Joined.difference" (* TODO: ? *)
   let merge f m1 m2 = failwith "MapDomain.Joined.merge" (* TODO: ? *)
   let fold f (e, r) a = f e r a
   let empty () = (E.bot (), R.bot ())

--- a/src/domain/mapDomain.ml
+++ b/src/domain/mapDomain.ml
@@ -31,6 +31,8 @@ sig
   val reflexive_subset_domain_for_all2: (value -> value -> bool) -> t -> t -> bool
   val idempotent_inter: (value -> value -> value) -> t -> t -> t
   val nonidempotent_inter: (value -> value -> value) -> t -> t -> t
+  val idempotent_inter_filter: (value -> value -> value option) -> t -> t -> t
+  val nonidempotent_inter_filter: (value -> value -> value option) -> t -> t -> t
   val idempotent_union: (value -> value -> value) -> t -> t -> t
   val nonidempotent_union: (value -> value -> value) -> t -> t -> t
   val difference: (value -> value -> value option) -> t -> t -> t
@@ -154,6 +156,8 @@ sig
   val nonidempotent_union: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
   val idempotent_inter: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
   val nonidempotent_inter: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val idempotent_inter_filter: ('a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+  val nonidempotent_inter_filter: ('a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
   val difference: ('a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
   val reflexive_compare: ('a -> 'a -> int) -> 'a t -> 'a t -> int
   val reflexive_equal: ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
@@ -212,6 +216,17 @@ struct
   let idempotent_inter f m1 m2 =
     if m1 == m2 then m1 else nonidempotent_inter f m1 m2
 
+  let nonidempotent_inter_filter op =
+    let f k v1 v2 =
+      match v1, v2 with
+      | Some v1, Some v2 -> op v1 v2
+      | _ -> None
+    in
+    merge f
+
+  let idempotent_inter_filter f m1 m2 =
+    if m1 == m2 then m1 else nonidempotent_inter_filter f m1 m2
+
   let difference f =
     merge (fun _ v1 v2 ->
         match v1, v2 with
@@ -230,6 +245,8 @@ struct
   let nonidempotent_union f = nonidempotent_union (fun _ v v' -> f v v')
   let idempotent_inter f = idempotent_inter (fun _ v v' -> f v v')
   let nonidempotent_inter f = nonidempotent_inter_no_share (fun _ v v' -> f v v')
+  let idempotent_inter_filter f = idempotent_inter_filter (fun _ v v' -> f v v')
+  let nonidempotent_inter_filter f = nonidempotent_inter_filter_no_share (fun _ v v' -> f v v')
   let difference f = difference (fun _ v v' -> f v v')
   let reflexive_subset_domain_for_all2 f = reflexive_subset_domain_for_all2 (fun _ v v' -> f v v')
   let exists f m = not (for_all (fun k v -> not (f k v)) m)
@@ -329,6 +346,8 @@ struct
 
   let idempotent_inter op = lift_f2' (M.idempotent_inter op)
   let nonidempotent_inter op = lift_f2' (M.nonidempotent_inter op)
+  let idempotent_inter_filter op = lift_f2' (M.idempotent_inter_filter op)
+  let nonidempotent_inter_filter op = lift_f2' (M.nonidempotent_inter_filter op)
 
   let difference op = lift_f2' (M.difference op)
 
@@ -387,6 +406,8 @@ struct
 
   let idempotent_inter op = lift_f2' (M.idempotent_inter op)
   let nonidempotent_inter op = lift_f2' (M.nonidempotent_inter op)
+  let idempotent_inter_filter op = lift_f2' (M.idempotent_inter_filter op)
+  let nonidempotent_inter_filter op = lift_f2' (M.nonidempotent_inter_filter op)
 
   let difference op = lift_f2' (M.difference op)
 
@@ -464,6 +485,8 @@ struct
 
   let idempotent_inter f x y = time "idempotent_inter" (M.idempotent_inter f x) y
   let nonidempotent_inter f x y = time "nonidempotent_inter" (M.nonidempotent_inter f x) y
+  let idempotent_inter_filter f x y = time "idempotent_inter_filter" (M.idempotent_inter_filter f x) y
+  let nonidempotent_inter_filter f x y = time "nonidempotent_inter_filter" (M.nonidempotent_inter_filter f x) y
 
   let difference f x y = time "difference" (M.difference f x) y
 
@@ -623,6 +646,16 @@ struct
     | `Lifted x, `Lifted y -> `Lifted (M.nonidempotent_inter f x y)
     | _ -> raise (Fn_over_All "nonidempotent_inter")
 
+  let idempotent_inter_filter f x y =
+    match x, y with
+    | `Lifted x, `Lifted y -> `Lifted (M.idempotent_inter_filter f x y)
+    | _ -> raise (Fn_over_All "idempotent_inter_filter")
+
+  let nonidempotent_inter_filter f x y =
+    match x, y with
+    | `Lifted x, `Lifted y -> `Lifted (M.nonidempotent_inter_filter f x y)
+    | _ -> raise (Fn_over_All "nonidempotent_inter_filter")
+
   let idempotent_union f x y =
     match x, y with
     | `Lifted x, `Lifted y -> `Lifted (M.idempotent_union f x y)
@@ -772,6 +805,16 @@ struct
     | `Lifted x, `Lifted y -> `Lifted (M.nonidempotent_inter f x y)
     | _ -> raise (Fn_over_All "nonidempotent_inter")
 
+  let idempotent_inter_filter f x y =
+    match x, y with
+    | `Lifted x, `Lifted y -> `Lifted (M.idempotent_inter_filter f x y)
+    | _ -> raise (Fn_over_All "idempotent_inter_filter")
+
+  let nonidempotent_inter_filter f x y =
+    match x, y with
+    | `Lifted x, `Lifted y -> `Lifted (M.nonidempotent_inter_filter f x y)
+    | _ -> raise (Fn_over_All "nonidempotent_inter_filter")
+
   let idempotent_union f x y =
     match x, y with
     | `Lifted x, `Lifted y -> `Lifted (M.idempotent_union f x y)
@@ -887,6 +930,8 @@ struct
   let mapi f (e, r) = (e, f e r)
   let idempotent_inter f (e, r) (e', r') = (E.meet e e', f r r') (* TODO: does this make sense? *)
   let nonidempotent_inter f (e, r) (e', r') = (E.meet e e', f r r') (* TODO: does this make sense? *)
+  let idempotent_inter_filter f (e, r) (e', r') = failwith "MapDomain.Joined.idempotent_inter_filter" (* TODO: ? *)
+  let nonidempotent_inter_filter f (e, r) (e', r') = failwith "MapDomain.Joined.nonidempotent_inter_filter" (* TODO: ? *)
   let idempotent_union f (e, r) (e', r') = (E.join e e', f r r') (* TODO: does this make sense? *)
   let nonidempotent_union f (e, r) (e', r') = (E.join e e', f r r') (* TODO: does this make sense? *)
   let difference f m1 m2 = failwith "MapDomain.Joined.difference" (* TODO: ? *)

--- a/src/domain/mapDomain.ml
+++ b/src/domain/mapDomain.ml
@@ -730,13 +730,16 @@ struct
     | `Lifted x -> `Lifted (M.mapi f x)
 end
 
-module MapBot_LiftTop (Domain: Printable.S) (Range: Lattice.S) : S with
+module GenMapBot_LiftTop (Domain: Printable.S) (M: MapS with type key = Domain.t) (Range: Lattice.S) : S with
   type key = Domain.t and
   type value = Range.t =
 struct
-  module M = MapBot (Domain) (Range)
+  module M = GenMapBot (Domain) (M) (Range)
   include LiftTop (Range) (M)
 end
+
+module MapBot_LiftTop (Domain: Printable.S) (Range: Lattice.S) = GenMapBot_LiftTop (Domain) (StdMap (Domain)) (Range)
+module PatriciaMapBot_LiftTop (Domain: Printable.S) (Range: Lattice.S) = GenMapBot_LiftTop (Domain) (PatriciaMap (struct include Domain let to_int = tag end)) (Range)
 
 
 module LiftBot (Range: Lattice.S) (M: S with type value = Range.t): S with
@@ -884,13 +887,16 @@ struct
     | `Lifted x -> `Lifted (M.mapi f x)
 end
 
-module MapTop_LiftBot (Domain: Printable.S) (Range: Lattice.S): S with
+module GenMapTop_LiftBot (Domain: Printable.S) (M: MapS with type key = Domain.t) (Range: Lattice.S): S with
   type key = Domain.t and
   type value = Range.t =
 struct
-  module M = MapTop (Domain) (Range)
+  module M = GenMapTop (Domain) (M) (Range)
   include LiftBot (Range) (M)
 end
+
+module MapTop_LiftBot (Domain: Printable.S) (Range: Lattice.S) = GenMapTop_LiftBot (Domain) (StdMap (Domain)) (Range)
+module PatriciaMapTop_LiftBot (Domain: Printable.S) (Range: Lattice.S) = GenMapTop_LiftBot (Domain) (PatriciaMap (struct include Domain let to_int = tag end)) (Range)
 
 (** Map abstracted by a single (joined) key. *)
 module Joined (E: Lattice.S) (R: Lattice.S): S with type key = E.t and type value = R.t =

--- a/src/domain/mapDomain.ml
+++ b/src/domain/mapDomain.ml
@@ -36,7 +36,6 @@ sig
   val idempotent_union: (value -> value -> value) -> t -> t -> t
   val nonidempotent_union: (value -> value -> value) -> t -> t -> t
   val difference: (value -> value -> value option) -> t -> t -> t
-  val merge : (key -> value option -> value option -> value option) -> t -> t -> t (* TODO: remove? *)
 
   val cardinal: t -> int
   val choose: t -> key * value
@@ -151,7 +150,6 @@ sig
   val add: key -> 'a -> 'a t -> 'a t
   val singleton: key -> 'a -> 'a t
   val remove: key -> 'a t -> 'a t
-  val merge: (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
   val idempotent_union: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
   val nonidempotent_union: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
   val idempotent_inter: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
@@ -240,7 +238,6 @@ module PatriciaMap (K: PatriciaTree.KEY): MapS with type key = K.t =
 struct
   include PatriciaTree.MakeMap (K)
 
-  let merge = slow_merge (* TODO: get rid of this *)
   let idempotent_union f = idempotent_union (fun _ v v' -> f v v')
   let nonidempotent_union f = nonidempotent_union (fun _ v v' -> f v v')
   let idempotent_inter f = idempotent_inter (fun _ v v' -> f v v')
@@ -323,7 +320,6 @@ struct
   let mapi f = lift_f' (M.mapi f)
   let fold f x a = M.fold f (unlift x) a
   let filter f = lift_f' (M.filter f)
-  let merge f = lift_f2' (M.merge f)
   let for_all f = lift_f (M.for_all f)
 
   let cardinal = lift_f M.cardinal
@@ -383,7 +379,6 @@ struct
   let mapi f = lift_f' (M.mapi f)
   let fold f x a = M.fold f (unlift x) a
   let filter f = lift_f' (M.filter f)
-  let merge f = lift_f2' (M.merge f)
   let for_all f = lift_f (M.for_all f)
 
   let cardinal = lift_f M.cardinal
@@ -464,7 +459,6 @@ struct
   let mapi f x = time "mapi" (M.mapi f) x
   let fold f x a = time "fold" (M.fold f x) a
   let filter f x = time "filter" (M.filter f) x
-  let merge f x y = time "merge" (M.merge f x) y
   let for_all f x = time "for_all" (M.for_all f) x
 
   let cardinal x = time "cardinal" M.cardinal x
@@ -689,11 +683,6 @@ struct
     | `Top -> raise (Fn_over_All "filter")
     | `Lifted x -> `Lifted (M.filter f x)
 
-  let merge f x y  =
-    match x, y with
-    | `Lifted x, `Lifted y -> `Lifted (M.merge f x y)
-    | _ -> raise (Fn_over_All "merge")
-
   let reflexive_subset_domain_for_all2 f x y =
     match (x,y) with
     | (_, `Top) -> true
@@ -848,11 +837,6 @@ struct
     | `Bot -> raise (Fn_over_All "filter")
     | `Lifted x -> `Lifted (M.filter f x)
 
-  let merge f x y  =
-    match x, y with
-    | `Lifted x, `Lifted y -> `Lifted (M.merge f x y)
-    | _ -> raise (Fn_over_All "merge")
-
   let join_with_fct f x y =
     match (x,y) with
     | (`Bot, x) -> x
@@ -935,7 +919,6 @@ struct
   let idempotent_union f (e, r) (e', r') = (E.join e e', f r r') (* TODO: does this make sense? *)
   let nonidempotent_union f (e, r) (e', r') = (E.join e e', f r r') (* TODO: does this make sense? *)
   let difference f m1 m2 = failwith "MapDomain.Joined.difference" (* TODO: ? *)
-  let merge f m1 m2 = failwith "MapDomain.Joined.merge" (* TODO: ? *)
   let fold f (e, r) a = f e r a
   let empty () = (E.bot (), R.bot ())
   let add e r (e', r') = (E.join e e', R.join r r')

--- a/src/lifters/contextGasLifter.ml
+++ b/src/lifters/contextGasLifter.ml
@@ -125,7 +125,7 @@ let get_gas_lifter () =
       (* 5 join 4 = 4 *)
       module G = Lattice.Reverse(GasChain)
       (* Missing bindings are bot, i.e., have maximal gas for this function *)
-      module M = MapDomain.MapBot_LiftTop(CilType.Fundec)(G)
+      module M = MapDomain.PatriciaMapBot_LiftTop(CilType.Fundec)(G)
       let startgas () = M.empty ()
       let is_exhausted f v = GobOption.exists (fun g -> g <= 0) (M.find_opt f v)  (* v <= 0 *)
       let callee_gas f v =

--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -454,7 +454,7 @@ struct
     include S.D
     let printXml f d = BatPrintf.fprintf f "<value>%a</value>" printXml d
   end
-  module M = MapDomain.MapBot (Basetype.Variables) (DD) (* should be CilFun -> S.C, but CilFun is not Groupable, and S.C is no Lattice *)
+  module M = MapDomain.PatriciaMapBot (Basetype.Variables) (DD) (* should be CilFun -> S.C, but CilFun is not Groupable, and S.C is no Lattice *)
 
   module D = struct
     include Lattice.Prod (S.D) (M)


### PR DESCRIPTION
This is on top of #2002.

### Changes
1. Remove slow `merge` from `MapDomain` interface altogether. All of its uses have possibly more efficient alternatives in the patricia-tree library.
2. Use `PatriciaMapBot` for other domains than base values.
3. Add lifted versions of `Patricia` functors to `MapDomain`.

### TODO
- [ ] Use patricia-tree also in `SetDomain`? **Not sure what this would improve, sets don't do such value operations.**