### PR TITLE
Barriers: When checking if #waiters is exactly capacity use TIDs

### DIFF
--- a/src/analyses/pthreadBarriers.ml
+++ b/src/analyses/pthreadBarriers.ml
@@ -108,17 +108,27 @@ struct
                     in
                     let can_proceed = exists_k can_proceed_pred (min_cap - 1) relevant_waiters in
                     if not can_proceed then raise Analyses.Deadcode;
-                    (* All TIDs are definite here, they may have other MCPA stuff but that is irrelevant. *)
-                    let tids = waiters |> List.map snd |> List.sort_uniq TID.compare in
-                    (* limit to this case to avoid having to construct all permutations above *)
-                    if BatList.compare_length_with tids (min_cap - 1) = 0 then
-                      List.fold_left (fun acc tid ->
-                          let curr = MustObserved.find tid acc in
-                          let must' = MustObserved.add tid (Barriers.add addr curr) acc in
-                          must'
-                        ) must tids
-                    else
+                    let exists_non_unique = List.exists (function
+                        | _, `Lifted tid -> not @@ ThreadIdDomain.Thread.is_unique tid
+                        | _ -> true
+                      ) waiters
+                    in
+                    if exists_non_unique then
+                      (* There can be non-unique threads that don't race with themselves because of mutexes etc *)
+                      (* We do nothing for those cases *)
                       must
+                    else
+                      (* All TIDs are definite here, they may have other MCPA stuff but that is irrelevant. *)
+                      let tids = waiters |> List.map snd |> List.sort_uniq TID.compare in
+                      (* limit to this case to avoid having to construct all permutations above *)
+                      if BatList.compare_length_with tids (min_cap - 1) = 0 then
+                        List.fold_left (fun acc tid ->
+                            let curr = MustObserved.find tid acc in
+                            let must' = MustObserved.add tid (Barriers.add addr curr) acc in
+                            must'
+                          ) must tids
+                      else
+                        must
                   in
                   (may, must)
                 else

--- a/src/analyses/pthreadBarriers.ml
+++ b/src/analyses/pthreadBarriers.ml
@@ -108,13 +108,15 @@ struct
                     in
                     let can_proceed = exists_k can_proceed_pred (min_cap - 1) relevant_waiters in
                     if not can_proceed then raise Analyses.Deadcode;
+                    (* All TIDs are definite here, they may have other MCPA stuff but that is irrelevant. *)
+                    let tids = waiters |> List.map snd |> List.sort_uniq TID.compare in
                     (* limit to this case to avoid having to construct all permutations above *)
-                    if BatList.compare_length_with waiters (min_cap - 1) = 0 then
-                      List.fold_left (fun acc (_,tid) ->
+                    if BatList.compare_length_with tids (min_cap - 1) = 0 then
+                      List.fold_left (fun acc tid ->
                           let curr = MustObserved.find tid acc in
                           let must' = MustObserved.add tid (Barriers.add addr curr) acc in
                           must'
-                        ) must waiters
+                        ) must tids
                     else
                       must
                   in

--- a/tests/regression/86-barrier/15-race-and-creationlockset.c
+++ b/tests/regression/86-barrier/15-race-and-creationlockset.c
@@ -1,0 +1,34 @@
+// NOMAC PARAM: --set ana.activated[+] 'pthreadBarriers' --set 'ana.activated[+]' threadJoins --set 'ana.activated[+]' threadDescendants --set 'ana.activated[+]' creationLockset
+#include<pthread.h>
+#include<stdio.h>
+#include<unistd.h>
+#include<goblint.h>
+
+int g;
+int h;
+
+pthread_barrier_t barrier;
+pthread_mutex_t mutex;
+
+void* f1(void* ptr) {
+    g = 2; //NORACE
+    pthread_barrier_wait(&barrier);
+
+    return NULL;
+}
+
+int main(int argc, char const *argv[])
+{
+    int top;
+    int i = 0;
+
+    pthread_barrier_init(&barrier, NULL, 2);
+
+    pthread_t t1;
+    pthread_create(&t1,NULL,f1,NULL);
+
+    pthread_barrier_wait(&barrier);
+    g = 3; //NORACE
+
+    return 0;
+}


### PR DESCRIPTION
@DrMichaelPetter and @dabund24 observed that enabling additional analyses that contribute to MHP can make our barrier analysis _less_ precise.

The issue is the following: To decide whether we can proceed past a `wait`, we need to solve the question if a `(cap - 1)` clique exists in the graph where nodes are MCP.Access tuples of **other** threads than the ego thread calling `wait` and an edge means that `A.may_race` is true.

To then conclude that a certain thread id must be involved, we would need to construct _all_ `(cap-1)` cliques and check if a certain thread id appears in all of them. We are too lazy to do this, so instead we only do something if there are exactly `(cap-1)` other threads that have called `wait`. 

Except that the code checks whether there are `(cap-1)` MCPAccess tuples instead of other threads instead of `(cap-1)` threads. Enabling further analyses can cause the number of MCPAccess tuples to grow, even if there is the same number of threads, leading to the analysis becoming less precise.

This now fixes the problem by (provided all threads are unique) checking whether there `(cap-1)` threads, regardless of the MCP tuples.


Closes #2082 