### PR TITLE
Remove duplicate binop handling from memOutOfBounds

### DIFF
--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -116,19 +116,6 @@ struct
     | TPtr (t, _) -> Some t
     | _ -> None
 
-  let eval_ptr_offset_in_binop man exp ptr_contents_typ =
-    let eval_offset = man.ask (Queries.EvalInt exp) in
-    match eval_offset with
-    | `Lifted eo ->
-      let ptr_contents_typ_size_in_bytes = size_of_type_in_bytes ptr_contents_typ in
-      let casted_eo = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) eo in (* TODO: proper castkind *)
-      begin
-        try `Lifted (ID.mul casted_eo ptr_contents_typ_size_in_bytes)
-        with IntDomain.ArithmeticOnIntegerBot _ -> `Bot
-      end
-    | `Top -> `Top
-    | `Bot -> `Bot
-
   let rec offs_to_idx typ offs =
     match offs with
     | `NoOffset -> intdom_of_int 0
@@ -222,14 +209,7 @@ struct
                 Checks.warn Checks.Category.InvalidMemoryAccess "Could not compare size of lval dereference expression (%a) (in bytes) with offset by (%a) (in bytes). Memory out-of-bounds access might occur" ID.pretty casted_es ID.pretty casted_offs
             end
         end;
-        begin match e with
-          | Lval (Var v, _) as lval_exp -> check_no_binop_deref man lval_exp
-          | BinOp (binop, e1, e2, t) when binop = PlusPI || binop = MinusPI || binop = IndexPI ->
-            check_binop_exp man binop e1 e2 t;
-            check_exp_for_oob_access man ~is_implicitly_derefed e1;
-            check_exp_for_oob_access man ~is_implicitly_derefed e2
-          | _ -> check_exp_for_oob_access man ~is_implicitly_derefed e
-        end
+        check_no_binop_deref man e
 
   and check_no_binop_deref man lval_exp =
     let behavior = Undefined MemoryOutOfBoundsAccess in
@@ -292,72 +272,6 @@ struct
     | Lval lval
     | StartOf lval
     | AddrOf lval -> check_lval_for_oob_access man ~is_implicitly_derefed lval
