### PR TITLE
Fix test annotations in 28-race_reach

### DIFF
--- a/scripts/regression2sv-benchmarks.py
+++ b/scripts/regression2sv-benchmarks.py
@@ -124,10 +124,10 @@ def process_files():
             # if didn't contain RACE!, must be race-free
             properties["../properties/no-data-race.prp"] = True
 
-        if re.search(r"assert_racefree[^\n]*//\s*UNKNOWN", content):
+        if re.search(r"assert_racefree[^\n]*//\s*UNKNOWN!", content):
             properties["../properties/unreach-call.prp"] = False
         elif "assert_racefree" in content:
-            # if didn't contain UNKNOWN assert_racefree, must be race-free
+            # if didn't contain UNKNOWN! assert_racefree, must be race-free
             properties["../properties/unreach-call.prp"] = True
 
         handle_asserts(properties, content, task_name, top_comment)

--- a/tests/regression/28-race_reach/01-simple_racing.c
+++ b/tests/regression/28-race_reach/01-simple_racing.c
@@ -16,7 +16,7 @@ void *t_fun(void *arg) {
 int main(void) {
   create_threads(t);
   pthread_mutex_lock(&mutex2);
-  assert_racefree(global);  // UNKNOWN
+  assert_racefree(global);  // UNKNOWN!
   pthread_mutex_unlock(&mutex2);
   join_threads(t);
   return 0;

--- a/tests/regression/28-race_reach/03-munge_racing.c
+++ b/tests/regression/28-race_reach/03-munge_racing.c
@@ -8,7 +8,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 void munge(pthread_mutex_t *m) {
   pthread_mutex_lock(m);
-  access_or_assert_racefree(global); // UNKNOWN
+  access_or_assert_racefree(global); // UNKNOWN!
   pthread_mutex_unlock(m);
 }
 

--- a/tests/regression/28-race_reach/06-cond_racing1.c
+++ b/tests/regression/28-race_reach/06-cond_racing1.c
@@ -24,7 +24,7 @@ int main() {
   if (i) pthread_mutex_lock(&mutex2);
 
   printf("Now we do the work..\n");
-  if (i) assert_racefree(global);  // UNKNOWN
+  if (i) assert_racefree(global);  // UNKNOWN!
 
   printf("Work is completed...");
   if (i) pthread_mutex_unlock(&mutex2);

--- a/tests/regression/28-race_reach/07-cond_racing2.c
+++ b/tests/regression/28-race_reach/07-cond_racing2.c
@@ -22,7 +22,7 @@ int main() {
   if (i) pthread_mutex_lock(&mutex1);
 
   printf("Now we do the work..\n");
-  if (i+1) assert_racefree(global); // UNKNOWN
+  if (i+1) assert_racefree(global); // UNKNOWN!
 
   printf("Work is completed...");
   if (i) pthread_mutex_unlock(&mutex1);

--- a/tests/regression/28-race_reach/09-ptrmunge_racing.c
+++ b/tests/regression/28-race_reach/09-ptrmunge_racing.c
@@ -10,7 +10,7 @@ pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 void munge(pthread_mutex_t *m, int *v) {
   pthread_mutex_lock(m);
-  access_or_assert_racefree(*v); // UNKNOWN
+  access_or_assert_racefree(*v); // UNKNOWN!
   pthread_mutex_unlock(m);
 }
 

--- a/tests/regression/28-race_reach/11-ptr_racing.c
+++ b/tests/regression/28-race_reach/11-ptr_racing.c
@@ -17,7 +17,7 @@ void *t_fun(void *arg) {
 int main(void) {
   create_threads(t);
   pthread_mutex_lock(&mutex2);
-  assert_racefree(global);  // UNKNOWN
+  assert_racefree(global);  // UNKNOWN!
   pthread_mutex_unlock(&mutex2);
   join_threads(t);
   return 0;

--- a/tests/regression/28-race_reach/19-callback_racing.c
+++ b/tests/regression/28-race_reach/19-callback_racing.c
@@ -26,7 +26,7 @@ int bar() {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&mutex2);
-  assert_racefree(glob); // UNKNOWN
+  assert_racefree(glob); // UNKNOWN!
   pthread_mutex_unlock(&mutex2);
   return NULL;
 }

--- a/tests/regression/28-race_reach/21-deref_read_racing.c
+++ b/tests/regression/28-race_reach/21-deref_read_racing.c
@@ -17,6 +17,6 @@ void *t_fun(void *arg) {
 int main() {
   create_threads(t);
   q = p;
-  assert_racefree(*q); // UNKNOWN
+  assert_racefree(*q); // UNKNOWN!
   return 0;
 }

--- a/tests/regression/28-race_reach/23-sound_unlock_racing.c
+++ b/tests/regression/28-race_reach/23-sound_unlock_racing.c
@@ -26,7 +26,7 @@ int main(void) {
   create_threads(t);
   pthread_mutex_lock(&mutex1);
   pthread_mutex_unlock(m); // no UB because ERRORCHECK
-  assert_racefree(global); // UNKNOWN
+  assert_racefree(global); // UNKNOWN!
   pthread_mutex_unlock(&mutex1); // no UB because ERRORCHECK
   join_threads(t);
   return 0;

--- a/tests/regression/28-race_reach/24-sound_lock_racing.c
+++ b/tests/regression/28-race_reach/24-sound_lock_racing.c
@@ -19,7 +19,7 @@ int main(void) {
   if (i) m = &mutex2;
   create_threads(t);
   pthread_mutex_lock(m);
-  assert_racefree(global); // UNKNOWN
+  assert_racefree(global); // UNKNOWN!
   pthread_mutex_unlock(m);
   join_threads(t);
   return 0;

--- a/tests/regression/28-race_reach/27-funptr_racing.c
+++ b/tests/regression/28-race_reach/27-funptr_racing.c
@@ -38,7 +38,7 @@ int main() {
   pthread_mutex_unlock(&fm);
 
   pthread_mutex_lock(&gm);
-  assert_racefree(global); // UNKNOWN
+  assert_racefree(global); // UNKNOWN!
   pthread_mutex_unlock(&gm);
 
   join_threads(t);

--- a/tests/regression/28-race_reach/37-indirect_racing.c
+++ b/tests/regression/28-race_reach/37-indirect_racing.c
@@ -20,7 +20,7 @@ int main(void) {
 
   create_threads(t);
 
-  assert_racefree(*g2); // UNKNOWN
+  assert_racefree(*g2); // UNKNOWN!
 
   join_threads(t);
   return 0;

--- a/tests/regression/28-race_reach/40-trylock_racing.c
+++ b/tests/regression/28-race_reach/40-trylock_racing.c
@@ -22,7 +22,7 @@ int main(void) {
   create_threads(t);
 
   pthread_mutex_trylock(&mutex);
-  assert_racefree(global); // UNKNOWN
+  assert_racefree(global); // UNKNOWN!
   pthread_mutex_unlock(&mutex); // no UB because ERRORCHECK
   join_threads(t);
   return 0;

--- a/tests/regression/28-race_reach/45-escape_racing.c
+++ b/tests/regression/28-race_reach/45-escape_racing.c
@@ -18,7 +18,7 @@ int main(void) {
   int i = 0;
   pthread_create(&id, NULL, t_fun, (void *) &i);
   pthread_mutex_lock(&mutex2);
-  assert_racefree(i); // UNKNOWN
+  assert_racefree(i); // UNKNOWN!
   pthread_mutex_unlock(&mutex2);
   pthread_join(id, NULL);
   return 0;

--- a/tests/regression/28-race_reach/61-invariant_racing.c
+++ b/tests/regression/28-race_reach/61-invariant_racing.c
@@ -23,7 +23,7 @@ int main(void) {
   create_threads(t);
   access(x);
   pthread_mutex_lock(&mutex);
-  assert_racefree(x); // UNKNOWN
+  assert_racefree(x); // UNKNOWN!
   pthread_mutex_unlock(&mutex);
   join_threads(t);
   return 0;

--- a/tests/regression/28-race_reach/71-funloop_racing.c
+++ b/tests/regression/28-race_reach/71-funloop_racing.c
@@ -10,7 +10,7 @@ struct cache_entry {
 
 void cache_entry_addref(struct cache_entry *entry) {
   pthread_mutex_lock(&entry->refs_mutex);
-  access_or_assert_racefree(entry->refs); // UNKNOWN
+  access_or_assert_racefree(entry->refs); // UNKNOWN!
   pthread_mutex_unlock(&entry->refs_mutex);
 }
 
@@ -30,7 +30,7 @@ int main () {
 
   for(i=0; i<10; i++)
     cache_entry_addref(&cache[i]);
-  access_or_assert_racefree(cache[5].refs); // UNKNOWN
+  access_or_assert_racefree(cache[5].refs); // UNKNOWN!
 
   join_threads(t);
   return 0;

--- a/tests/regression/28-race_reach/72-funloop_hard_racing.c
+++ b/tests/regression/28-race_reach/72-funloop_hard_racing.c
@@ -10,7 +10,7 @@ struct cache_entry {
 
 void cache_entry_addref(struct cache_entry *entry) {
   pthread_mutex_lock(&entry->refs_mutex);
-  access_or_assert_racefree(entry->refs); // UNKNOWN
+  access_or_assert_racefree(entry->refs); // UNKNOWN!
   pthread_mutex_unlock(&entry->refs_mutex);
 }
 
@@ -30,7 +30,7 @@ int main () {
   for(i=0; i<10; i++) cache_entry_addref(&cache[i]);
 
   pthread_mutex_lock(&cache[4].refs_mutex);
-  access_or_assert_racefree(cache[5].refs); // UNKNOWN
+  access_or_assert_racefree(cache[5].refs); // UNKNOWN!
   pthread_mutex_unlock(&cache[4].refs_mutex);
 
   join_threads(t);

--- a/tests/regression/28-race_reach/77-tricky_address4_racing.c
+++ b/tests/regression/28-race_reach/77-tricky_address4_racing.c
@@ -14,7 +14,7 @@ void *t_fun(void *arg) {
   struct s *p = &a[i];
   pthread_mutex_lock(&p->mutex);
   i++;
-  access_or_assert_racefree(a[i].datum); // UNKNOWN
+  access_or_assert_racefree(a[i].datum); // UNKNOWN!
   pthread_mutex_unlock(&p->mutex);
   return NULL;
 }
@@ -28,7 +28,7 @@ int main () {
   create_threads(t);
 
   pthread_mutex_lock(&a[i].mutex);
-  access_or_assert_racefree(a[i].datum); // UNKNOWN
+  access_or_assert_racefree(a[i].datum); // UNKNOWN!
   pthread_mutex_unlock(&a[i].mutex);
 
   join_threads(t);

--- a/tests/regression/28-race_reach/78-equ_racing.c
+++ b/tests/regression/28-race_reach/78-equ_racing.c
@@ -12,7 +12,7 @@ struct s {
 
 void *t_fun(void *arg) {
   pthread_mutex_lock(&A.mutex);
-  access_or_assert_racefree(B.datum); // UNKNOWN
+  access_or_assert_racefree(B.datum); // UNKNOWN!
   pthread_mutex_unlock(&A.mutex);
   return NULL;
 }
@@ -45,7 +45,7 @@ int main () {
   create_threads(t);
 
   pthread_mutex_lock(m);
-  access_or_assert_racefree(*d); // UNKNOWN
+  access_or_assert_racefree(*d); // UNKNOWN!
   pthread_mutex_unlock(m);
 
   join_threads(t);

--- a/tests/regression/28-race_reach/81-list_racing.c
+++ b/tests/regression/28-race_reach/81-list_racing.c
@@ -43,7 +43,7 @@ void *t1_fun(void *arg) {
 
 void *t2_fun(void *arg) {
   struct s *p = take(A);
-  access_or_assert_racefree(p->datum); // UNKNOWN
+  access_or_assert_racefree(p->datum); // UNKNOWN!
   return NULL;
 }
 

--- a/tests/regression/28-race_reach/82-list_racefree.c
+++ b/tests/regression/28-race_reach/82-list_racefree.c
@@ -43,7 +43,7 @@ void *t1_fun(void *arg) {
 void *t2_fun(void *arg) {
   struct s *p = take(A);
   pthread_mutex_lock(&data_mutex);
-  access_or_assert_racefree(p->datum); // UNKNOWN!
+  access_or_assert_racefree(p->datum); // UNKNOWN
   pthread_mutex_unlock(&data_mutex);
   return NULL;
 }

--- a/tests/regression/28-race_reach/82-list_racefree.c
+++ b/tests/regression/28-race_reach/82-list_racefree.c
@@ -43,7 +43,7 @@ void *t1_fun(void *arg) {
 void *t2_fun(void *arg) {
   struct s *p = take(A);
   pthread_mutex_lock(&data_mutex);
-  access_or_assert_racefree(p->datum); // UNKNOWN
+  access_or_assert_racefree(p->datum); // UNKNOWN!
   pthread_mutex_unlock(&data_mutex);
   return NULL;
 }

--- a/tests/regression/28-race_reach/83-list2_racing1.c
+++ b/tests/regression/28-race_reach/83-list2_racing1.c
@@ -46,7 +46,7 @@ void *t1_fun(void *arg) {
 void *t2_fun(void *arg) {
   struct s *p = take(A);
   pthread_mutex_lock(&A_mutex);
-  access_or_assert_racefree(p->datum); // UNKNOWN
+  access_or_assert_racefree(p->datum); // UNKNOWN!
   pthread_mutex_unlock(&A_mutex);
   return NULL;
 }
@@ -54,7 +54,7 @@ void *t2_fun(void *arg) {
 void *t3_fun(void *arg) {
   struct s *p = take(A);
   pthread_mutex_lock(&B_mutex);
-  access_or_assert_racefree(p->datum); // UNKNOWN
+  access_or_assert_racefree(p->datum); // UNKNOWN!
   pthread_mutex_unlock(&B_mutex);
   return NULL;
 }

--- a/tests/regression/28-race_reach/84-list2_racing2.c
+++ b/tests/regression/28-race_reach/84-list2_racing2.c
@@ -46,7 +46,7 @@ void *t1_fun(void *arg) {
 void *t2_fun(void *arg) {
   struct s *p = take(A);
   pthread_mutex_lock(&A_mutex);
-  access_or_assert_racefree(p->datum); // UNKNOWN
+  access_or_assert_racefree(p->datum); // UNKNOWN!
   pthread_mutex_unlock(&A_mutex);
   return NULL;
 }
@@ -54,7 +54,7 @@ void *t2_fun(void *arg) {
 void *t3_fun(void *arg) {
   struct s *p = take(B);
   pthread_mutex_lock(&B_mutex);
-  access_or_assert_racefree(p->datum); // UNKNOWN
+  access_or_assert_racefree(p->datum); // UNKNOWN!
   pthread_mutex_unlock(&B_mutex);
   return NULL;
 }

--- a/tests/regression/28-race_reach/86-lists_racing.c
+++ b/tests/regression/28-race_reach/86-lists_racing.c
@@ -46,7 +46,7 @@ void *t2_fun(void *arg) {
   int j = __VERIFIER_nondet_int() % 256;
   struct s *p = take(buckets[j]);
   pthread_mutex_lock(&mutexes[i]);
-  access_or_assert_racefree(p->datum); // UNKNOWN
+  access_or_assert_racefree(p->datum); // UNKNOWN!
   pthread_mutex_unlock(&mutexes[i]);
   return NULL;
 }

--- a/tests/regression/28-race_reach/90-arrayloop2_racing.c
+++ b/tests/regression/28-race_reach/90-arrayloop2_racing.c
@@ -53,7 +53,7 @@ void *t1_fun(void *arg) {
     pos = (struct s *)((char *)p - (size_t)(& ((struct s *)0)->list));
 
     while (& pos->list != & c.slot[j]) {
-      access_or_assert_racefree(pos->datum); // UNKNOWN
+      access_or_assert_racefree(pos->datum); // UNKNOWN!
       q = pos->list.next;
       pos = (struct s *)((char *)q - (size_t)(& ((struct s *)0)->list));
     }
@@ -77,7 +77,7 @@ void *t2_fun(void *arg) {
     pos = (struct s *)((char *)p - (size_t)(& ((struct s *)0)->list));
 
     while (& pos->list != & c.slot[j]) {
-      access_or_assert_racefree(pos->datum); // UNKNOWN
+      access_or_assert_racefree(pos->datum); // UNKNOWN!
       q = pos->list.next;
       pos = (struct s *)((char *)q - (size_t)(& ((struct s *)0)->list));
     }

--- a/tests/regression/28-race_reach/92-evilcollapse_racing.c
+++ b/tests/regression/28-race_reach/92-evilcollapse_racing.c
@@ -61,7 +61,7 @@ void *t_fun(void *arg) {
     pos = (struct s *)((char *)p - (size_t)(& ((struct s *)0)->list));
 
     while (& pos->list != & c.slot[j]) {
-      access_or_assert_racefree(pos->datum); // UNKNOWN
+      access_or_assert_racefree(pos->datum); // UNKNOWN!
       q = pos->list.next;
       pos = (struct s *)((char *)q - (size_t)(& ((struct s *)0)->list));
     }

--- a/tests/regression/28-race_reach/94-alloc_region_racing.c
+++ b/tests/regression/28-race_reach/94-alloc_region_racing.c
@@ -31,7 +31,7 @@ void *t_fun(void *arg) {
   pthread_mutex_unlock(&A_mutex);
 
   pthread_mutex_lock(&B_mutex);
-  access_or_assert_racefree(p->datum); // UNKNOWN
+  access_or_assert_racefree(p->datum); // UNKNOWN!
   pthread_mutex_unlock(&B_mutex);
   return NULL;
 }
@@ -53,7 +53,7 @@ int main () {
   pthread_mutex_lock(&A_mutex);
   p = A;
   while (p->next) {
-    access_or_assert_racefree(p->datum); // UNKNOWN
+    access_or_assert_racefree(p->datum); // UNKNOWN!
     p = p->next;
   }
   pthread_mutex_unlock(&A_mutex);


### PR DESCRIPTION
In https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/merge_requests/1759 one of the submitted race_reach expected verdicts was found to be incorrect.

I wondered how this happened. These tests were probably created before we were proper about distinguishing `UNKNOWN` from `UNKNOWN!`, so they all had `UNKNOWN`. But one of those was in a supposedly racefree test, just because Goblint itself is imprecise.

This PR changes all others to `UNKNOWN!` to match our current conventions and fixes the regression2sv-benchmarks.py script accordingly (although I didn't test the script).