### PR TITLE
Phase Ghost Support for Non-Relational Mutex-Meet-TID

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1666,6 +1666,7 @@ struct
     | Q.MaySignedOverflow e -> (let res = exp_may_signed_overflow man e in
                                 if M.tracing then M.trace "signed_overflow" "base exp_may_signed_overflow %a. Result = %b" d_plainexp e res; res
                                )
+    | Q.LMust -> Priv.lmust man.local
     | _ -> Q.Result.top q
 
   let update_variable variable typ value cpa =
@@ -3169,6 +3170,8 @@ struct
         ) man.local lval
     | Events.PhaseChange {old_phase; new_phase} ->
       Priv.phase_change ask old_phase new_phase (priv_getg man.global) (priv_sideg man.sideg) st
+    | Events.GrowLMust lmust ->
+      Priv.grow_lmust st lmust
     | _ ->
       man.local
 end

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -747,15 +747,23 @@ struct
           match lock with
           | `Left mutex ->
             if Locksets.((MustLockset.mem mutex (current_lockset ask))) then
-              (* Do not propagate to next phase here already, unlock will propagate appropriate value *)
-              ()
+              let will_side_on_unlock = W.exists (is_protected_by ~protection:Weak ask mutex) w in
+              if will_side_on_unlock then
+                (* Do not propagate to next phase here already, unlock will propagate appropriate value *)
+                ()
+              else
+                (* Propagate here, as a later unlock may or may not trigger a side-effect here *)
+                (* TODO: To improve precision, we could also consider adding things to W here? *)
+                sideg (V.mutex mutex) (G.create_mutex sideval)
             else
               sideg (V.mutex mutex) (G.create_mutex sideval)
           | `Right g ->
-            (* Publishing here is unconditional,  *)
+            (* Publishing here is unconditional, should this be like this *)
             sideg (V.global g) (G.create_global sideval)
         in
         L.iter publish_l l;
+        (* Actually, we need to propagate only contributions form _other_ threads here *)
+        (* If I am doing the join optimization, I need not publish to unknowns of threads that are must-joined *)
         let publish_others l (lock:LLock.t) =
           let other_map = getg (V.mutex l) in
           let mtx = G.mutex other_map in

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -730,7 +730,42 @@ struct
     (* so the cpa component of st is bot. *)
     {st with cpa = CPA.bot (); priv = (W.bot (),lmust,l)}
 
-  let phase_change ask _old_phase _new_phase _getg _sideg st = st
+  let phase_change ask _old_phase _new_phase getg sideg (st: BaseComponents (D).t) =
+    if Digest.requiresActionOnPhaseChange then
+      (* getg will refer to incorrect phase here by default, namely new_phase(!) *)
+      (* can publish to others can skip publishing to those that are must-accounted for in the local
+         state ? *)
+      begin
+        (* Iterate over all mutexes, carry forward L component, as well as other global views (?) *)
+        (* What about other threads? Should only carry forward their globals? *)
+        (* What is the timing of the phaseChange Event relative to unlocks? *)
+        (* Skip those that are currently held, these will be published on unlock *)
+        let (w, lmust, l) = st.priv in
+        let publish_l (lock:LLock.t) (value:L.value) =
+          let digest = Digest.current ask in
+          let sideval = GMutex.singleton digest value in
+          match lock with
+          | `Left mutex ->
+            if Locksets.((MustLockset.mem mutex (current_lockset ask))) then
+              (* Do not propagate to next phase here already, unlock will propagate appropriate value *)
+              ()
+            else
+              sideg (V.mutex mutex) (G.create_mutex sideval)
+          | `Right g ->
+            (* Publishing here is unconditional,  *)
+            sideg (V.global g) (G.create_global sideval)
+        in
+        L.iter publish_l l;
+        let publish_others l (lock:LLock.t) =
+          let other_map = getg (V.mutex l) in
+
+          ()
+
+        in
+        st
+      end
+    else
+      st
 
   let threadspawn (ask:Queries.ask) get set (st: BaseComponents (D).t) =
     let is_recovered_st = ThreadFlag.has_ever_been_multi ask && not @@ ThreadFlag.is_currently_multi ask in

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -730,11 +730,11 @@ struct
     (* so the cpa component of st is bot. *)
     {st with cpa = CPA.bot (); priv = (W.bot (),lmust,l)}
 
-  let phase_change ask _old_phase _new_phase getg sideg (st: BaseComponents (D).t) =
-    if Digest.requiresActionOnPhaseChange then
-      (* getg will refer to incorrect phase here by default, namely new_phase(!) *)
-      (* can publish to others can skip publishing to those that are must-accounted for in the local
-         state ? *)
+  let phase_change ask old_phase _new_phase getg sideg (st: BaseComponents (D).t) =
+    if not Digest.requiresActionOnPhaseChange then
+      st
+    else
+      (* can publish to others can skip publishing to those that are must-accounted for in the local state ? *)
       begin
         (* Iterate over all mutexes, carry forward L component, as well as other global views (?) *)
         (* What about other threads? Should only carry forward their globals? *)
