### PR TITLE
 Improve memOutOfBounds precision by being relational w.r.t. size and offset

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2328,7 +2328,7 @@ struct
       M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Pointer %a in function %s doesn't evaluate to a valid address. Invalid memory deallocation may occur" d_exp ptr special_fn.vname;
       Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a in function %s doesn't evaluate to a valid address. Invalid memory deallocation may occur" d_exp ptr special_fn.vname
 
-  let get_addr_size man ptr (addr: Queries.AD.elt) = (* TODO: remove ptr argument *) (* TODO: deduplicate with memOutOfBounds (this uses IsHeapVar) *)
+  let get_addr_size man (addr: Queries.AD.elt) = (* TODO: deduplicate with memOutOfBounds (this uses IsHeapVar) *)
     let intdom_of_int x =
       ID.of_int (Cilfacade.ptrdiff_ikind ()) (Z.of_int x)
     in
@@ -2362,7 +2362,7 @@ struct
   let get_size_of_ptr_target man ptr =
     man.ask (Queries.MayPointTo ptr)
     |> Queries.AD.to_seq
-    |> Seq.map (get_addr_size man ptr)
+    |> Seq.map (get_addr_size man)
     |> Seq.fold_left ValueDomainQueries.ID.join `Bot
 
   let special man (lv:lval option) (f: varinfo) (args: exp list) =

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2337,50 +2337,43 @@ struct
       M.warn ~category:(Behavior (Undefined InvalidMemoryDeallocation)) ~tags:[CWE 590] "Pointer %a in function %s doesn't evaluate to a valid address. Invalid memory deallocation may occur" d_exp ptr special_fn.vname;
       Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a in function %s doesn't evaluate to a valid address. Invalid memory deallocation may occur" d_exp ptr special_fn.vname
 
-  let get_size_of_ptr_target man ptr = (* TODO: deduplicate with memOutOfBounds (this uses IsHeapVar) *)
+  let get_addr_size man ptr (addr: Queries.AD.elt) = (* TODO: remove ptr argument *) (* TODO: deduplicate with memOutOfBounds (this uses IsHeapVar) *)
     let intdom_of_int x =
       ID.of_int (Cilfacade.ptrdiff_ikind ()) (Z.of_int x)
     in
     let size_of_type_in_bytes typ =
       intdom_of_int (Cilfacade.bytesSizeOf typ)
     in
+    match addr with
+    | Addr (v, _) when man.ask (Queries.IsHeapVar v) ->
+      (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
+      man.ask (Queries.BlobSize {exp = ptr; base_address = true}) (* TODO: only query for addr/v *)
+    | Addr (v, _) ->
+      begin match Cil.unrollType v.vtype with
+        | TArray (item_typ, _, _) ->
+          let item_typ_size_in_bytes = size_of_type_in_bytes item_typ in
+          begin match man.ask (Queries.EvalLength ptr) with (* TODO: only query for addr/v *)
+            | `Lifted arr_len ->
+              let arr_len_casted = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) arr_len in (* TODO: proper castkind *)
+              begin
+                try `Lifted (ID.mul item_typ_size_in_bytes arr_len_casted)
+                with IntDomain.ArithmeticOnIntegerBot _ -> `Bot
+              end
+            | `Bot -> `Bot
+            | `Top -> `Top
+          end
+        | _ ->
+          let type_size_in_bytes = size_of_type_in_bytes v.vtype in
+          `Lifted type_size_in_bytes
+      end
+    | _ -> `Top
+
+  let get_size_of_ptr_target man ptr =
     match man.ask (Queries.MayPointTo ptr) with
     | a when not (Queries.AD.is_top a) ->
