### PR TITLE
 Improve memOutOfBounds precision by querying size/length of particular variable

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1549,26 +1549,17 @@ struct
       end
     | Q.EvalValue e ->
       eval_rv ~man man.local e
-    | Q.BlobSize {exp = e; base_address = from_base_addr} -> begin
+    | Q.BlobSize e -> begin
         let p = eval_rv_address ~man man.local e in
         (* ignore @@ printf "BlobSize %a MayPointTo %a\n" d_plainexp e VD.pretty p; *)
         match p with
         | Address a ->
           (* If there's a non-heap var or an offset in the lval set, we answer with bottom *)
-          (* If we're asking for the BlobSize from the base address, then don't check for offsets => we want to avoid getting bot *)
           if AD.exists (function
-              | Addr (v,o) -> is_not_alloc_var man v || (if not from_base_addr then o <> `NoOffset else false)
+              | Addr (v,o) -> is_not_alloc_var man v || o <> `NoOffset
               | _ -> false) a then
             Queries.Result.bot q
           else (
-            (* If we need the BlobSize from the base address, then remove any offsets *)
-            let a =
-              if from_base_addr then AD.map (function
-                  | Addr (v, o) -> Addr (v, `NoOffset)
-                  | addr -> addr) a
-              else
-                a
-            in
             let r = get ~man ~full:true man.local a None in
             (* ignore @@ printf "BlobSize %a = %a\n" d_plainexp e VD.pretty r; *)
             (match r with
@@ -2351,7 +2342,7 @@ struct
         begin match addr with
           | Addr (v, _) when man.ask (Queries.IsHeapVar v) ->
             (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
-            man.ask (Queries.BlobSize {exp = AddrOf (Var v, NoOffset); base_address = true}) (* TODO: is base_address necessary anymore? *)
+            man.ask (Queries.BlobSize (AddrOf (Var v, NoOffset)))
           | Addr (v, _) ->
             begin match Cil.unrollType v.vtype with
               | TArray (item_typ, _, _) ->
@@ -2501,7 +2492,7 @@ struct
         | Bot, Array array_s2 ->
           (* If we have bot inside here, we assume the blob is used as a char array and create one inside *)
           let ptrdiff_ik = Cilfacade.ptrdiff_ikind () in
-          let size = man.ask (Q.BlobSize {exp = s1; base_address = false}) in
+          let size = man.ask (Q.BlobSize s1) in
           let s_id =
             try ValueDomainQueries.ID.unlift (ID.cast_to ~kind:Internal ptrdiff_ik) size (* TODO: proper castkind *)
             with Failure _ -> ID.top_of ptrdiff_ik in
@@ -2510,7 +2501,7 @@ struct
         | Bot , _ when CilType.Typ.equal s2_typ charPtrType ->
           (* If we have bot inside here, we assume the blob is used as a char array and create one inside *)
           let ptrdiff_ik = Cilfacade.ptrdiff_ikind () in
-          let size = man.ask (Q.BlobSize {exp = s1; base_address = false}) in
+          let size = man.ask (Q.BlobSize s1) in
           let s_id =
             try ValueDomainQueries.ID.unlift (ID.cast_to ~kind:Internal ptrdiff_ik) size (* TODO: proper castkind *)
             with Failure _ -> ID.top_of ptrdiff_ik in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1575,10 +1575,10 @@ struct
              | Array a ->
                (* unroll into array for Calloc calls *)
                (match ValueDomain.CArrays.get (Queries.to_value_domain_ask (Analyses.ask_of_man man)) a (None, (IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) Z.zero)) with
-                | Blob (_,s,_) -> `Lifted s
+                | Blob (_,s,_) -> `Lifted (ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) s) (* TODO: should be size_t *) (* TODO: should really be casted on creation *)
                 | _ -> Queries.Result.top q
                )
-             | Blob (_,s,_) -> `Lifted s
+             | Blob (_,s,_) -> `Lifted (ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) s) (* TODO: should be size_t *) (* TODO: should really be casted on creation *)
              | _ -> Queries.Result.top q)
           )
         | _ -> Queries.Result.top q

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1540,7 +1540,7 @@ struct
             | TArray (_, l, _) -> (try Some (lenOfArray l) with LenOfArray -> None)
             | _ -> None
           in
-          let alen = Seq.filter_map (fun v -> lenOf v.vtype) (List.to_seq (AD.to_var_may a)) in
+          let alen = Seq.filter_map (fun v -> lenOf v.vtype) (List.to_seq (AD.to_var_may a)) in (* TODO: shouldn't addr offset matter? *)
           let d = Seq.fold_left ID.join (ID.bot_of (Cilfacade.ptrdiff_ikind ())) (Seq.map (ID.of_int (Cilfacade.ptrdiff_ikind ()) %Z.of_int) (Seq.append slen alen)) in
           (* ignore @@ printf "EvalLength %a = %a\n" d_exp e ID.pretty d; *)
           `Lifted d

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1554,7 +1554,7 @@ struct
         (* ignore @@ printf "BlobSize %a MayPointTo %a\n" d_plainexp e VD.pretty p; *)
         match p with
         | Address a ->
-          (* If there's a non-heap var or an offset in the lval set, we answer with bottom *)
+          (* If there's a non-alloc var or an offset in the lval set, we answer with bottom *)
           if AD.exists (function
               | Addr (v,o) -> is_not_alloc_var man v || o <> `NoOffset
               | _ -> false) a then
@@ -2341,7 +2341,7 @@ struct
       let pts_elems_to_sizes (addr: Queries.AD.elt) =
         begin match addr with
           | Addr (v, _) when man.ask (Queries.IsHeapVar v) ->
-            (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
+            (* Ask for BlobSize from the base address in order to avoid BlobSize giving us bot *)
             man.ask (Queries.BlobSize (AddrOf (Var v, NoOffset)))
           | Addr (v, _) ->
             begin match Cil.unrollType v.vtype with

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2351,12 +2351,12 @@ struct
         begin match addr with
           | Addr (v, _) when man.ask (Queries.IsHeapVar v) ->
             (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
-            man.ask (Queries.BlobSize {exp = ptr; base_address = true}) (* TODO: only query for addr/v *)
+            man.ask (Queries.BlobSize {exp = AddrOf (Var v, NoOffset); base_address = true}) (* TODO: is base_address necessary anymore? *)
           | Addr (v, _) ->
             begin match Cil.unrollType v.vtype with
               | TArray (item_typ, _, _) ->
                 let item_typ_size_in_bytes = size_of_type_in_bytes item_typ in
-                begin match man.ask (Queries.EvalLength ptr) with (* TODO: only query for addr/v *)
+                begin match man.ask (Queries.EvalLength (AddrOf (Var v, NoOffset))) with (* TODO: shouldn't addr offset matter? *)
                   | `Lifted arr_len ->
                     let arr_len_casted = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) arr_len in (* TODO: proper castkind *)
                     begin

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -87,7 +87,7 @@ struct
         begin match addr with
           | Addr (v, _) when man.ask (Queries.IsAllocVar v) ->
             (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
-            man.ask (Queries.BlobSize {exp = AddrOf (Var v, NoOffset); base_address = true}) (* TODO: is base_address necessary anymore? *)
+            man.ask (Queries.BlobSize (AddrOf (Var v, NoOffset)))
           | Addr (v, _) ->
             if hasAttribute "goblint_cil_nested" v.vattr then (
               set_mem_safety_flag InvalidDeref;

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -86,7 +86,7 @@ struct
       let pts_elems_to_sizes (addr: Queries.AD.elt) =
         begin match addr with
           | Addr (v, _) when man.ask (Queries.IsAllocVar v) ->
-            (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
+            (* Ask for BlobSize from the base address in order to avoid BlobSize giving us bot *)
             man.ask (Queries.BlobSize (AddrOf (Var v, NoOffset)))
           | Addr (v, _) ->
             if hasAttribute "goblint_cil_nested" v.vattr then (

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -87,7 +87,7 @@ struct
         begin match addr with
           | Addr (v, _) when man.ask (Queries.IsAllocVar v) ->
             (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
-            man.ask (Queries.BlobSize {exp = ptr; base_address = true}) (* TODO: only query for addr/v *)
+            man.ask (Queries.BlobSize {exp = AddrOf (Var v, NoOffset); base_address = true}) (* TODO: is base_address necessary anymore? *)
           | Addr (v, _) ->
             if hasAttribute "goblint_cil_nested" v.vattr then (
               set_mem_safety_flag InvalidDeref;
@@ -97,7 +97,7 @@ struct
             begin match Cil.unrollType v.vtype with
               | TArray (item_typ, _, _) ->
                 let item_typ_size_in_bytes = size_of_type_in_bytes item_typ in
-                begin match man.ask (Queries.EvalLength ptr) with (* TODO: only query for addr/v *)
+                begin match man.ask (Queries.EvalLength (AddrOf (Var v, NoOffset))) with (* TODO: shouldn't addr offset matter? *)
                   | `Lifted arr_len ->
                     let arr_len_casted = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) arr_len in (* TODO: proper castkind *)
                     begin

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -105,7 +105,7 @@ type _ t =
   | EvalStr: exp -> SD.t t
   | EvalLength: exp -> ID.t t (* length of an array or string *)
   | EvalValue: exp -> VD.t t
-  | BlobSize: {exp: Cil.exp; base_address: bool} -> ID.t t
+  | BlobSize: exp -> ID.t t
   (* Size of a dynamically allocated `Blob pointed to by exp. *)
   (* If the record's second field is set to true, then address offsets are discarded and the size of the `Blob is asked for the base address. *)
   | CondVars: exp -> ES.t t
@@ -355,12 +355,7 @@ struct
       | Any (EvalLength e1), Any (EvalLength e2) -> CilType.Exp.compare e1 e2
       | Any (EvalMutexAttr e1), Any (EvalMutexAttr e2) -> CilType.Exp.compare e1 e2
       | Any (EvalValue e1), Any (EvalValue e2) -> CilType.Exp.compare e1 e2
-      | Any (BlobSize {exp = e1; base_address = b1}), Any (BlobSize {exp = e2; base_address = b2}) ->
-        let r = CilType.Exp.compare e1 e2 in
-        if r <> 0 then
-          r
-        else
-          Stdlib.compare b1 b2
+      | Any (BlobSize e1), Any (BlobSize e2) -> CilType.Exp.compare e1 e2
       | Any (CondVars e1), Any (CondVars e2) -> CilType.Exp.compare e1 e2
       | Any (PartAccess p1), Any (PartAccess p2) -> compare_access p1 p2
       | Any (IterPrevVars ip1), Any (IterPrevVars ip2) -> compare_iterprevvar ip1 ip2
@@ -416,7 +411,7 @@ struct
     | Any (EvalLength e) -> CilType.Exp.hash e
     | Any (EvalMutexAttr e) -> CilType.Exp.hash e
     | Any (EvalValue e) -> CilType.Exp.hash e
-    | Any (BlobSize {exp = e; base_address = b}) -> CilType.Exp.hash e + Hashtbl.hash b
+    | Any (BlobSize e) -> CilType.Exp.hash e
     | Any (CondVars e) -> CilType.Exp.hash e
     | Any (PartAccess p) -> hash_access p
     | Any (IterPrevVars i) -> 0
@@ -474,7 +469,7 @@ struct
     | Any (EvalStr e) -> Pretty.dprintf "EvalStr %a" CilType.Exp.pretty e
     | Any (EvalLength e) -> Pretty.dprintf "EvalLength %a" CilType.Exp.pretty e
     | Any (EvalValue e) -> Pretty.dprintf "EvalValue %a" CilType.Exp.pretty e
-    | Any (BlobSize {exp = e; base_address = b}) -> Pretty.dprintf "BlobSize %a (base_address: %b)" CilType.Exp.pretty e b
+    | Any (BlobSize e) -> Pretty.dprintf "BlobSize %a" CilType.Exp.pretty e
     | Any (CondVars e) -> Pretty.dprintf "CondVars %a" CilType.Exp.pretty e
     | Any (PartAccess p) -> Pretty.dprintf "PartAccess _"
     | Any (IterPrevVars i) -> Pretty.dprintf "IterPrevVars _"

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -105,9 +105,7 @@ type _ t =
   | EvalStr: exp -> SD.t t
   | EvalLength: exp -> ID.t t (* length of an array or string *)
   | EvalValue: exp -> VD.t t
-  | BlobSize: exp -> ID.t t
-  (* Size of a dynamically allocated `Blob pointed to by exp. *)
-  (* If the record's second field is set to true, then address offsets are discarded and the size of the `Blob is asked for the base address. *)
+  | BlobSize: exp -> ID.t t (** Size of a dynamically allocated [`Blob] pointed to by [exp]. *)
   | CondVars: exp -> ES.t t
   | PartAccess: access -> Obj.t t (** Only queried by access and deadlock analysis. [Obj.t] represents [MCPAccess.A.t], needed to break dependency cycle. *)
   | IterPrevVars: iterprevvar -> Unit.t t


### PR DESCRIPTION
This is a continuation of #2030.

It is necessary to make the analysis relational between the address base size and the offset (PR to come) but already on its own reveals some issues.