### PR TITLE
Use `ValueDomainQueries` for `ArrayDomain` smart ops

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1204,7 +1204,7 @@ struct
   (* Evaluate an expression containing only locals. This is needed for smart joining the partitioned arrays where man is not accessible. *)
   (* This will yield `Top for expressions containing any access to globals, and does not make use of the query system. *)
   (* Wherever possible, don't use this but the query system or normal eval_rv instead. *)
-  let eval_exp st =
+  let to_value_domain_ask st =
     (* Since man is not available here, we need to make some adjustments *)
     let rec query: type a. Queries.Set.t -> a Queries.t -> a Queries.result = fun asked q ->
       let anyq = Queries.Any q in
@@ -1218,17 +1218,17 @@ struct
     and gs = function `Left _ -> `Lifted1 (Priv.G.top ()) | `Right _ -> `Lifted2 (VD.top ()) (* the expression is guaranteed to not contain globals *)
     and man' asked =
       { ask = (fun (type a) (q: a Queries.t) -> query asked q)
-      ; emit   = (fun _ -> failwith "Cannot \"emit\" in base eval_exp context.")
+      ; emit   = (fun _ -> failwith "Cannot \"emit\" in base to_value_domain_ask context.")
       ; node    = MyCFG.dummy_node
       ; prev_node = MyCFG.dummy_node
-      ; control_context = (fun () -> man_failwith "Base eval_exp has no context.")
-      ; context = (fun () -> man_failwith "Base eval_exp has no context.")
+      ; control_context = (fun () -> man_failwith "Base to_value_domain_ask has no context.")
+      ; context = (fun () -> man_failwith "Base to_value_domain_ask has no context.")
       ; edge    = MyCFG.Skip
       ; local   = st
       ; global  = gs
-      ; spawn   = (fun ?(multiple=false) _ -> failwith "Base eval_exp should never spawn threads. What is going on?")
-      ; split   = (fun _ -> failwith "Base eval_exp trying to split paths.")
-      ; sideg   = (fun g d -> failwith "Base eval_exp trying to side effect.")
+      ; spawn   = (fun ?(multiple=false) _ -> failwith "Base to_value_domain_ask should never spawn threads. What is going on?")
+      ; split   = (fun _ -> failwith "Base to_value_domain_ask trying to split paths.")
+      ; sideg   = (fun g d -> failwith "Base to_value_domain_ask trying to side effect.")
       }
     in
     Queries.to_value_domain_ask (Analyses.ask_of_man (man' Queries.Set.empty))
@@ -1813,7 +1813,7 @@ struct
                 Analyses.ask_of_man (man' Queries.Set.empty)
               in
               let moved_by = fun x -> Some 0 in (* this is ok, the information is not provided if it *)
-              (* TODO: why does affect_move need general ask (of any query) instead of eval_exp? *)
+              (* TODO: why does affect_move need general ask (of any query) instead of to_value_domain_ask? *)
               VD.affect_move (Queries.to_value_domain_ask patched_ask) v x moved_by     (* was a set call caused e.g. by a guard *)
           in
           { st with cpa = update_variable arr arr.vtype nval st.cpa }

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1204,7 +1204,7 @@ struct
   (* Evaluate an expression containing only locals. This is needed for smart joining the partitioned arrays where man is not accessible. *)
   (* This will yield `Top for expressions containing any access to globals, and does not make use of the query system. *)
   (* Wherever possible, don't use this but the query system or normal eval_rv instead. *)
-  let eval_exp st (exp:exp) =
+  let eval_exp st =
     (* Since man is not available here, we need to make some adjustments *)
     let rec query: type a. Queries.Set.t -> a Queries.t -> a Queries.result = fun asked q ->
       let anyq = Queries.Any q in
@@ -1231,9 +1231,7 @@ struct
       ; sideg   = (fun g d -> failwith "Base eval_exp trying to side effect.")
       }
     in
