### PR TITLE
Improve readability of `Spec` lifted domains

### DIFF
--- a/src/constraint/translators.ml
+++ b/src/constraint/translators.ml
@@ -37,8 +37,8 @@ struct
   module Var = Var2(S.LVar)(S.GVar)
   module Dom =
   struct
-    include Lattice.Lift2 (S.G) (S.D)
-    let printXml f = function
+    include Lattice.Lift2Conf (struct include Printable.DefaultConf let expand1 = false let expand2 = false end) (S.G) (S.D)
+    let printXml f = function (* TODO: redundant? *)
       | `Lifted1 a -> S.G.printXml f a
       | `Lifted2 a -> S.D.printXml f a
       | (`Bot | `Top) as x -> printXml f x

--- a/src/constraint/translators.ml
+++ b/src/constraint/translators.ml
@@ -35,14 +35,7 @@ module EqConstrSysFromGlobConstrSys (S:DemandGlobConstrSys)
 =
 struct
   module Var = Var2(S.LVar)(S.GVar)
-  module Dom =
-  struct
-    include Lattice.Lift2Conf (struct include Printable.DefaultConf let expand1 = false let expand2 = false end) (S.G) (S.D)
-    let printXml f = function (* TODO: redundant? *)
-      | `Lifted1 a -> S.G.printXml f a
-      | `Lifted2 a -> S.D.printXml f a
-      | (`Bot | `Top) as x -> printXml f x
-  end
+  module Dom = Lattice.Lift2Conf (struct include Printable.DefaultConf let expand1 = false let expand2 = false end) (S.G) (S.D)
   type v = Var.t
   type d = Dom.t
 

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -97,7 +97,7 @@ struct
     let name () = "contexts"
   end
 
-  include Lattice.Lift2 (G) (CSet)
+  include Lattice.Lift2Conf (struct include Printable.DefaultConf let expand1 = false let expand2 = false end) (G) (CSet)
 
   let spec = function
     | `Bot -> G.bot ()
@@ -123,9 +123,9 @@ exception Deadcode
 module Dom (LD: Lattice.S) =
 struct
   include Lattice.LiftConf (struct
-      include Printable.DefaultConf
       let bot_name = "Dead code"
       let top_name = "Totally unknown and messed up"
+      let expand1 = false
     end) (LD)
 
   let unlift x =

--- a/src/lifters/contextGasLifter.ml
+++ b/src/lifters/contextGasLifter.ml
@@ -28,7 +28,12 @@ struct
 
   module Context_Gas_Prod (Base1: Lattice.S) (Base2: Lattice.S) =
   struct
-    include Lattice.Prod (Base1) (Base2)
+    module Base2 =
+    struct
+      include Base2
+      let name () = "context gas"
+    end
+    include Lattice.Prod (Base1) (Base2) (* TODO: suppress S.D name? *)
     let printXml f (x,y) =
       BatPrintf.fprintf f "\n%a<analysis name=\"context gas value\">\n%a\n</analysis>" Base1.printXml x Base2.printXml y
   end

--- a/src/lifters/longjmpLifter.ml
+++ b/src/lifters/longjmpLifter.ml
@@ -11,7 +11,7 @@ struct
 
   module V =
   struct
-    include Printable.Either3Conf (struct let expand1 = false let expand2 = true let expand3 = true end) (S.V) (Printable.Prod (Node) (C)) (Printable.Prod (CilType.Fundec) (C))
+    include Printable.Either3Conf (struct let expand1 = false let expand2 = true let expand3 = true end) (S.V) (Printable.Prod (Node) (C)) (Printable.Prod (CilType.Fundec) (C)) (* TODO: add names to 2nd and 3rd component *)
     let name () = "longjmp"
     let s x = `Left x
     let longjmpto x = `Middle x
@@ -23,7 +23,7 @@ struct
 
   module G =
   struct
-    include Lattice.Lift2 (S.G) (S.D)
+    include Lattice.Lift2Conf (struct include Printable.DefaultConf let expand1 = false let expand2 = false end) (S.G) (S.D)
 
     let s = function
       | `Bot -> S.G.bot ()

--- a/src/lifters/longjmpLifter.ml
+++ b/src/lifters/longjmpLifter.ml
@@ -11,7 +11,17 @@ struct
 
   module V =
   struct