@@ -758,21 +758,28 @@ struct
             else
               sideg (V.mutex mutex) (G.create_mutex sideval)
           | `Right g ->
-            (* Publishing here is unconditional, should this be like this *)
+            (* Publishing here is unconditional, should this be like this ? *)
             sideg (V.global g) (G.create_global sideval)
         in
         L.iter publish_l l;
         (* Actually, we need to propagate only contributions form _other_ threads here *)
         (* If I am doing the join optimization, I need not publish to unknowns of threads that are must-joined *)
+        let old_phase = Option.get @@ Digest.of_phase ask old_phase in
+        (* TODO: Where on earth do I get them from? *)
         let publish_others l (lock:LLock.t) =
-          let other_map = getg (V.mutex l) in
-          let mtx = G.mutex other_map in
-          GMutex.fold (fun _ _ _ -> ()) mtx ()
+          let current_bindings = G.mutex @@ getg (V.mutex l) in
+          (*
+            Look up all current bindings and if we find one that belongs to the old phase
+            but a different thread, carry it forward
+          *)
+          let carry_if_needed (digest:Digest.t) (value:L.value) (acc:GMutex.t) =
+            acc
+          in
+          let res = GMutex.fold carry_if_needed current_bindings (GMutex.empty ()) in
+          sideg (V.mutex l) (G.create_mutex res)
         in
         st
       end
-    else
-      st
 
   let threadspawn (ask:Queries.ask) get set (st: BaseComponents (D).t) =
     let is_recovered_st = ThreadFlag.has_ever_been_multi ask && not @@ ThreadFlag.is_currently_multi ask in
@@ -2282,7 +2289,7 @@ let priv_module: (module S) Lazy.t =
         | "mutex-oplus" -> (module PerMutexOplusPriv)
         | "mutex-meet" -> (module PerMutexMeetPriv)
         | "mutex-meet-tid" -> (module PerMutexMeetTIDPriv (ThreadDigest))
-        | "mutex-meet-tid-ghost" -> (module PerMutexMeetTIDPriv (GhostPhase)) (* TODO: Implement *)
+        | "mutex-meet-tid-ghost" -> (module PerMutexMeetTIDPriv (GhostPhaseLifter(GhostPhase))) (* TODO: Implement *)
         | "protection" -> (module ProtectionBasedPriv (ProtDom) (struct let check_read_unprotected = false let handle_atomic = false end)(NoWrapper))
         | "protection-tid" -> (module ProtectionBasedPriv (ProtDom) (struct let check_read_unprotected = false let handle_atomic = false end)(DigestWrapper(ThreadNotStartedDigest)))
         | "protection-atomic" -> (module ProtectionBasedPriv (ProtDom) (struct let check_read_unprotected = false let handle_atomic = true end)(NoWrapper)) (* experimental *)

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -87,7 +87,8 @@ sig
   module G: Lattice.S
   module Digest: CommonPriv.Digest
 
-  val requiresActionOnPhaseChange: bool
+  val actionOnPhaseChange: (Digest.t phaseChange) option
+
   val getg: Q.ask -> ('a -> G.t) -> 'a -> GBase.t
   val getg_digest_override: Digest.t -> Q.ask -> ('a -> G.t) -> 'a -> GBase.t
   val sideg: Q.ask -> ('a -> G.t -> unit) -> 'a -> GBase.t -> unit
@@ -99,7 +100,8 @@ module NoWrapper:PrivatizationWrapper = functor (GBase:Lattice.S) ->
     module G = GBase
     module Digest = CommonPriv.UnitDigest
 
-    let requiresActionOnPhaseChange = false
+    let actionOnPhaseChange = None
+
     let getg _ getg = getg
     let sideg _ sideg = sideg
     let getg_digest_override _ = getg
@@ -110,7 +112,7 @@ module DigestWrapper(Digest: Digest):PrivatizationWrapper =  functor (GBase:Latt
     module G = MapDomain.MapBot_LiftTop (Digest) (GBase)
     module Digest = Digest
 
-    let requiresActionOnPhaseChange = Digest.requiresActionOnPhaseChange
+    let actionOnPhaseChange = Digest.actionOnPhaseChange
 
     let getg ask getg x =
       let vs = getg x in
@@ -731,9 +733,9 @@ struct
     {st with cpa = CPA.bot (); priv = (W.bot (),lmust,l)}
 
   let phase_change ask old_phase _new_phase getg sideg (st: BaseComponents (D).t) =
-    if not Digest.requiresActionOnPhaseChange then
-      st
-    else
+    match Digest.actionOnPhaseChange with
+    | None -> st
+    | Some {of_phase; to_phase} ->
       (* can publish to others can skip publishing to those that are must-accounted for in the local state ? *)
       begin
         (* Iterate over all mutexes, carry forward L component, as well as other global views (?) *)
@@ -764,7 +766,7 @@ struct
         L.iter publish_l l;
         (* Actually, we need to propagate only contributions form _other_ threads here *)
         (* If I am doing the join optimization, I need not publish to unknowns of threads that are must-joined *)
-        let old_phase = Option.get @@ Digest.of_phase ask old_phase in
+        let old_phase = of_phase ask old_phase in
         (* TODO: Where on earth do I get them from? *)
         let publish_others l (lock:LLock.t) =
           let current_bindings = G.mutex @@ getg (V.mutex l) in
@@ -773,6 +775,7 @@ struct
             but a different thread, carry it forward
           *)
           let carry_if_needed (digest:Digest.t) (value:L.value) (acc:GMutex.t) =
+
             acc
           in
           let res = GMutex.fold carry_if_needed current_bindings (GMutex.empty ()) in
@@ -1139,7 +1142,9 @@ struct
   let threadspawn ask get set st = st
 
   let phase_change ask old_phase new_phase getg sideg (st: BaseComponents (D).t) =
-    if Wrapper.requiresActionOnPhaseChange then
+    match Wrapper.actionOnPhaseChange with
+    | None -> st
+    | Some {of_phase; to_phase} ->
       let publish_global_to_newphase g =
         if (P.mem g @@ D.getP st.priv) then (
           (* TODO: Or propagate only unprotected, protected will be published later?
@@ -1153,7 +1158,7 @@ struct
         )
         else (
           if M.tracing then M.tracel "phase" "Propagating value for %s from %s to %s" g.vname (Queries.PhaseDigest.show old_phase) (Queries.PhaseDigest.show new_phase);
-          let old_phase = Option.get @@ Wrapper.Digest.of_phase ask old_phase in
+          let old_phase = of_phase ask old_phase in
           let old_phase_getg = Wrapper.getg_digest_override old_phase ask getg in
           let old_protected = old_phase_getg (V.protected g) in
           let old_unprotected = old_phase_getg (V.unprotected g) in
@@ -1177,8 +1182,7 @@ struct
       let alloc_varinfos = ask.f Queries.AllocVars in
       Q.VS.iter publish_global_to_newphase alloc_varinfos;
       st
-    else
-      st
+
 
   let thread_join ?(force=false) ask get e st = st
   let thread_return ask get set tid st = st

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -737,7 +737,7 @@ struct
     match Digest.actionOnPhaseChange with
     | None -> st
     | Some {of_phase; to_phase; patch_phase} ->
-      (* can publish to others can skip publishing to those that are must-accounted for in the local state ? *)
+      (* TODO: What if overall we're still in ST mode? *)
       begin
         (* What about other threads? Should only carry forward their globals? *)
         (* What is the timing of the phaseChange Event relative to unlocks? *)
@@ -749,7 +749,7 @@ struct
           let sideval = GMutex.singleton current_digest value in
           match lock with
           | `Left mutex ->
-            if Locksets.((MustLockset.mem mutex (current_lockset ask))) then
+            if Locksets.(MustLockset.mem mutex (current_lockset ask)) then
               let will_side_on_unlock = W.exists (is_protected_by ~protection:Weak ask mutex) w in
               if will_side_on_unlock then
                 (* Do not propagate to next phase here already, unlock will propagate appropriate value *)
@@ -765,9 +765,8 @@ struct
             sideg (V.global g) (G.create_global sideval)
         in
         L.iter publish_l l;
