### PR TITLE
fix unwrapping of VarVarinfoMap into normal variable info to avoid mismatches in c2po

### DIFF
--- a/src/cdomains/duplicateVars.ml
+++ b/src/cdomains/duplicateVars.ml
@@ -117,7 +117,10 @@ struct
     VarVarinfoMap.to_varinfo (ReturnAux typ)
 
   let to_varinfo v =
-    let res = VarVarinfoMap.to_varinfo v in
+    let res = match v with
+      | NormalVar v -> v
+      | v -> VarVarinfoMap.to_varinfo v
+    in
     if M.tracing then M.trace "c2po-varinfo" "to_varinfo: %a -> %a" d_type (get_type v) d_type res.vtype;
     res
 

--- a/tests/regression/84-c2po/31-callee-global-pointer-write.c
+++ b/tests/regression/84-c2po/31-callee-global-pointer-write.c
@@ -1,0 +1,21 @@
+// PARAM: --set ana.activated[+] c2po --set ana.activated[+] startState --set ana.activated[+] taintPartialContexts
+
+#include <goblint.h>
+
+int a, b;
+int *p, *q;
+
+void repoint(int c) {
+  if (c)
+    q = &a;
+  else
+    q = &b;
+}
+
+int main(int argc, char **argv) {
+  q = &a;
+  p = q;
+  repoint(argc);
+  __goblint_check(p == q); // UNKNOWN!
+  return 0;
+}


### PR DESCRIPTION
This attempts to fix #2104
The underlying reason seems to be that rich variable info was not correctly unwrapped, thus causing mismatches in c2po which then unsoundly ignored taint