-      let pts_list = Queries.AD.elements a in
-      let pts_elems_to_sizes (addr: Queries.AD.elt) =
-        begin match addr with
-          | Addr (v, _) when man.ask (Queries.IsHeapVar v) ->
-            (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
-            man.ask (Queries.BlobSize {exp = ptr; base_address = true}) (* TODO: only query for addr/v *)
-          | Addr (v, _) ->
-            begin match Cil.unrollType v.vtype with
-              | TArray (item_typ, _, _) ->
-                let item_typ_size_in_bytes = size_of_type_in_bytes item_typ in
-                begin match man.ask (Queries.EvalLength ptr) with (* TODO: only query for addr/v *)
-                  | `Lifted arr_len ->
-                    let arr_len_casted = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) arr_len in (* TODO: proper castkind *)
-                    begin
-                      try `Lifted (ID.mul item_typ_size_in_bytes arr_len_casted)
-                      with IntDomain.ArithmeticOnIntegerBot _ -> `Bot
-                    end
-                  | `Bot -> `Bot
-                  | `Top -> `Top
-                end
-              | _ ->
-                let type_size_in_bytes = size_of_type_in_bytes v.vtype in
-                `Lifted type_size_in_bytes
-            end
-          | _ -> `Top
-        end
-      in
-      (* Map each points-to-set element to its size *)
-      let pts_sizes = List.map pts_elems_to_sizes pts_list in
-      (* Take the smallest of all sizes that ptr's contents may have *)
-      begin match pts_sizes with
-        | [] -> `Bot
-        | [x] -> x
-        | x::xs -> List.fold_left ValueDomainQueries.ID.join x xs
-      end
+      Queries.AD.to_seq a
+      |> Seq.map (get_addr_size man ptr)
+      |> Seq.fold_left ValueDomainQueries.ID.join `Bot
     | _ ->
       (M.warn "Pointer %a has a points-to-set of top. An invalid memory access might occur" d_exp ptr;
        Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has a points-to-set of top. An invalid memory access might occur" d_exp ptr;

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2369,15 +2369,10 @@ struct
     | _ -> `Top
 
   let get_size_of_ptr_target man ptr =
-    match man.ask (Queries.MayPointTo ptr) with
-    | a when not (Queries.AD.is_top a) ->
-      Queries.AD.to_seq a
-      |> Seq.map (get_addr_size man ptr)
-      |> Seq.fold_left ValueDomainQueries.ID.join `Bot
-    | _ ->
-      (M.warn "Pointer %a has a points-to-set of top. An invalid memory access might occur" d_exp ptr;
-       Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has a points-to-set of top. An invalid memory access might occur" d_exp ptr;
-       `Top)
+    man.ask (Queries.MayPointTo ptr)
+    |> Queries.AD.to_seq
+    |> Seq.map (get_addr_size man ptr)
+    |> Seq.fold_left ValueDomainQueries.ID.join `Bot
 
   let special man (lv:lval option) (f: varinfo) (args: exp list) =
     let invalidate_ret_lv st =

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -199,35 +199,24 @@ struct
     (* Intuition: if ptr evaluates to top, it could all sorts of things and not only string addresses *)
     | _ -> false
 
-  let get_mval_offset ptr t (_, o) =
-    offs_to_idx t o
+  let get_addr_offset ptr t (addr: ValueDomain.Addr.t) =
+    match addr with
+    | Addr (_, o) -> offs_to_idx t o
+    | UnknownPtr -> ID.top_of @@ Cilfacade.ptrdiff_ikind () (* TODO: does this make sense? *)
+    | NullPtr
+    | StrPtr _ -> ID.bot_of @@ Cilfacade.ptrdiff_ikind () (* TODO: do these make sense? *)
 
   let rec get_addr_offs man ptr =
-    match man.ask (Queries.MayPointTo ptr) with
-    | a when not (VDQ.AD.is_top a) ->
-      let ptr_deref_type = get_ptr_deref_type @@ typeOf ptr in
-      begin match ptr_deref_type with
-        | Some t ->
-          begin match VDQ.AD.is_empty a with
-            | true ->
-              M.warn "Pointer %a has an empty points-to-set" d_exp ptr;
-              Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has an empty points-to-set" d_exp ptr;
-              ID.top_of @@ Cilfacade.ptrdiff_ikind ()
-            | false ->
-              (* Get the address offsets of all points-to set elements *)
-              VDQ.AD.to_mval a
-              |> List.to_seq
-              |> Seq.map (get_mval_offset ptr t)
-              |> Seq.fold_left ID.join (ID.bot_of @@ Cilfacade.ptrdiff_ikind ())
-          end
-        | None ->
-          M.error "Expression %a doesn't have pointer type" d_exp ptr;
-          ID.top_of @@ Cilfacade.ptrdiff_ikind ()
-      end
-    | _ ->
-      set_mem_safety_flag InvalidDeref;
-      M.warn "Pointer %a has a points-to-set of top. An invalid memory access might occur" d_exp ptr;
-      Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has a points-to-set of top. An invalid memory access might occur" d_exp ptr;
+    let ptr_deref_type = get_ptr_deref_type @@ typeOf ptr in
+    match ptr_deref_type with
+    | Some t ->
+      (* Get the address offsets of all points-to set elements *)
+      man.ask (Queries.MayPointTo ptr)
+      |> VDQ.AD.to_seq
+      |> Seq.map (get_addr_offset ptr t)
+      |> Seq.fold_left ID.join (ID.bot_of @@ Cilfacade.ptrdiff_ikind ())
+    | None ->
+      M.error "Expression %a doesn't have pointer type" d_exp ptr;
       ID.top_of @@ Cilfacade.ptrdiff_ikind ()
 
   and check_lval_for_oob_access man ?(is_implicitly_derefed = false) lval =

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -200,21 +200,7 @@ struct
     | _ -> false
 
   let get_mval_offset ptr t (_, o) =
-    let x = offs_to_idx t o in
-    if ID.is_bot x then (
-      set_mem_safety_flag InvalidDeref;
-      M.warn "Pointer %a has a bot address offset. An invalid memory access may occur" d_exp ptr;
-      Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has a bot address offset. An invalid memory access may occur" d_exp ptr
-    )
-    else if ID.is_top_of (Cilfacade.ptrdiff_ikind ()) x then (
-      set_mem_safety_flag InvalidDeref;
-      M.warn "Pointer %a has a top address offset. An invalid memory access may occur" d_exp ptr;
-      Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has a top address offset. An invalid memory access may occur" d_exp ptr
-    )
-    else (
-      Checks.safe Checks.Category.InvalidMemoryAccess
-    );
-    x
+    offs_to_idx t o
 
   let rec get_addr_offs man ptr =
     match man.ask (Queries.MayPointTo ptr) with

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -79,49 +79,42 @@ struct
     in
     host_contains_a_ptr host || offset_contains_a_ptr offset
 
-  let get_size_of_ptr_target man ptr = (* TODO: deduplicate with base (this uses IsAllocVar) *)
+  let get_addr_size man ptr (addr: Queries.AD.elt) = (* TODO: remove ptr argument *) (* TODO: deduplicate with base (this uses IsAllocVar) *)
+    match addr with
+    | Addr (v, _) when man.ask (Queries.IsAllocVar v) ->
+      (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
+      man.ask (Queries.BlobSize {exp = ptr; base_address = true}) (* TODO: only query for addr/v *)
+    | Addr (v, _) ->
+      if hasAttribute "goblint_cil_nested" v.vattr then (
+        set_mem_safety_flag InvalidDeref;
+        M.warn "Var %a is potentially accessed out-of-scope. Invalid memory access may occur" CilType.Varinfo.pretty v;
+        Checks.warn Checks.Category.InvalidMemoryAccess "Var %a is potentially accessed out-of-scope. Invalid memory access may occur" CilType.Varinfo.pretty v
+      );
+      begin match Cil.unrollType v.vtype with
+        | TArray (item_typ, _, _) ->
+          let item_typ_size_in_bytes = size_of_type_in_bytes item_typ in
+          begin match man.ask (Queries.EvalLength ptr) with (* TODO: only query for addr/v *)
+            | `Lifted arr_len ->
+              let arr_len_casted = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) arr_len in (* TODO: proper castkind *)
+              begin
+                try `Lifted (ID.mul item_typ_size_in_bytes arr_len_casted)
+                with IntDomain.ArithmeticOnIntegerBot _ -> `Bot
+              end
+            | `Bot -> `Bot
+            | `Top -> `Top
+          end
+        | _ ->
+          let type_size_in_bytes = size_of_type_in_bytes v.vtype in
+          `Lifted type_size_in_bytes
+      end
+    | _ -> `Top
+
+  let get_size_of_ptr_target man ptr =
     match man.ask (Queries.MayPointTo ptr) with
     | a when not (Queries.AD.is_top a) ->
