### PR TITLE
Delay `Spec` lifter argument conversions until exception handlers inside `lift_fun`

### DIFF
--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -601,9 +601,9 @@ struct
   let combine_assign man r fe f args fc es f_ask = lift_fun man D.lift S.combine_assign (fun p -> p r fe f args fc (D.unlift es) f_ask) `Bot
 
   let threadenter man ~multiple lval f args = lift_fun man (List.map D.lift) (S.threadenter ~multiple) ((|>) args % (|>) f % (|>) lval) []
-  let threadspawn man ~multiple lval f args fman = lift_fun man D.lift (S.threadspawn ~multiple) ((|>) (conv fman) % (|>) args % (|>) f % (|>) lval) `Bot
+  let threadspawn man ~multiple lval f args fman = lift_fun man D.lift (S.threadspawn ~multiple) (fun p -> p lval f args (conv fman)) `Bot (* fun to delay (conv fman) until exception handler inside lift_fun *)
 
-  let event (man:(D.t,G.t,C.t,V.t) man) (e:Events.t) (oman:(D.t,G.t,C.t,V.t) man):D.t = lift_fun man D.lift S.event ((|>) (conv oman) % (|>) e) `Bot
+  let event (man:(D.t,G.t,C.t,V.t) man) (e:Events.t) (oman:(D.t,G.t,C.t,V.t) man):D.t = lift_fun man D.lift S.event (fun p -> p e (conv oman)) `Bot (* fun to delay (conv oman) until exception handler inside lift_fun *)
 end
 
 

--- a/src/lifters/wideningTokenLifter.ml
+++ b/src/lifters/wideningTokenLifter.ml
@@ -180,6 +180,6 @@ struct
   let combine_assign man r fe f args fc es f_ask = lift_fun man lift' S.combine_assign (fun p -> p r fe f args fc (D.unlift es) f_ask) (* TODO: use tokens from es *)
 
   let threadenter man  ~multiple lval f args = lift_fun man (fun l ts -> List.map (Fun.flip lift' ts) l) (S.threadenter ~multiple) ((|>) args % (|>) f % (|>) lval )
-  let threadspawn man ~multiple lval f args fman = lift_fun man lift' (S.threadspawn ~multiple) ((|>) (conv fman) % (|>) args % (|>) f % (|>) lval)
-  let event man e oman = lift_fun man lift' S.event ((|>) (conv oman) % (|>) e)
+  let threadspawn man ~multiple lval f args fman = lift_fun man lift' (S.threadspawn ~multiple) (fun p -> p lval f args (conv fman)) (* fun to delay (conv fman) until exception handler inside lift_fun *)
+  let event man e oman = lift_fun man lift' S.event (fun p -> p e (conv oman)) (* fun to delay (conv oman) until exception handler inside lift_fun *)
 end


### PR DESCRIPTION
In particular, this should fix an issue encountered by Kalmer's QSolvers where the `Deadcode` exception escaped to the top level due to `conv` on bottom happening outside the exception handler.


* At 5410a4ffd700c65a68086f0bbd12793d65c1d9b6, the `qsr` solver crashes on Concrat pigz after 13.8s:
   ```console
   ./goblint --enable ana.sv-comp.enabled --enable ana.sv-comp.functions --set 'lib.activated[+]' zlib --set 'lib.activated[+]' pcre --set 'lib.activated[+]' liblzma -v --set solver qsr --sets ana.specification /mnt/goblint-svcomp/goblint-bench/bench/concrat/properties/no-data-race.prp --sets exp.architecture 64bit /mnt/goblint-svcomp/goblint-bench/bench/concrat/pigz/main.c
   ```
  ```
  Fatal error: exception Goblint_lib__Analyses.Deadcode
  Marked with transfer function at /mnt/goblint-svcomp/goblint-bench/bench/concrat/pigz/main.c:8695:3-8695:49
  Raised at Goblint_lib__Analyses.Dom.unlift in file "src/framework/analyses.ml", line 134, characters 11-25
  Called from Goblint_lib__SpecLifters.DeadCodeLifter.conv in file "src/lifters/specLifters.ml", line 570, characters 23-41
  Called from Goblint_lib__SpecLifters.DeadCodeLifter.event in file "src/lifters/specLifters.ml", line 606, characters 122-133
  Called from Goblint_lib__SpecLifters.DomainLifter.event in file "src/lifters/specLifters.ml", line 109, characters 14-46
  Called from Goblint_lib__Constraints.FromSpec.tf_proc.tf_special_call.once in file "src/framework/constraints.ml", line 273, characters 19-84
  Called from Goblint_lib__Constraints.FromSpec.tf_proc.one_function in file "src/framework/constraints.ml", line 317, characters 15-36
  [...]
  ```

* At a6eed62dcc10a4a2d2935704e73e59418fb6582a (on master), the `td3` solver with `narrow-globs` crashes on Concrat pigz after 1.26s:
  ```console
  ./goblint --enable ana.sv-comp.enabled --enable ana.sv-comp.functions --set 'lib.activated[+]' zlib --set 'lib.activated[+]' pcre --set 'lib.activated[+]' liblzma -v --set solver td3 --enable solvers.td3.narrow-globs.enabled --set solvers.td3.side_widen_gas 2 --set solvers.td3.widen_gas 2 --enable solvers.td3.narrow-globs.eliminate-dead --set solvers.td3.narrow-globs.narrow-gas -1 --sets ana.specification /mnt/goblint-svcomp/goblint-bench/bench/concrat/properties/no-data-race.prp --sets exp.architecture 64bit /mnt/goblint-svcomp/goblint-bench/bench/concrat/pigz/main.c
  ```
  ```
  Fatal error: exception Fun.Finally_raised: Fun.Finally_raised: Fun.Finally_raised: Fun.Finally_raised: Fun.Finally_raised: Goblint_lib__Analyses.Deadcode
  Marked with transfer function at /home/simmo/dev/goblint/sv-comp/goblint-bench/concrat/pigz/main.c:2862:7-2862:71
  Marked with transfer function at /home/simmo/dev/goblint/sv-comp/goblint-bench/concrat/pigz/main.c:3746:7-3746:23
  Marked with transfer function at /home/simmo/dev/goblint/sv-comp/goblint-bench/concrat/pigz/main.c:5332:3-5332:25
  Marked with transfer function at /home/simmo/dev/goblint/sv-comp/goblint-bench/concrat/pigz/main.c:7452:7-7452:18
  Marked with transfer function at /home/simmo/dev/goblint/sv-comp/goblint-bench/concrat/pigz/main.c:7395:9-7395:23
  Marked with transfer function at /home/simmo/dev/goblint/sv-comp/goblint-bench/concrat/pigz/main.c:8575:13-8575:30
  Raised at Goblint_lib__Analyses.Dom.unlift in file "src/framework/analyses.ml", line 134, characters 11-25
  Called from Goblint_lib__SpecLifters.DeadCodeLifter.conv in file "src/lifters/specLifters.ml", line 570, characters 23-41
  Called from Goblint_lib__SpecLifters.DeadCodeLifter.event in file "src/lifters/specLifters.ml", line 606, characters 122-133
  Called from Goblint_lib__SpecLifters.DomainLifter.event in file "src/lifters/specLifters.ml", line 109, characters 14-46
  Called from Goblint_lib__Constraints.FromSpec.tf_proc.tf_special_call.once in file "src/framework/constraints.ml", line 273, characters 19-84
  [...]
  ```

### TODO
- [x] Test that the issue with QSolvers is fixed: no crash in 15min.
- [x] Test that the issue with TD3 is fixed: no crash in 15min.