-        (* TODO: Where on earth do I get them from? *)
-        let publish_others l (lock:LLock.t) =
-          let current_bindings = G.mutex @@ getg (V.mutex l) in
+        let publish_others mutex =
+          let current_bindings = G.mutex @@ getg (V.mutex mutex) in
           (*
             Look up all current bindings and if we find one that belongs to the old phase,
             but is not accounted for, carry it forward.
@@ -787,8 +786,10 @@ struct
               GMutex.add target value acc
           in
           let res = GMutex.fold carry_if_needed current_bindings (GMutex.empty ()) in
-          sideg (V.mutex l) (G.create_mutex res)
+          sideg (V.mutex mutex) (G.create_mutex res)
         in
+        let mutexes = ask.f Queries.AppearingMutexes in
+        LockDomain.AppearingMutexesQuery.iter publish_others mutexes;
         st
       end
 

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -2310,7 +2310,7 @@ let priv_module: (module S) Lazy.t =
         | "mutex-oplus" -> (module PerMutexOplusPriv)
         | "mutex-meet" -> (module PerMutexMeetPriv)
         | "mutex-meet-tid" -> (module PerMutexMeetTIDPriv (ThreadDigest))
-        | "mutex-meet-tid-ghost" -> (module PerMutexMeetTIDPriv (GhostPhaseLifter(GhostPhase))) (* TODO: Implement *)
+        | "mutex-meet-tid-ghost" -> (module PerMutexMeetTIDPriv (GhostPhaseLifter(ThreadDigest))) (* TODO: Implement *)
         | "protection" -> (module ProtectionBasedPriv (ProtDom) (struct let check_read_unprotected = false let handle_atomic = false end)(NoWrapper))
         | "protection-tid" -> (module ProtectionBasedPriv (ProtDom) (struct let check_read_unprotected = false let handle_atomic = false end)(DigestWrapper(ThreadNotStartedDigest)))
         | "protection-atomic" -> (module ProtectionBasedPriv (ProtDom) (struct let check_read_unprotected = false let handle_atomic = true end)(NoWrapper)) (* experimental *)

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -2310,7 +2310,7 @@ let priv_module: (module S) Lazy.t =
         | "mutex-oplus" -> (module PerMutexOplusPriv)
         | "mutex-meet" -> (module PerMutexMeetPriv)
         | "mutex-meet-tid" -> (module PerMutexMeetTIDPriv (ThreadDigest))
-        | "mutex-meet-tid-ghost" -> (module PerMutexMeetTIDPriv (GhostPhaseLifter(ThreadDigest))) (* TODO: Implement *)
+        | "mutex-meet-tid-ghost" -> (module PerMutexMeetTIDPriv (GhostPhaseLifter(ThreadDigest)))
         | "protection" -> (module ProtectionBasedPriv (ProtDom) (struct let check_read_unprotected = false let handle_atomic = false end)(NoWrapper))
         | "protection-tid" -> (module ProtectionBasedPriv (ProtDom) (struct let check_read_unprotected = false let handle_atomic = false end)(DigestWrapper(ThreadNotStartedDigest)))
         | "protection-atomic" -> (module ProtectionBasedPriv (ProtDom) (struct let check_read_unprotected = false let handle_atomic = true end)(NoWrapper)) (* experimental *)

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -758,9 +758,8 @@ struct
         L.iter publish_l l;
         let publish_others l (lock:LLock.t) =
           let other_map = getg (V.mutex l) in
-
-          ()
-
+          let mtx = G.mutex other_map in
+          GMutex.fold (fun _ _ _ -> ()) mtx ()
         in
         st
       end

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -765,8 +765,8 @@ struct
             sideg (V.global g) (G.create_global sideval)
         in
         L.iter publish_l l;
-        let publish_others mutex =
-          let current_bindings = G.mutex @@ getg (V.mutex mutex) in
+        let publish_others (mutex:V.t) =
+          let current_bindings = G.mutex @@ getg mutex in
           (*
             Look up all current bindings and if we find one that belongs to the old phase,
             but is not accounted for, carry it forward.
@@ -786,10 +786,18 @@ struct
               GMutex.add target value acc
           in
           let res = GMutex.fold carry_if_needed current_bindings (GMutex.empty ()) in
-          sideg (V.mutex mutex) (G.create_mutex res)
+          sideg mutex (G.create_mutex res)
         in
         let mutexes = ask.f Queries.AppearingMutexes in
-        LockDomain.AppearingMutexesQuery.iter publish_others mutexes;
+        LockDomain.AppearingMutexesQuery.iter (fun mutex -> publish_others (V.mutex mutex)) mutexes;
+        (* Propagate for syntactic globals. *)
+        List.iter (function
+            | GVar (x, _, _) -> publish_others (V.global x)
+            | _ -> ()
+          ) !Cilfacade.current_file.globals;
+        (* Propagate for heap variables *)
+        let alloc_varinfos = ask.f Queries.AllocVars in
+        Q.VS.iter (fun v -> publish_others (V.global v)) alloc_varinfos;
         st
       end
 

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -1146,8 +1146,8 @@ struct
         )
         else (
           if M.tracing then M.tracel "phase" "Propagating value for %s from %s to %s" g.vname (Queries.PhaseDigest.show old_phase) (Queries.PhaseDigest.show new_phase);
-          let old_phase_magic = Option.get @@ Wrapper.Digest.of_phase ask old_phase in
-          let old_phase_getg = Wrapper.getg_digest_override old_phase_magic ask getg in
+          let old_phase = Option.get @@ Wrapper.Digest.of_phase ask old_phase in
+          let old_phase_getg = Wrapper.getg_digest_override old_phase ask getg in
           let old_protected = old_phase_getg (V.protected g) in
           let old_unprotected = old_phase_getg (V.unprotected g) in
           Wrapper.sideg ask sideg (V.protected g) old_protected;

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -61,6 +61,7 @@ sig
   val invariant_vars: Q.ask -> (V.t -> G.t) -> BaseComponents (D).t -> varinfo list
 
   val lmust: BaseDomain.BaseComponents (D).t -> Queries.LMust.t
+  val grow_lmust: BaseDomain.BaseComponents (D).t -> Queries.LMust.t -> BaseDomain.BaseComponents (D).t
 
   val init: unit -> unit
   val finalize: unit -> unit
@@ -72,6 +73,7 @@ struct
 
   let phase_change _ _ _ _ _ st = st
   let lmust _ = Queries.LMust.bot ()
+  let grow_lmust st _ = st
 end
 
 let old_threadenter (type d) ask (st: d BaseDomain.basecomponents_t) =
@@ -808,6 +810,13 @@ struct
     let (_, lmust, _) = st.priv in
     let elems = List.map fst (LMust.elements lmust) in
     Queries.LMust.of_list elems
+
+  let grow_lmust (st: BaseComponents (D).t) (lmust: Queries.LMust.t) =
+    let (w, lmust_old, l) = st.priv in
+    let lmust_elems = Queries.LMust.elements lmust in
+    let l' = List.map (fun lm -> (lm, ())) lmust_elems in
+    let new_lmust = LMust.union lmust_old (LMust.of_list l') in
+    {st with priv = (w, new_lmust, l)}
 
   let threadspawn (ask:Queries.ask) get set (st: BaseComponents (D).t) =
     let is_recovered_st = ThreadFlag.has_ever_been_multi ask && not @@ ThreadFlag.is_currently_multi ask in
@@ -2158,6 +2167,7 @@ struct
   let init () = time "init" (Priv.init) ()
   let finalize () = time "finalize" (Priv.finalize) ()
   let lmust st = time "lmust" (Priv.lmust) st
+  let grow_lmust st lmust = time "grow_must" (Priv.grow_lmust st) lmust
 end
 
 module PrecisionDumpPriv (Priv: S): S with module D = Priv.D =

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -60,6 +60,8 @@ sig
   val invariant_global: Q.ask -> (V.t -> G.t) -> V.t -> Invariant.t
   val invariant_vars: Q.ask -> (V.t -> G.t) -> BaseComponents (D).t -> varinfo list
 
+  val lmust: BaseDomain.BaseComponents (D).t -> Queries.LMust.t
+
   val init: unit -> unit
   val finalize: unit -> unit
 end
@@ -69,6 +71,7 @@ struct
   let finalize () = ()
 
   let phase_change _ _ _ _ _ st = st
+  let lmust _ = Queries.LMust.bot ()
 end
 
 let old_threadenter (type d) ask (st: d BaseDomain.basecomponents_t) =
@@ -800,6 +803,11 @@ struct
         Q.VS.iter (fun v -> publish_others (V.global v)) alloc_varinfos;
         st
       end
+
+  let lmust (st: BaseComponents (D).t) =
+    let (_, lmust, _) = st.priv in
+    let elems = List.map fst (LMust.elements lmust) in
+    Queries.LMust.of_list elems
 
   let threadspawn (ask:Queries.ask) get set (st: BaseComponents (D).t) =
     let is_recovered_st = ThreadFlag.has_ever_been_multi ask && not @@ ThreadFlag.is_currently_multi ask in
@@ -2149,6 +2157,7 @@ struct
 
   let init () = time "init" (Priv.init) ()
   let finalize () = time "finalize" (Priv.finalize) ()
+  let lmust st = time "lmust" (Priv.lmust) st
 end
 
 module PrecisionDumpPriv (Priv: S): S with module D = Priv.D =

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -732,20 +732,21 @@ struct
     (* so the cpa component of st is bot. *)
     {st with cpa = CPA.bot (); priv = (W.bot (),lmust,l)}
 
-  let phase_change ask old_phase _new_phase getg sideg (st: BaseComponents (D).t) =
+  let phase_change ask old_phase new_phase getg sideg (st: BaseComponents (D).t) =
+    let module Phase = Queries.PhaseDigest in
     match Digest.actionOnPhaseChange with
     | None -> st
-    | Some {of_phase; to_phase} ->
+    | Some {of_phase; to_phase; patch_phase} ->
       (* can publish to others can skip publishing to those that are must-accounted for in the local state ? *)
       begin
-        (* Iterate over all mutexes, carry forward L component, as well as other global views (?) *)
         (* What about other threads? Should only carry forward their globals? *)
         (* What is the timing of the phaseChange Event relative to unlocks? *)
         (* Skip those that are currently held, these will be published on unlock *)
         let (w, lmust, l) = st.priv in
+        let current_digest = Digest.current ask in
         let publish_l (lock:LLock.t) (value:L.value) =
-          let digest = Digest.current ask in
-          let sideval = GMutex.singleton digest value in
+          (* Carry forward L component of current thread *)
+          let sideval = GMutex.singleton current_digest value in
           match lock with
           | `Left mutex ->
             if Locksets.((MustLockset.mem mutex (current_lockset ask))) then
@@ -764,19 +765,26 @@ struct
             sideg (V.global g) (G.create_global sideval)
         in
         L.iter publish_l l;
-        (* Actually, we need to propagate only contributions form _other_ threads here *)
-        (* If I am doing the join optimization, I need not publish to unknowns of threads that are must-joined *)
-        let old_phase = of_phase ask old_phase in
         (* TODO: Where on earth do I get them from? *)
         let publish_others l (lock:LLock.t) =
           let current_bindings = G.mutex @@ getg (V.mutex l) in
           (*
-            Look up all current bindings and if we find one that belongs to the old phase
-            but a different thread, carry it forward
+            Look up all current bindings and if we find one that belongs to the old phase,
+            but is not accounted for, carry it forward.
           *)
           let carry_if_needed (digest:Digest.t) (value:L.value) (acc:GMutex.t) =
-
-            acc
+            let entry_phase = to_phase digest in
+            let target = patch_phase digest new_phase in
+            if not @@ Phase.equal entry_phase old_phase then
+              (* The phase does not match the phase before, no need to propagate *)
+              acc
+            else if Digest.accounted_for ask ~current:current_digest ~other:target then
+              (* New digest would be accounted for; could be because it is the same thread, ... *)
+              (* TODO: Is this correct when considering must-joining? *)
+              (* Reasoning: If I am doing the join optimization, I need not publish to unknowns of threads that are must-joined *)
+              acc
+            else
+              GMutex.add target value acc
           in
           let res = GMutex.fold carry_if_needed current_bindings (GMutex.empty ()) in
           sideg (V.mutex l) (G.create_mutex res)
@@ -1144,7 +1152,7 @@ struct
   let phase_change ask old_phase new_phase getg sideg (st: BaseComponents (D).t) =
     match Wrapper.actionOnPhaseChange with
     | None -> st
-    | Some {of_phase; to_phase} ->
+    | Some {of_phase; to_phase; patch_phase: _ } ->
       let publish_global_to_newphase g =
         if (P.mem g @@ D.getP st.priv) then (
           (* TODO: Or propagate only unprotected, protected will be published later?

--- a/src/analyses/basePriv.mli
+++ b/src/analyses/basePriv.mli
@@ -43,6 +43,8 @@ sig
   (** Returns global variables which are privatized. *)
 
   val lmust: BaseDomain.BaseComponents (D).t -> Queries.LMust.t
+  val grow_lmust: BaseDomain.BaseComponents (D).t -> Queries.LMust.t -> BaseDomain.BaseComponents (D).t
+
 
   val init: unit -> unit
   val finalize: unit -> unit

--- a/src/analyses/basePriv.mli
+++ b/src/analyses/basePriv.mli
@@ -42,6 +42,8 @@ sig
   val invariant_vars: Queries.ask -> (V.t -> G.t) -> BaseDomain.BaseComponents (D).t -> varinfo list
   (** Returns global variables which are privatized. *)
 
+  val lmust: BaseDomain.BaseComponents (D).t -> Queries.LMust.t
+
   val init: unit -> unit
   val finalize: unit -> unit
 end

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -186,13 +186,13 @@ struct
   end
 end
 
+type 'a phaseChange = { of_phase: Q.ask -> Queries.PhaseDigest.t -> 'a; to_phase: 'a -> Queries.PhaseDigest.t }
+
 module type Digest =
 sig
   include Printable.S
 
-  val requiresActionOnPhaseChange: bool
-  val of_phase: Q.ask -> Queries.PhaseDigest.t -> t option
-
+  val actionOnPhaseChange: (t phaseChange) option
   val current: Q.ask -> t
   val accounted_for: Q.ask -> current:t -> other:t -> bool
 end
@@ -206,8 +206,7 @@ struct
 
   module TID = ThreadIdDomain.Thread
 
-  let requiresActionOnPhaseChange = false
-  let of_phase _ _ = None
+  let actionOnPhaseChange = None
 
   let current (ask: Q.ask) =
     ThreadId.get_current ask
@@ -228,8 +227,8 @@ end
 
 module UnitDigest:Digest = struct
   include Printable.Unit
-  let requiresActionOnPhaseChange = false
-  let of_phase _ _ = None
+
+  let actionOnPhaseChange = None
 
   let current (ask:Q.ask) = ()
   let accounted_for (ask:Q.ask) ~current ~other = false
@@ -244,8 +243,7 @@ struct
 
   module TID = ThreadIdDomain.Thread
 
-  let requiresActionOnPhaseChange = false
-  let of_phase _ _ = None
+  let actionOnPhaseChange = None
 
   let current (ask: Q.ask) =
     ThreadId.get_current ask
@@ -261,8 +259,10 @@ module GhostPhase:Digest =
 struct
   include Q.PhaseDigest
 
-  let requiresActionOnPhaseChange = true
-  let of_phase (ask:Q.ask) d = Some d
+  let actionOnPhaseChange =
+    let of_phase (ask:Q.ask) d = d in
+    Some { of_phase; to_phase = Fun.id }
+
 
   let current (ask: Q.ask) = ask.f Q.PhaseDigest
   let accounted_for (ask:Q.ask)  ~(current: t) ~(other: t) =
@@ -276,18 +276,19 @@ module GhostPhaseLifter(Inner:Digest):Digest =
 struct
   include Printable.Prod (Q.PhaseDigest) (Inner)
 
-  let requiresActionOnPhaseChange = true
-  let of_phase ask p =
-    (*
+  let actionOnPhaseChange =
+    let of_phase ask p =
+      (*
 
-     TODO: Is this correct here? Always take current digest of inner?
-      - Do I need this at all or can I just publish my local view?
-      - What about threads that are not unique?
+      TODO: Is this correct here? Always take current digest of inner?
+        - Do I need this at all or can I just publish my local view?
+        - What about threads that are not unique?
 
-    *)
-    let inner = Inner.current ask in
-    Some (p, inner)
-
+      *)
+      let inner = Inner.current ask in
+      (p, inner)
+    in
+    Some { of_phase; to_phase = fst }
 
   let current (ask:Q.ask) = (ask.f Q.PhaseDigest, Inner.current ask)
 

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -356,6 +356,7 @@ struct
       | `Bot -> GThread.bot ()
       | `Lifted2 x -> x
       | _ -> failwith "PerMutexMeetPrivTID.thread"
+
     let create_mutex mutex = `Lifted1 mutex
     let create_global global = `Lifted1 global
     let create_thread thread = `Lifted2 thread

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -186,7 +186,7 @@ struct
   end
 end
 
-type 'a phaseChange = { of_phase: Q.ask -> Queries.PhaseDigest.t -> 'a; to_phase: 'a -> Queries.PhaseDigest.t }
+type 'a phaseChange = { of_phase: Q.ask -> Queries.PhaseDigest.t -> 'a; to_phase: 'a -> Queries.PhaseDigest.t; patch_phase: 'a -> Queries.PhaseDigest.t -> 'a }
 
 module type Digest =
 sig
@@ -261,7 +261,8 @@ struct
 
   let actionOnPhaseChange =
     let of_phase (ask:Q.ask) d = d in
-    Some { of_phase; to_phase = Fun.id }
+    let patch_phase _ d = d in
+    Some { of_phase; to_phase = Fun.id; patch_phase }
 
 
   let current (ask: Q.ask) = ask.f Q.PhaseDigest
@@ -288,7 +289,8 @@ struct
       let inner = Inner.current ask in
       (p, inner)
     in
-    Some { of_phase; to_phase = fst }
+    let patch_phase (phase, inner) phase' = (phase', inner) in
+    Some { of_phase; to_phase = fst; patch_phase }
 
   let current (ask:Q.ask) = (ask.f Q.PhaseDigest, Inner.current ask)
 

--- a/src/analyses/mutexEventsAnalysis.ml
+++ b/src/analyses/mutexEventsAnalysis.ml
@@ -15,7 +15,13 @@ struct
   include UnitAnalysis.Spec
   let name () = "mutexEvents"
 
+  module G = LockDomain.AppearingMutexes
+  module V = Analyses.UnitV
+
   let eval_exp_addr (a: Queries.ask) exp = a.f (Queries.MayPointTo exp)
+
+  let add_appearing_mutex man addr =
+    CommonPriv.lift_lock (Analyses.ask_of_man man) (fun () m -> man.sideg () (G.singleton m)) () addr
 
   let lock man rw may_fail nonzero_return_when_aquired a lv_opt arg =
     let compute_refine_split (e: Addr.t) = match e with
@@ -31,6 +37,7 @@ struct
     match lv_opt with
     | None ->
       Queries.AD.iter (fun e ->
+          add_appearing_mutex man e;
           man.split () (Events.Lock (e, rw) :: compute_refine_split e)
         ) (eval_exp_addr a arg);
       if may_fail then
@@ -39,6 +46,7 @@ struct
     | Some lv ->
       let sb = Events.SplitBranch (Lval lv, nonzero_return_when_aquired) in
       Queries.AD.iter (fun e ->
+          add_appearing_mutex man e;
           man.split () (sb :: Events.Lock (e, rw) :: compute_refine_split e);
         ) (eval_exp_addr a arg);
       if may_fail then (
@@ -55,7 +63,9 @@ struct
     && String.starts_with fundec.svar.vname ~prefix:"__VERIFIER_atomic_"
     && not (String.starts_with fundec.svar.vname ~prefix:"__VERIFIER_atomic_instrument_")
     then
-      man.emit (Events.Unlock (LockDomain.Addr.of_var LF.verifier_atomic_var))
+      let addr = LockDomain.Addr.of_var LF.verifier_atomic_var in
+      add_appearing_mutex man addr;
+      man.emit (Events.Unlock addr)
 
   let body man f : D.t =
     (* deprecated but still valid SV-COMP convention for atomic block *)
@@ -63,12 +73,15 @@ struct
     && String.starts_with f.svar.vname ~prefix:"__VERIFIER_atomic_"
     && not (String.starts_with f.svar.vname ~prefix:"__VERIFIER_atomic_instrument_")
     then
-      man.emit (Events.Lock (LockDomain.Addr.of_var LF.verifier_atomic_var, true))
+      let addr = LockDomain.Addr.of_var LF.verifier_atomic_var in
+      add_appearing_mutex man addr;
+      man.emit (Events.Lock (addr, true))
 
   let special (man: (unit, _, _, _) man) lv f arglist : D.t =
     let remove_rw x = x in
     let unlock arg remove_fn =
       Queries.AD.iter (fun e ->
+          add_appearing_mutex man e;
           man.split () [Events.Unlock (remove_fn e)]
         ) (eval_exp_addr (Analyses.ask_of_man man) arg);
       raise Analyses.Deadcode
@@ -85,6 +98,7 @@ struct
       (* emit unlock-lock events for privatization *)
       let ms = eval_exp_addr (Analyses.ask_of_man man) m_arg in
       Queries.AD.iter (fun m ->
+          add_appearing_mutex man m;
           (* unlock-lock each possible mutex as a split to be dependent *)
           (* otherwise may-point-to {a, b} might unlock a, but relock b *)
           man.split () [Events.Unlock m; Events.Lock (m, true)];
@@ -92,6 +106,13 @@ struct
       raise Deadcode (* splits cover all cases *)
     | _ ->
       ()
+
+  let query man (type a) (q: a Queries.t): a Queries.result =
+    match q with
+    | Queries.AppearingMutexes ->
+      `Lifted (man.global ())
+    | _ ->
+      Queries.Result.top q
 
 end
 

--- a/src/analyses/phaseGhostSplit.ml
+++ b/src/analyses/phaseGhostSplit.ml
@@ -59,10 +59,10 @@ struct
 
     let can_change_to (_, changes) target currmhp =
       match PhaseChanges.find_opt (`Lifted target) changes with
-      | None ->
-        false
-      | Some (accesses, _) ->
-        MHPs.can_any_mhp currmhp accesses
+      | Some (accesses, lmust) when MHPs.can_any_mhp currmhp accesses ->
+        Some lmust
+      | _ ->
+        None
   end
 
   let initial_ghost_values () =
@@ -181,36 +181,39 @@ struct
       let may_be_advanced_here m var =
         if man.ask Queries.MustBeAtomic then
           (* Shortcut, would also be caught below, but as it is common cheaper to check here *)
-          (if M.tracing then M.tracel "phaseGhost" "Is atomic -> not advancing phase"; false)
+          (if M.tracing then M.tracel "phaseGhost" "Is atomic -> not advancing phase"; None)
         else
           match man.ask (Queries.Owner var), man.ask Queries.CurrentThreadId, D.find var m  with
           | `Bot, _, _
           | _, `Bot, _ ->
-            false
+            None
           | `Lifted owner, _ , `Lifted z ->
             G.can_change_to (man.global var) (Z.succ z) (current_mhp man)
           | _ ->
             failwith "assumption about ghost owner violated"
       in
-      let rec handle_vars m = function
-        | []  -> man.split m []
+      let rec handle_vars (m, lmust) = function
+        | []  ->
+          man.split m [Events.GrowLMust lmust]
         | var :: vars ->
-          if may_be_advanced_here m var then
+          match may_be_advanced_here m var with
+          | Some curr_lmust ->
             (let v' = (match (D.find var m) with
                  | `Lifted x -> Z.succ x
                  | _ -> failwith "assumption")
              in
              let advanced = D.add var (`Lifted v') m in
-             handle_vars advanced (var::vars);
-             handle_vars m vars)
-          else
-            handle_vars m vars
+             let lmust' = LMust.union lmust curr_lmust in
+             handle_vars (advanced, lmust') (var::vars);
+             handle_vars (m, lmust) vars)
+          | None ->
+            handle_vars (m, lmust) vars
       in
       let traceEvolution () =
         YamlWitness.VarSet.iter (fun var ->
             let owner = man.ask (Queries.Owner var) in
             let phase_ghost = is_phase_ghost man var in
-            let may_advance = phase_ghost && may_be_advanced_here local var in
+            let may_advance = phase_ghost && Option.is_some (may_be_advanced_here local var) in
             M.tracel "phaseGhost" "Ghost %a is %sa phase ghost, has owner %a and may %s be advanced here" (* nosemgrep: trace-not-in-tracing *)
               CilType.Varinfo.pretty var
               (if phase_ghost then "" else "not ")
@@ -219,7 +222,7 @@ struct
           ) !(YamlWitness.ghostVars)
       in
       if M.tracing then traceEvolution ();
-      handle_vars local (phase_ghosts man);
+      handle_vars (local, LMust.empty ()) (phase_ghosts man);
       raise Deadcode
 
 

--- a/src/analyses/phaseGhostSplit.ml
+++ b/src/analyses/phaseGhostSplit.ml
@@ -34,27 +34,34 @@ struct
     let name () = "ghost-phase-accesses"
   end
 
+  module LMust = Queries.LMust
+
+  module MHPsPlusLMust =
+  struct
+    include Lattice.Prod (MHPs) (Queries.LMust)
+  end
+
   module PhaseChanges =
   struct
-    include MapDomain.MapBot (Const) (MHPs)
+    include MapDomain.MapBot (Const) (MHPsPlusLMust)
     let name () = "ghost-phase-changes"
   end
 
   module G =
   struct
     (* fist component: constant value when the thread returns *)
-    (* secone component: map from target of phase change to MHP information under which this change can happen  *)
+    (* second component: map from target of phase change to MHP information under which this change can happen  *)
     include Lattice.Prod (Const) (PhaseChanges)
     let const_at_thread_end (const, _) = const
     let changes (_, changes) = changes
     let create_const_at_thread_end const = (const, PhaseChanges.bot ())
-    let create_change phase mhp = (Const.bot (), PhaseChanges.singleton phase (MHPs.singleton mhp))
+    let create_change phase mhp lmust = (Const.bot (), (PhaseChanges.singleton phase (MHPs.singleton mhp, lmust)))
 
-    let can_change_to (_,changes) target currmhp =
+    let can_change_to (_, changes) target currmhp =
       match PhaseChanges.find_opt (`Lifted target) changes with
       | None ->
         false
-      | Some accesses ->
+      | Some (accesses, _) ->
         MHPs.can_any_mhp currmhp accesses
   end
 
@@ -229,7 +236,7 @@ struct
          | Some z ->
            (let v = Z.succ z in
             let local_new = D.add var (`Lifted v) local in
-            man.sideg var (G.create_change (`Lifted v) (current_mhp man));
+            man.sideg var (G.create_change (`Lifted v) (current_mhp man) (man.ask LMust));
             (* TODO: Prolong until after atomic is over? *)
             if not (D.equal local local_new) then
               man.emit (Events.PhaseChange {old_phase = `Lifted local; new_phase = `Lifted local_new});

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -46,6 +46,18 @@ struct
   let is_all (set: t) = set = `Top
 end
 
+module AppearingMutexes =
+struct
+  include SetDomain.Make (MustLock)
+  let name () = "appearing mutexes"
+end
+
+module AppearingMutexesQuery =
+struct
+  include SetDomain.LiftTop (AppearingMutexes) (struct let topname = "All appearing mutexes" end)
+  let name () = "appearing mutexes query"
+end
+
 (* true means exclusive lock and false represents reader lock*)
 module RW   = BoolDomain.MayBool (* TODO: name booleans? *)
 

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -782,9 +782,9 @@
             "privatization": {
               "title": "ana.base.privatization",
               "description":
-                "Which privatization to use? none/vojdani/mutex-oplus/mutex-meet/mutex-meet-tid/protection/protection-read/mine/mine-nothread/mine-W/mine-W-noinit/lock/lock-tid/write/write-tid/write+lock/write+lock-tid",
+                "Which privatization to use? none/vojdani/mutex-oplus/mutex-meet/mutex-meet-tid/mutex-meet-tid-ghost/protection/protection-read/mine/mine-nothread/mine-W/mine-W-noinit/lock/lock-tid/write/write-tid/write+lock/write+lock-tid",
               "type": "string",
-              "enum": ["none", "vojdani", "mutex-oplus", "mutex-meet", "protection", "protection-tid", "protection-atomic", "protection-read", "protection-read-tid", "protection-read-atomic", "mine", "mine-nothread", "mine-W", "mine-W-noinit", "lock", "lock-tid", "write", "write-tid", "write+lock", "write+lock-tid", "mutex-meet-tid","protection-atomic-ghost"],
+              "enum": ["none", "vojdani", "mutex-oplus", "mutex-meet", "mutex-meet-tid-ghost", "protection", "protection-tid", "protection-atomic", "protection-read", "protection-read-tid", "protection-read-atomic", "mine", "mine-nothread", "mine-W", "mine-W-noinit", "lock", "lock-tid", "write", "write-tid", "write+lock", "write+lock-tid", "mutex-meet-tid","protection-atomic-ghost"],
               "default": "protection-read"
             },
             "priv": {

--- a/src/domains/events.ml
+++ b/src/domains/events.ml
@@ -19,6 +19,7 @@ type t =
   | EnterOnce of {once_control: CilType.Exp.t; ran:bool} (** Once is transformed into a sequence of: enter_once(o) if(!ran(o)) f() leave_once(o) *)
   | LeaveOnce of {once_control: CilType.Exp.t}
   | PhaseChange of {old_phase: Queries.PhaseDigest.t; new_phase: Queries.PhaseDigest.t}
+  | GrowLMust of Queries.LMust.t
 
 (** Should event be emitted after transfer function raises [Deadcode]? *)
 let emit_on_deadcode = function
@@ -26,7 +27,8 @@ let emit_on_deadcode = function
   | Escape _ (* Privatization must still handle escapes. *)
   | EnterMultiThreaded (* Privatization must still publish. *)
   | Access _ (* Protection and races must still consider access. *)
-  | PhaseChange _ -> (* Not sure, but save default *)
+  | PhaseChange _ (* Not sure, but safe default *)
+  | GrowLMust _ -> (* Not sure, but safe default *)
     true
   | Lock _ (* Doesn't need to publish. *)
   | SplitBranch _ (* only emitted in split, which is never dead. *)
@@ -56,3 +58,4 @@ let pretty () = function
   | EnterOnce {once_control; ran} -> dprintf "EnterOnce {once_control=%a; ran=%B}" CilType.Exp.pretty once_control ran
   | LeaveOnce {once_control} -> dprintf "LeaveOnce {once_control=%a}" CilType.Exp.pretty once_control
   | PhaseChange {old_phase; new_phase} -> dprintf "PhaseChange {old_phase=%a; new_phase=%a}" Queries.PhaseDigest.pretty old_phase Queries.PhaseDigest.pretty new_phase
+  | GrowLMust lmust -> dprintf "GrowLMust %a" Queries.LMust.pretty lmust

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -112,6 +112,7 @@ type _ t =
   | MayBePublicWithout: maybepublicwithout -> MayBool.t t
   | MustBeProtectedBy: mustbeprotectedby -> MustBool.t t
   | MustLockset: LockDomain.MustLockset.t t
+  | AppearingMutexes: LockDomain.AppearingMutexesQuery.t t
   | MustBeAtomic: MustBool.t t
   | MustBeSingleThreaded: {since_start: bool} -> MustBool.t t (** Use via {!ThreadFlag.is_currently_multi} and {!ThreadFlag.has_ever_been_multi}. *)
   | MustBeUniqueThread: MustBool.t t
@@ -198,6 +199,7 @@ struct
     | ReachableFrom _ -> (module AD)
     | Regions _ -> (module LS)
     | MustLockset -> (module LockDomain.MustLockset)
+    | AppearingMutexes -> (module LockDomain.AppearingMutexesQuery)
     | EvalFunvar _ -> (module AD)
     | ReachableUkTypes _ -> (module TS)
     | MayEscape _ -> (module MayBool)
@@ -280,6 +282,7 @@ struct
     | ReachableFrom _ -> AD.top ()
     | Regions _ -> LS.top ()
     | MustLockset -> LockDomain.MustLockset.top ()
+    | AppearingMutexes -> LockDomain.AppearingMutexesQuery.top ()
     | EvalFunvar _ -> AD.top ()
     | ReachableUkTypes _ -> TS.top ()
     | MayEscape _ -> MayBool.top ()
@@ -498,6 +501,7 @@ struct
     | Any (MayBePublicWithout x) -> Pretty.dprintf "MayBePublicWithout _"
     | Any (MustBeProtectedBy x) -> Pretty.dprintf "MustBeProtectedBy _"
     | Any MustLockset -> Pretty.dprintf "MustLockset"
+    | Any AppearingMutexes -> Pretty.dprintf "AppearingMutexes"
     | Any MustBeAtomic -> Pretty.dprintf "MustBeAtomic"
     | Any (MustBeSingleThreaded {since_start}) -> Pretty.dprintf "MustBeSingleThreaded since_start=%b" since_start
     | Any MustBeUniqueThread -> Pretty.dprintf "MustBeUniqueThread"

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -99,6 +99,18 @@ module CL = MapDomain.MapBot_LiftTop (ThreadIdDomain.Thread) (LockDomain.MustLoc
 
 module LH = MapDomain.MapTop (LockDomain.MustLock) (SetDomain.Reverse (ConcDomain.ThreadSet))
 
+module LLock =
+struct
+  include Printable.Either (LockDomain.MustLock) (struct include CilType.Varinfo let name () = "global" end)
+  let mutex m = `Left m
+  let global x = `Right x
+end
+
+module LMust =
+struct
+  include SetDomain.Reverse (SetDomain.ToppedSet (LLock) (struct let topname = "All locks" end))
+  let name () = "LMust"
+end
 
 (** GADT for queries with specific result type. *)
 type _ t =
@@ -176,6 +188,7 @@ type _ t =
   | DescendantThreads: ThreadIdDomain.Thread.t -> ConcDomain.ThreadSet.t t
   | CreationLockset: ThreadIdDomain.Thread.t -> CL.t t
   | MustlockHistory: LH.t t
+  | LMust: LMust.t t
   | TutorialEffectivelyLocal: varinfo -> MustBool.t t (** Used in tutorial for effectively local variables. *)
 
 type 'a result = 'a
@@ -260,6 +273,7 @@ struct
     | DescendantThreads _ -> (module ConcDomain.ThreadSet)
     | CreationLockset _ -> (module CL)
     | MustlockHistory -> (module LH)
+    | LMust -> (module LMust)
     | TutorialEffectivelyLocal _ -> (module MustBool)
 
   (** Get bottom result for query. *)
@@ -343,6 +357,7 @@ struct
     | DescendantThreads _ -> ConcDomain.ThreadSet.top ()
     | CreationLockset _ -> CL.top ()
     | MustlockHistory -> LH.top ()
+    | LMust -> LMust.top ()
     | TutorialEffectivelyLocal _ -> MustBool.top ()
 end
 
@@ -558,6 +573,7 @@ struct
     | Any PhaseDigest -> Pretty.dprintf "PhaseDigest"
     | Any (CreationLockset t) -> Pretty.dprintf "CreationLockset %a" ThreadIdDomain.Thread.pretty t
     | Any (MustlockHistory) -> Pretty.dprintf "MustlockHistory"
+    | Any LMust -> Pretty.dprintf "LMust"
     | Any (TutorialEffectivelyLocal v) -> Pretty.dprintf "TutorialEffectivelyLocal %a" CilType.Varinfo.pretty v
 end
 

--- a/tests/regression/19-ghost-witness/14-mutex-meet-tid-ghost-bounds.c
+++ b/tests/regression/19-ghost-witness/14-mutex-meet-tid-ghost-bounds.c
@@ -1,0 +1,30 @@
+// CRAM
+// Ghost phases recover protected values that plain mutex-meet-tid cannot validate.
+#include<pthread.h>
+#include<goblint.h>
+
+int x;
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+
+void fun() {
+    pthread_mutex_lock(&m);
+    x = 1;
+    pthread_mutex_unlock(&m);
+
+    pthread_mutex_lock(&m);
+    x = 2;
+    pthread_mutex_unlock(&m);
+}
+
+int main(void) {
+    pthread_t thread;
+    pthread_create(&thread, NULL, (void*)fun, NULL);
+
+    pthread_mutex_lock(&m);
+    
+    pthread_mutex_unlock(&m);
+    pthread_join(thread, NULL);
+
+    return 0;
+}

--- a/tests/regression/19-ghost-witness/14-mutex-meet-tid-ghost-bounds.t
+++ b/tests/regression/19-ghost-witness/14-mutex-meet-tid-ghost-bounds.t
@@ -12,7 +12,7 @@ ghost-conditioned protected value remains out of reach.
 With `mutex-meet-tid-ghost`, the phase ghost becomes part of the digest and the
 same protected value invariant is validated.
 
-  $ goblint --disable warn.race --disable warn.integer --enable warn.deterministic --enable ana.sv-comp.functions --set witness.yaml.validate 14-mutex-meet-tid-ghost-bounds.yml --set ana.activated[+] phaseGhost --set ana.activated[+] phaseGhostSplit --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set lib.activated[+] sv-comp --set ana.base.privatization mutex-meet-tid-ghost --enable ana.int.interval --set colors never 14-mutex-meet-tid-ghost-bounds.c --html
+  $ goblint --disable warn.race --disable warn.integer --enable warn.deterministic --enable ana.sv-comp.functions --set witness.yaml.validate 14-mutex-meet-tid-ghost-bounds.yml --set ana.activated[+] phaseGhost --set ana.activated[+] phaseGhostSplit --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set lib.activated[+] sv-comp --set ana.base.privatization mutex-meet-tid-ghost --enable ana.int.interval --set colors never 14-mutex-meet-tid-ghost-bounds.c > 14-mutex-meet-tid-ghost.out 2>&1
 
   $ grep -F "invariant confirmed: (ghost_a == 0 && x == 0) || (ghost_a == 1 && x == 1) || (ghost_a == 2 && x == 2)" 14-mutex-meet-tid-ghost.out
   [Success][Witness] invariant confirmed: (ghost_a == 0 && x == 0) || (ghost_a == 1 && x == 1) || (ghost_a == 2 && x == 2) (14-mutex-meet-tid-ghost-bounds.c:25:5)

--- a/tests/regression/19-ghost-witness/14-mutex-meet-tid-ghost-bounds.t
+++ b/tests/regression/19-ghost-witness/14-mutex-meet-tid-ghost-bounds.t
@@ -1,0 +1,21 @@
+Plain `mutex-meet-tid` does not keep the ghost phase in its digest, so the
+ghost-conditioned protected value remains out of reach.
+
+  $ goblint --disable warn.race --disable warn.integer --enable warn.deterministic --enable ana.sv-comp.functions --set witness.yaml.validate 14-mutex-meet-tid-ghost-bounds.yml --set ana.activated[+] phaseGhost --set ana.activated[+] phaseGhostSplit --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set lib.activated[+] sv-comp --set ana.base.privatization mutex-meet-tid --enable ana.int.interval --set colors never 14-mutex-meet-tid-ghost-bounds.c > 14-mutex-meet-tid.out 2>&1
+
+  $ grep -F "invariant unconfirmed: (ghost_a == 0 && x == 0) || (ghost_a == 1 && x == 1) || (ghost_a == 2 && x == 2)" 14-mutex-meet-tid.out
+  [Warning][Witness] invariant unconfirmed: (ghost_a == 0 && x == 0) || (ghost_a == 1 && x == 1) || (ghost_a == 2 && x == 2) (14-mutex-meet-tid-ghost-bounds.c:25:5)
+
+  $ grep -F "invariant confirmed: ghost_a >= 0 && ghost_a <= 2" 14-mutex-meet-tid.out
+  [Success][Witness] invariant confirmed: ghost_a >= 0 && ghost_a <= 2 (14-mutex-meet-tid-ghost-bounds.c:25:5)
+
+With `mutex-meet-tid-ghost`, the phase ghost becomes part of the digest and the
+same protected value invariant is validated.
+
+  $ goblint --disable warn.race --disable warn.integer --enable warn.deterministic --enable ana.sv-comp.functions --set witness.yaml.validate 14-mutex-meet-tid-ghost-bounds.yml --set ana.activated[+] phaseGhost --set ana.activated[+] phaseGhostSplit --set ana.path_sens[+] threadflag --set ana.activated[+] threadJoins --set lib.activated[+] sv-comp --set ana.base.privatization mutex-meet-tid-ghost --enable ana.int.interval --set colors never 14-mutex-meet-tid-ghost-bounds.c --html
+
+  $ grep -F "invariant confirmed: (ghost_a == 0 && x == 0) || (ghost_a == 1 && x == 1) || (ghost_a == 2 && x == 2)" 14-mutex-meet-tid-ghost.out
+  [Success][Witness] invariant confirmed: (ghost_a == 0 && x == 0) || (ghost_a == 1 && x == 1) || (ghost_a == 2 && x == 2) (14-mutex-meet-tid-ghost-bounds.c:25:5)
+
+  $ grep -F "invariant confirmed: ghost_a >= 0 && ghost_a <= 2" 14-mutex-meet-tid-ghost.out
+  [Success][Witness] invariant confirmed: ghost_a >= 0 && ghost_a <= 2 (14-mutex-meet-tid-ghost-bounds.c:25:5)

--- a/tests/regression/19-ghost-witness/14-mutex-meet-tid-ghost-bounds.yml
+++ b/tests/regression/19-ghost-witness/14-mutex-meet-tid-ghost-bounds.yml
@@ -1,0 +1,82 @@
+- entry_type: ghost_instrumentation
+  metadata:
+    format_version: "2.1-goblint"
+    uuid: 00000000-0000-0000-0000-000000000141
+    creation_time: 2026-04-21T00:00:00Z
+    producer:
+      name: Test
+      version: "0.0"
+    task:
+      input_files:
+      - 14-mutex-meet-tid-ghost-bounds.c
+      input_file_hashes:
+        14-mutex-meet-tid-ghost-bounds.c: "0000000000000000000000000000000000000000000000000000000000000000"
+      data_model: LP64
+      language: C
+  content:
+    ghost_variables:
+    - name: ghost_a
+      scope: global
+      type: int
+      initial:
+        value: "0"
+        format: c_expression
+    - name: ghost_b
+      scope: global
+      type: int
+      initial:
+        value: "0"
+        format: c_expression
+    ghost_updates:
+    - location:
+        file_name: 14-mutex-meet-tid-ghost-bounds.c
+        line: 12
+        column: 5
+        function: fun
+      updates:
+      - variable: ghost_a
+        value: "ghost_a + 1"
+        format: c_expression
+    - location:
+        file_name: 14-mutex-meet-tid-ghost-bounds.c
+        line: 16
+        column: 5
+        function: fun
+      updates:
+      - variable: ghost_a
+        value: "ghost_a + 1"
+        format: c_expression
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: 00000000-0000-0000-0000-000000000142
+    creation_time: 2026-04-21T00:00:00Z
+    producer:
+      name: Test
+      version: "0.0"
+    task:
+      input_files:
+      - 14-mutex-meet-tid-ghost-bounds.c
+      input_file_hashes:
+        14-mutex-meet-tid-ghost-bounds.c: "0000000000000000000000000000000000000000000000000000000000000000"
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 14-mutex-meet-tid-ghost-bounds.c
+        line: 25
+        column: 5
+        function: main
+      value: (ghost_a == 0 && x == 0) || (ghost_a == 1 && x == 1) || (ghost_a == 2 && x == 2)
+      format: c_expression
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: 14-mutex-meet-tid-ghost-bounds.c
+        line: 25
+        column: 5
+        function: main
+      value: ghost_a >= 0 && ghost_a <= 2
+      format: c_expression

--- a/tests/regression/56-witness/30-base-unassume-inc-dec.t
+++ b/tests/regression/56-witness/30-base-unassume-inc-dec.t
@@ -24,7 +24,7 @@ Assertions not proven.
 
 Easiest to run again to get evals.
   $ goblint --enable ana.int.interval --set solvers.td3.side_widen always --set ana.base.privatization vojdani 30-base-unassume-inc-dec.c -v 2>&1 | grep 'evals'
-  [Info] vars = 38    evals = 73    narrow_reuses = 3
+  [Info] vars = 39    evals = 73    narrow_reuses = 3
 
 ## Unassume after lock
 
@@ -53,7 +53,7 @@ Assertions proven.
 Evals less than from scratch.
 TODO: Should not be according to Simmo's PhD thesis?
   $ goblint --enable ana.int.interval --set solvers.td3.side_widen always --set ana.base.privatization vojdani --set ana.activated[+] unassume --set witness.yaml.unassume 30-base-unassume-inc-dec.yml --enable ana.widen.tokens 30-base-unassume-inc-dec.c -v 2>&1 | grep 'evals'
-  [Info] vars = 38    evals = 58    narrow_reuses = 3
+  [Info] vars = 39    evals = 58    narrow_reuses = 3
 
 ## Unassume after lock and before unlock
 
@@ -85,7 +85,7 @@ Assertions proven.
 
 Evals less than from scratch.
   $ goblint --enable ana.int.interval --set solvers.td3.side_widen always --set ana.base.privatization vojdani --set ana.activated[+] unassume --set witness.yaml.unassume 30-base-unassume-inc-dec2.yml --enable ana.widen.tokens 30-base-unassume-inc-dec.c -v 2>&1 | grep 'evals'
-  [Info] vars = 38    evals = 49    narrow_reuses = 2
+  [Info] vars = 39    evals = 49    narrow_reuses = 2
 
 ## Unassume before unlock
 
@@ -116,7 +116,7 @@ Assertions proven.
 Evals less than from scratch.
 TODO: Why more than unassume after lock and before unlock?
   $ goblint --enable ana.int.interval --set solvers.td3.side_widen always --set ana.base.privatization vojdani --set ana.activated[+] unassume --set witness.yaml.unassume 30-base-unassume-inc-dec3.yml --enable ana.widen.tokens 30-base-unassume-inc-dec.c -v 2>&1 | grep 'evals'
-  [Info] vars = 38    evals = 54    narrow_reuses = 2
+  [Info] vars = 39    evals = 54    narrow_reuses = 2
 
 
 # Protection-Based Reading
@@ -144,7 +144,7 @@ Assertions not proven.
     total memory locations: 1
 
   $ goblint --enable ana.int.interval --set solvers.td3.side_widen always --set ana.base.privatization protection 30-base-unassume-inc-dec.c -v 2>&1 | grep 'evals'
-  [Info] vars = 39    evals = 53    narrow_reuses = 3
+  [Info] vars = 40    evals = 53    narrow_reuses = 3
 
 ## Unassume after lock
 
@@ -173,7 +173,7 @@ Assertions proven.
 Evals not less than from scratch.
 Fits old TODO from Simmo's PhD thesis: "No improvement in number of steps using W set. Without it the improvement was 44 → 26."
   $ goblint --enable ana.int.interval --set solvers.td3.side_widen always --set ana.base.privatization protection --set ana.activated[+] unassume --set witness.yaml.unassume 30-base-unassume-inc-dec.yml --enable ana.widen.tokens 30-base-unassume-inc-dec.c -v 2>&1 | grep 'evals'
-  [Info] vars = 39    evals = 54    narrow_reuses = 3
+  [Info] vars = 40    evals = 54    narrow_reuses = 3
 
 ## Unassume after lock and before unlock
 
@@ -205,7 +205,7 @@ Assertions proven.
 
 Evals less than from scratch.
   $ goblint --enable ana.int.interval --set solvers.td3.side_widen always --set ana.base.privatization protection --set ana.activated[+] unassume --set witness.yaml.unassume 30-base-unassume-inc-dec2.yml --enable ana.widen.tokens 30-base-unassume-inc-dec.c -v 2>&1 | grep 'evals'
-  [Info] vars = 39    evals = 41    narrow_reuses = 2
+  [Info] vars = 40    evals = 41    narrow_reuses = 2
 
 ## Unassume before unlock
 
@@ -236,4 +236,4 @@ Assertions proven.
 Evals less than from scratch.
 Evals same as unassume after lock and before unlock, matches Simmo's PhD thesis.
   $ goblint --enable ana.int.interval --set solvers.td3.side_widen always --set ana.base.privatization protection --set ana.activated[+] unassume --set witness.yaml.unassume 30-base-unassume-inc-dec3.yml --enable ana.widen.tokens 30-base-unassume-inc-dec.c -v 2>&1 | grep 'evals'
-  [Info] vars = 39    evals = 41    narrow_reuses = 2
+  [Info] vars = 40    evals = 41    narrow_reuses = 2


### PR DESCRIPTION
Beyond support for the non-relational non-thread-id protection analysis, this is supposed to add phase support for mutex-meet plus thread ids