-      let pts_list = Queries.AD.elements a in
-      let pts_elems_to_sizes (addr: Queries.AD.elt) =
-        begin match addr with
-          | Addr (v, _) when man.ask (Queries.IsAllocVar v) ->
-            (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
-            man.ask (Queries.BlobSize {exp = ptr; base_address = true}) (* TODO: only query for addr/v *)
-          | Addr (v, _) ->
-            if hasAttribute "goblint_cil_nested" v.vattr then (
-              set_mem_safety_flag InvalidDeref;
-              M.warn "Var %a is potentially accessed out-of-scope. Invalid memory access may occur" CilType.Varinfo.pretty v;
-              Checks.warn Checks.Category.InvalidMemoryAccess "Var %a is potentially accessed out-of-scope. Invalid memory access may occur" CilType.Varinfo.pretty v
-            );
-            begin match Cil.unrollType v.vtype with
-              | TArray (item_typ, _, _) ->
-                let item_typ_size_in_bytes = size_of_type_in_bytes item_typ in
-                begin match man.ask (Queries.EvalLength ptr) with (* TODO: only query for addr/v *)
-                  | `Lifted arr_len ->
-                    let arr_len_casted = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) arr_len in (* TODO: proper castkind *)
-                    begin
-                      try `Lifted (ID.mul item_typ_size_in_bytes arr_len_casted)
-                      with IntDomain.ArithmeticOnIntegerBot _ -> `Bot
-                    end
-                  | `Bot -> `Bot
-                  | `Top -> `Top
-                end
-              | _ ->
-                let type_size_in_bytes = size_of_type_in_bytes v.vtype in
-                `Lifted type_size_in_bytes
-            end
-          | _ -> `Top
-        end
-      in
-      (* Map each points-to-set element to its size *)
-      let pts_sizes = List.map pts_elems_to_sizes pts_list in
-      (* Take the smallest of all sizes that ptr's contents may have *)
-      begin match pts_sizes with
-        | [] -> `Bot
-        | [x] -> x
-        | x::xs -> List.fold_left VDQ.ID.join x xs
-      end
+      Queries.AD.to_seq a
+      |> Seq.map (get_addr_size man ptr)
+      |> Seq.fold_left VDQ.ID.join `Bot
     | _ ->
       (set_mem_safety_flag InvalidDeref;
        M.warn "Pointer %a has a points-to-set of top. An invalid memory access might occur" d_exp ptr;

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -94,9 +94,9 @@ struct
       );
       begin match Cil.unrollType v.vtype with
         | TArray (item_typ, _, _) ->
-          let item_typ_size_in_bytes = size_of_type_in_bytes item_typ in
           begin match man.ask (Queries.EvalLength (AddrOf (Var v, NoOffset))) with (* TODO: shouldn't addr offset matter? *)
             | `Lifted arr_len ->
+              let item_typ_size_in_bytes = size_of_type_in_bytes item_typ in
               let arr_len_casted = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) arr_len in (* TODO: proper castkind *)
               begin
                 try `Lifted (ID.mul item_typ_size_in_bytes arr_len_casted)
@@ -118,9 +118,9 @@ struct
 
   let eval_ptr_offset_in_binop man exp ptr_contents_typ =
     let eval_offset = man.ask (Queries.EvalInt exp) in
-    let ptr_contents_typ_size_in_bytes = size_of_type_in_bytes ptr_contents_typ in
     match eval_offset with
     | `Lifted eo ->