-    include Printable.Either3Conf (struct let expand1 = false let expand2 = true let expand3 = true end) (S.V) (Printable.Prod (Node) (C)) (Printable.Prod (CilType.Fundec) (C)) (* TODO: add names to 2nd and 3rd component *)
+    module Longjmpto =
+    struct
+      include Printable.Prod (Node) (C)
+      let name () = "longjmpto"
+    end
+    module Longjmpret =
+    struct
+      include Printable.Prod (CilType.Fundec) (C)
+      let name () = "longjmpret"
+    end
+    include Printable.Either3Conf (struct let expand1 = false let expand2 = true let expand3 = true end) (S.V) (Longjmpto) (Longjmpret)
     let name () = "longjmp"
     let s x = `Left x
     let longjmpto x = `Middle x

--- a/src/lifters/recursionTermLifter.ml
+++ b/src/lifters/recursionTermLifter.ml
@@ -31,7 +31,7 @@ struct
 
   module G =
   struct
-    include Lattice.Lift2 (G) (CallerSet)
+    include Lattice.Lift2Conf (struct include Printable.DefaultConf let expand1 = false let expand2 = false end) (G) (CallerSet)
 
     let spec = function
       | `Bot -> G.bot ()

--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -321,14 +321,20 @@ module OptEqual (S: Spec) = struct
   include (S : Spec with module D := D and module G := G and module C := C)
 end
 
+module LevelSliceDomain =
+struct
+  include Lattice.Reverse (IntDomain.Lifted)
+  let name () = "level"
+end
+
 (** If dbg.slice.on, stops entering functions after dbg.slice.n levels. *)
 module LevelSliceLifter (S:Spec)
-  : Spec with module D = Lattice.Prod (S.D) (Lattice.Reverse (IntDomain.Lifted))
+  : Spec with module D = Lattice.Prod (S.D) (LevelSliceDomain)
           and module G = S.G
           and module C = S.C
 =
 struct
-  module D = Lattice.Prod (S.D) (Lattice.Reverse (IntDomain.Lifted)) (* TODO: suppress Base name? *) (* TODO: add name to 2nd component *)
+  module D = Lattice.Prod (S.D) (LevelSliceDomain) (* TODO: suppress Base name? *)
   module G = S.G
   module C = S.C
   module V = S.V
@@ -454,7 +460,11 @@ struct
     include S.D
     let printXml f d = BatPrintf.fprintf f "<value>%a</value>" printXml d
   end
-  module M = MapDomain.PatriciaMapBot (Basetype.Variables) (DD) (* should be CilFun -> S.C, but CilFun is not Groupable, and S.C is no Lattice *)
+  module M =
+  struct
+    include MapDomain.PatriciaMapBot (Basetype.Variables) (DD) (* should be CilFun -> S.C, but CilFun is not Groupable, and S.C is no Lattice *)
+    let name () = "widen-context"
+  end
 
   module D = struct
     include Lattice.Prod (S.D) (M) (* TODO: suppress S.D name? *)
@@ -763,6 +773,11 @@ struct
 
   module V =
   struct
+    module Node =
+    struct
+      include Node
+      let name () = "deadbranch"
+    end
     include Printable.EitherConf (struct let expand1 = false let expand2 = true end) (S.V) (Node)
     let name () = "DeadBranch"
     let s x = `Left x

--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -328,7 +328,7 @@ module LevelSliceLifter (S:Spec)
           and module C = S.C
 =
 struct
-  module D = Lattice.Prod (S.D) (Lattice.Reverse (IntDomain.Lifted))
+  module D = Lattice.Prod (S.D) (Lattice.Reverse (IntDomain.Lifted)) (* TODO: suppress Base name? *) (* TODO: add name to 2nd component *)
   module G = S.G
   module C = S.C
   module V = S.V
@@ -457,7 +457,7 @@ struct
   module M = MapDomain.PatriciaMapBot (Basetype.Variables) (DD) (* should be CilFun -> S.C, but CilFun is not Groupable, and S.C is no Lattice *)
 
   module D = struct
