### PR TITLE
Use non-deprecated qcheck combinators

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -43,7 +43,7 @@ Goblint includes analyses for assertions, overflows, deadlocks, etc and can be e
     (patricia-tree (>= 0.14.0))
     (zarith (>= 1.12))
     (yojson (and (>= 2.0.0) (< 3))) ; json-data-encoding has incompatible yojson representation for yojson 3
-    (qcheck-core (>= 0.19))
+    (qcheck-core (>= 0.90))
     (ppx_deriving (>= 6.0.2))
     (ppx_deriving_hash (>= 0.1.2))
     (ppx_deriving_yojson (>= 3.7.0))

--- a/goblint.opam
+++ b/goblint.opam
@@ -44,7 +44,7 @@ depends: [
   "patricia-tree" {>= "0.14.0"}
   "zarith" {>= "1.12"}
   "yojson" {>= "2.0.0" & < "3"}
-  "qcheck-core" {>= "0.19"}
+  "qcheck-core" {>= "0.90"}
   "ppx_deriving" {>= "6.0.2"}
   "ppx_deriving_hash" {>= "0.1.2"}
   "ppx_deriving_yojson" {>= "3.7.0"}

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -108,8 +108,8 @@ depends: [
   "ppx_yojson_conv_lib" {= "v0.16.0" & with-dev-setup}
   "ppxlib" {= "0.35.0"}
   "ptime" {= "1.2.0" & with-doc}
-  "qcheck-core" {= "0.25"}
-  "qcheck-ounit" {= "0.25" & with-test}
+  "qcheck-core" {= "0.91"}
+  "qcheck-ounit" {= "0.91" & with-test}
   "re" {= "1.11.0" & with-doc}
   "result" {= "1.5" & with-doc}
   "rresult" {= "0.7.0"}

--- a/src/cdomain/value/cdomains/int/defExcDomain.ml
+++ b/src/cdomain/value/cdomains/int/defExcDomain.ml
@@ -583,7 +583,7 @@ struct
       | `Definite x -> (return `Bot) <+> (GobQCheck.shrink (IntOps.BigIntOps.arbitrary ()) x >|= definite)
       | `Bot -> empty
     in
-    QCheck.frequency ~shrink ~print:show [
+    QCheck.oneof_weighted ~shrink ~print:show [
       20, QCheck.map excluded (S.arbitrary ());
       10, QCheck.map definite (IntOps.BigIntOps.arbitrary ());
       1, QCheck.always `Bot

--- a/src/cdomain/value/cdomains/int/enumsDomain.ml
+++ b/src/cdomain/value/cdomains/int/enumsDomain.ml
@@ -449,7 +449,7 @@ module Enums : S with type int_t = Z.t = struct
       | Exc (s, _) -> GobQCheck.shrink (BISet.arbitrary ()) s >|= neg (* S TODO: possibly shrink neg to pos *)
       | Inc s -> GobQCheck.shrink (BISet.arbitrary ()) s >|= pos
     in
-    QCheck.frequency ~shrink ~print:show [
+    QCheck.oneof_weighted ~shrink ~print:show [
       20, QCheck.map neg (BISet.arbitrary ());
       10, QCheck.map pos (BISet.arbitrary ());
     ] (* S TODO: decide frequencies *)

--- a/src/cdomain/value/cdomains/int/intervalSetDomain.ml
+++ b/src/cdomain/value/cdomains/int/intervalSetDomain.ml
@@ -617,7 +617,7 @@ struct
     (* TODO: apparently bigints are really slow compared to int64 for domaintest *)
     let int_arb = QCheck.map ~rev:Ints_t.to_int64 Ints_t.of_int64 GobQCheck.Arbitrary.int64 in
     let pair_arb = QCheck.pair int_arb int_arb in
-    let list_pair_arb = QCheck.small_list pair_arb in
+    let list_pair_arb = QCheck.list_small pair_arb in
     let canonize_randomly_generated_list = (fun x -> norm_intvs ik  x |> fst) in
     let shrink xs = GobQCheck.shrink list_pair_arb xs >|= canonize_randomly_generated_list
     in QCheck.(set_shrink shrink @@ set_print show @@ map (*~rev:BatOption.get*) canonize_randomly_generated_list list_pair_arb)

--- a/src/common/domains/printable.ml
+++ b/src/common/domains/printable.ml
@@ -296,7 +296,7 @@ struct
       | `Bot -> empty
       | `Top -> GobQCheck.Iter.of_arbitrary ~n:20 (Base.arbitrary ()) >|= lift
     in
-    QCheck.frequency ~shrink ~print:show [
+    QCheck.oneof_weighted ~shrink ~print:show [
       20, QCheck.map lift (Base.arbitrary ());
       1, QCheck.always `Bot;
       1, QCheck.always `Top
@@ -721,7 +721,7 @@ struct
       | `Lifted x -> GobQCheck.shrink (Base.arbitrary ()) x >|= lift
       | `Top -> GobQCheck.Iter.of_arbitrary ~n:20 (Base.arbitrary ()) >|= lift
     in
-    QCheck.frequency ~shrink ~print:show [
+    QCheck.oneof_weighted ~shrink ~print:show [
       20, QCheck.map lift (Base.arbitrary ());
       1, QCheck.always `Top
     ] (* S TODO: decide frequencies *)

--- a/src/domain/hoareDomain.ml
+++ b/src/domain/hoareDomain.ml
@@ -220,7 +220,7 @@ struct
   let of_list xs = List.fold_right add xs (empty ()) |> reduce (* TODO: why not use Make's of_list if reduce anyway, right now add also is special *)
 
   (* Copied from Make *)
-  let arbitrary () = QCheck.map ~rev:elements of_list @@ QCheck.small_list (B.arbitrary ())
+  let arbitrary () = QCheck.map ~rev:elements of_list @@ QCheck.list_small (B.arbitrary ())
 
   let pretty_diff () ((s1:t),(s2:t)): Pretty.doc =
     if leq s1 s2 then dprintf "%s (%d and %d paths): These are fine!" (name ()) (cardinal s1) (cardinal s2) else begin

--- a/src/domain/setDomain.ml
+++ b/src/domain/setDomain.ml
@@ -201,7 +201,7 @@ struct
       Pretty.dprintf "%s: %a not leq %a\n  @[because %a@]" (name ()) pretty x pretty y Base.pretty evil
     end
 
-  let arbitrary () = QCheck.map ~rev:elements of_list @@ QCheck.small_list (Base.arbitrary ())
+  let arbitrary () = QCheck.map ~rev:elements of_list @@ QCheck.list_small (Base.arbitrary ())
 end
 
 (** A functor for creating a path sensitive set domain, that joins the base
@@ -455,7 +455,7 @@ struct
   module E =
   struct
     include E
-    let arbitrary () = QCheck.oneofl E.elems
+    let arbitrary () = QCheck.oneof_list E.elems
   end
 
   include Make (E)


### PR DESCRIPTION
The unlocked CI jobs (and opam-repository CI) show a bunch of deprecation warnings for qcheck on newer versions.
This upgrades Goblint to those newer versions with non-deprecated combinator names.