### PR TITLE
Remove `EvalValue` queries from memOutOfBounds

### DIFF
--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -167,24 +167,6 @@ struct
     PreValueDomain.Offs.to_index (convert_offset offs)
 
 
-  let check_unknown_addr_deref man ptr =
-    let may_contain_unknown_addr =
-      match man.ask (Queries.EvalValue ptr) with
-      | a when not (Queries.VD.is_top a) ->
-        begin match a with
-          | Address a -> ValueDomain.AD.may_be_unknown a
-          | _ -> false
-        end
-      (* Intuition: if ptr evaluates to top, it could potentially evaluate to the unknown address *)
-      | _ -> true
-    in
-    if may_contain_unknown_addr then begin
-      set_mem_safety_flag InvalidDeref;
-      M.warn ~category:(Behavior (Undefined Other)) "Pointer %a contains an unknown address. Invalid dereference may occur" d_exp ptr;
-      Checks.warn Checks.Category.InvalidMemoryAccess "Pointer %a contains an unknown address. Invalid dereference may occur" d_exp ptr
-    end else
-      Checks.safe Checks.Category.InvalidMemoryAccess
-
   let ptr_only_has_str_addr man ptr =
     ValueDomain.AD.for_all (function StrPtr _ -> true | _ -> false) (man.ask (Queries.MayPointTo ptr))
 
@@ -250,7 +232,6 @@ struct
         end
 
   and check_no_binop_deref man lval_exp =
-    check_unknown_addr_deref man lval_exp;
     let behavior = Undefined MemoryOutOfBoundsAccess in
     let cwe_number = 823 in
     let ptr_type = typeOf lval_exp in
@@ -313,7 +294,6 @@ struct
     | AddrOf lval -> check_lval_for_oob_access man ~is_implicitly_derefed lval
 
   and check_binop_exp man binop e1 e2 t =
-    check_unknown_addr_deref man e1;
     let binopexp = BinOp (binop, e1, e2, t) in
     let behavior = Undefined MemoryOutOfBoundsAccess in
     let cwe_number = 823 in

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -186,14 +186,7 @@ struct
       Checks.safe Checks.Category.InvalidMemoryAccess
 
   let ptr_only_has_str_addr man ptr =
-    match man.ask (Queries.EvalValue ptr) with
-    | a when not (Queries.VD.is_top a) ->
-      begin match a with
-        | Address a -> ValueDomain.AD.for_all (fun addr -> match addr with | StrPtr _ -> true | _ -> false) a
-        | _ -> false
-      end
-    (* Intuition: if ptr evaluates to top, it could all sorts of things and not only string addresses *)
-    | _ -> false
+    ValueDomain.AD.for_all (function StrPtr _ -> true | _ -> false) (man.ask (Queries.MayPointTo ptr))
 
   let get_addr_offset t (addr: ValueDomain.Addr.t) =
     match addr with
@@ -204,7 +197,7 @@ struct
 
   let rec check_lval_for_oob_access man ?(is_implicitly_derefed = false) lval =
     (* If the lval does not contain a pointer or if it does contain a pointer, but only points to string addresses, then no need to WARN *)
-    if (not @@ lval_contains_a_ptr lval) || ptr_only_has_str_addr man (Lval lval) then ()
+    if (not @@ lval_contains_a_ptr lval) || ptr_only_has_str_addr man (Lval lval) then () (* TODO: why are StrPtrs special? *)
     else
       (* If the lval doesn't indicate an explicit dereference, we still need to check for an implicit dereference *)
       (* An implicit dereference is, e.g., printf("%p", ptr), where ptr is a pointer *)


### PR DESCRIPTION
Doing an `EvalValue` query to look at the `Address` case is just a roundabout way of querying `MayPointTo`.

`check_unknown_addr_deref` is redundant because if it can be an unknown pointer, then the general per-addr logic already checks it anyway.
