### PR TITLE
Emit witness invariants for `static` (pulled-up) globals

### DIFF
--- a/goblint.opam
+++ b/goblint.opam
@@ -106,7 +106,7 @@ x-maintenance-intent: ["(latest)" "(latest).(latest-1)"]
 # also remember to generate/adjust goblint.opam.locked!
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 pin-depends: [
-  [ "goblint-cil.2.1.0" "git+https://github.com/goblint/cil.git#76083d655d56e4c7791d457db57f0dd6461faf71" ]
+  [ "goblint-cil.2.1.0" "git+https://github.com/goblint/cil.git#f2f244ec2ebb73536a15eb7488af10122c16907e" ]
   # pinned for performance (https://github.com/ocaml-batteries-team/batteries-included/pull/1149) via fork, remove after new batteries release (and then bump the batteries lower-bound accordingly)
   [ "batteries.3.11.0" "git+https://github.com/sim642/batteries-included.git#3920bdf614e4a12120fabfa2c97ee913cc246b13" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -164,7 +164,7 @@ post-messages: [
 pin-depends: [
   [
     "goblint-cil.2.1.0"
-    "git+https://github.com/goblint/cil.git#76083d655d56e4c7791d457db57f0dd6461faf71"
+    "git+https://github.com/goblint/cil.git#f2f244ec2ebb73536a15eb7488af10122c16907e"
   ]
   [
     "batteries.3.11.0"

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -2,7 +2,7 @@
 # also remember to generate/adjust goblint.opam.locked!
 available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
 pin-depends: [
-  [ "goblint-cil.2.1.0" "git+https://github.com/goblint/cil.git#76083d655d56e4c7791d457db57f0dd6461faf71" ]
+  [ "goblint-cil.2.1.0" "git+https://github.com/goblint/cil.git#f2f244ec2ebb73536a15eb7488af10122c16907e" ]
   # pinned for performance (https://github.com/ocaml-batteries-team/batteries-included/pull/1149) via fork, remove after new batteries release (and then bump the batteries lower-bound accordingly)
   [ "batteries.3.11.0" "git+https://github.com/sim642/batteries-included.git#3920bdf614e4a12120fabfa2c97ee913cc246b13" ]
   # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release

--- a/src/cdomain/value/domains/invariantCil.ml
+++ b/src/cdomain/value/domains/invariantCil.ml
@@ -36,19 +36,19 @@ let var_may_be_shadowed scope vi =
 
 let var_is_in_scope scope vi =
   let var_nested () =
-    not (GobConfig.get_bool "witness.invariant.all-locals" || (not @@ hasAttribute "goblint_cil_nested" vi.vattr))
+    not (GobConfig.get_bool "witness.invariant.all-locals") && hasAttribute "goblint_cil_nested" vi.vattr
   in
   match Cilfacade.find_scope_fundec vi with
   | None ->
     (* CIL pulls static locals into globals, but they aren't syntactically in global scope *)
-    not (vi.vstorage = Static &&
-         match Cilfacade.findAttribute "goblint_cil_pulledup" vi.vattr with
-         | Some [AStr static_fun_name] ->
-           static_fun_name <> scope.svar.vname ||
-           var_nested ()
-         | Some _ -> failwith "InvariantCil.var_is_in_scope: invalid goblint_cil_pulledup attribute parameters"
-         | None -> false (* normal static global *)
-        ) &&
+    (vi.vstorage <> Static ||
+     match Cilfacade.findAttribute "goblint_cil_pulledup" vi.vattr with
+     | Some [AStr static_fun_name] ->
+       static_fun_name = scope.svar.vname &&
+       not (var_nested ())
+     | Some _ -> failwith "InvariantCil.var_is_in_scope: invalid goblint_cil_pulledup attribute parameters"
+     | None -> true (* normal static global *)
+    ) &&
     not (var_may_be_shadowed scope vi)
   | Some fd ->
     CilType.Fundec.equal fd scope &&

--- a/src/cdomain/value/domains/invariantCil.ml
+++ b/src/cdomain/value/domains/invariantCil.ml
@@ -37,7 +37,7 @@ let var_may_be_shadowed scope vi =
 let var_is_in_scope scope vi =
   match Cilfacade.find_scope_fundec vi with
   | None ->
-    vi.vstorage <> Static && (* CIL pulls static locals into globals, but they aren't syntactically in global scope *)
+    not (vi.vstorage = Static && hasAttribute "goblint_cil_pulledup" vi.vattr) && (* CIL pulls static locals into globals, but they aren't syntactically in global scope *)
     not (var_may_be_shadowed scope vi)
   | Some fd ->
     CilType.Fundec.equal fd scope &&

--- a/src/cdomain/value/domains/invariantCil.ml
+++ b/src/cdomain/value/domains/invariantCil.ml
@@ -37,7 +37,13 @@ let var_may_be_shadowed scope vi =
 let var_is_in_scope scope vi =
   match Cilfacade.find_scope_fundec vi with
   | None ->
-    not (vi.vstorage = Static && hasAttribute "goblint_cil_pulledup" vi.vattr) && (* CIL pulls static locals into globals, but they aren't syntactically in global scope *)
+    (* CIL pulls static locals into globals, but they aren't syntactically in global scope *)
+    not (vi.vstorage = Static &&
+         match Cilfacade.findAttribute "goblint_cil_pulledup" vi.vattr with
+         | Some [AStr static_fun_name] -> static_fun_name <> scope.svar.vname
+         | Some _ -> failwith "InvariantCil.var_is_in_scope: invalid goblint_cil_pulledup attribute parameters"
+         | None -> false (* normal static global *)
+        ) &&
     not (var_may_be_shadowed scope vi)
   | Some fd ->
     CilType.Fundec.equal fd scope &&

--- a/src/cdomain/value/domains/invariantCil.ml
+++ b/src/cdomain/value/domains/invariantCil.ml
@@ -40,7 +40,9 @@ let var_is_in_scope scope vi =
     (* CIL pulls static locals into globals, but they aren't syntactically in global scope *)
     not (vi.vstorage = Static &&
          match Cilfacade.findAttribute "goblint_cil_pulledup" vi.vattr with
-         | Some [AStr static_fun_name] -> static_fun_name <> scope.svar.vname
+         | Some [AStr static_fun_name] ->
+          static_fun_name <> scope.svar.vname ||
+          not (GobConfig.get_bool "witness.invariant.all-locals" || (not @@ hasAttribute "goblint_cil_nested" vi.vattr))
          | Some _ -> failwith "InvariantCil.var_is_in_scope: invalid goblint_cil_pulledup attribute parameters"
          | None -> false (* normal static global *)
         ) &&

--- a/src/cdomain/value/domains/invariantCil.ml
+++ b/src/cdomain/value/domains/invariantCil.ml
@@ -35,21 +35,24 @@ let var_may_be_shadowed scope vi =
   List.exists local_may_shadow scope.sformals || List.exists local_may_shadow scope.slocals
 
 let var_is_in_scope scope vi =
+  let var_nested () =
+    not (GobConfig.get_bool "witness.invariant.all-locals" || (not @@ hasAttribute "goblint_cil_nested" vi.vattr))
+  in
   match Cilfacade.find_scope_fundec vi with
   | None ->
     (* CIL pulls static locals into globals, but they aren't syntactically in global scope *)
     not (vi.vstorage = Static &&
          match Cilfacade.findAttribute "goblint_cil_pulledup" vi.vattr with
          | Some [AStr static_fun_name] ->
-          static_fun_name <> scope.svar.vname ||
-          not (GobConfig.get_bool "witness.invariant.all-locals" || (not @@ hasAttribute "goblint_cil_nested" vi.vattr))
+           static_fun_name <> scope.svar.vname ||
+           var_nested ()
          | Some _ -> failwith "InvariantCil.var_is_in_scope: invalid goblint_cil_pulledup attribute parameters"
          | None -> false (* normal static global *)
         ) &&
     not (var_may_be_shadowed scope vi)
   | Some fd ->
     CilType.Fundec.equal fd scope &&
-    (GobConfig.get_bool "witness.invariant.all-locals" || (not @@ hasAttribute "goblint_cil_nested" vi.vattr)) &&
+    not (var_nested ()) &&
     not (var_may_be_shadowed scope vi) (* TODO: could distinguish non-nested and nested? *)
 
 class exp_is_in_scope_visitor (scope: fundec) (acc: bool ref) = object

--- a/src/common/util/cilfacade.ml
+++ b/src/common/util/cilfacade.ml
@@ -58,6 +58,12 @@ let is_first_field x = match x.fcomp.cfields with
   | [] -> false
   | f :: _ -> CilType.Fieldinfo.equal f x
 
+let findAttribute name attrs =
+  List.find_map (function
+      | Attr (name', params) when name' = name -> Some params
+      | _ -> None
+    ) attrs
+
 let init_options () =
   Mergecil.merge_inlines := get_bool "cil.merge.inlines";
   Cil.cstd := (

--- a/tests/regression/56-witness/77-static-invariant.c
+++ b/tests/regression/56-witness/77-static-invariant.c
@@ -1,0 +1,12 @@
+// CRAM
+
+static int static_global = 1;
+
+void foo() {
+  static int static_local = 2;
+}
+
+int main() {
+  foo();
+  return 0;
+}

--- a/tests/regression/56-witness/77-static-invariant.c
+++ b/tests/regression/56-witness/77-static-invariant.c
@@ -4,6 +4,9 @@ static int static_global = 1;
 
 void foo() {
   static int static_local = 2;
+  {
+    static int static_local_nested = 3;
+  }
 }
 
 int main() {

--- a/tests/regression/56-witness/77-static-invariant.t
+++ b/tests/regression/56-witness/77-static-invariant.t
@@ -4,11 +4,38 @@
     dead: 0
     total lines: 5
   [Info][Witness] witness generation summary:
-    location invariants: 0
+    location invariants: 3
     loop invariants: 0
     flow-insensitive invariants: 0
     total generation entries: 1
 
   $ yamlWitnessStrip < witness.yml
   - entry_type: invariant_set
-    content: []
+    content:
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 77-static-invariant.c
+          line: 7
+          column: 1
+          function: foo
+        value: static_global == 1
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 77-static-invariant.c
+          line: 10
+          column: 3
+          function: main
+        value: static_global == 1
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 77-static-invariant.c
+          line: 11
+          column: 3
+          function: main
+        value: static_global == 1
+        format: c_expression

--- a/tests/regression/56-witness/77-static-invariant.t
+++ b/tests/regression/56-witness/77-static-invariant.t
@@ -1,0 +1,14 @@
+  $ goblint --enable witness.yaml.enabled --enable witness.invariant.other 77-static-invariant.c
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 5
+    dead: 0
+    total lines: 5
+  [Info][Witness] witness generation summary:
+    location invariants: 0
+    loop invariants: 0
+    flow-insensitive invariants: 0
+    total generation entries: 1
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: invariant_set
+    content: []

--- a/tests/regression/56-witness/77-static-invariant.t
+++ b/tests/regression/56-witness/77-static-invariant.t
@@ -1,4 +1,4 @@
-  $ goblint --enable witness.yaml.enabled --enable witness.invariant.other 77-static-invariant.c
+  $ goblint --enable witness.yaml.enabled --enable witness.invariant.other --enable witness.invariant.all-locals 77-static-invariant.c
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 5
     dead: 0
@@ -38,6 +38,59 @@
           column: 1
           function: foo
         value: static_local_nested == 3
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 77-static-invariant.c
+          line: 13
+          column: 3
+          function: main
+        value: static_global == 1
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 77-static-invariant.c
+          line: 14
+          column: 3
+          function: main
+        value: static_global == 1
+        format: c_expression
+
+
+  $ goblint --enable witness.yaml.enabled --enable witness.invariant.other --disable witness.invariant.all-locals 77-static-invariant.c
+  [Warning] Disabling witness.invariant.all-locals implicitly enables cil.addNestedScopeAttr.
+  [Info][Deadcode] Logical lines of code (LLoC) summary:
+    live: 5
+    dead: 0
+    total lines: 5
+  [Info][Witness] witness generation summary:
+    location invariants: 4
+    loop invariants: 0
+    flow-insensitive invariants: 0
+    total generation entries: 1
+
+  $ yamlWitnessStrip < witness.yml
+  - entry_type: invariant_set
+    content:
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 77-static-invariant.c
+          line: 10
+          column: 1
+          function: foo
+        value: static_global == 1
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 77-static-invariant.c
+          line: 10
+          column: 1
+          function: foo
+        value: static_local == 2
         format: c_expression
     - invariant:
         type: location_invariant

--- a/tests/regression/56-witness/77-static-invariant.t
+++ b/tests/regression/56-witness/77-static-invariant.t
@@ -4,7 +4,7 @@
     dead: 0
     total lines: 5
   [Info][Witness] witness generation summary:
-    location invariants: 3
+    location invariants: 4
     loop invariants: 0
     flow-insensitive invariants: 0
     total generation entries: 1
@@ -20,6 +20,15 @@
           column: 1
           function: foo
         value: static_global == 1
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 77-static-invariant.c
+          line: 7
+          column: 1
+          function: foo
+        value: static_local == 2
         format: c_expression
     - invariant:
         type: location_invariant

--- a/tests/regression/56-witness/77-static-invariant.t
+++ b/tests/regression/56-witness/77-static-invariant.t
@@ -4,7 +4,7 @@
     dead: 0
     total lines: 5
   [Info][Witness] witness generation summary:
-    location invariants: 4
+    location invariants: 5
     loop invariants: 0
     flow-insensitive invariants: 0
     total generation entries: 1
@@ -16,7 +16,7 @@
         type: location_invariant
         location:
           file_name: 77-static-invariant.c
-          line: 7
+          line: 10
           column: 1
           function: foo
         value: static_global == 1
@@ -25,7 +25,7 @@
         type: location_invariant
         location:
           file_name: 77-static-invariant.c
-          line: 7
+          line: 10
           column: 1
           function: foo
         value: static_local == 2
@@ -35,6 +35,15 @@
         location:
           file_name: 77-static-invariant.c
           line: 10
+          column: 1
+          function: foo
+        value: static_local_nested == 3
+        format: c_expression
+    - invariant:
+        type: location_invariant
+        location:
+          file_name: 77-static-invariant.c
+          line: 13
           column: 3
           function: main
         value: static_global == 1
@@ -43,7 +52,7 @@
         type: location_invariant
         location:
           file_name: 77-static-invariant.c
-          line: 11
+          line: 14
           column: 3
           function: main
         value: static_global == 1


### PR DESCRIPTION
Closes #1538.

This emits witness invariants for two kinds of `static` globals:
1. Globals which are actually global in the input file, i.e. at the file level. These have no scoping issue.
2. Globals which are actually `static` locals of a function but pulled up to be global by CIL. For these we check which function they were from and only emit if we're in the same function.

### TODO
- [x] Merge https://github.com/goblint/cil/pull/226.