### PR TITLE
Split memLeak paths with `sem.malloc.fail`

### DIFF
--- a/src/analyses/memLeak.ml
+++ b/src/analyses/memLeak.ml
@@ -199,8 +199,14 @@ struct
     | Calloc _
     | Realloc _ ->
       man.sideg () true;
-      begin match man.ask (Queries.AllocVar Heap) with
-        | `Lifted var ->
+      begin match man.ask (Queries.AllocVar Heap), lval with
+        | `Lifted var, Some lval ->
+          man.split (ToppedVarInfoSet.add var state) [SplitBranch (Lval lval, true)];
+          if GobConfig.get_bool "sem.malloc.fail" then
+            man.split state [SplitBranch (Lval lval, false)];
+          raise Analyses.Deadcode
+        | `Lifted var, None ->
+          (* No reason to split without lval: the untracked memory cannot be freed anyway. *)
           ToppedVarInfoSet.add var state
         | _ -> state
       end

--- a/tests/regression/76-memleak/33-malloc-fail-no-mem-leak.c
+++ b/tests/regression/76-memleak/33-malloc-fail-no-mem-leak.c
@@ -1,0 +1,9 @@
+// PARAM: --set ana.malloc.unique_address_count 1 --set ana.activated[+] memLeak --enable sem.malloc.fail
+
+#include <stdlib.h>
+
+int main() {
+  int *p = malloc(sizeof(int));
+  free(p);
+  return 0; // NOWARN
+}


### PR DESCRIPTION
Closes #2093.

### TODO
- [x] sv-benchmarks.