-    include Lattice.Prod (S.D) (M)
+    include Lattice.Prod (S.D) (M) (* TODO: suppress S.D name? *)
     let printXml f (d,m) = BatPrintf.fprintf f "\n%a<analysis name=\"widen-context\">\n%a\n</analysis>" S.D.printXml d M.printXml m
   end
   module G = S.G
@@ -780,7 +780,7 @@ struct
 
   module G =
   struct
-    include Lattice.Lift2 (S.G) (EM)
+    include Lattice.Lift2Conf (struct include Printable.DefaultConf let expand1 = false let expand2 = false end) (S.G) (EM)
     let name () = "deadbranch"
 
     let s = function

--- a/src/lifters/wideningDelay.ml
+++ b/src/lifters/wideningDelay.ml
@@ -21,8 +21,8 @@ end
 
 module Dom (Base: S) (ChainParams: Printable.ChainParams) =
 struct
-  module Chain = Printable.Chain (ChainParams)
-  include Printable.Prod (Base) (Chain)
+  module Chain = Printable.Chain (ChainParams) (* TODO: add name *)
+  include Printable.Prod (Base) (Chain) (* TODO: suppress Base name? *)
 
   let lift d = (d, 0)
   let unlift (d, _) = d

--- a/src/lifters/wideningDelay.ml
+++ b/src/lifters/wideningDelay.ml
@@ -21,7 +21,11 @@ end
 
 module Dom (Base: S) (ChainParams: Printable.ChainParams) =
 struct
-  module Chain = Printable.Chain (ChainParams) (* TODO: add name *)
+  module Chain =
+  struct
+    include Printable.Chain (ChainParams)
+    let name () = "widen-delay"
+  end
   include Printable.Prod (Base) (Chain) (* TODO: suppress Base name? *)
 
   let lift d = (d, 0)

--- a/src/lifters/wideningToken.ml
+++ b/src/lifters/wideningToken.ml
@@ -14,3 +14,5 @@ end
 
 (* Change to variant type if need other tokens than witness UUIDs. *)
 include Printable.Prod (Uuid) (Index)
+
+let name () = "widen-token"

--- a/src/lifters/wideningTokenLifter.ml
+++ b/src/lifters/wideningTokenLifter.ml
@@ -6,10 +6,10 @@
 
     @see <http://www2.in.tum.de/bib/files/mihaila13widening.pdf> Mihaila, B., Sepp, A. & Simon, A. Widening as Abstract Domain. *)
 
-module Token = WideningToken
+module Token = WideningToken (* TODO: add name? *)
 
 (** Widening token set. *)
-module TS = SetDomain.ToppedSet (Token) (struct let topname = "Top" end)
+module TS = SetDomain.ToppedSet (Token) (struct let topname = "Top" end) (* TODO: add name? *)
 
 (** Reference to current {!add} implementation. Maintained by {!Lifter}. *)
 let add_ref: (Token.t -> unit) Domain.DLS.key = Domain.DLS.new_key (fun () _ ->
@@ -58,7 +58,7 @@ open Analyses
     except widening tokens are used to delay widenings. *)
 module Dom (D: Lattice.S) =
 struct
-  include Lattice.Prod (D) (TS)
+  include Lattice.Prod (D) (TS) (* TODO: suppress Base name? *)
   let unlift (d, _) = d
   let lift d = (d, TS.bot ())
 

--- a/src/lifters/wideningTokenLifter.ml
+++ b/src/lifters/wideningTokenLifter.ml
@@ -6,10 +6,14 @@
 
     @see <http://www2.in.tum.de/bib/files/mihaila13widening.pdf> Mihaila, B., Sepp, A. & Simon, A. Widening as Abstract Domain. *)
 
-module Token = WideningToken (* TODO: add name? *)
+module Token = WideningToken
 
 (** Widening token set. *)