+      let ptr_contents_typ_size_in_bytes = size_of_type_in_bytes ptr_contents_typ in
       let casted_eo = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) eo in (* TODO: proper castkind *)
       begin
         try `Lifted (ID.mul casted_eo ptr_contents_typ_size_in_bytes)
@@ -213,10 +213,11 @@ struct
       | (Var v, _), true -> check_no_binop_deref man (Lval lval)
       | (Mem e, o), _ ->
         let ptr_deref_type = get_ptr_deref_type @@ typeOf e in
-        let offs_intdom = begin match ptr_deref_type with
+        let offs_intdom = match ptr_deref_type with
           | Some t -> cil_offs_to_idx man t o
           | None -> ID.bot_of @@ Cilfacade.ptrdiff_ikind ()
-        end in
+        in
+        let casted_offs = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) offs_intdom in (* TODO: proper castkind *)
         let* addr = man.ask (Queries.MayPointTo e) in
         let e_size = get_addr_size man addr in
         begin match e_size with
@@ -230,7 +231,6 @@ struct
             Checks.warn Checks.Category.InvalidMemoryAccess "Size of lval dereference expression %a is bot. Out-of-bounds memory access may occur" d_exp e
           | `Lifted es ->
             let casted_es = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) es in (* TODO: proper castkind *)
