### PR TITLE
Remove incorrect one-past-end distinction in memOutOfBounds

### DIFF
--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -38,19 +38,12 @@ struct
     try ID.lt offs (intdom_of_int 0)
     with IntDomain.ArithmeticOnIntegerBot _ -> None
 
-  let check_deref_offset_bounds ptr_size offs =
+  let check_offset_bounds ptr_size offs =
     let ptr_size_le_offs =
       try ID.le ptr_size offs
       with IntDomain.ArithmeticOnIntegerBot _ -> None
     in
     offs_lt_zero offs, ptr_size_le_offs
-
-  let check_ptr_offset_bounds ptr_size offs =
-    let ptr_size_lt_offs =
-      try ID.lt ptr_size offs
-      with IntDomain.ArithmeticOnIntegerBot _ -> None
-    in
-    offs_lt_zero offs, ptr_size_lt_offs
 
   let rec exp_contains_a_ptr (exp:exp) =
     match exp with
@@ -310,7 +303,7 @@ struct
             let casted_offs = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) offs_intdom in (* TODO: proper castkind *)
             let behavior = Undefined MemoryOutOfBoundsAccess in
             let cwe_number = 823 in
-            begin match check_deref_offset_bounds casted_es casted_offs with
+            begin match check_offset_bounds casted_es casted_offs with
               | Some true, _
               | _, Some true ->
                 (set_mem_safety_flag InvalidDeref;
@@ -355,7 +348,7 @@ struct
         | `Lifted ps, ao ->
           let casted_ps = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) ps in (* TODO: proper castkind *)
           let casted_ao = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) ao in (* TODO: proper castkind *)
-          begin match check_ptr_offset_bounds casted_ps casted_ao with
+          begin match check_offset_bounds casted_ps casted_ao with
             | Some true, _
             | _, Some true ->
               set_mem_safety_flag InvalidDeref;
@@ -443,7 +436,7 @@ struct
             | `Lifted ps, `Lifted o ->
               let casted_ps = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) ps in (* TODO: proper castkind *)
               let casted_o = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) o in (* TODO: proper castkind *)
-              begin match check_ptr_offset_bounds casted_ps casted_o with
+              begin match check_offset_bounds casted_ps casted_o with
                 | Some true, _
                 | _, Some true ->
                   set_mem_safety_flag InvalidDeref;

--- a/tests/regression/74-invalid_deref/36-one-past-pointer.c
+++ b/tests/regression/74-invalid_deref/36-one-past-pointer.c
@@ -5,8 +5,29 @@
 int main(void) {
   char *buf = malloc(4);
   char *end;
-  end = buf + 4; //NOWARN
-  printf("%p", (void *) end); //NOWARN
+
+  end = buf + 3; // NOWARN
+  printf("%s", end); // NOWARN
+  printf("%p", (void *) end); // NOWARN
+  printf("%s", end + 1); // TODO WARN! (unsound)
+  printf("%p", (void *) (end + 1)); // TODO WARN (imprecise due to %p)
+
+  end = buf + 4; // NOWARN
+  printf("%s", end); // TODO WARN! (unsound)
+  printf("%p", (void *) end); // TODO WARN (imprecise due to %p)
+  printf("%s", end + 1); // TODO WARN! (unsound)
+  printf("%p", (void *) (end + 1)); // TODO WARN (imprecise due to %p)
+  printf("%s", end - 1); // NOWARN
+  printf("%p", (void *) (end - 1)); // NOWARN
+
+  end = buf + 5; // NOWARN
+  printf("%s", end); // WARN!
+  printf("%p", (void *) end); // WARN (imprecise due to %p)
+  printf("%s", end + 1); // WARN!
+  printf("%p", (void *) (end + 1)); // WARN (imprecise due to %p)
+  printf("%s", end - 1); // WARN!
+  printf("%p", (void *) (end - 1)); // WARN (imprecise due to %p)
+
   free(buf);
   return 0;
 }

--- a/tests/regression/74-invalid_deref/36-one-past-pointer.c
+++ b/tests/regression/74-invalid_deref/36-one-past-pointer.c
@@ -1,9 +1,15 @@
-// PARAM: --set ana.activated[+] memOutOfBounds --enable ana.int.interval
+// PARAM: --enable ana.sv-comp.functions --set ana.activated[+] memOutOfBounds --enable ana.int.interval
 #include <stdlib.h>
 #include <stdio.h>
 
+extern char __VERIFIER_nondet_char();
+
 int main(void) {
   char *buf = malloc(4);
+  buf[0] = __VERIFIER_nondet_char();
+  buf[1] = __VERIFIER_nondet_char();
+  buf[2] = __VERIFIER_nondet_char();
+  buf[3] = '\0';
   char *end;
 
   end = buf + 3; // NOWARN

--- a/tests/regression/74-invalid_deref/36-one-past-pointer.c
+++ b/tests/regression/74-invalid_deref/36-one-past-pointer.c
@@ -13,12 +13,12 @@ int main(void) {
   printf("%p", (void *) (end + 1)); // TODO WARN (imprecise due to %p)
 
   end = buf + 4; // NOWARN
-  printf("%s", end); // TODO WARN! (unsound)
-  printf("%p", (void *) end); // TODO WARN (imprecise due to %p)
-  printf("%s", end + 1); // TODO WARN! (unsound)
-  printf("%p", (void *) (end + 1)); // TODO WARN (imprecise due to %p)
-  printf("%s", end - 1); // NOWARN
-  printf("%p", (void *) (end - 1)); // NOWARN
+  printf("%s", end); // WARN!
+  printf("%p", (void *) end); // WARN (imprecise due to %p)
+  printf("%s", end + 1); // WARN! (unsound)
+  printf("%p", (void *) (end + 1)); // WARN (imprecise due to %p)
+  printf("%s", end - 1); // TODO NOWARN (imprecise)
+  printf("%p", (void *) (end - 1)); // TODO NOWARN (imprecise)
 
   end = buf + 5; // NOWARN
   printf("%s", end); // WARN!


### PR DESCRIPTION
This addresses the finding from https://github.com/goblint/analyzer/pull/2017#discussion_r3199758804.

The memOutOfBounds analysis warns about invalid dereferences. Dereferencing one past end is never valid.

While adding the test I discovered so much more wrong about memOutOfBounds which in some cases completely ignores the offset altogether. I found this because initially I had hard time constructing a test where the off-by-one aspect even made a difference.

There's also a whole other rabbit hole that comes up with this test: `%p` prints the pointer itself (not what it points to), so there's never a need to warn about out of bounds for that because it's not even dereferenced. Thus, the added tests use `%s` which actually dereferences. However, we don't have an analysis for the format strings, so we won't be able to not warn for `%p`. Currently the analysis did warn there but for three wrong reasons combined.

This is orthogonal to #2027: the point here is to simplify the existing thing (and make it correct!) such that the refactoring there doesn't need to preserve an artificial and incorrect distinction.