-module TS = SetDomain.ToppedSet (Token) (struct let topname = "Top" end) (* TODO: add name? *)
+module TS =
+struct
+  include SetDomain.ToppedSet (Token) (struct let topname = "Top" end)
+  let name () = "widen-tokens"
+end
 
 (** Reference to current {!add} implementation. Maintained by {!Lifter}. *)
 let add_ref: (Token.t -> unit) Domain.DLS.key = Domain.DLS.new_key (fun () _ ->

--- a/tests/regression/00-sanity/33-hoare-over-paths.t
+++ b/tests/regression/00-sanity/33-hoare-over-paths.t
@@ -9,220 +9,219 @@
   $ cat pretty.txt
   Mapping {
     33-hoare-over-paths.c:9:7-9:8(main) ->
-      PathSensitive (ProjectiveSet (MCP.D * map)):{(MCP.D:[expRelation:(),
-                                                           mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-                                                           base:({
-                                                                   Global {
-                                                                     m ->   mutex
-                                                                   }
-                                                                   Local {
-                                                                     r ->   ⊤
-                                                                   }
-                                                                 }, {}, {}, {}),
-                                                           threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-                                                           threadflag:Singlethreaded,
-                                                           threadreturn:true,
-                                                           escape:{},
-                                                           mutexEvents:(),
-                                                           access:(),
-                                                           mutex:(lockset:{}, multiplicity:{}),
-                                                           race:(),
-                                                           mhp:(),
-                                                           assert:(),
-                                                           pthreadMutexType:()], map:{})}
+      {(MCP.D:[expRelation:(),
+               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+               base:({
+                       Global {
+                         m ->   mutex
+                       }
+                       Local {
+                         r ->   ⊤
+                       }
+                     }, {}, {}, {}),
+               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+               threadflag:Singlethreaded,
+               threadreturn:true,
+               escape:{},
+               mutexEvents:(),
+               access:(),
+               mutex:(lockset:{}, multiplicity:{}),
+               race:(),
+               mhp:(),
+               assert:(),
+               pthreadMutexType:()], map:{})}
     33-hoare-over-paths.c:10:5-10:10(main) ->
-      PathSensitive (ProjectiveSet (MCP.D * map)):{(MCP.D:[expRelation:(),
-                                                           mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-                                                           base:({
-                                                                   Global {
-                                                                     m ->   mutex
-                                                                   }
-                                                                   Local {
-                                                                     r ->
-                                                                       (Not {0}([-31,31]))
-                                                                   }
-                                                                 }, {}, {}, {}),
-                                                           threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-                                                           threadflag:Singlethreaded,
-                                                           threadreturn:true,
-                                                           escape:{},
-                                                           mutexEvents:(),
-                                                           access:(),
-                                                           mutex:(lockset:{}, multiplicity:{}),
-                                                           race:(),
-                                                           mhp:(),
-                                                           assert:(),
-                                                           pthreadMutexType:()], map:{})}
+      {(MCP.D:[expRelation:(),
+               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+               base:({
+                       Global {
+                         m ->   mutex
+                       }
+                       Local {
+                         r ->   (Not {0}([-31,31]))
+                       }
+                     }, {}, {}, {}),
+               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+               threadflag:Singlethreaded,
+               threadreturn:true,
+               escape:{},
+               mutexEvents:(),
+               access:(),
+               mutex:(lockset:{}, multiplicity:{}),
+               race:(),
+               mhp:(),
+               assert:(),
+               pthreadMutexType:()], map:{})}
     33-hoare-over-paths.c:11:5-11:24(main) ->
-      PathSensitive (ProjectiveSet (MCP.D * map)):{(MCP.D:[expRelation:(),
-                                                           mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-                                                           base:({
-                                                                   Global {
-                                                                     m ->   mutex
-                                                                   }
-                                                                   Local {
-                                                                     r ->   0
-                                                                   }
-                                                                 }, {}, {}, {}),
-                                                           threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-                                                           threadflag:Singlethreaded,
-                                                           threadreturn:true,
-                                                           escape:{},
-                                                           mutexEvents:(),
-                                                           access:(),
-                                                           mutex:(lockset:{}, multiplicity:{}),
-                                                           race:(),
-                                                           mhp:(),
-                                                           assert:(),
-                                                           pthreadMutexType:()], map:{})}
+      {(MCP.D:[expRelation:(),
+               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+               base:({
+                       Global {
+                         m ->   mutex
+                       }
+                       Local {
+                         r ->   0
+                       }
+                     }, {}, {}, {}),
+               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+               threadflag:Singlethreaded,
+               threadreturn:true,
+               escape:{},
+               mutexEvents:(),
+               access:(),
+               mutex:(lockset:{}, multiplicity:{}),
+               race:(),
+               mhp:(),
+               assert:(),
+               pthreadMutexType:()], map:{})}
     33-hoare-over-paths.c:15:5-15:27(main) ->
-      PathSensitive (ProjectiveSet (MCP.D * map)):{(MCP.D:[expRelation:(),
-                                                           mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-                                                           base:({
-                                                                   Global {
-                                                                     m ->   mutex
-                                                                   }
-                                                                   Local {
-                                                                     r ->   0
-                                                                   }
-                                                                 }, {}, {}, {}),
-                                                           threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-                                                           threadflag:Singlethreaded,
-                                                           threadreturn:true,
-                                                           escape:{},
-                                                           mutexEvents:(),
-                                                           access:(),
-                                                           mutex:(lockset:{}, multiplicity:{}),
-                                                           race:(),
-                                                           mhp:(),
-                                                           assert:(),
-                                                           pthreadMutexType:()], map:{})}
+      {(MCP.D:[expRelation:(),
+               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+               base:({
+                       Global {
+                         m ->   mutex
+                       }
+                       Local {
+                         r ->   0
+                       }
+                     }, {}, {}, {}),
+               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+               threadflag:Singlethreaded,
+               threadreturn:true,
+               escape:{},
+               mutexEvents:(),
+               access:(),
+               mutex:(lockset:{}, multiplicity:{}),
+               race:(),
+               mhp:(),
+               assert:(),
+               pthreadMutexType:()], map:{})}
     33-hoare-over-paths.c:16:5-16:24(main) ->
-      PathSensitive (ProjectiveSet (MCP.D * map)):{(MCP.D:[expRelation:(),
-                                                           mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-                                                           base:({
-                                                                   Global {
-                                                                     m ->   mutex
-                                                                   }
-                                                                   Local {
-                                                                     r ->   0
-                                                                   }
-                                                                 }, {}, {}, {}),
-                                                           threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-                                                           threadflag:Singlethreaded,
-                                                           threadreturn:true,
-                                                           escape:{},
-                                                           mutexEvents:(),
-                                                           access:(),
-                                                           mutex:(lockset:{m}, multiplicity:{}),
-                                                           race:(),
-                                                           mhp:(),
-                                                           assert:(),
-                                                           pthreadMutexType:()], map:{})}
+      {(MCP.D:[expRelation:(),
+               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+               base:({
+                       Global {
+                         m ->   mutex
+                       }
+                       Local {
+                         r ->   0
+                       }
+                     }, {}, {}, {}),
+               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+               threadflag:Singlethreaded,
+               threadreturn:true,
+               escape:{},
+               mutexEvents:(),
+               access:(),
+               mutex:(lockset:{m}, multiplicity:{}),
+               race:(),
+               mhp:(),
+               assert:(),
+               pthreadMutexType:()], map:{})}
     33-hoare-over-paths.c:33:10-33:11(main) ->
-      PathSensitive (ProjectiveSet (MCP.D * map)):{(MCP.D:[expRelation:(),
-                                                           mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-                                                           base:({
-                                                                   Global {
-                                                                     m ->   mutex
-                                                                   }
-                                                                   Local {
-                                                                     r ->   0
-                                                                   }
-                                                                 }, {}, {}, {}),
-                                                           threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-                                                           threadflag:Singlethreaded,
-                                                           threadreturn:true,
-                                                           escape:{},
-                                                           mutexEvents:(),
-                                                           access:(),
-                                                           mutex:(lockset:{m}, multiplicity:{}),
-                                                           race:(),
-                                                           mhp:(),
-                                                           assert:(),
-                                                           pthreadMutexType:()], map:{}),
-                                                   (MCP.D:[expRelation:(),
-                                                           mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-                                                           base:({
-                                                                   Global {
-                                                                     m ->   mutex
-                                                                   }
-                                                                   Local {
-                                                                     r ->   0
-                                                                   }
-                                                                 }, {}, {}, {}),
-                                                           threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-                                                           threadflag:Singlethreaded,
-                                                           threadreturn:true,
-                                                           escape:{},
-                                                           mutexEvents:(),
-                                                           access:(),
-                                                           mutex:(lockset:{}, multiplicity:{}),
-                                                           race:(),
-                                                           mhp:(),
-                                                           assert:(),
-                                                           pthreadMutexType:()], map:{})}
+      {(MCP.D:[expRelation:(),
+               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+               base:({
+                       Global {
+                         m ->   mutex
+                       }
+                       Local {
+                         r ->   0
+                       }
+                     }, {}, {}, {}),
+               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+               threadflag:Singlethreaded,
+               threadreturn:true,
+               escape:{},
+               mutexEvents:(),
+               access:(),
+               mutex:(lockset:{m}, multiplicity:{}),
+               race:(),
+               mhp:(),
+               assert:(),
+               pthreadMutexType:()], map:{}),
+       (MCP.D:[expRelation:(),
+               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+               base:({
+                       Global {
+                         m ->   mutex
+                       }
+                       Local {
+                         r ->   0
+                       }
+                     }, {}, {}, {}),
+               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+               threadflag:Singlethreaded,
+               threadreturn:true,
+               escape:{},
+               mutexEvents:(),
+               access:(),
+               mutex:(lockset:{}, multiplicity:{}),
+               race:(),
+               mhp:(),
+               assert:(),
+               pthreadMutexType:()], map:{})}
     33-hoare-over-paths.c:7:1-34:1(main) ->
-      PathSensitive (ProjectiveSet (MCP.D * map)):{(MCP.D:[expRelation:(),
-                                                           mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-                                                           base:({
-                                                                   Global {
-                                                                     m ->   mutex
-                                                                   }
-                                                                 }, {}, {}, {}),
-                                                           threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-                                                           threadflag:Singlethreaded,
-                                                           threadreturn:true,
-                                                           escape:{},
-                                                           mutexEvents:(),
-                                                           access:(),
-                                                           mutex:(lockset:{}, multiplicity:{}),
-                                                           race:(),
-                                                           mhp:(),
-                                                           assert:(),
-                                                           pthreadMutexType:()], map:{})}
+      {(MCP.D:[expRelation:(),
+               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+               base:({
+                       Global {
+                         m ->   mutex
+                       }
+                     }, {}, {}, {}),
+               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+               threadflag:Singlethreaded,
+               threadreturn:true,
+               escape:{},
+               mutexEvents:(),
+               access:(),
+               mutex:(lockset:{}, multiplicity:{}),
+               race:(),
+               mhp:(),
+               assert:(),
+               pthreadMutexType:()], map:{})}
     33-hoare-over-paths.c:7:1-34:1(main) ->
-      PathSensitive (ProjectiveSet (MCP.D * map)):{(MCP.D:[expRelation:(),
-                                                           mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-                                                           base:({
-                                                                   Global {
-                                                                     m ->   mutex
-                                                                   }
-                                                                   Temp {
-                                                                     RETURN ->   0
-                                                                   }
-                                                                 }, {}, {}, {}),
-                                                           threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-                                                           threadflag:Singlethreaded,
-                                                           threadreturn:true,
-                                                           escape:{},
-                                                           mutexEvents:(),
-                                                           access:(),
-                                                           mutex:(lockset:{m}, multiplicity:{}),
-                                                           race:(),
-                                                           mhp:(),
-                                                           assert:(),
-                                                           pthreadMutexType:()], map:{}),
-                                                   (MCP.D:[expRelation:(),
-                                                           mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-                                                           base:({
-                                                                   Global {
-                                                                     m ->   mutex
-                                                                   }
-                                                                   Temp {
-                                                                     RETURN ->   0
-                                                                   }
-                                                                 }, {}, {}, {}),
-                                                           threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-                                                           threadflag:Singlethreaded,
-                                                           threadreturn:true,
-                                                           escape:{},
-                                                           mutexEvents:(),
-                                                           access:(),
-                                                           mutex:(lockset:{}, multiplicity:{}),
-                                                           race:(),
-                                                           mhp:(),
-                                                           assert:(),
-                                                           pthreadMutexType:()], map:{})}
+      {(MCP.D:[expRelation:(),
+               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+               base:({
+                       Global {
+                         m ->   mutex
+                       }
+                       Temp {
+                         RETURN ->   0
+                       }
+                     }, {}, {}, {}),
+               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+               threadflag:Singlethreaded,
+               threadreturn:true,
+               escape:{},
+               mutexEvents:(),
+               access:(),
+               mutex:(lockset:{m}, multiplicity:{}),
+               race:(),
+               mhp:(),
+               assert:(),
+               pthreadMutexType:()], map:{}),
+       (MCP.D:[expRelation:(),
+               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+               base:({
+                       Global {
+                         m ->   mutex
+                       }
+                       Temp {
+                         RETURN ->   0
+                       }
+                     }, {}, {}, {}),
+               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+               threadflag:Singlethreaded,
+               threadreturn:true,
+               escape:{},
+               mutexEvents:(),
+               access:(),
+               mutex:(lockset:{}, multiplicity:{}),
+               race:(),
+               mhp:(),
+               assert:(),
+               pthreadMutexType:()], map:{})}
     OTHERS -> Not available
   }

--- a/tests/regression/00-sanity/33-hoare-over-paths.t
+++ b/tests/regression/00-sanity/33-hoare-over-paths.t
@@ -29,7 +29,7 @@
                race:(),
                mhp:(),
                assert:(),
-               pthreadMutexType:()], map:{})}
+               pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:10:5-10:10(main) ->
       {(MCP.D:[expRelation:(),
                mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
@@ -51,7 +51,7 @@
                race:(),
                mhp:(),
                assert:(),
-               pthreadMutexType:()], map:{})}
+               pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:11:5-11:24(main) ->
       {(MCP.D:[expRelation:(),
                mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
@@ -73,7 +73,7 @@
                race:(),
                mhp:(),
                assert:(),
-               pthreadMutexType:()], map:{})}
+               pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:15:5-15:27(main) ->
       {(MCP.D:[expRelation:(),
                mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
@@ -95,7 +95,7 @@
                race:(),
                mhp:(),
                assert:(),
-               pthreadMutexType:()], map:{})}
+               pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:16:5-16:24(main) ->
       {(MCP.D:[expRelation:(),
                mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
@@ -117,7 +117,7 @@
                race:(),
                mhp:(),
                assert:(),
-               pthreadMutexType:()], map:{})}
+               pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:33:10-33:11(main) ->
       {(MCP.D:[expRelation:(),
                mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
@@ -139,7 +139,7 @@
                race:(),
                mhp:(),
                assert:(),
-               pthreadMutexType:()], map:{}),
+               pthreadMutexType:()], widen-context:{}),
        (MCP.D:[expRelation:(),
                mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
                base:({
@@ -160,7 +160,7 @@
                race:(),
                mhp:(),
                assert:(),
-               pthreadMutexType:()], map:{})}
+               pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:7:1-34:1(main) ->
       {(MCP.D:[expRelation:(),
                mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
@@ -179,7 +179,7 @@
                race:(),
                mhp:(),
                assert:(),
-               pthreadMutexType:()], map:{})}
+               pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:7:1-34:1(main) ->
       {(MCP.D:[expRelation:(),
                mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
@@ -201,7 +201,7 @@
                race:(),
                mhp:(),
                assert:(),
-               pthreadMutexType:()], map:{}),
+               pthreadMutexType:()], widen-context:{}),
        (MCP.D:[expRelation:(),
                mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
                base:({
@@ -222,6 +222,6 @@
                race:(),
                mhp:(),
                assert:(),
-               pthreadMutexType:()], map:{})}
+               pthreadMutexType:()], widen-context:{})}
     OTHERS -> Not available
   }


### PR DESCRIPTION
I did something like this in #1294 but various `Spec` lifters have been added since and they should also be adapted.
There are examples of the improvements in cram tests.

As an another example, consider `./regtest.sh 04 01 --trace sol --trace sol2`.
From local states, this removes the following unwieldy prefix:
```
HConsed lifted PathSensitive (ProjectiveSet (MCP.D * map)):PathSensitive (ProjectiveSet (MCP.D * map)):
```
From global states, this removes prefixes like:
```
lifted lifted deadbranch and HConsed lifted PathSensitive (ProjectiveSet (MCP.D * map)) and contexts:lifted deadbranch and HConsed lifted PathSensitive (ProjectiveSet (MCP.D * map)):deadbranch:MCP.G:
```
This makes tracing a lot more readable by removing redundant information and some massive indentations.

Additionally it adds names to some domains, so they're more descriptive than `map` or `chain`.