### PR TITLE
Try to make `graph-easy` deterministic in general

### DIFF
--- a/tests/dune
+++ b/tests/dune
@@ -1,0 +1,7 @@
+(env
+ (_
+  (env-vars
+   ; graph-easy seems to use srand(), so fixing PERL_RAND_SEED, but that isn't enough.
+   ; It also seems to depend on hashtable hash order, so also fixing PERL_HASH_SEED.
+   (PERL_RAND_SEED 0)
+   (PERL_HASH_SEED 0))))


### PR DESCRIPTION
In https://github.com/goblint/analyzer/pull/2067#issuecomment-5328148703 I found out that `graph-easy` isn't deterministic.
In that PR the env variables are added to the single test, but if they work then they should be applied to all tests.

I did this PR separately because I was afraid this might cause changes to existing tests with `graph-easy`. Luckily that's not the case, which matches with the fact that this issue never came up before.
