### PR TITLE
Remove `warn_and_top_on_zero` from `BaseInvariant` for division by zero

### DIFF
--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -291,12 +291,6 @@ struct
     (* inverse values for binary operation a `op` b == c *)
     (* ikind is the type of a for limiting ranges of the operands a, b. The only binops which can have different types for a, b are Shiftlt, Shiftrt (not handled below; don't use ikind to limit b there). *)
     let inv_bin_int (a, b) ikind c op =
-      let warn_and_top_on_zero x =
-        if ID.equal_to Z.zero x = `Eq then
-          ID.top_of ikind
-        else
-          x
-      in
       let meet_bin a' b'  = id_meet_down ~old:a ~c:a', id_meet_down ~old:b ~c:b' in
       let meet_com oi = (* commutative *)
         try
@@ -320,8 +314,6 @@ struct
         (refine_by a b, refine_by b a)
       | MinusA -> meet_non ID.add ID.sub
       | Div    ->
-        (* If b must be zero, we have must UB *)
-        let b = warn_and_top_on_zero b in
         (* Integer division means we need to add the remainder, so instead of just `a = c*b` we have `a = c*b + a%b`.
          * However, a%b will give [-b+1, b-1] for a=top, but we only want the positive/negative side depending on the sign of c*b.
          * If c*b = 0 or it can be positive or negative, we need the full range for the remainder. *)
@@ -335,8 +327,6 @@ struct
         in
         meet_bin (ID.add (ID.mul b c) rem) (ID.div (ID.sub a rem) c)
       | Mod    -> (* a % b == c *)
-        (* If b must be zero, we have must UB *)
-        let b = warn_and_top_on_zero b in
         (* a' = a/b*b + c and derived from it b' = (a-c)/(a/b)
          * The idea is to formulate a' as quotient * divisor + remainder. *)
         let a' = ID.add (ID.mul (ID.div a b) b) c in


### PR DESCRIPTION
This is the continuation of #1892 regarding the top-ification aspect.

I tried to just remove it and no tests fail. But I'll see on sv-benchmarks if this actually matters sometime.


### Question

In https://github.com/goblint/analyzer/issues/1892#issuecomment-4054491792:
> Okay, so here specifically the question is what the backward transfer function should be for `c = a / [0;0]`, given some value for `c`, how can one refine `a`? And what about `c = a / [0;1]`...

The strange thing is that the `warn_and_top_on_zero` code is about the second argument, not the first one.

And it looks like it just tries to avoid a definite division by zero in the calculations that follow, e.g. `ID.div a b`. But doing so isn't actually a problem: once we're doing the refinement, we've already forward-evaluated that exact calculation with the zero divisor without issues. I don't think the abstract division operator in int domains should fail because of that.
Also note that the second argument (without top-ification) would still be, e.g., `[0,0]`, not bottom. So it's not triggering `ArithmeticOnIntegerBot` by doing that.

Maybe some git archeology is needed for this code. Perhaps it was added at a time when the division operators in int domains had problems with doing this and `warn_and_top_on_zero` was added to work around them.

### TODO
- [x] sv-benchmarks