### PR TITLE
Consider `Calloc` and `Realloc` for autotuners

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2833,6 +2833,7 @@ struct
           let lv_addr = eval_lv ~man st lv in
           let blob_set = Option.map_default (fun heap_addr -> [heap_addr, TVoid [], heap_val]) [] heap_var in
           (* TODO: free (i.e. invalidate) old blob if successful? *)
+          (* TODO: realloc may return the same pointer, is this handled correctly? *)
           set_many ~man st ((lv_addr, Cilfacade.typeOfLval lv, Address addr) :: blob_set)
         ) st lv
     | Free ptr, _ ->

--- a/src/analyses/c2poAnalysis.ml
+++ b/src/analyses/c2poAnalysis.ml
@@ -212,7 +212,7 @@ struct
               let cc = begin match desc.special exprs with
                 | Malloc _
                 | Calloc _
-                | Alloca _ -> (* TODO: Why not Realloc? *)
+                | Alloca _ -> (* No Realloc because it may return the same pointer. *)
                   add_block_diseqs cc lterm
                 | _ -> cc
               end

--- a/src/analyses/c2poAnalysis.ml
+++ b/src/analyses/c2poAnalysis.ml
@@ -212,7 +212,7 @@ struct
               let cc = begin match desc.special exprs with
                 | Malloc _
                 | Calloc _
-                | Alloca _ ->
+                | Alloca _ -> (* TODO: Why not Realloc? *)
                   add_block_diseqs cc lterm
                 | _ -> cc
               end

--- a/src/analyses/mallocFresh.ml
+++ b/src/analyses/mallocFresh.ml
@@ -47,7 +47,7 @@ struct
     match desc.special args with
     | Malloc _
     | Calloc _
-    | Realloc _ -> alloc_var Heap
+    | Realloc _ -> alloc_var Heap (* TODO: realloc may return the same pointer, is this handled correctly? *)
     | Alloca _ -> alloc_var Stack
     | _ ->
       match lval with

--- a/src/analyses/wrapperFunctionAnalysis.ml
+++ b/src/analyses/wrapperFunctionAnalysis.ml
@@ -40,6 +40,7 @@ struct
   end
 
   module UniqueCount = UniqueCount
+  module WrapperArgs = WrapperArgs
 
   (* Map for counting function call node visits up to n (of the current thread). *)
   module UniqueCallCounter =
@@ -110,7 +111,7 @@ struct
 end
 
 
-module MallocWrapper : MCPSpec = struct
+module MallocWrapper = struct
 
   include SpecBase
       (MallocUniqueCount)
@@ -118,7 +119,7 @@ module MallocWrapper : MCPSpec = struct
         let wrappers () = get_string_list "ana.malloc.wrappers"
 
         let is_wrapped = function
-          | LibraryDesc.(Malloc _ | Calloc _ | Realloc _) -> true (* TODO: why not Alloca? *)
+          | LibraryDesc.(Malloc _ | Calloc _ | Realloc _) -> true (* No Alloca because alloca variables are out of scope and invalid when returned from a wrapper anyway. *)
           | _ -> false
       end)
 
@@ -194,7 +195,7 @@ module MallocWrapper : MCPSpec = struct
 end
 
 
-module ThreadCreateWrapper : MCPSpec = struct
+module ThreadCreateWrapper = struct
 
   include SpecBase
       (ThreadCreateUniqueCount)

--- a/src/analyses/wrapperFunctionAnalysis.ml
+++ b/src/analyses/wrapperFunctionAnalysis.ml
@@ -118,7 +118,7 @@ module MallocWrapper : MCPSpec = struct
         let wrappers () = get_string_list "ana.malloc.wrappers"
 
         let is_wrapped = function
-          | LibraryDesc.(Malloc _ | Calloc _ | Realloc _) -> true
+          | LibraryDesc.(Malloc _ | Calloc _ | Realloc _) -> true (* TODO: why not Alloca? *)
           | _ -> false
       end)
 

--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -66,7 +66,9 @@ class findAllocsInLoops = object
       let desc = LibraryFunctions.find f in
       begin match desc.special args with
         | Malloc _
-        | Alloca _ when inloop -> raise Found (* TODO: why not Calloc, Realloc? *)
+        | Calloc _
+        | Realloc _
+        | Alloca _ when inloop -> raise Found
         | _ -> DoChildren
       end
     | _ -> DoChildren

--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -100,7 +100,7 @@ let findMallocWrappers () =
     if LibraryFunctions.is_special f then
       let desc = LibraryFunctions.find f in
       let args = functionArgs f in
-      GobOption.exists (fun args -> match desc.special args with Malloc _ -> true | _ -> false) args (* TODO: Why not Calloc, Realloc, Alloca? *)
+      GobOption.exists (fun args -> WrapperFunctionAnalysis.MallocWrapper.WrapperArgs.is_wrapped (desc.special args)) args
     else
       false
   in

--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -66,7 +66,7 @@ class findAllocsInLoops = object
       let desc = LibraryFunctions.find f in
       begin match desc.special args with
         | Malloc _
-        | Alloca _ when inloop -> raise Found
+        | Alloca _ when inloop -> raise Found (* TODO: why not Calloc, Realloc? *)
         | _ -> DoChildren
       end
     | _ -> DoChildren
@@ -100,7 +100,7 @@ let findMallocWrappers () =
     if LibraryFunctions.is_special f then
       let desc = LibraryFunctions.find f in
       let args = functionArgs f in
-      GobOption.exists (fun args -> match desc.special args with Malloc _ -> true | _ -> false) args
+      GobOption.exists (fun args -> match desc.special args with Malloc _ -> true | _ -> false) args (* TODO: Why not Calloc, Realloc, Alloca? *)
     else
       false
   in


### PR DESCRIPTION
While debugging https://github.com/goblint/analyzer/pull/2030#issuecomment-4448496014 I noticed that the mallocWrappers autotuner doesn't pick up on the wrapper of `calloc`. Despite the name, it makes sense to do so (and with `realloc`). The mallocWrapper analysis also already considers them.

After reviewing all pattern matchings for these allocation kinds, I also found the same being missing from the allocation loop unrolling autotuner.

### TODO
- [x] sv-benchmarks