### PR TITLE
Pin batteries with hashconsing performance improvements

### DIFF
--- a/goblint.opam
+++ b/goblint.opam
@@ -107,7 +107,7 @@ x-maintenance-intent: ["(latest)" "(latest).(latest-1)"] # also keep previous mi
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 pin-depends: [
   [ "goblint-cil.2.0.9" "git+https://github.com/goblint/cil.git#2243aad0e34cb59b7d2d18415ab88a7767c108b7" ]
-  # pinned for performance (https://github.com/ocaml-batteries-team/batteries-included/pull/1149), remove after new batteries release
+  # pinned for performance (https://github.com/ocaml-batteries-team/batteries-included/pull/1149) via fork, remove after new batteries release (and then bump the batteries lower-bound accordingly)
   [ "batteries.3.11.0" "git+https://github.com/sim642/batteries-included.git#3920bdf614e4a12120fabfa2c97ee913cc246b13" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
   [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]

--- a/goblint.opam
+++ b/goblint.opam
@@ -107,6 +107,8 @@ x-maintenance-intent: ["(latest)" "(latest).(latest-1)"] # also keep previous mi
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 pin-depends: [
   [ "goblint-cil.2.0.9" "git+https://github.com/goblint/cil.git#2243aad0e34cb59b7d2d18415ab88a7767c108b7" ]
+  # pinned for performance (https://github.com/ocaml-batteries-team/batteries-included/pull/1149), remove after new batteries release
+  [ "batteries.3.11.0" "git+https://github.com/sim642/batteries-included.git#3920bdf614e4a12120fabfa2c97ee913cc246b13" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
   [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]
 ]

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -32,7 +32,7 @@ depends: [
   "base-bytes" {= "base" & with-dev-setup}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
-  "batteries" {= "3.9.0"}
+  "batteries" {= "3.11.0"}
   "benchmark" {= "1.6" & with-test}
   "bigarray-compat" {= "1.1.0"}
   "bigstringaf" {= "0.9.1"}
@@ -163,6 +163,10 @@ pin-depends: [
   [
     "goblint-cil.2.0.9"
     "git+https://github.com/goblint/cil.git#2243aad0e34cb59b7d2d18415ab88a7767c108b7"
+  ]
+  [
+    "batteries.3.11.0"
+    "git+https://github.com/sim642/batteries-included.git#3920bdf614e4a12120fabfa2c97ee913cc246b13"
   ]
   [
     "apron.v0.9.15"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -4,6 +4,8 @@ x-maintenance-intent: ["(latest)" "(latest).(latest-1)"] # also keep previous mi
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 pin-depends: [
   [ "goblint-cil.2.0.9" "git+https://github.com/goblint/cil.git#2243aad0e34cb59b7d2d18415ab88a7767c108b7" ]
+  # pinned for performance (https://github.com/ocaml-batteries-team/batteries-included/pull/1149), remove after new batteries release
+  [ "batteries.3.11.0" "git+https://github.com/sim642/batteries-included.git#3920bdf614e4a12120fabfa2c97ee913cc246b13" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
   [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]
 ]

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -4,7 +4,7 @@ x-maintenance-intent: ["(latest)" "(latest).(latest-1)"] # also keep previous mi
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 pin-depends: [
   [ "goblint-cil.2.0.9" "git+https://github.com/goblint/cil.git#2243aad0e34cb59b7d2d18415ab88a7767c108b7" ]
-  # pinned for performance (https://github.com/ocaml-batteries-team/batteries-included/pull/1149), remove after new batteries release
+  # pinned for performance (https://github.com/ocaml-batteries-team/batteries-included/pull/1149) via fork, remove after new batteries release (and then bump the batteries lower-bound accordingly)
   [ "batteries.3.11.0" "git+https://github.com/sim642/batteries-included.git#3920bdf614e4a12120fabfa2c97ee913cc246b13" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
   [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]


### PR DESCRIPTION
This pins https://github.com/ocaml-batteries-team/batteries-included/pull/1149.

The performance improvement is quite significant: https://github.com/ocaml/ocaml/issues/13733#issuecomment-4572552390 (first plot). That is on OCaml 5.5, but the improvements are very similar on OCaml 4.14 as well.