### PR TITLE
Fix `memOutOfBounds` handling of negative pointer offsets

### DIFF
--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -41,9 +41,7 @@ struct
   let check_deref_offset_bounds ptr_size offs =
     let ptr_size_lt_offs =
       try
-        let one = intdom_of_int 1 in
-        let max_valid_offs = ID.sub ptr_size one in
-        ID.lt max_valid_offs offs
+        ID.le ptr_size offs
       with IntDomain.ArithmeticOnIntegerBot _ -> None
     in
     offs_lt_zero offs, ptr_size_lt_offs

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -39,12 +39,11 @@ struct
     with IntDomain.ArithmeticOnIntegerBot _ -> None
 
   let check_deref_offset_bounds ptr_size offs =
-    let ptr_size_lt_offs =
-      try
-        ID.le ptr_size offs
+    let ptr_size_le_offs =
+      try ID.le ptr_size offs
       with IntDomain.ArithmeticOnIntegerBot _ -> None
     in
-    offs_lt_zero offs, ptr_size_lt_offs
+    offs_lt_zero offs, ptr_size_le_offs
 
   let check_ptr_offset_bounds ptr_size offs =
     let ptr_size_lt_offs =

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -34,6 +34,27 @@ struct
   let size_of_type_in_bytes typ =
     intdom_of_int (Cilfacade.bytesSizeOf typ)
 
+  let offs_lt_zero offs =
+    try ID.lt offs (intdom_of_int 0)
+    with IntDomain.ArithmeticOnIntegerBot _ -> None
+
+  let check_deref_offset_bounds ptr_size offs =
+    let ptr_size_lt_offs =
+      try
+        let one = intdom_of_int 1 in
+        let max_valid_offs = ID.sub ptr_size one in
+        ID.lt max_valid_offs offs
+      with IntDomain.ArithmeticOnIntegerBot _ -> None
+    in
+    offs_lt_zero offs, ptr_size_lt_offs
+
+  let check_ptr_offset_bounds ptr_size offs =
+    let ptr_size_lt_offs =
+      try ID.lt ptr_size offs
+      with IntDomain.ArithmeticOnIntegerBot _ -> None
+    in
+    offs_lt_zero offs, ptr_size_lt_offs
+
   let rec exp_contains_a_ptr (exp:exp) =
     match exp with
     | Const _
@@ -290,21 +311,9 @@ struct
           | `Lifted es ->
             let casted_es = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) es in (* TODO: proper castkind *)
             let casted_offs = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) offs_intdom in (* TODO: proper castkind *)
-            let ptr_size_lt_offs =
-              let one = intdom_of_int 1 in
-              let casted_es = ID.sub casted_es one in
-              begin try ID.lt casted_es casted_offs
-                with IntDomain.ArithmeticOnIntegerBot _ -> None
-              end
-            in
-            let offs_lt_zero =
-              let zero = intdom_of_int 0 in
-              try ID.lt casted_offs zero
-              with IntDomain.ArithmeticOnIntegerBot _ -> None
-            in
             let behavior = Undefined MemoryOutOfBoundsAccess in
             let cwe_number = 823 in
-            begin match offs_lt_zero, ptr_size_lt_offs with
+            begin match check_deref_offset_bounds casted_es casted_offs with
               | Some true, _
               | _, Some true ->
                 (set_mem_safety_flag InvalidDeref;
@@ -349,15 +358,7 @@ struct
         | `Lifted ps, ao ->
           let casted_ps = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) ps in (* TODO: proper castkind *)
           let casted_ao = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) ao in (* TODO: proper castkind *)
-          let offs_lt_zero =
-            try ID.lt casted_ao (intdom_of_int 0)
-            with IntDomain.ArithmeticOnIntegerBot _ -> None
-          in
-          let ptr_size_lt_offs = 
-            try ID.lt casted_ps casted_ao
-            with IntDomain.ArithmeticOnIntegerBot _ -> None
-          in
-          begin match offs_lt_zero, ptr_size_lt_offs with
+          begin match check_ptr_offset_bounds casted_ps casted_ao with
             | Some true, _
             | _, Some true ->
               set_mem_safety_flag InvalidDeref;
@@ -445,15 +446,7 @@ struct
             | `Lifted ps, `Lifted o ->
               let casted_ps = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) ps in (* TODO: proper castkind *)
               let casted_o = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) o in (* TODO: proper castkind *)
-              let offs_lt_zero =
-                try ID.lt casted_o (intdom_of_int 0)
-                with IntDomain.ArithmeticOnIntegerBot _ -> None
-              in
-              let ptr_size_lt_offs =
-                try ID.lt casted_ps casted_o
-                with IntDomain.ArithmeticOnIntegerBot _ -> None
-              in
-              begin match offs_lt_zero, ptr_size_lt_offs with
+              begin match check_ptr_offset_bounds casted_ps casted_o with
                 | Some true, _
                 | _, Some true ->
                   set_mem_safety_flag InvalidDeref;

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -297,16 +297,22 @@ struct
                 with IntDomain.ArithmeticOnIntegerBot _ -> None
               end
             in