-            let casted_offs = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) offs_intdom in (* TODO: proper castkind *)
             let behavior = Undefined MemoryOutOfBoundsAccess in
             let cwe_number = 823 in
             begin match check_offset_bounds casted_es casted_offs with
@@ -332,10 +332,10 @@ struct
       let ptr_contents_type = get_ptr_deref_type ptr_type in
       begin match ptr_contents_type with
         | Some t ->
+          let offset_size = eval_ptr_offset_in_binop man e2 t in
           let* addr = man.ask (Queries.MayPointTo e1) in
           let ptr_size = get_addr_size man addr in
           let addr_offs = get_addr_offset t addr in
-          let offset_size = eval_ptr_offset_in_binop man e2 t in
           (* Make sure to add the address offset to the binop offset *)
           let offset_size_with_addr_size = match offset_size with
             | `Lifted os ->
@@ -390,9 +390,9 @@ struct
   let check_count man fun_name ptr n =
     let (behavior:MessageCategory.behavior) = Undefined MemoryOutOfBoundsAccess in
     let cwe_number = 823 in
+    let eval_n = man.ask (Queries.EvalInt n) in
     let* addr = man.ask (Queries.MayPointTo ptr) in
     let ptr_size = get_addr_size man addr in
-    let eval_n = man.ask (Queries.EvalInt n) in
     let addr_offs =
       let ptr_deref_type = get_ptr_deref_type @@ typeOf ptr in
       match ptr_deref_type with

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -28,6 +28,8 @@ struct
 
   (* HELPER FUNCTIONS *)
 
+  let (let*) ad f = ValueDomain.AD.iter f ad
+
   let intdom_of_int x =
     ID.of_int (Cilfacade.ptrdiff_ikind ()) (Z.of_int x)
 
@@ -108,12 +110,6 @@ struct
           `Lifted type_size_in_bytes
       end
     | _ -> `Top
-
-  let get_size_of_ptr_target man ptr =
-    man.ask (Queries.MayPointTo ptr)
-    |> Queries.AD.to_seq
-    |> Seq.map (get_addr_size man ptr)
-    |> Seq.fold_left VDQ.ID.join `Bot
 
   let get_ptr_deref_type ptr_typ =
     match Cil.unrollType ptr_typ with
@@ -199,27 +195,14 @@ struct
     (* Intuition: if ptr evaluates to top, it could all sorts of things and not only string addresses *)
     | _ -> false
 
-  let get_addr_offset ptr t (addr: ValueDomain.Addr.t) =
+  let get_addr_offset ptr t (addr: ValueDomain.Addr.t) = (* TODO: remove ptr argument *)
     match addr with
     | Addr (_, o) -> offs_to_idx t o
     | UnknownPtr -> ID.top_of @@ Cilfacade.ptrdiff_ikind () (* TODO: does this make sense? *)
     | NullPtr
     | StrPtr _ -> ID.bot_of @@ Cilfacade.ptrdiff_ikind () (* TODO: do these make sense? *)
 
-  let rec get_addr_offs man ptr =
-    let ptr_deref_type = get_ptr_deref_type @@ typeOf ptr in
-    match ptr_deref_type with
-    | Some t ->
-      (* Get the address offsets of all points-to set elements *)
-      man.ask (Queries.MayPointTo ptr)
-      |> VDQ.AD.to_seq
-      |> Seq.map (get_addr_offset ptr t)
-      |> Seq.fold_left ID.join (ID.bot_of @@ Cilfacade.ptrdiff_ikind ())
-    | None ->
-      M.error "Expression %a doesn't have pointer type" d_exp ptr;
-      ID.top_of @@ Cilfacade.ptrdiff_ikind ()
-
-  and check_lval_for_oob_access man ?(is_implicitly_derefed = false) lval =
+  let rec check_lval_for_oob_access man ?(is_implicitly_derefed = false) lval =
     (* If the lval does not contain a pointer or if it does contain a pointer, but only points to string addresses, then no need to WARN *)
     if (not @@ lval_contains_a_ptr lval) || ptr_only_has_str_addr man (Lval lval) then ()
     else