-    match eval_rv ~man:(man' Queries.Set.empty) st exp with
-    | Int x -> ValueDomain.ID.to_int x
-    | _ -> None
+    Queries.to_value_domain_ask (Analyses.ask_of_man (man' Queries.Set.empty))
 
   let eval_funvar man fval: Queries.AD.t =
     let fp = eval_fv ~man man.local fval in

--- a/src/analyses/threadEscape.ml
+++ b/src/analyses/threadEscape.ml
@@ -9,7 +9,7 @@ module AD = Queries.AD
 let has_escaped (ask: Queries.ask) (v: varinfo): bool =
   assert (not v.vglob);
   if not v.vaddrof then
-    false (* Cannot have escaped without taking address. Override provides extra precision for degenerate ask in base eval_exp used for partitioned arrays. *)
+    false (* Cannot have escaped without taking address. Override provides extra precision for degenerate ask in base to_value_domain_ask used for partitioned arrays. *)
   else if GobConfig.get_bool "exp.single-threaded" then
     false (* Cannot have escaped if no other threads are assumed to exist. Override provides extra precision for analyzing single-threaded programs without escape analysis. *)
   else

--- a/src/cdomain/value/cdomains/arrayDomain.ml
+++ b/src/cdomain/value/cdomains/arrayDomain.ml
@@ -52,9 +52,9 @@ sig
   val get_vars_in_e: t -> Cil.varinfo list
   val map: (value -> value) -> t -> t
   val fold_left: ('a -> value -> 'a) -> 'a -> t -> 'a
-  val smart_join: (exp -> Z.t option) -> (exp -> Z.t option) -> t -> t -> t
-  val smart_widen: (exp -> Z.t option) -> (exp -> Z.t option) -> t -> t -> t
-  val smart_leq: (exp -> Z.t option) -> (exp -> Z.t option) -> t -> t -> bool
+  val smart_join: VDQ.t -> VDQ.t -> t -> t -> t
+  val smart_widen: VDQ.t -> VDQ.t -> t -> t -> t
+  val smart_leq: VDQ.t -> VDQ.t -> t -> t -> bool
   val update_length: idx -> t -> t
 
   val project: ?varAttr:attributes -> ?typAttr:attributes -> VDQ.t -> t -> t
@@ -101,9 +101,9 @@ end
 module type LatticeWithSmartOps =
 sig
   include LatticeWithInvalidate
-  val smart_join: (Cil.exp -> Z.t option) -> (Cil.exp -> Z.t option) -> t -> t -> t
-  val smart_widen: (Cil.exp -> Z.t option) -> (Cil.exp -> Z.t option) -> t -> t -> t
-  val smart_leq: (Cil.exp -> Z.t option) -> (Cil.exp -> Z.t option) -> t -> t -> bool
+  val smart_join: VDQ.t -> VDQ.t -> t -> t -> t
+  val smart_widen: VDQ.t -> VDQ.t -> t -> t -> t
+  val smart_leq: VDQ.t -> VDQ.t -> t -> t -> bool
 end
 
 module type Null =
@@ -301,9 +301,9 @@ module type SPartitioned =
 sig
   include S
   val set_with_length: idx option -> VDQ.t -> t -> Basetype.CilExp.t option * idx -> value -> t
-  val smart_join_with_length: idx option -> (exp -> Z.t option) -> (exp -> Z.t option) -> t -> t -> t
-  val smart_widen_with_length: idx option -> (exp -> Z.t option) -> (exp -> Z.t option)  -> t -> t-> t
-  val smart_leq_with_length: idx option -> (exp -> Z.t option) -> (exp -> Z.t option) -> t -> t -> bool
+  val smart_join_with_length: idx option -> VDQ.t -> VDQ.t -> t -> t -> t
+  val smart_widen_with_length: idx option -> VDQ.t -> VDQ.t  -> t -> t-> t
+  val smart_leq_with_length: idx option -> VDQ.t -> VDQ.t -> t -> t -> bool
   val move_if_affected_with_length: ?replace_with_const:bool -> idx option -> VDQ.t -> t -> Cil.varinfo -> (Cil.exp -> int option) -> t
 end
 
@@ -651,12 +651,12 @@ struct
 
   let length _ = None
 
-  let must_i_one_smaller l i =
-    GobOption.exists2 (fun l i -> Z.equal i (Z.pred l)) (Option.bind l Idx.to_int) i
+  let must_i_one_smaller l (VDQ.{eval_int; _}, e) =
+    GobOption.exists (fun l -> VDQ.must_be_equal eval_int e (Cil.kintegerCilint (Cilfacade.ptrdiff_ikind ()) (Z.pred l))) (Option.bind l Idx.to_int)
 
-  let must_be_zero = GobOption.exists (Z.equal Z.zero)
+  let must_be_zero (VDQ.{eval_int; _}, e) = VDQ.must_be_equal eval_int e Cil.zero
 
-  let smart_op (op: Val.t -> Val.t -> Val.t) length x1 x2 x1_eval_int x2_eval_int =
+  let smart_op (op: Val.t -> Val.t -> Val.t) length x1 x2 (x1_eval_int: VDQ.t) (x2_eval_int: VDQ.t) =
     normalize @@
     let must_be_length_minus_one = must_i_one_smaller length in
     let op_over_all = op (join_of_all_parts x1) (join_of_all_parts x2) in
@@ -668,8 +668,8 @@ struct
         let op = Val.join in (* widen between different components isn't called validly *)
         let over_all_x1 = op (op xl1 xm1) xr1 in
         let over_all_x2 = op (op xl2 xm2) xr2 in
-        let e1_in_state_of_x2 = x2_eval_int e1 in
-        let e2_in_state_of_x1 = x1_eval_int e2 in
+        let e1_in_state_of_x2 = (x2_eval_int, e1) in
+        let e2_in_state_of_x1 = (x1_eval_int, e2) in
         (* TODO: why does this depend on exp comparison? probably to use "simpler" expression according to constructor order in compare *)
         (* It is mostly SOME order to ensure commutativity of join *)
         let e1_is_better = (not (Cil.isConstant e1) && Cil.isConstant e2) || Basetype.CilExp.compare e1 e2 < 0 in
@@ -700,16 +700,16 @@ struct
     | Joint _, Joint _ ->
       Joint op_over_all
     | Joint x1, Partitioned (e2, (xl2, xm2, xr2)) ->
-      if must_be_zero (x1_eval_int e2) then
+      if must_be_zero (x1_eval_int, e2) then
         Partitioned (e2, (xl2, op x1 xm2, op x1 xr2))
-      else if must_be_length_minus_one (x1_eval_int e2) then
+      else if must_be_length_minus_one (x1_eval_int, e2) then
         Partitioned (e2, (op x1 xl2, op x1 xm2, xr2))
       else
         Joint op_over_all
     | Partitioned (e1, (xl1, xm1, xr1)), Joint x2 ->
-      if must_be_zero (x2_eval_int e1) then
+      if must_be_zero (x2_eval_int, e1) then
         Partitioned (e1, (xl1, op xm1 x2, op xr1 x2))
-      else if must_be_length_minus_one (x2_eval_int e1) then
+      else if must_be_length_minus_one (x2_eval_int, e1) then
         Partitioned (e1, (op xl1 x2, op xm1 x2, xr1))
       else
         Joint op_over_all
@@ -732,20 +732,20 @@ struct
     | Partitioned (e1, (xl1, xm1, xr1)), Partitioned (e2, (xl2, xm2, xr2)) ->
       if Basetype.CilExp.equal e1 e2 then
         leq' xl1 xl2 && leq' xm1 xm2 && leq' xr1 xr2
-      else if must_be_zero (x1_eval_int e2) then
+      else if must_be_zero (x1_eval_int, e2) then
         (* A read will never be from xl2 -> we can ignore that here *)
         let l = join_of_all_parts x1 in
         leq' l xm2 && leq' l xr2
-      else if must_be_length_minus_one (x1_eval_int e2) then
+      else if must_be_length_minus_one (x1_eval_int, e2) then
         (* A read will never be from xr2 -> we can ignore that here *)
         let l = join_of_all_parts x1 in
         leq' l xl2 && leq' l xm2
       else
         false
     | Joint x1, Partitioned (e2, (xl2, xm2, xr2)) ->
-      if must_be_zero (x1_eval_int e2) then
+      if must_be_zero (x1_eval_int, e2) then
         leq' x1 xm2 && leq' x1 xr2
-      else if must_be_length_minus_one (x1_eval_int e2) then
+      else if must_be_length_minus_one (x1_eval_int, e2) then
         leq' x1 xl2 && leq' x1 xm2
       else
         leq' x1 xl2 && leq' x1 xr2 && leq' x1 xm2 && leq' x1 xr2

--- a/src/cdomain/value/cdomains/arrayDomain.ml
+++ b/src/cdomain/value/cdomains/arrayDomain.ml
@@ -656,7 +656,7 @@ struct
 
   let must_be_zero (VDQ.{eval_int; _}, e) = VDQ.must_be_equal eval_int e Cil.zero
 
-  let smart_op (op: Val.t -> Val.t -> Val.t) length x1 x2 (x1_eval_int: VDQ.t) (x2_eval_int: VDQ.t) =
+  let smart_op (op: Val.t -> Val.t -> Val.t) length x1 x2 (x1_vdq: VDQ.t) (x2_vdq: VDQ.t) =
     normalize @@
     let must_be_length_minus_one = must_i_one_smaller length in
     let op_over_all = op (join_of_all_parts x1) (join_of_all_parts x2) in
@@ -668,8 +668,8 @@ struct
         let op = Val.join in (* widen between different components isn't called validly *)
         let over_all_x1 = op (op xl1 xm1) xr1 in
         let over_all_x2 = op (op xl2 xm2) xr2 in
-        let e1_in_state_of_x2 = (x2_eval_int, e1) in
-        let e2_in_state_of_x1 = (x1_eval_int, e2) in
+        let e1_in_state_of_x2 = (x2_vdq, e1) in
+        let e2_in_state_of_x1 = (x1_vdq, e2) in
         (* TODO: why does this depend on exp comparison? probably to use "simpler" expression according to constructor order in compare *)
         (* It is mostly SOME order to ensure commutativity of join *)
         let e1_is_better = (not (Cil.isConstant e1) && Cil.isConstant e2) || Basetype.CilExp.compare e1 e2 < 0 in
@@ -700,28 +700,28 @@ struct
     | Joint _, Joint _ ->
       Joint op_over_all
     | Joint x1, Partitioned (e2, (xl2, xm2, xr2)) ->
-      if must_be_zero (x1_eval_int, e2) then
+      if must_be_zero (x1_vdq, e2) then
         Partitioned (e2, (xl2, op x1 xm2, op x1 xr2))
-      else if must_be_length_minus_one (x1_eval_int, e2) then
+      else if must_be_length_minus_one (x1_vdq, e2) then
         Partitioned (e2, (op x1 xl2, op x1 xm2, xr2))
       else
         Joint op_over_all
     | Partitioned (e1, (xl1, xm1, xr1)), Joint x2 ->
-      if must_be_zero (x2_eval_int, e1) then
+      if must_be_zero (x2_vdq, e1) then
         Partitioned (e1, (xl1, op xm1 x2, op xr1 x2))
-      else if must_be_length_minus_one (x2_eval_int, e1) then
+      else if must_be_length_minus_one (x2_vdq, e1) then
         Partitioned (e1, (op xl1 x2, op xm1 x2, xr1))
       else
         Joint op_over_all
 
-  let smart_join_with_length length x1_eval_int x2_eval_int x1 x2 =
-    smart_op (Val.smart_join x1_eval_int x2_eval_int) length x1 x2 x1_eval_int x2_eval_int
+  let smart_join_with_length length x1_vdq x2_vdq x1 x2 =
+    smart_op (Val.smart_join x1_vdq x2_vdq) length x1 x2 x1_vdq x2_vdq
 
-  let smart_widen_with_length length x1_eval_int x2_eval_int x1 x2  =
-    smart_op (Val.smart_widen x1_eval_int x2_eval_int) length x1 x2 x1_eval_int x2_eval_int
+  let smart_widen_with_length length x1_vdq x2_vdq x1 x2  =
+    smart_op (Val.smart_widen x1_vdq x2_vdq) length x1 x2 x1_vdq x2_vdq
 
-  let smart_leq_with_length length x1_eval_int x2_eval_int x1 x2 =
-    let leq' = Val.smart_leq x1_eval_int x2_eval_int in
+  let smart_leq_with_length length x1_vdq x2_vdq x1 x2 =
+    let leq' = Val.smart_leq x1_vdq x2_vdq in
     let must_be_length_minus_one = must_i_one_smaller length in
     match x1, x2 with
     | Joint x1, Joint x2 ->
@@ -732,20 +732,20 @@ struct
     | Partitioned (e1, (xl1, xm1, xr1)), Partitioned (e2, (xl2, xm2, xr2)) ->
       if Basetype.CilExp.equal e1 e2 then
         leq' xl1 xl2 && leq' xm1 xm2 && leq' xr1 xr2
-      else if must_be_zero (x1_eval_int, e2) then
+      else if must_be_zero (x1_vdq, e2) then
         (* A read will never be from xl2 -> we can ignore that here *)
         let l = join_of_all_parts x1 in
         leq' l xm2 && leq' l xr2
-      else if must_be_length_minus_one (x1_eval_int, e2) then
+      else if must_be_length_minus_one (x1_vdq, e2) then
         (* A read will never be from xr2 -> we can ignore that here *)
         let l = join_of_all_parts x1 in
         leq' l xl2 && leq' l xm2
       else
         false
     | Joint x1, Partitioned (e2, (xl2, xm2, xr2)) ->
-      if must_be_zero (x1_eval_int, e2) then
+      if must_be_zero (x1_vdq, e2) then
         leq' x1 xm2 && leq' x1 xr2
-      else if must_be_length_minus_one (x1_eval_int, e2) then
+      else if must_be_length_minus_one (x1_vdq, e2) then
         leq' x1 xl2 && leq' x1 xm2
       else
         leq' x1 xl2 && leq' x1 xr2 && leq' x1 xm2 && leq' x1 xr2
@@ -900,17 +900,17 @@ struct
   let fold_left f a (x, l) = Base.fold_left f a x
   let get_vars_in_e (x, _) = Base.get_vars_in_e x
 
-  let smart_join x_eval_int y_eval_int (x,xl) (y,yl) =
+  let smart_join x_vdq y_vdq (x,xl) (y,yl) =
     let l = Idx.join xl yl in
-    (Base.smart_join_with_length (Some l) x_eval_int y_eval_int x y , l)
+    (Base.smart_join_with_length (Some l) x_vdq y_vdq x y , l)
 
-  let smart_widen x_eval_int y_eval_int (x,xl) (y,yl) =
+  let smart_widen x_vdq y_vdq (x,xl) (y,yl) =
     let l = Idx.join xl yl in
-    (Base.smart_widen_with_length (Some l) x_eval_int y_eval_int x y, l)
+    (Base.smart_widen_with_length (Some l) x_vdq y_vdq x y, l)
 
-  let smart_leq x_eval_int y_eval_int (x,xl) (y,yl)  =
+  let smart_leq x_vdq y_vdq (x,xl) (y,yl)  =
     let l = Idx.join xl yl in
-    Idx.leq xl yl && Base.smart_leq_with_length (Some l) x_eval_int y_eval_int x y
+    Idx.leq xl yl && Base.smart_leq_with_length (Some l) x_vdq y_vdq x y
 
   (* It is not necessary to do a least-upper bound between the old and the new length here.   *)
   (* Any array can only be declared in one location. The value for newl that we get there is  *)

--- a/src/cdomain/value/cdomains/arrayDomain.mli
+++ b/src/cdomain/value/cdomains/arrayDomain.mli
@@ -46,9 +46,9 @@ sig
   val fold_left: ('a -> value -> 'a) -> 'a -> t -> 'a
   (** Left fold (like List.fold_left) over the arrays elements *)
 
-  val smart_join: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t  -> t
-  val smart_widen: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t -> t
-  val smart_leq: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t  -> bool
+  val smart_join: VDQ.t -> VDQ.t -> t -> t  -> t
+  val smart_widen: VDQ.t -> VDQ.t -> t -> t -> t
+  val smart_leq: VDQ.t -> VDQ.t -> t -> t  -> bool
   val update_length: idx -> t -> t
   val project: ?varAttr:Cil.attributes -> ?typAttr:Cil.attributes -> VDQ.t -> t -> t
   val invariant: value_invariant:(offset:Cil.offset -> lval:Cil.lval -> value -> Invariant.t) -> offset:Cil.offset -> lval:Cil.lval -> t -> Invariant.t
@@ -118,9 +118,9 @@ end
 module type LatticeWithSmartOps =
 sig
   include LatticeWithInvalidate
-  val smart_join: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t ->  t
-  val smart_widen: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t -> t
-  val smart_leq: (Cil.exp -> BigIntOps.t option) -> (Cil.exp -> BigIntOps.t option) -> t -> t -> bool
+  val smart_join: VDQ.t -> VDQ.t -> t -> t ->  t
+  val smart_widen: VDQ.t -> VDQ.t -> t -> t -> t
+  val smart_leq: VDQ.t -> VDQ.t -> t -> t -> bool
 end
 
 module type Null =

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -27,9 +27,9 @@ sig
   val is_statically_safe_cast: typ -> typ -> bool
   val is_dynamically_safe_cast: typ -> typ -> t -> bool
   val cast: kind:castkind -> typ -> t -> t
-  val smart_join: (exp -> Z.t option) -> (exp -> Z.t option) -> t -> t ->  t
-  val smart_widen: (exp -> Z.t option) -> (exp -> Z.t option) ->  t -> t -> t
-  val smart_leq: (exp -> Z.t option) -> (exp -> Z.t option) -> t -> t -> bool
+  val smart_join: VDQ.t -> VDQ.t -> t -> t ->  t
+  val smart_widen: VDQ.t -> VDQ.t ->  t -> t -> t
+  val smart_leq: VDQ.t -> VDQ.t -> t -> t -> bool
   val is_immediate_type: typ -> bool
   val is_mutex_type: typ -> bool
   val bot_value: ?varAttr:attributes -> typ -> t

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -667,37 +667,37 @@ struct
       warn_type "widen" x y;
       Top
 
-  let rec smart_join x_eval_int y_eval_int  (x:t) (y:t):t =
-    let join_elem: (t -> t -> t) = smart_join x_eval_int y_eval_int in  (* does not compile without type annotation *)
+  let rec smart_join x_vdq y_vdq  (x:t) (y:t):t =
+    let join_elem: (t -> t -> t) = smart_join x_vdq y_vdq in  (* does not compile without type annotation *)
     match (x,y) with
     | (Struct x, Struct y) -> Struct (Structs.join_with_fct join_elem x y)
     | (Union (f,x), Union (g,y)) ->
       let field = UnionDomain.Field.join f g in
       let value = join_elem x y in
       Union (field, value)
-    | (Array x, Array y) -> Array (CArrays.smart_join x_eval_int y_eval_int x y)
+    | (Array x, Array y) -> Array (CArrays.smart_join x_vdq y_vdq x y)
     | _ -> join x y  (* Others can not contain array -> normal join  *)
 
-  let rec smart_widen x_eval_int y_eval_int x y:t =
-    let widen_elem: (t -> t -> t) = smart_widen x_eval_int y_eval_int in (* does not compile without type annotation *)
+  let rec smart_widen x_vdq y_vdq x y:t =
+    let widen_elem: (t -> t -> t) = smart_widen x_vdq y_vdq in (* does not compile without type annotation *)
     match (x,y) with
     | (Struct x, Struct y) -> Struct (Structs.widen_with_fct widen_elem x y)
     | (Union (f,x), Union (g,y)) ->
       let field = UnionDomain.Field.widen f g in
       let value = widen_elem x y in
       Union (field, value)
-    | (Array x, Array y) -> Array (CArrays.smart_widen x_eval_int y_eval_int x y)
+    | (Array x, Array y) -> Array (CArrays.smart_widen x_vdq y_vdq x y)
     | _ -> widen x y  (* Others can not contain array -> normal widen  *)
 
 
-  let rec smart_leq x_eval_int y_eval_int x y =
-    let leq_elem:(t ->t -> bool) = smart_leq x_eval_int y_eval_int in (* does not compile without type annotation *)
+  let rec smart_leq x_vdq y_vdq x y =
+    let leq_elem:(t ->t -> bool) = smart_leq x_vdq y_vdq in (* does not compile without type annotation *)
     match (x,y) with
     | (Struct x, Struct y) ->
       Structs.leq_with_fct leq_elem x y
     | (Union (f, x), Union (g, y)) ->
       UnionDomain.Field.leq f g && leq_elem x y
-    | (Array x, Array y) -> CArrays.smart_leq x_eval_int y_eval_int x y
+    | (Array x, Array y) -> CArrays.smart_leq x_vdq y_vdq x y
     | _ -> leq x y (* Others can not contain array -> normal leq *)
 
   let rec meet x y =

--- a/src/cdomains/baseDomain.ml
+++ b/src/cdomains/baseDomain.ml
@@ -107,7 +107,7 @@ end
 module type ExpEvaluator =
 sig
   type t
-  val eval_exp: t  ->  ValueDomainQueries.t
+  val to_value_domain_ask: t  ->  ValueDomainQueries.t
 end
 
 (* Takes a module for privatization component and a module specifying how expressions can be evaluated inside the domain and returns the domain *)
@@ -116,14 +116,14 @@ struct
   include BaseComponents (PrivD)
 
   let join (one:t) (two:t): t =
-    let cpa_join = CPA.join_with_fct (VD.smart_join (ExpEval.eval_exp one) (ExpEval.eval_exp two)) in
+    let cpa_join = CPA.join_with_fct (VD.smart_join (ExpEval.to_value_domain_ask one) (ExpEval.to_value_domain_ask two)) in
     op_scheme cpa_join PartDeps.join WeakUpdates.join PrivD.join one two
 
   let leq one two =
-    let cpa_leq = CPA.leq_with_fct (VD.smart_leq (ExpEval.eval_exp one) (ExpEval.eval_exp two)) in
+    let cpa_leq = CPA.leq_with_fct (VD.smart_leq (ExpEval.to_value_domain_ask one) (ExpEval.to_value_domain_ask two)) in
     cpa_leq one.cpa two.cpa && PartDeps.leq one.deps two.deps && WeakUpdates.leq one.weak two.weak && PrivD.leq one.priv two.priv
 
   let widen one two: t =
-    let cpa_widen = CPA.widen_with_fct (VD.smart_widen (ExpEval.eval_exp one) (ExpEval.eval_exp two)) in
+    let cpa_widen = CPA.widen_with_fct (VD.smart_widen (ExpEval.to_value_domain_ask one) (ExpEval.to_value_domain_ask two)) in
     op_scheme cpa_widen PartDeps.widen WeakUpdates.widen PrivD.widen one two
 end

--- a/src/cdomains/baseDomain.ml
+++ b/src/cdomains/baseDomain.ml
@@ -107,7 +107,7 @@ end
 module type ExpEvaluator =
 sig
   type t
-  val eval_exp: t  ->  Cil.exp -> Z.t option
+  val eval_exp: t  ->  ValueDomainQueries.t
 end
 
 (* Takes a module for privatization component and a module specifying how expressions can be evaluated inside the domain and returns the domain *)
@@ -127,19 +127,3 @@ struct
     let cpa_widen = CPA.widen_with_fct (VD.smart_widen (ExpEval.eval_exp one) (ExpEval.eval_exp two)) in
     op_scheme cpa_widen PartDeps.widen WeakUpdates.widen PrivD.widen one two
 end
-
-
-(* The domain with an ExpEval that only returns constant values for top-level vars that are definite ints *)
-module DomWithTrivialExpEval (PrivD: Lattice.S) = DomFunctor (PrivD) (struct
-
-  type t = BaseComponents (PrivD).t
-  let eval_exp (r: t) e =
-    match e with
-    | Lval (Var v, NoOffset) ->
-      begin
-        match CPA.find v r.cpa with
-        | Int i -> ValueDomain.ID.to_int i
-        | _ -> None
-      end
-    | _ -> None
-end)


### PR DESCRIPTION
While working on #2081, especially the `smart_*` ops, I noticed that they could also use `ValueDomainQueries`, exists for other `ArrayDomain` functions.