### PR TITLE
Infer effective length for single-blob arrays

### DIFF
--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -900,6 +900,28 @@ struct
     else
       x (* This already contains some value *)
 
+  let effective_array_length (ask: VDQ.t) (array: CArrays.t) (elem_typ: typ) =
+    let ik = Cilfacade.ptrdiff_ikind () in
+    let elem_typ =
+      match Cil.unrollType elem_typ with
+      | TArray (elem_typ, _, _) -> elem_typ
+      | TPtr (elem_typ, _) -> elem_typ
+      | elem_typ -> elem_typ
+    in
+    match CArrays.length array with
+    | Some l when not (ID.is_bot l) && ID.equal_to Z.one l = `Eq -> begin
+        match CArrays.get ~checkBounds:false ask array (None, IndexDomain.of_int ik Z.zero) with
+        | Blob (_, size, _) -> begin
+            try
+              let elem_size = ID.of_int ik (Z.of_int (Cilfacade.bytesSizeOf elem_typ)) in
+              ID.div size elem_size
+            with Cilfacade.TypeOfError _ -> l
+          end
+        | _ -> l
+      end
+    | Some l -> l
+    | None -> ID.top_of ik
+
   (* Funny, this does not compile without the final type annotation! *)
   let rec eval_offset (ask: VDQ.t) f (x: t) (offs:offs) (exp:exp option) (v:lval option) (t:typ): t =
     let rec do_eval_offset (x:t) (offs:offs) (l:lval option) (o:offset option): t =
@@ -958,6 +980,7 @@ struct
               match x with
               | Array x ->
                 let e = determine_offset ask l o exp v in
+                let x = CArrays.update_length (effective_array_length ask x t) x in
                 do_eval_offset (CArrays.get ask x (e, idx)) offs l' o'
               | Address _ ->
                 begin
@@ -1133,6 +1156,7 @@ struct
                 match x with
                 | Array x' ->
                   let e = determine_offset ask l o exp (Some v) in
+                  let x' = CArrays.update_length (effective_array_length ask x' t) x' in
                   let new_value_at_index = do_update_offset (CArrays.get ask x' (e,idx)) offs l' o' in
                   let new_array_value = CArrays.set ask x' (e, idx) new_value_at_index in
                   Array new_array_value

--- a/tests/regression/74-invalid_deref/36-calloc-byte-array-index.c
+++ b/tests/regression/74-invalid_deref/36-calloc-byte-array-index.c
@@ -1,0 +1,12 @@
+// PARAM: --enable ana.arrayoob --enable ana.int.interval
+#include <stdlib.h>
+
+int main() {
+    int size = 50;
+    unsigned char *randomString = (unsigned char *)calloc(size, sizeof(unsigned char));
+
+    randomString[17] = 42; //NOWARN
+
+    free(randomString);
+    return 0;
+}


### PR DESCRIPTION
This PR fixes array out-of-bounds handling for dynamically allocated arrays whose abstract array length is initially represented as a single blob. This was found using the dashboard comparison between Goblint and Mopsa and was exposed by the SV-COMP task `memsafety-cve/libredwg.i`.

Goblint output spurious error messages for the program:
```shell
[Error][Behavior > Undefined > ArrayOutOfBounds > PastEnd] Must access array past end (/home/holterka/sv-benchmarks/c/memsafety-cve/libredwg.i:425:5-425:48)
[Error][Behavior > Undefined > ArrayOutOfBounds > PastEnd] Must access array past end (/home/holterka/sv-benchmarks/c/memsafety-cve/libredwg.i:425:5-425:48)
[Error][Behavior > Undefined > ArrayOutOfBounds > PastEnd] Must access array past end (/home/holterka/sv-benchmarks/c/memsafety-cve/libredwg.i:425:5-425:48)
[Error][Behavior > Undefined > ArrayOutOfBounds > PastEnd] Must access array past end (/home/holterka/sv-benchmarks/c/memsafety-cve/libredwg.i:425:5-425:48)
```

With the offending code being:
```c
unsigned char *getRandomByteStream(int size) {
  unsigned char *randomString = (unsigned char *)calloc(size, sizeof(unsigned char));
  if (randomString == ((void *)0)) {
    printf("Out of memory\n");
    exit(1);
  }
  for (int i = 0; i < size; i++) {
    randomString[i] = __VERIFIER_nondet_uchar();
  }
  return randomString;
```

where `size` was a constant of 50 during the function call, but Goblint's `array_oob_check` considered the array size as 1.

The change computes an effective array length from the blob size divided by the element size, then uses that length before indexed reads and writes. This prevents valid accesses into calloc-allocated arrays from being treated imprecisely.

- Added a regression test for a valid access into a `calloc`-allocated `unsigned char` array.
- Added `effective_array_length` to derive array length from blob size when possible.
- Apply the effective length before array indexed reads.
- Apply the effective length before array indexed writes.