-
-  and check_binop_exp man binop e1 e2 t =
-    let binopexp = BinOp (binop, e1, e2, t) in
-    let behavior = Undefined MemoryOutOfBoundsAccess in
-    let cwe_number = 823 in
-    match binop with
-    | PlusPI
-    | IndexPI
-    | MinusPI ->
-      let ptr_type = typeOf e1 in
-      let ptr_contents_type = get_ptr_deref_type ptr_type in
-      begin match ptr_contents_type with
-        | Some t ->
-          let offset_size = eval_ptr_offset_in_binop man e2 t in
-          let* addr = man.ask (Queries.MayPointTo e1) in
-          let ptr_size = get_addr_size man addr in
-          let addr_offs = get_addr_offset t addr in
-          (* Make sure to add the address offset to the binop offset *)
-          let offset_size_with_addr_size = match offset_size with
-            | `Lifted os ->
-              let casted_os = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) os in (* TODO: proper castkind *)
-              let casted_ao = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) addr_offs in (* TODO: proper castkind *)
-              begin
-                try `Lifted (ID.add casted_os casted_ao)
-                with IntDomain.ArithmeticOnIntegerBot _ -> `Bot
-              end
-            | `Top -> `Top
-            | `Bot -> `Bot
-          in
-          begin match ptr_size, offset_size_with_addr_size with
-            | `Top, _ ->
-              set_mem_safety_flag InvalidDeref;
-              M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Size of pointer %a in expression %a is top. Memory out-of-bounds access might occur" d_exp e1 d_exp binopexp;
-              Checks.warn Checks.Category.InvalidMemoryAccess "Size of pointer %a in expression %a is top. Memory out-of-bounds access might occur" d_exp e1 d_exp binopexp
-            | _, `Top ->
-              set_mem_safety_flag InvalidDeref;
-              M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Operand value for pointer arithmetic in expression %a is top. Memory out-of-bounds access might occur" d_exp binopexp;
-              Checks.warn Checks.Category.InvalidMemoryAccess "Operand value for pointer arithmetic in expression %a is top. Memory out-of-bounds access might occur" d_exp binopexp
-            | `Bot, _ ->
-              set_mem_safety_flag InvalidDeref;
-              M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Size of pointer %a in expression %a is bottom. Memory out-of-bounds access might occur" d_exp e1 d_exp binopexp;
-              Checks.warn Checks.Category.InvalidMemoryAccess "Size of pointer %a in expression %a is bottom. Memory out-of-bounds access might occur" d_exp e1 d_exp binopexp
-            | _, `Bot ->
-              set_mem_safety_flag InvalidDeref;
-              M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Operand value for pointer arithmetic in expression %a is bottom. Memory out-of-bounds access might occur" d_exp binopexp;
-              Checks.warn Checks.Category.InvalidMemoryAccess "Operand value for pointer arithmetic in expression %a is bottom. Memory out-of-bounds access might occur" d_exp binopexp
-            | `Lifted ps, `Lifted o ->
-              let casted_ps = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) ps in (* TODO: proper castkind *)
-              let casted_o = ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) o in (* TODO: proper castkind *)
-              begin match check_offset_bounds casted_ps casted_o with
-                | Some true, _
-                | _, Some true ->
-                  set_mem_safety_flag InvalidDeref;
-                  M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Size of pointer in expression %a is %a (in bytes). It is offset by %a (in bytes). Memory out-of-bounds access must occur" d_exp binopexp ID.pretty casted_ps ID.pretty casted_o;
-                  Checks.warn Checks.Category.InvalidMemoryAccess "Size of pointer in expression %a is %a (in bytes). It is offset by %a (in bytes). Memory out-of-bounds access must occur" d_exp binopexp ID.pretty casted_ps ID.pretty casted_o
-                | Some false, Some false ->
-                  Checks.safe Checks.Category.InvalidMemoryAccess
-                | _ ->
-                  set_mem_safety_flag InvalidDeref;
-                  M.warn ~category:(Behavior behavior) ~tags:[CWE cwe_number] "Could not compare pointer size (%a) with offset (%a). Memory out-of-bounds access may occur" ID.pretty casted_ps ID.pretty casted_o;
-                  Checks.warn Checks.Category.InvalidMemoryAccess "Could not compare pointer size (%a) with offset (%a). Memory out-of-bounds access may occur" ID.pretty casted_ps ID.pretty casted_o
-              end
-          end
-        | _ -> M.error "Binary expression %a doesn't have a pointer" d_exp binopexp
-      end
-    | _ -> ()
 
   (* For memset() and memcpy() *)
   let check_count man fun_name ptr n =

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -209,7 +209,8 @@ struct
                 Checks.warn Checks.Category.InvalidMemoryAccess "Could not compare size of lval dereference expression (%a) (in bytes) with offset by (%a) (in bytes). Memory out-of-bounds access might occur" ID.pretty casted_es ID.pretty casted_offs
             end
         end;
-        check_no_binop_deref man e;
+        check_no_binop_deref man e; (* TODO: the above check and the one in check_no_binop_deref should probably be combined into one *)
+        (* TODO: accesses in index expressions don't seem to be checked anywhere (unlike with access events) *)
         check_exp_for_oob_access man ~is_implicitly_derefed e (* See 74-invalid_deref/42-oob-mem-nested *)
 
   and check_no_binop_deref man lval_exp =
@@ -272,7 +273,7 @@ struct
       check_exp_for_oob_access man ~is_implicitly_derefed e3
     | Lval lval
     | StartOf lval
-    | AddrOf lval -> check_lval_for_oob_access man ~is_implicitly_derefed lval
+    | AddrOf lval -> check_lval_for_oob_access man ~is_implicitly_derefed lval (* TODO: StartOf and AddrOf don't actually access, so this does spurious checks (moving over to access events would fix this) *)
 
   (* For memset() and memcpy() *)
   let check_count man fun_name ptr n =

--- a/src/analyses/memOutOfBounds.ml
+++ b/src/analyses/memOutOfBounds.ml
@@ -209,7 +209,8 @@ struct
                 Checks.warn Checks.Category.InvalidMemoryAccess "Could not compare size of lval dereference expression (%a) (in bytes) with offset by (%a) (in bytes). Memory out-of-bounds access might occur" ID.pretty casted_es ID.pretty casted_offs
             end
         end;
-        check_no_binop_deref man e
+        check_no_binop_deref man e;
+        check_exp_for_oob_access man ~is_implicitly_derefed e (* See 74-invalid_deref/42-oob-mem-nested *)
 
   and check_no_binop_deref man lval_exp =
     let behavior = Undefined MemoryOutOfBoundsAccess in

--- a/tests/regression/74-invalid_deref/01-oob-heap-simple.t
+++ b/tests/regression/74-invalid_deref/01-oob-heap-simple.t
@@ -1,7 +1,7 @@
   $ goblint --set ana.activated[+] memOutOfBounds --enable ana.int.interval 01-oob-heap-simple.c 2>&1 | tee default-output.txt
   [Warning] The memOutOfBounds analysis enables cil.addNestedScopeAttr.
-  [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Size of pointer in expression ptr + 10 is 5 (in bytes). It is offset by 10 (in bytes). Memory out-of-bounds access must occur (01-oob-heap-simple.c:10:5-10:22)
-  [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Could not compare pointer size (5) with offset (⊤). Memory out-of-bounds access may occur (01-oob-heap-simple.c:11:5-11:21)
+  [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Size of pointer is 5 (in bytes). It is offset by 10 (in bytes) due to pointer arithmetic. Memory out-of-bounds access must occur (01-oob-heap-simple.c:10:5-10:22)
+  [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Could not compare size of pointer (5) (in bytes) with offset by (⊤) (in bytes). Memory out-of-bounds access might occur (01-oob-heap-simple.c:11:5-11:21)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 8
     dead: 0
@@ -11,9 +11,9 @@
 
   $ diff default-output.txt full-output.txt
   2,3c2,3
-  < [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Size of pointer in expression ptr + 10 is 5 (in bytes). It is offset by 10 (in bytes). Memory out-of-bounds access must occur (01-oob-heap-simple.c:10:5-10:22)
-  < [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Could not compare pointer size (5) with offset (⊤). Memory out-of-bounds access may occur (01-oob-heap-simple.c:11:5-11:21)
+  < [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Size of pointer is 5 (in bytes). It is offset by 10 (in bytes) due to pointer arithmetic. Memory out-of-bounds access must occur (01-oob-heap-simple.c:10:5-10:22)
+  < [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Could not compare size of pointer (5) (in bytes) with offset by (⊤) (in bytes). Memory out-of-bounds access might occur (01-oob-heap-simple.c:11:5-11:21)
   ---
-  > [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Size of pointer in expression ptr + 10 is (5,[5,5]) (in bytes). It is offset by (10,[10,10]) (in bytes). Memory out-of-bounds access must occur (01-oob-heap-simple.c:10:5-10:22)
-  > [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Could not compare pointer size ((5,[5,5])) with offset ((Unknown int([-63,63]),[-9223372036854775808,9223372036854775807])). Memory out-of-bounds access may occur (01-oob-heap-simple.c:11:5-11:21)
+  > [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Size of pointer is (5,[5,5]) (in bytes). It is offset by (10,[10,10]) (in bytes) due to pointer arithmetic. Memory out-of-bounds access must occur (01-oob-heap-simple.c:10:5-10:22)
+  > [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Could not compare size of pointer ((5,[5,5])) (in bytes) with offset by ((Unknown int([-63,63]),[-9223372036854775808,9223372036854775807])) (in bytes). Memory out-of-bounds access might occur (01-oob-heap-simple.c:11:5-11:21)
   [1]

--- a/tests/regression/74-invalid_deref/40-oob-deref-cast.c
+++ b/tests/regression/74-invalid_deref/40-oob-deref-cast.c
@@ -1,0 +1,9 @@
+// PARAM: --set ana.activated[+] memOutOfBounds --enable ana.int.interval
+#include <stdlib.h>
+
+int main() {
+  char* s = malloc(10);
+  s += 10; // NOWARN
+  unsigned char ch = (*(unsigned char *) s); // TODO WARN!
+  return 0;
+}

--- a/tests/regression/74-invalid_deref/41-oob-coreutils-seq-incr.c
+++ b/tests/regression/74-invalid_deref/41-oob-coreutils-seq-incr.c
@@ -1,4 +1,5 @@
-// PARAM: --set ana.activated[+] memOutOfBounds --enable ana.int.interval
+// PARAM: --set ana.activated[+] memOutOfBounds --enable ana.int.interval --disable warn.info
+// TODO: The "--disable warn.info" part is a temporary fix and needs to be removed once the MacOS CI job is fixed
 #include <stdlib.h>
 #include <string.h>
 

--- a/tests/regression/74-invalid_deref/41-oob-coreutils-seq-incr.c
+++ b/tests/regression/74-invalid_deref/41-oob-coreutils-seq-incr.c
@@ -1,0 +1,37 @@
+// PARAM: --set ana.activated[+] memOutOfBounds --enable ana.int.interval
+#include <stdlib.h>
+#include <string.h>
+
+// This is some wild C code from coreutils seq.
+static void
+incr (char **s0, size_t *s_len)
+{
+  char *s = *s0; // NOWARN
+  char *endp = s + *s_len - 1; // NOWARN
+  do
+    {
+      if ((*endp)++ < '9') // TODO NOWARN
+        return;
+      *endp-- = '0'; // TODO NOWARN
+    }
+  while (endp >= s);
+  *--(*s0) = '1'; // TODO WARN!
+  ++*s_len; // NOWARN
+}
+
+int main() {
+  char* s = malloc(10);
+  memset(s, '0', 10); // NOWARN
+
+  char* s2 = s + 9;
+  size_t len = 1;
+  incr(&s2, &len); // everything in this should be in bounds
+
+  memset(s, '9', 10); // NOWARN
+
+  s2 = s;
+  len = 10;
+  incr(&s2, &len); // something in this could be out of bounds
+
+  return 0;
+}

--- a/tests/regression/74-invalid_deref/42-oob-mem-nested.c
+++ b/tests/regression/74-invalid_deref/42-oob-mem-nested.c
@@ -1,0 +1,25 @@
+// PARAM: --set ana.activated[+] memOutOfBounds --enable ana.int.interval
+#include <goblint.h>
+
+int main() {
+  int x = 0;
+  int *p = &x;
+  int y;
+
+  y = *p; // NOWARN
+  __goblint_check(y == 0);
+  y = *(p + 0); // NOWARN
+  __goblint_check(y == 0);
+  y = *(p + *p); // NOWARN
+  __goblint_check(y == 0);
+  y = *(p + p[0]); // NOWARN
+  __goblint_check(y == 0);
+  y = *(p + p[-1]); // WARN!
+  __goblint_check(y == 0); // UNKNOWN!
+  y = *(p + 0 * p[-1]); // TODO WARN! (must disable global constant folding)
+  __goblint_check(y == 0);
+  y = *(p + x * p[-1]); // WARN!
+  __goblint_check(y == 0);
+
+  return 0;
+}

--- a/tests/regression/74-invalid_deref/42-oob-mem-nested.t
+++ b/tests/regression/74-invalid_deref/42-oob-mem-nested.t
@@ -6,9 +6,11 @@
   [Success][Assert] Assertion "y == 0" will succeed (42-oob-mem-nested.c:16:3-16:26)
   [Warning][Imprecise][Program] Trying to read an index, but was not given an array (0) (42-oob-mem-nested.c:17:3-17:19)
   [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Could not compare size of pointer (4) (in bytes) with offset by ((Unknown int([-63,63]),[-8589934592,8589934588])) (in bytes). Memory out-of-bounds access might occur (42-oob-mem-nested.c:17:3-17:19)
+  [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Size of pointer is 4 (in bytes). It is offset by -4 (in bytes) due to pointer arithmetic. Memory out-of-bounds access must occur (42-oob-mem-nested.c:17:3-17:19)
   [Warning][Assert] Assertion "y == 0" is unknown. (42-oob-mem-nested.c:18:3-18:26)
   [Success][Assert] Assertion "y == 0" will succeed (42-oob-mem-nested.c:20:3-20:26)
   [Warning][Imprecise][Program] Trying to read an index, but was not given an array (0) (42-oob-mem-nested.c:21:3-21:23)
+  [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Size of pointer is 4 (in bytes). It is offset by -4 (in bytes) due to pointer arithmetic. Memory out-of-bounds access must occur (42-oob-mem-nested.c:21:3-21:23)
   [Success][Assert] Assertion "y == 0" will succeed (42-oob-mem-nested.c:22:3-22:26)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 18

--- a/tests/regression/74-invalid_deref/42-oob-mem-nested.t
+++ b/tests/regression/74-invalid_deref/42-oob-mem-nested.t
@@ -1,0 +1,18 @@
+  $ goblint --set ana.activated[+] memOutOfBounds --enable ana.int.interval 42-oob-mem-nested.c
+  [Warning] The memOutOfBounds analysis enables cil.addNestedScopeAttr.
+  [Success][Assert] Assertion "y == 0" will succeed (42-oob-mem-nested.c:10:3-10:26)
+  [Success][Assert] Assertion "y == 0" will succeed (42-oob-mem-nested.c:12:3-12:26)
+  [Success][Assert] Assertion "y == 0" will succeed (42-oob-mem-nested.c:14:3-14:26)
+  [Success][Assert] Assertion "y == 0" will succeed (42-oob-mem-nested.c:16:3-16:26)
+  [Warning][Imprecise][Program] Trying to read an index, but was not given an array (0) (42-oob-mem-nested.c:17:3-17:19)
+  [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Could not compare pointer size (4) with offset ((Unknown int([-63,63]),[-8589934592,8589934588])). Memory out-of-bounds access may occur (42-oob-mem-nested.c:17:3-17:19)
+  [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Size of pointer in expression p + -1 is 4 (in bytes). It is offset by -4 (in bytes). Memory out-of-bounds access must occur (42-oob-mem-nested.c:17:3-17:19)
+  [Warning][Assert] Assertion "y == 0" is unknown. (42-oob-mem-nested.c:18:3-18:26)
+  [Success][Assert] Assertion "y == 0" will succeed (42-oob-mem-nested.c:20:3-20:26)
+  [Warning][Imprecise][Program] Trying to read an index, but was not given an array (0) (42-oob-mem-nested.c:21:3-21:23)
+  [Warning][Behavior > Undefined > MemoryOutOfBoundsAccess][CWE-823] Size of pointer in expression p + -1 is 4 (in bytes). It is offset by -4 (in bytes). Memory out-of-bounds access must occur (42-oob-mem-nested.c:21:3-21:23)
+  [Success][Assert] Assertion "y == 0" will succeed (42-oob-mem-nested.c:22:3-22:26)
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 18
+    dead: 0
+    total lines: 18


### PR DESCRIPTION
After inspecting the dashboard checks, turns out this also fixes a soundness issue. The previous handling for `Mem` strangely only covered dereferencing of variables and binops but nothing else.
The extracted tests contain dereferences of other expressions like `*(unsigned char *) s` and `*--(*s0)` (this one is wild!).

I think some redundancy/incorrectness might still remain: `Mem` does two different bounds checks, one doesn't account for offsets of the `Mem`, the other doesn't account for offsets of the address under `Mem`. I suspect these should be one combined check to be tried out in a future PR.

### TODO
- [x] Figure out oob-coreutils-seq-incr test failures on MacOS.
- [x] New OVD comparison.