+            let offs_lt_zero =
+              let zero = intdom_of_int 0 in
+              try ID.lt casted_offs zero
+              with IntDomain.ArithmeticOnIntegerBot _ -> None
+            in
             let behavior = Undefined MemoryOutOfBoundsAccess in
             let cwe_number = 823 in
-            begin match ptr_size_lt_offs with
-              | Some true ->
+            begin match offs_lt_zero, ptr_size_lt_offs with
+              | Some true, _
+              | _, Some true ->
                 (set_mem_safety_flag InvalidDeref;
                  M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Size of lval dereference expression is %a (in bytes). It is offset by %a (in bytes). Memory out-of-bounds access must occur" ID.pretty casted_es ID.pretty casted_offs);
                 Checks.warn Checks.Category.InvalidMemoryAccess "Size of lval dereference expression is %a (in bytes). It is offset by %a (in bytes). Memory out-of-bounds access must occur" ID.pretty casted_es ID.pretty casted_offs
-              | Some false ->
+              | Some false, Some false ->
                 Checks.safe Checks.Category.InvalidMemoryAccess
-              | None ->
+              | _ ->
                 (set_mem_safety_flag InvalidDeref;
                  M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Could not compare size of lval dereference expression (%a) (in bytes) with offset by (%a) (in bytes). Memory out-of-bounds access might occur" ID.pretty casted_es ID.pretty casted_offs);
                 Checks.warn Checks.Category.InvalidMemoryAccess "Could not compare size of lval dereference expression (%a) (in bytes) with offset by (%a) (in bytes). Memory out-of-bounds access might occur" ID.pretty casted_es ID.pretty casted_offs
@@ -343,15 +349,20 @@ struct
         | `Lifted ps, ao ->
           let casted_ps = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) ps in (* TODO: proper castkind *)
           let casted_ao = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) ao in (* TODO: proper castkind *)
+          let offs_lt_zero =
+            try ID.lt casted_ao (intdom_of_int 0)
+            with IntDomain.ArithmeticOnIntegerBot _ -> None
+          in
           let ptr_size_lt_offs = ID.lt casted_ps casted_ao in
-          begin match ptr_size_lt_offs with
-            | Some true ->
+          begin match offs_lt_zero, ptr_size_lt_offs with
+            | Some true, _
+            | _, Some true ->
               set_mem_safety_flag InvalidDeref;
               M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Size of pointer is %a (in bytes). It is offset by %a (in bytes) due to pointer arithmetic. Memory out-of-bounds access must occur" ID.pretty casted_ps ID.pretty casted_ao;
               Checks.warn Checks.Category.InvalidMemoryAccess "Size of pointer is %a (in bytes). It is offset by %a (in bytes) due to pointer arithmetic. Memory out-of-bounds access must occur" ID.pretty casted_ps ID.pretty casted_ao
-            | Some false ->
+            | Some false, Some false ->
               Checks.safe Checks.Category.InvalidMemoryAccess
-            | None ->
+            | _ ->
               set_mem_safety_flag InvalidDeref;
               M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Could not compare size of pointer (%a) (in bytes) with offset by (%a) (in bytes). Memory out-of-bounds access might occur" ID.pretty casted_ps ID.pretty casted_ao;
               Checks.warn Checks.Category.InvalidMemoryAccess "Could not compare size of pointer (%a) (in bytes) with offset by (%a) (in bytes). Memory out-of-bounds access might occur" ID.pretty casted_ps ID.pretty casted_ao
@@ -431,15 +442,20 @@ struct
             | `Lifted ps, `Lifted o ->
               let casted_ps = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) ps in (* TODO: proper castkind *)
               let casted_o = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) o in (* TODO: proper castkind *)
+              let offs_lt_zero =
+                try ID.lt casted_o (intdom_of_int 0)
+                with IntDomain.ArithmeticOnIntegerBot _ -> None
+              in
               let ptr_size_lt_offs = ID.lt casted_ps casted_o in
-              begin match ptr_size_lt_offs with
-                | Some true ->
+              begin match offs_lt_zero, ptr_size_lt_offs with
+                | Some true, _
+                | _, Some true ->
                   set_mem_safety_flag InvalidDeref;
                   M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Size of pointer in expression %a is %a (in bytes). It is offset by %a (in bytes). Memory out-of-bounds access must occur" d_exp binopexp ID.pretty casted_ps ID.pretty casted_o;
                   Checks.warn Checks.Category.InvalidMemoryAccess "Size of pointer in expression %a is %a (in bytes). It is offset by %a (in bytes). Memory out-of-bounds access must occur" d_exp binopexp ID.pretty casted_ps ID.pretty casted_o
-                | Some false ->
+                | Some false, Some false ->
                   Checks.safe Checks.Category.InvalidMemoryAccess
-                | None ->
+                | _ ->
                   set_mem_safety_flag InvalidDeref;
                   M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Could not compare pointer size (%a) with offset (%a). Memory out-of-bounds access may occur" ID.pretty casted_ps ID.pretty casted_o;
                   Checks.warn Checks.Category.InvalidMemoryAccess "Could not compare pointer size (%a) with offset (%a). Memory out-of-bounds access may occur" ID.pretty casted_ps ID.pretty casted_o

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -353,7 +353,10 @@ struct
             try ID.lt casted_ao (intdom_of_int 0)
             with IntDomain.ArithmeticOnIntegerBot _ -> None
           in
-          let ptr_size_lt_offs = ID.lt casted_ps casted_ao in
+          let ptr_size_lt_offs = 
+            try ID.lt casted_ps casted_ao
+            with IntDomain.ArithmeticOnIntegerBot _ -> None
+          in
           begin match offs_lt_zero, ptr_size_lt_offs with
             | Some true, _
             | _, Some true ->
@@ -446,7 +449,10 @@ struct
                 try ID.lt casted_o (intdom_of_int 0)
                 with IntDomain.ArithmeticOnIntegerBot _ -> None
               in
-              let ptr_size_lt_offs = ID.lt casted_ps casted_o in
+              let ptr_size_lt_offs =
+                try ID.lt casted_ps casted_o
+                with IntDomain.ArithmeticOnIntegerBot _ -> None
+              in
               begin match offs_lt_zero, ptr_size_lt_offs with
                 | Some true, _
                 | _, Some true ->

--- a/tests/regression/74-invalid_deref/34-negative-index-after-ptr-increment.c
+++ b/tests/regression/74-invalid_deref/34-negative-index-after-ptr-increment.c
@@ -1,0 +1,14 @@
+// PARAM: --set ana.activated[+] memOutOfBounds --enable ana.int.interval
+#include <stdlib.h>
+
+int main() {
+    int *b = malloc(2 * sizeof(int));
+    int x;
+
+    *b++ = 0; //NOWARN
+
+    x = *(b - 2); //WARN
+
+    free(b - 1);
+    return x;
+}

--- a/tests/regression/74-invalid_deref/35-negative-index-after-ptr-increment-index-syntax.c
+++ b/tests/regression/74-invalid_deref/35-negative-index-after-ptr-increment-index-syntax.c
@@ -1,0 +1,14 @@
+// PARAM: --set ana.activated[+] memOutOfBounds --enable ana.int.interval
+#include <stdlib.h>
+
+int main() {
+    int *b = malloc(2 * sizeof(int));
+
+    *b++ = 0; //NOWARN
+
+    if (b[-2]) //WARN
+        return 1;
+
+    free(b - 1);
+    return 0;
+}

--- a/tests/regression/74-invalid_deref/36-one-past-pointer.c
+++ b/tests/regression/74-invalid_deref/36-one-past-pointer.c
@@ -1,0 +1,12 @@
+// PARAM: --set ana.activated[+] memOutOfBounds --enable ana.int.interval
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(void) {
+  char *buf = malloc(4);
+  char *end;
+  end = buf + 4; //NOWARN
+  printf("%p", (void *) end); //NOWARN
+  free(buf);
+  return 0;
+}

--- a/tests/regression/74-invalid_deref/37-one-past-deref-offset.c
+++ b/tests/regression/74-invalid_deref/37-one-past-deref-offset.c
@@ -1,0 +1,16 @@
+// PARAM: --set ana.activated[+] memOutOfBounds --enable ana.int.interval
+#include <stdlib.h>
+
+struct S {
+  unsigned char a;
+  unsigned char b:2;
+  unsigned char c:2;
+  unsigned char d;
+} __attribute__((packed));
+
+int main(void) {
+  struct S *p = malloc(2);
+  p->d = 1; //WARN
+  free(p);
+  return 0;
+}


### PR DESCRIPTION
This PR fixes a bug in `memOutOfBounds` where before-start accesses were classified as safe when the offset was negative and precise enough under `ana.int.interval`, i.e., the bug only manifested when interval domain was turned on. With `ana.int.interval`, Goblint can compute offsets precisely enough that negative-offset accesses no longer stay at top. This issue was found using the dashboard comparison between Goblint and Mopsa and was exposed by the SV-COMP task `list-ext-properties/960521-1_1-1.i`. 


* Added regressions for negative-offset `memOutOfBounds` cases in `tests/regression/74-invalid_deref`.
* Fixed `memOutOfBounds` to warn when the computed byte offset is negative, in addition to the existing past-the-end check.
* Made the `ptr_size_lt_offs` comparison sites handle `IntDomain.ArithmeticOnIntegerBot` consistently by falling back to the existing conservative “could not compare” behavior.
* Refactored the duplicated offset-bound comparison logic into top-level helpers, while preserving the original distinction between:
    * dereference-offset checks using `(size - 1) < offset`
    * pointer-offset checks using `size < offset`