### PR TITLE
Fix deadlock in descendant lockset test case

### DIFF
--- a/tests/regression/53-races-mhp/61-dl_sometimes_creation_without_lock_racing.c
+++ b/tests/regression/53-races-mhp/61-dl_sometimes_creation_without_lock_racing.c
@@ -7,6 +7,7 @@ pthread_t id1;
 
 void *t1(void *arg) {
   pthread_mutex_lock(&mutex);
+  pthread_mutex_unlock(&mutex);
   global++; // RACE!
   return NULL;
 }


### PR DESCRIPTION
@michael-schwarz discovered that 53/61 actually produces a deadlock. This pr fixes this