### PR TITLE
Fix `ArrayDomain.Partitioned.make` returning non-normalized values

### DIFF
--- a/src/cdomain/value/cdomains/arrayDomain.ml
+++ b/src/cdomain/value/cdomains/arrayDomain.ml
@@ -642,12 +642,7 @@ struct
 
 
   let make ?(varAttr=[]) ?(typAttr=[]) i v:t =
-    if Idx.to_int i = Some Z.one  then
-      Partitioned ((Cil.integer 0), (v, v, v))
-    else if Val.is_bot v then
-      Joint (Val.bot ())
-    else
-      Joint v
+    Joint v
 
   let length _ = None
 


### PR DESCRIPTION
In https://github.com/goblint/analyzer/pull/2081#issuecomment-5341778576, I noticed the following partitioned array abstract value
```
Array (part. by 0): (Unknown -- Unknown -- Unknown)
```
This is strange because it should be normalized away by
https://github.com/goblint/analyzer/blob/1daf1de9c543f34727e84a8584dd7dd42242332f/src/cdomain/value/cdomains/arrayDomain.ml#L331-L336

I looked through all the `Partitioned`-creating places and found that `make` is the only one which doesn't call `normalize`.
So this essentially also applies `normalize` to `make` but simplifies away all the unnecessary back-and-forth.

According to git blame, this strange all-same partitioned value originates from 577ac0ddfbfbe562f6af9526664378b61bb95497. Prior to that the surrounding elements were `Val.bot ()`.
I'm not sure why the special case is there to begin with. Perhaps it should still be there but something from 577ac0ddfbfbe562f6af9526664378b61bb95497 should be reverted instead.
So I don't know if this is necessarily the right solution. But it is one way to ensure that only normalized abstract values are ever used.