### PR TITLE
Allow $schema in configuration files

### DIFF
--- a/src/config/gobConfig.ml
+++ b/src/config/gobConfig.ml
@@ -395,6 +395,11 @@ struct
       Printexc.raise_with_backtrace e bt
 
   let merge json =
+    (* $schema is an editor annotation, not a Goblint option. *)
+    let json = match json with
+      | `Assoc fields -> `Assoc (List.filter (fun (name, _) -> name <> "$schema") fields)
+      | json -> json
+    in
     Validator.validate_exn json;
     set_conf (GobYojson.merge !json_conf json)
 

--- a/tests/unit/config/gobConfigTest.ml
+++ b/tests/unit/config/gobConfigTest.ml
@@ -1,0 +1,21 @@
+open OUnit2
+
+let test_merge_ignores_schema _ =
+  let original = GobConfig.get_conf () in
+  Fun.protect
+    ~finally:(fun () -> GobConfig.set_conf original)
+    (fun () ->
+       GobConfig.merge (`Assoc [
+           ("$schema", `String "https://example.com/goblint.schema.json");
+           ("jobs", `Int 2);
+         ]);
+       assert_equal 2 (GobConfig.get_int "jobs");
+       match GobConfig.get_conf () with
+       | `Assoc fields -> assert_bool "$schema should not be stored" (not (List.mem_assoc "$schema" fields))
+       | _ -> assert_failure "configuration should be an object"
+    )
+
+let tests =
+  "gobConfig" >::: [
+    "merge ignores $schema" >:: test_merge_ignores_schema;
+  ]

--- a/tests/unit/mainTest.ml
+++ b/tests/unit/mainTest.ml
@@ -15,6 +15,7 @@ let all_tests =
     "domaintest" >::: QCheck_ounit.to_ounit2_test_list Maindomaintest.all_testsuite;
     IntOpsTest.tests;
     ThreadIdDomainTest.tests;
+    GobConfigTest.tests;
   ]
 
 let () =


### PR DESCRIPTION
Closes #1011.

Root-level `$schema` fields are editor annotations rather than Goblint options. This removes them before validating and merging configuration input, while leaving validation of every real option unchanged.

The unit test also verifies that the annotation is not retained in Goblint's active configuration.

Tested with `opam exec -- dune runtest tests/unit` (3,379 tests).