### PR TITLE
Fix GobView build regarding patricia-tree and batteries

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -40,7 +40,7 @@ Goblint includes analyses for assertions, overflows, deadlocks, etc and can be e
     (ocaml (>= 4.14))
     (goblint-cil (>= 2.0.9)) ; TODO no way to define as pin-depends? Used goblint.opam.template to add it for now. https://github.com/ocaml/dune/issues/3231. Alternatively, removing this line and adding cil as a git submodule and `(vendored_dirs cil)` as ./dune also works. This way, no more need to reinstall the pinned cil opam package on changes. However, then cil is cleaned and has to be rebuild together with goblint.
     (batteries (>= 3.9.0))
-    (patricia-tree (>= 0.13.0))
+    (patricia-tree (>= 0.14.0))
     (zarith (>= 1.12))
     (yojson (and (>= 2.0.0) (< 3))) ; json-data-encoding has incompatible yojson representation for yojson 3
     (qcheck-core (>= 0.19))

--- a/goblint.opam
+++ b/goblint.opam
@@ -41,7 +41,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "goblint-cil" {>= "2.0.9"}
   "batteries" {>= "3.9.0"}
-  "patricia-tree" {>= "0.13.0"}
+  "patricia-tree" {>= "0.14.0"}
   "zarith" {>= "1.12"}
   "yojson" {>= "2.0.0" & < "3"}
   "qcheck-core" {>= "0.19"}

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -98,7 +98,7 @@ depends: [
   "odoc-parser" {= "3.0.0" & with-doc}
   "ordering" {= "3.21.1"}
   "ounit2" {= "2.2.7" & with-test}
-  "patricia-tree" {= "0.13.0"}
+  "patricia-tree" {= "0.14.0"}
   "pp" {= "2.0.0"}
   "ppx_blob" {= "0.9.0"}
   "ppx_derivers" {= "1.2.1"}


### PR DESCRIPTION
https://github.com/goblint/analyzer/pull/2002#issuecomment-4487313768 broke GobView but the new version of patricia-tree should fix the issue: https://github.com/codex-semantics-library/patricia-tree/issues/33.

Also, https://github.com/goblint/analyzer/pull/2050 pinned a new version of batteries that needs to be updated in GobView's lock file.