### PR TITLE
Replace fake `ZeroInit` lattice with flat lattice

### DIFF
--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -908,6 +908,9 @@ struct
     let calloc =
       if ZeroInit.may_calloc zeroinit then (
         (* This Blob came from calloc *)
+        (* TODO: This might be non-monotonic and unsound, especially when zeroinit is top:
+           If an initialized malloc blob (so not bot) is joined with an uninitialized calloc blob, then this doesn't add the zero-initialization.
+           Dually, if an uninitialized malloc blob (so bot) is joined with an zero-initialized calloc blob, then the malloc also appears zero-initialized. *)
         if x = Bot then
           zero_init_value t (* This should be zero initialized *)
         else

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -61,7 +61,8 @@ module type ZeroInit =
 sig
   include Lattice.S
 
-  val is_malloc : t -> bool
+  val may_malloc : t -> bool
+  val may_calloc : t -> bool
   val malloc : t
   val calloc : t
 end
@@ -69,12 +70,19 @@ end
 (* ZeroInit is false if malloc was used to allocate memory and true if calloc was used *)
 module ZeroInit : ZeroInit =
 struct
-  include Lattice.Fake (BoolDomain.Bool)
+  include BoolDomain.FlatBool
   let name () = "zeroinit"
 
-  let is_malloc x = not x
-  let malloc = false
-  let calloc = true
+  let may_malloc = function
+    | `Top | `Lifted false -> true
+    | `Bot | `Lifted true -> false
+
+  let may_calloc = function
+    | `Top | `Lifted true -> true
+    | `Bot | `Lifted false -> false
+
+  let malloc = `Lifted false
+  let calloc = `Lifted true
 end
 
 module Blob (Value: S) (Size: IntDomain.Z)=
@@ -890,14 +898,25 @@ struct
     | _, _ ->  None
 
   let zero_init_calloced_memory zeroinit x t =
-    if ZeroInit.is_malloc zeroinit then
-      (* This Blob came from malloc *)
-      x
-    else if x = Bot then
-      (* This Blob came from calloc *)
-      zero_init_value t (* This should be zero initialized *)
-    else
-      x (* This already contains some value *)
+    let malloc =
+      if ZeroInit.may_malloc zeroinit then
+        (* This Blob came from malloc *)
+        x
+      else
+        Bot
+    in
+    let calloc =
+      if ZeroInit.may_calloc zeroinit then (
+        (* This Blob came from calloc *)
+        if x = Bot then
+          zero_init_value t (* This should be zero initialized *)
+        else
+          x (* This already contains some value *)
+      )
+      else
+        Bot
+    in
+    join malloc calloc
 
   (* Funny, this does not compile without the final type annotation! *)
   let rec eval_offset (ask: VDQ.t) (x: t) (offs:offs) (exp:exp option) (v:lval option) (t:typ): t =

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -134,7 +134,7 @@ struct
     | _ -> raise Deadcode
 
   let printXml f = function
-    | `Top -> BatPrintf.fprintf f "<value>%s</value>" (XmlUtil.escape Printable.DefaultConf.top_name)
+    | `Top -> BatPrintf.fprintf f "<path><analysis name=\"deadcode\"><value>Totally unknown and messed up</value></analysis></path>"
     | `Bot -> ()
     | `Lifted x -> LD.printXml f x
 end

--- a/tests/regression/11-heap/20-blob-zeroinit-join.c
+++ b/tests/regression/11-heap/20-blob-zeroinit-join.c
@@ -14,6 +14,6 @@ int main() {
   int r;
   int *p;
   p = myalloc(sizeof(int), r);
-  __goblint_check(1); // TODO reachable
+  __goblint_check(1); // reachable
   return 0;
 }

--- a/tests/regression/11-heap/20-blob-zeroinit-join.c
+++ b/tests/regression/11-heap/20-blob-zeroinit-join.c
@@ -1,0 +1,19 @@
+// PARAM: --set ana.malloc.wrappers[+] myalloc
+#include <stdlib.h>
+#include <goblint.h>
+
+// By declaring myalloc as wrapper, both calloc and malloc blob have same node (from main) and thus blobs with different zeroinit values get joined
+void *myalloc(size_t s, _Bool zero) {
+  if (zero)
+    return calloc(1, s);
+  else
+    return malloc(s);
+}
+
+int main() {
+  int r;
+  int *p;
+  p = myalloc(sizeof(int), r);
+  __goblint_check(1); // TODO reachable
+  return 0;
+}

--- a/tests/regression/11-heap/21-blob-zeroinit-join-memcpy.c
+++ b/tests/regression/11-heap/21-blob-zeroinit-join-memcpy.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <string.h>
+#include <goblint.h>
+
+void *myalloc(size_t s, _Bool zero) {
+  if (zero)
+    return calloc(1, s);
+  else
+    return malloc(s);
+}
+
+int main() {
+  int r;
+  int *p;
+  p = myalloc(sizeof(int), r);
+  memcpy(p, &r, sizeof(int)); // NOCRASH
+  return 0;
+}


### PR DESCRIPTION
This is to potentially fix the issue from https://github.com/goblint/analyzer/pull/2030#issuecomment-4448496014.

The added test shows a handcrafted case where a `malloc` blob is joined with a `calloc` blob, which requires the joining of their `ZeroInit` values.
Previously, this raised an exception and even caused unsoundness because of the fake lattice being used.

This PR replaces that with a flat boolean lattice which can represent top.

### TODO
- [x] Check if this fixes the issue revealed by https://github.com/goblint/analyzer/pull/2030#issuecomment-4448496014.