@@ -234,7 +217,8 @@ struct
           | Some t -> cil_offs_to_idx man t o
           | None -> ID.bot_of @@ Cilfacade.ptrdiff_ikind ()
         end in
-        let e_size = get_size_of_ptr_target man e in
+        let* addr = man.ask (Queries.MayPointTo e) in
+        let e_size = get_addr_size man e addr in
         begin match e_size with
           | `Top ->
             (set_mem_safety_flag InvalidDeref;
@@ -276,12 +260,13 @@ struct
     check_unknown_addr_deref man lval_exp;
     let behavior = Undefined MemoryOutOfBoundsAccess in
     let cwe_number = 823 in
-    let ptr_size = get_size_of_ptr_target man lval_exp in
-    let addr_offs = get_addr_offs man lval_exp in
     let ptr_type = typeOf lval_exp in
     let ptr_contents_type = get_ptr_deref_type ptr_type in
     match ptr_contents_type with
     | Some t ->
+      let* addr = man.ask (Queries.MayPointTo lval_exp) in
+      let ptr_size = get_addr_size man lval_exp addr in
+      let addr_offs = get_addr_offset lval_exp t addr in
       begin match ptr_size, addr_offs with
         | `Top, _ ->
           set_mem_safety_flag InvalidDeref;
@@ -343,12 +328,13 @@ struct
     | PlusPI
     | IndexPI
     | MinusPI ->
-      let ptr_size = get_size_of_ptr_target man e1 in
-      let addr_offs = get_addr_offs man e1 in
       let ptr_type = typeOf e1 in
       let ptr_contents_type = get_ptr_deref_type ptr_type in
       begin match ptr_contents_type with
         | Some t ->
+          let* addr = man.ask (Queries.MayPointTo e1) in
+          let ptr_size = get_addr_size man e1 addr in
+          let addr_offs = get_addr_offset e1 t addr in
           let offset_size = eval_ptr_offset_in_binop man e2 t in
           (* Make sure to add the address offset to the binop offset *)
           let offset_size_with_addr_size = match offset_size with
@@ -404,9 +390,17 @@ struct
   let check_count man fun_name ptr n =
     let (behavior:MessageCategory.behavior) = Undefined MemoryOutOfBoundsAccess in
     let cwe_number = 823 in
-    let ptr_size = get_size_of_ptr_target man ptr in
+    let* addr = man.ask (Queries.MayPointTo ptr) in
+    let ptr_size = get_addr_size man ptr addr in
     let eval_n = man.ask (Queries.EvalInt n) in
-    let addr_offs = get_addr_offs man ptr in
+    let addr_offs =
+      let ptr_deref_type = get_ptr_deref_type @@ typeOf ptr in
+      match ptr_deref_type with
+      | Some t -> get_addr_offset ptr t addr
+      | None ->
+        M.error "Expression %a doesn't have pointer type" d_exp ptr;
+        ID.top_of @@ Cilfacade.ptrdiff_ikind ()
+    in
     match ptr_size, eval_n with
     | `Top, _ ->
       set_mem_safety_flag InvalidDeref;

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -110,16 +110,10 @@ struct
     | _ -> `Top
 
   let get_size_of_ptr_target man ptr =
