### PR TITLE
Add all possible failures to `GobYaml.to_string'`

### DIFF
--- a/src/util/std/gobYaml.ml
+++ b/src/util/std/gobYaml.ml
@@ -3,7 +3,7 @@ let to_string' ?(len=65535 * 4) ?encoding ?scalar_style ?layout_style v =
   let rec aux len =
     match Yaml.to_string ~len ?encoding ?scalar_style ?layout_style v with
     | Ok _ as o -> o
-    | Error (`Msg ("scalar failed" | "doc_end failed" | "seq_end failed" | "mapping_start failed")) when len < Sys.max_string_length / 2 ->
+    | Error (`Msg ("stream_start failed" | "stream_end failed" | "doc_start failed" | "doc_end failed" | "scalar failed" | "seq_start failed" | "seq_end failed" | "mapping_start failed" | "mapping_end failed" | "alias failed")) when len < Sys.max_string_length / 2 ->
       aux (len * 2)
     | Error (`Msg _) as e -> e
   in


### PR DESCRIPTION
Based on ocaml-yaml source.

PR #1882 adds `mapping_start`, so let's just add all of them now.