### PR TITLE
Work around opam bug in make setup for opam < 2.2

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -8,7 +8,12 @@ opam_setup() {
   set -x
   opam init -y -a --bare $SANDBOXING # sandboxing is disabled in travis and docker
   opam update
-  opam switch -y create . --deps-only --packages=ocaml-variants.4.14.2+options,ocaml-option-flambda --locked
+  # This is what we used to do and what we'd like to do:
+  # opam switch -y create . --deps-only --packages=ocaml-variants.4.14.2+options,ocaml-option-flambda --locked
+  # But this fails on opam < 2.2 due to a bug (https://github.com/ocaml/opam/issues/6946).
+  # So this is the workaround from @kit-ty-kate (while we still want to support opam < 2.2):
+  opam switch -y create . --no-install --packages=ocaml-variants.4.14.2+options,ocaml-option-flambda
+  opam install -y ./*.opam.locked --deps-only
 }
 
 rule() {


### PR DESCRIPTION
The nightly build immediately failed after merging #2036.
My guess is that this happens during `make setup` with opam version < 2.2.

Although `with-dev-setup` was supposed to be ignored by old opams, it's not with `--locked`: https://github.com/ocaml/opam/issues/6946.
So this is a workaround that should still allow using opam < 2.2.