-    match man.ask (Queries.MayPointTo ptr) with
-    | a when not (Queries.AD.is_top a) ->
-      Queries.AD.to_seq a
-      |> Seq.map (get_addr_size man ptr)
-      |> Seq.fold_left VDQ.ID.join `Bot
-    | _ ->
-      (set_mem_safety_flag InvalidDeref;
-       M.warn "Pointer %a has a points-to-set of top. An invalid memory access might occur" d_exp ptr;
-       Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has a points-to-set of top. An invalid memory access might occur" d_exp ptr;
-       `Top)
+    man.ask (Queries.MayPointTo ptr)
+    |> Queries.AD.to_seq
+    |> Seq.map (get_addr_size man ptr)
+    |> Seq.fold_left VDQ.ID.join `Bot
 
   let get_ptr_deref_type ptr_typ =
     match Cil.unrollType ptr_typ with

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -205,6 +205,23 @@ struct
     (* Intuition: if ptr evaluates to top, it could all sorts of things and not only string addresses *)
     | _ -> false
 
+  let get_mval_offset ptr t (_, o) =
+    let x = offs_to_idx t o in
+    if ID.is_bot x then (
+      set_mem_safety_flag InvalidDeref;
+      M.warn "Pointer %a has a bot address offset. An invalid memory access may occur" d_exp ptr;
+      Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has a bot address offset. An invalid memory access may occur" d_exp ptr
+    )
+    else if ID.is_top_of (Cilfacade.ptrdiff_ikind ()) x then (
+      set_mem_safety_flag InvalidDeref;
+      M.warn "Pointer %a has a top address offset. An invalid memory access may occur" d_exp ptr;
+      Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has a top address offset. An invalid memory access may occur" d_exp ptr
+    )
+    else (
+      Checks.safe Checks.Category.InvalidMemoryAccess
+    );
+    x
+
   let rec get_addr_offs man ptr =
     match man.ask (Queries.MayPointTo ptr) with
     | a when not (VDQ.AD.is_top a) ->
@@ -217,34 +234,11 @@ struct
               Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has an empty points-to-set" d_exp ptr;
               ID.top_of @@ Cilfacade.ptrdiff_ikind ()
             | false ->
-              if VDQ.AD.exists (function
-                  | Addr (_, o) -> ID.is_bot @@ offs_to_idx t o
-                  | _ -> false
-                ) a then (
-                set_mem_safety_flag InvalidDeref;
-                M.warn "Pointer %a has a bot address offset. An invalid memory access may occur" d_exp ptr;
-                Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has a bot address offset. An invalid memory access may occur" d_exp ptr
-              ) else if VDQ.AD.exists (function
-                  | Addr (_, o) -> ID.is_top_of (Cilfacade.ptrdiff_ikind ()) (offs_to_idx t o)
-                  | _ -> false
-                ) a then (
-                set_mem_safety_flag InvalidDeref;
-                M.warn "Pointer %a has a top address offset. An invalid memory access may occur" d_exp ptr;
-                Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a has a top address offset. An invalid memory access may occur" d_exp ptr
-              ) else (
-                Checks.safe Checks.Category.InvalidMemoryAccess
-              );
               (* Get the address offsets of all points-to set elements *)
-              let addr_offsets =
-                VDQ.AD.filter (function Addr (v, o) -> true | _ -> false) a
-                |> VDQ.AD.to_mval
-                |> List.map (fun (_, o) -> offs_to_idx t o)
-              in
-              begin match addr_offsets with
-                | [] -> ID.bot_of @@ Cilfacade.ptrdiff_ikind ()
-                | [x] -> x
-                | x::xs -> List.fold_left ID.join x xs
-              end
+              VDQ.AD.to_mval a
+              |> List.to_seq
+              |> Seq.map (get_mval_offset ptr t)
+              |> Seq.fold_left ID.join (ID.bot_of @@ Cilfacade.ptrdiff_ikind ())
           end
         | None ->
           M.error "Expression %a doesn't have pointer type" d_exp ptr;

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -81,7 +81,7 @@ struct
     in
     host_contains_a_ptr host || offset_contains_a_ptr offset
 
-  let get_addr_size man ptr (addr: Queries.AD.elt) = (* TODO: remove ptr argument *) (* TODO: deduplicate with base (this uses IsAllocVar) *)
+  let get_addr_size man (addr: Queries.AD.elt) = (* TODO: deduplicate with base (this uses IsAllocVar) *)
     match addr with
     | Addr (v, _) when man.ask (Queries.IsAllocVar v) ->
       (* Ask for BlobSize from the base address (the second component being set to true) in order to avoid BlobSize giving us bot *)
@@ -195,7 +195,7 @@ struct
     (* Intuition: if ptr evaluates to top, it could all sorts of things and not only string addresses *)
     | _ -> false
 
-  let get_addr_offset ptr t (addr: ValueDomain.Addr.t) = (* TODO: remove ptr argument *)
+  let get_addr_offset t (addr: ValueDomain.Addr.t) =
     match addr with
     | Addr (_, o) -> offs_to_idx t o
     | UnknownPtr -> ID.top_of @@ Cilfacade.ptrdiff_ikind () (* TODO: does this make sense? *)
@@ -218,7 +218,7 @@ struct
           | None -> ID.bot_of @@ Cilfacade.ptrdiff_ikind ()
         end in
         let* addr = man.ask (Queries.MayPointTo e) in
-        let e_size = get_addr_size man e addr in
+        let e_size = get_addr_size man addr in
         begin match e_size with
           | `Top ->
             (set_mem_safety_flag InvalidDeref;
@@ -265,8 +265,8 @@ struct
     match ptr_contents_type with
     | Some t ->
       let* addr = man.ask (Queries.MayPointTo lval_exp) in
-      let ptr_size = get_addr_size man lval_exp addr in
-      let addr_offs = get_addr_offset lval_exp t addr in
+      let ptr_size = get_addr_size man addr in
+      let addr_offs = get_addr_offset t addr in
       begin match ptr_size, addr_offs with
         | `Top, _ ->
           set_mem_safety_flag InvalidDeref;
@@ -333,8 +333,8 @@ struct
       begin match ptr_contents_type with
         | Some t ->
           let* addr = man.ask (Queries.MayPointTo e1) in
-          let ptr_size = get_addr_size man e1 addr in
-          let addr_offs = get_addr_offset e1 t addr in
+          let ptr_size = get_addr_size man addr in
+          let addr_offs = get_addr_offset t addr in
           let offset_size = eval_ptr_offset_in_binop man e2 t in
           (* Make sure to add the address offset to the binop offset *)
           let offset_size_with_addr_size = match offset_size with
@@ -391,12 +391,12 @@ struct
     let (behavior:MessageCategory.behavior) = Undefined MemoryOutOfBoundsAccess in
     let cwe_number = 823 in
     let* addr = man.ask (Queries.MayPointTo ptr) in
-    let ptr_size = get_addr_size man ptr addr in
+    let ptr_size = get_addr_size man addr in
     let eval_n = man.ask (Queries.EvalInt n) in
     let addr_offs =
       let ptr_deref_type = get_ptr_deref_type @@ typeOf ptr in
       match ptr_deref_type with
-      | Some t -> get_addr_offset ptr t addr
+      | Some t -> get_addr_offset t addr
       | None ->
         M.error "Expression %a doesn't have pointer type" d_exp ptr;
         ID.top_of @@ Cilfacade.ptrdiff_ikind ()

--- a/tests/regression/74-invalid_deref/39-oob-base-offset-relation.c
+++ b/tests/regression/74-invalid_deref/39-oob-base-offset-relation.c
@@ -14,6 +14,6 @@ int main(void) {
   else
     p = &bar[99];
 
-  *p = 42; // TODO NOWARN
+  *p = 42; // NOWARN
   return 0;
 }

--- a/tests/regression/74-invalid_deref/39-oob-base-offset-relation.c
+++ b/tests/regression/74-invalid_deref/39-oob-base-offset-relation.c
@@ -1,0 +1,19 @@
+// PARAM: --enable ana.sv-comp.functions --set ana.activated[+] memOutOfBounds --enable ana.int.interval
+#include <stdlib.h>
+#include <stdio.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+
+int main(void) {
+  int foo[4];
+  int bar[100];
+
+  int *p;
+  if (__VERIFIER_nondet_bool())
+    p = &foo[3];
+  else
+    p = &bar[99];
+
+  *p = 42; // TODO NOWARN
+  return 0;
+}


### PR DESCRIPTION
This is on top of #2057.

Previously memOutOfBounds was unnecessarily imprecise: for a points-to set, the sizes of targets and offsets of targets were joined separately, and then bounds were checked on the joined values.
This changes the bounds check to be per-target, without joining sizes and offsets.
It is illustrated by the added test which now passes.