### PR TITLE
Fix inverted zero-divisor check in base MaySignedOverflow

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1396,7 +1396,7 @@ struct
           | `Bot, _ -> false
           | _, `Bot -> false
           | `Lifted i1, `Lifted i2 ->
-            ( let divisor_contains_zero = (ID.is_bot @@ ID.meet i2 (ID.of_int ik Z.zero))  in
+            ( let divisor_contains_zero = not (ID.is_bot @@ ID.meet i2 (ID.of_int ik Z.zero)) in
               if divisor_contains_zero then true else
                 ( let (min_ik, max_ik) = IntDomain.Size.range ik in
                   let (min_i1, max_i1) = (IntDomain.IntDomTuple.minimal i1, IntDomain.IntDomTuple.maximal i1) in


### PR DESCRIPTION
The division case in `MaySignedOverflow` computed whether the divisor may contain zero with inverted logic. This caused nonzero divisors to be treated as possibly zero and vice versa.

Found when looking through sv-comp tasks, but I couldn't construct a good regression to expose it.