### PR TITLE
Improve readability of `Spec` lifted `Prod` domains

### DIFF
--- a/src/analyses/branchSet.ml
+++ b/src/analyses/branchSet.ml
@@ -7,7 +7,7 @@ module Spec =
 struct
   include Analyses.IdentitySpec
 
-  module Branch = Printable.ProdSimple(BoolDomain.Bool)(Node)
+  module Branch = Printable.Prod(BoolDomain.Bool)(Node)
   module BranchSet = SetDomain.Make(Branch)
 
   module D = BranchSet

--- a/src/cdomain/value/cdomains/arrayDomain.ml
+++ b/src/cdomain/value/cdomains/arrayDomain.ml
@@ -185,7 +185,7 @@ module Unroll (Val: LatticeWithInvalidate) (Idx:IntDomain.Z): S with type value 
 struct
   module Factor = struct let x () = (get_int "ana.base.arrays.unrolling-factor") end
   module Base = Lattice.ProdList (Val) (Factor)
-  include Lattice.ProdSimple(Base) (Val)
+  include Lattice.Prod (Base) (Val)
 
   let name () = "unrolled arrays"
   type idx = Idx.t

--- a/src/cdomain/value/cdomains/jmpBufDomain.ml
+++ b/src/cdomain/value/cdomains/jmpBufDomain.ml
@@ -1,6 +1,6 @@
 (** Domains for [setjmp] and [longjmp] analyses, and [setjmp] buffers. *)
 
-module BufferEntry = Printable.ProdSimple(Node)(ControlSpecC)
+module BufferEntry = Printable.Prod (Node)(ControlSpecC)
 
 module BufferEntryOrTop = struct
   include Printable.Std
@@ -61,7 +61,7 @@ end
 
 module ActiveLongjmps =
 struct
-  include Lattice.ProdSimple(JmpBufSet)(NodeSet)
+  include Lattice.Prod (JmpBufSet)(NodeSet)
 end
 
 module LocallyModifiedMap =

--- a/src/cdomains/musteqDomain.ml
+++ b/src/cdomains/musteqDomain.ml
@@ -84,7 +84,7 @@ struct
   let replace x exp (v,fd) = v, F.replace x exp fd
 end
 
-module P = Printable.ProdSimple (V) (V)
+module P = Printable.Prod (V) (V)
 
 (* TODO: unused, but should be used by something? region? *)
 module Equ =

--- a/src/common/domains/printable.ml
+++ b/src/common/domains/printable.ml
@@ -522,7 +522,6 @@ struct
 end
 
 module Prod = ProdConf (struct let expand_fst = true let expand_snd = true end)
-module ProdSimple = ProdConf (struct let expand_fst = false let expand_snd = false end)
 
 module Prod3 (Base1: S) (Base2: S) (Base3: S) =
 struct

--- a/src/common/domains/printable.ml
+++ b/src/common/domains/printable.ml
@@ -506,41 +506,18 @@ end
 
 module Prod = ProdConf (DefaultConf)
 
-module Prod3 (Base1: S) (Base2: S) (Base3: S) =
+module type Prod3Conf =
+sig
+  include ProdConf
+  val expand3: bool
+end
+
+module Prod3Conf (Conf: Prod3Conf) (Base1: S) (Base2: S) (Base3: S) =
 struct
   type t = Base1.t * Base2.t * Base3.t [@@deriving eq, ord, hash, relift]
   include Std
 
-  let show (x,y,z) =
-    (* TODO: remove ref *)
-    let first = ref "" in
-    let second= ref "" in
-    let third = ref "" in
-    first  := Base1.show x;
-    second := Base2.show y;
-    third  := Base3.show z;
-    "(" ^ !first ^ ", " ^ !second ^ ", " ^ !third ^ ")"
-
-  let pretty () (x,y,z) =
-    text "("
-    ++ text (Base1.name ())
-    ++ text ":"
-    ++ align
-    ++ Base1.pretty () x
-    ++ unalign
-    ++ text ", "
-    ++ text (Base2.name ())
-    ++ text ":"
-    ++ align
-    ++ Base2.pretty () y
-    ++ unalign
-    ++ text ", "
-    ++ text (Base3.name ())
-    ++ text ":"
-    ++ align
-    ++ Base3.pretty () z
-    ++ unalign
-    ++ text ")"
+  let name () = Base1.name () ^ " * " ^ Base2.name () ^ " * " ^ Base3.name ()
 
   let printXml f (x,y,z) =
     BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (XmlUtil.escape (Base1.name ())) Base1.printXml x (XmlUtil.escape (Base2.name ())) Base2.printXml y (XmlUtil.escape (Base3.name ())) Base3.printXml z
@@ -548,10 +525,23 @@ struct
   let to_yojson (x, y, z) =
     `Assoc [ (Base1.name (), Base1.to_yojson x); (Base2.name (), Base2.to_yojson y); (Base3.name (), Base3.to_yojson z) ]
 
-  let name () = Base1.name () ^ " * " ^ Base2.name () ^ " * " ^ Base3.name ()
+  (* Not using Prod3Conf for printXml and to_yojson, because cannot omit name there. *)
+  open struct
+    module Base1 = PrefixName (struct let expand = Conf.expand1 end) (Base1)
+    module Base2 = PrefixName (struct let expand = Conf.expand2 end) (Base2)
+    module Base3 = PrefixName (struct let expand = Conf.expand3 end) (Base3)
+  end
+
+  let pretty () (x, y, z) =
+    Pretty.dprintf "(%a, %a, %a)" Base1.pretty x Base2.pretty y Base3.pretty z
+
+  let show (x, y, z) =
+    "(" ^ Base1.show x ^ ", " ^ Base2.show y ^ ", " ^ Base3.show z ^ ")"
 
   let arbitrary () = QCheck.triple (Base1.arbitrary ()) (Base2.arbitrary ()) (Base3.arbitrary ())
 end
+
+module Prod3 = Prod3Conf (DefaultConf)
 
 module PQueue (Base: S) =
 struct

--- a/src/common/domains/printable.ml
+++ b/src/common/domains/printable.ml
@@ -470,47 +470,18 @@ struct
     | `Lifted2 x -> Base2.to_yojson x
 end
 
-module type ProdConfiguration =
+module type ProdConf =
 sig
-  val expand_fst: bool
-  val expand_snd: bool
+  val expand1: bool
+  val expand2: bool
 end
 
-module ProdConf (C: ProdConfiguration) (Base1: S) (Base2: S)=
+module ProdConf (Conf: ProdConf) (Base1: S) (Base2: S) =
 struct
-  include C
-
   type t = Base1.t * Base2.t [@@deriving eq, ord, hash, relift]
-
   include Std
 
-  let show (x,y) =
-    (* TODO: remove ref *)
-    let first  = ref "" in
-    let second = ref "" in
-    first  := Base1.show x;
-    second := Base2.show y;
-    "(" ^ !first ^ ", " ^ !second ^ ")"
-
   let name () = Base1.name () ^ " * " ^ Base2.name ()
-
-  let pretty () (x,y) =
-    if expand_fst || expand_snd then
-      text "("
-      ++ text (Base1.name ())
-      ++ text ":"
-      ++ align
-      ++ (if expand_fst then Base1.pretty () x else text (Base1.show x))
-      ++ unalign
-      ++ text ", "
-      ++ text (Base2.name ())
-      ++ text ":"
-      ++ align
-      ++ (if expand_snd then Base2.pretty () y else text (Base2.show y))
-      ++ unalign
-      ++ text ")"
-    else
-      text (show (x,y))
 
   let printXml f (x,y) =
     BatPrintf.fprintf f "<value>\n<map>\n<key>\n%s\n</key>\n%a<key>\n%s\n</key>\n%a</map>\n</value>\n" (XmlUtil.escape (Base1.name ())) Base1.printXml x (XmlUtil.escape (Base2.name ())) Base2.printXml y
@@ -518,10 +489,22 @@ struct
   let to_yojson (x, y) =
     `Assoc [ (Base1.name (), Base1.to_yojson x); (Base2.name (), Base2.to_yojson y) ]
 
+  (* Not using ProdConf for printXml and to_yojson, because cannot omit name there. *)
+  open struct
+    module Base1 = PrefixName (struct let expand = Conf.expand1 end) (Base1)
+    module Base2 = PrefixName (struct let expand = Conf.expand2 end) (Base2)
+  end
+
+  let pretty () (x, y) =
+    Pretty.dprintf "(%a, %a)" Base1.pretty x Base2.pretty y
+
+  let show (x, y) =
+    "(" ^ Base1.show x ^ ", " ^ Base2.show y ^ ")"
+
   let arbitrary () = QCheck.pair (Base1.arbitrary ()) (Base2.arbitrary ())
 end
 
-module Prod = ProdConf (struct let expand_fst = true let expand_snd = true end)
+module Prod = ProdConf (DefaultConf)
 
 module Prod3 (Base1: S) (Base2: S) (Base3: S) =
 struct

--- a/src/domain/lattice.ml
+++ b/src/domain/lattice.ml
@@ -398,7 +398,7 @@ end
 
 module Prod = ProdConf (Printable.DefaultConf)
 
-module Prod3 (Base1: S) (Base2: S) (Base3: S) =
+module Prod3Conf (Conf: Printable.Prod3Conf) (Base1: S) (Base2: S) (Base3: S) =
 struct
   open struct (* open to avoid leaking P and causing conflicts *)
     module P = Printable.Prod3 (Base1) (Base2) (Base3)
@@ -414,6 +414,8 @@ struct
     else
       Base3.pretty_diff () (x3,y3)
 end
+
+module Prod3 = Prod3Conf (Printable.DefaultConf)
 
 module LiftBot (Base : S) =
 struct

--- a/src/domain/lattice.ml
+++ b/src/domain/lattice.ml
@@ -381,10 +381,10 @@ end
 
 module Lift2 = Lift2Conf (Printable.DefaultConf)
 
-module ProdConf (C: Printable.ProdConfiguration) (Base1: S) (Base2: S) =
+module ProdConf (Conf: Printable.ProdConf) (Base1: S) (Base2: S) =
 struct
   open struct (* open to avoid leaking P and causing conflicts *)
-    module P = Printable.ProdConf (C) (Base1) (Base2)
+    module P = Printable.ProdConf (Conf) (Base1) (Base2)
   end
   type t = Base1.t * Base2.t [@@deriving lattice]
   include (P: module type of P with type t := t)
@@ -396,8 +396,7 @@ struct
       Base1.pretty_diff () (x1,y1)
 end
 
-
-module Prod = ProdConf (struct let expand_fst = true let expand_snd = true end)
+module Prod = ProdConf (Printable.DefaultConf)
 
 module Prod3 (Base1: S) (Base2: S) (Base3: S) =
 struct

--- a/src/domain/lattice.ml
+++ b/src/domain/lattice.ml
@@ -398,7 +398,6 @@ end
 
 
 module Prod = ProdConf (struct let expand_fst = true let expand_snd = true end)
-module ProdSimple = ProdConf (struct let expand_fst = false let expand_snd = false end)
 
 module Prod3 (Base1: S) (Base2: S) (Base3: S) =
 struct

--- a/src/domain/setDomain.ml
+++ b/src/domain/setDomain.ml
@@ -208,9 +208,9 @@ end
   * analysis whenever the user elements coincide. Just as above there is no top
   * element, and calling [top ()] will raise an exception *)
 (* TODO: unused *)
-module SensitiveConf (C: Printable.ProdConfiguration) (Base: Lattice.S) (User: Printable.S) =
+module SensitiveConf (Conf: Printable.ProdConf) (Base: Lattice.S) (User: Printable.S) =
 struct
-  module Elt = Printable.ProdConf (C) (Base) (User)
+  module Elt = Printable.ProdConf (Conf) (Base) (User)
   include Make(Elt)
   let name () = "Sensitive " ^ name ()
 

--- a/src/lifters/contextGasLifter.ml
+++ b/src/lifters/contextGasLifter.ml
@@ -33,7 +33,7 @@ struct
       include Base2
       let name () = "context gas"
     end
-    include Lattice.Prod (Base1) (Base2) (* TODO: suppress S.D name? *)
+    include Lattice.ProdConf (struct include Printable.DefaultConf let expand1 = false end) (Base1) (Base2)
     let printXml f (x,y) =
       BatPrintf.fprintf f "\n%a<analysis name=\"context gas value\">\n%a\n</analysis>" Base1.printXml x Base2.printXml y
   end

--- a/src/lifters/specLifters.ml
+++ b/src/lifters/specLifters.ml
@@ -334,7 +334,7 @@ module LevelSliceLifter (S:Spec)
           and module C = S.C
 =
 struct
-  module D = Lattice.Prod (S.D) (LevelSliceDomain) (* TODO: suppress Base name? *)
+  module D = Lattice.ProdConf (struct include Printable.DefaultConf let expand1 = false end) (S.D) (LevelSliceDomain)
   module G = S.G
   module C = S.C
   module V = S.V
@@ -467,7 +467,7 @@ struct
   end
 
   module D = struct
-    include Lattice.Prod (S.D) (M) (* TODO: suppress S.D name? *)
+    include Lattice.ProdConf (struct include Printable.DefaultConf let expand1 = false end) (S.D) (M)
     let printXml f (d,m) = BatPrintf.fprintf f "\n%a<analysis name=\"widen-context\">\n%a\n</analysis>" S.D.printXml d M.printXml m
   end
   module G = S.G

--- a/src/lifters/wideningDelay.ml
+++ b/src/lifters/wideningDelay.ml
@@ -26,7 +26,7 @@ struct
     include Printable.Chain (ChainParams)
     let name () = "widen-delay"
   end
-  include Printable.Prod (Base) (Chain) (* TODO: suppress Base name? *)
+  include Printable.ProdConf (struct include Printable.DefaultConf let expand1 = false end) (Base) (Chain)
 
   let lift d = (d, 0)
   let unlift (d, _) = d

--- a/src/lifters/wideningTokenLifter.ml
+++ b/src/lifters/wideningTokenLifter.ml
@@ -62,7 +62,7 @@ open Analyses
     except widening tokens are used to delay widenings. *)
 module Dom (D: Lattice.S) =
 struct
-  include Lattice.Prod (D) (TS) (* TODO: suppress Base name? *)
+  include Lattice.ProdConf (struct include Printable.DefaultConf let expand1 = false end) (D) (TS)
   let unlift (d, _) = d
   let lift d = (d, TS.bot ())
 

--- a/tests/regression/00-sanity/33-hoare-over-paths.t
+++ b/tests/regression/00-sanity/33-hoare-over-paths.t
@@ -9,219 +9,219 @@
   $ cat pretty.txt
   Mapping {
     33-hoare-over-paths.c:9:7-9:8(main) ->
-      {(MCP.D:[expRelation:(),
-               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-               base:({
-                       Global {
-                         m ->   mutex
-                       }
-                       Local {
-                         r ->   ⊤
-                       }
-                     }, {}, {}, {}),
-               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-               threadflag:Singlethreaded,
-               threadreturn:true,
-               escape:{},
-               mutexEvents:(),
-               access:(),
-               mutex:(lockset:{}, multiplicity:{}),
-               race:(),
-               mhp:(),
-               assert:(),
-               pthreadMutexType:()], widen-context:{})}
+      {([expRelation:(),
+         mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+         base:({
+                 Global {
+                   m ->   mutex
+                 }
+                 Local {
+                   r ->   ⊤
+                 }
+               }, {}, {}, {}),
+         threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+         threadflag:Singlethreaded,
+         threadreturn:true,
+         escape:{},
+         mutexEvents:(),
+         access:(),
+         mutex:(lockset:{}, multiplicity:{}),
+         race:(),
+         mhp:(),
+         assert:(),
+         pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:10:5-10:10(main) ->
-      {(MCP.D:[expRelation:(),
-               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-               base:({
-                       Global {
-                         m ->   mutex
-                       }
-                       Local {
-                         r ->   (Not {0}([-31,31]))
-                       }
-                     }, {}, {}, {}),
-               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-               threadflag:Singlethreaded,
-               threadreturn:true,
-               escape:{},
-               mutexEvents:(),
-               access:(),
-               mutex:(lockset:{}, multiplicity:{}),
-               race:(),
-               mhp:(),
-               assert:(),
-               pthreadMutexType:()], widen-context:{})}
+      {([expRelation:(),
+         mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+         base:({
+                 Global {
+                   m ->   mutex
+                 }
+                 Local {
+                   r ->   (Not {0}([-31,31]))
+                 }
+               }, {}, {}, {}),
+         threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+         threadflag:Singlethreaded,
+         threadreturn:true,
+         escape:{},
+         mutexEvents:(),
+         access:(),
+         mutex:(lockset:{}, multiplicity:{}),
+         race:(),
+         mhp:(),
+         assert:(),
+         pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:11:5-11:24(main) ->
-      {(MCP.D:[expRelation:(),
-               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-               base:({
-                       Global {
-                         m ->   mutex
-                       }
-                       Local {
-                         r ->   0
-                       }
-                     }, {}, {}, {}),
-               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-               threadflag:Singlethreaded,
-               threadreturn:true,
-               escape:{},
-               mutexEvents:(),
-               access:(),
-               mutex:(lockset:{}, multiplicity:{}),
-               race:(),
-               mhp:(),
-               assert:(),
-               pthreadMutexType:()], widen-context:{})}
+      {([expRelation:(),
+         mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+         base:({
+                 Global {
+                   m ->   mutex
+                 }
+                 Local {
+                   r ->   0
+                 }
+               }, {}, {}, {}),
+         threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+         threadflag:Singlethreaded,
+         threadreturn:true,
+         escape:{},
+         mutexEvents:(),
+         access:(),
+         mutex:(lockset:{}, multiplicity:{}),
+         race:(),
+         mhp:(),
+         assert:(),
+         pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:15:5-15:27(main) ->
-      {(MCP.D:[expRelation:(),
-               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-               base:({
-                       Global {
-                         m ->   mutex
-                       }
-                       Local {
-                         r ->   0
-                       }
-                     }, {}, {}, {}),
-               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-               threadflag:Singlethreaded,
-               threadreturn:true,
-               escape:{},
-               mutexEvents:(),
-               access:(),
-               mutex:(lockset:{}, multiplicity:{}),
-               race:(),
-               mhp:(),
-               assert:(),
-               pthreadMutexType:()], widen-context:{})}
+      {([expRelation:(),
+         mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+         base:({
+                 Global {
+                   m ->   mutex
+                 }
+                 Local {
+                   r ->   0
+                 }
+               }, {}, {}, {}),
+         threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+         threadflag:Singlethreaded,
+         threadreturn:true,
+         escape:{},
+         mutexEvents:(),
+         access:(),
+         mutex:(lockset:{}, multiplicity:{}),
+         race:(),
+         mhp:(),
+         assert:(),
+         pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:16:5-16:24(main) ->
-      {(MCP.D:[expRelation:(),
-               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-               base:({
-                       Global {
-                         m ->   mutex
-                       }
-                       Local {
-                         r ->   0
-                       }
-                     }, {}, {}, {}),
-               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-               threadflag:Singlethreaded,
-               threadreturn:true,
-               escape:{},
-               mutexEvents:(),
-               access:(),
-               mutex:(lockset:{m}, multiplicity:{}),
-               race:(),
-               mhp:(),
-               assert:(),
-               pthreadMutexType:()], widen-context:{})}
+      {([expRelation:(),
+         mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+         base:({
+                 Global {
+                   m ->   mutex
+                 }
+                 Local {
+                   r ->   0
+                 }
+               }, {}, {}, {}),
+         threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+         threadflag:Singlethreaded,
+         threadreturn:true,
+         escape:{},
+         mutexEvents:(),
+         access:(),
+         mutex:(lockset:{m}, multiplicity:{}),
+         race:(),
+         mhp:(),
+         assert:(),
+         pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:33:10-33:11(main) ->
-      {(MCP.D:[expRelation:(),
-               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-               base:({
-                       Global {
-                         m ->   mutex
-                       }
-                       Local {
-                         r ->   0
-                       }
-                     }, {}, {}, {}),
-               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-               threadflag:Singlethreaded,
-               threadreturn:true,
-               escape:{},
-               mutexEvents:(),
-               access:(),
-               mutex:(lockset:{m}, multiplicity:{}),
-               race:(),
-               mhp:(),
-               assert:(),
-               pthreadMutexType:()], widen-context:{}),
-       (MCP.D:[expRelation:(),
-               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-               base:({
-                       Global {
-                         m ->   mutex
-                       }
-                       Local {
-                         r ->   0
-                       }
-                     }, {}, {}, {}),
-               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-               threadflag:Singlethreaded,
-               threadreturn:true,
-               escape:{},
-               mutexEvents:(),
-               access:(),
-               mutex:(lockset:{}, multiplicity:{}),
-               race:(),
-               mhp:(),
-               assert:(),
-               pthreadMutexType:()], widen-context:{})}
+      {([expRelation:(),
+         mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+         base:({
+                 Global {
+                   m ->   mutex
+                 }
+                 Local {
+                   r ->   0
+                 }
+               }, {}, {}, {}),
+         threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+         threadflag:Singlethreaded,
+         threadreturn:true,
+         escape:{},
+         mutexEvents:(),
+         access:(),
+         mutex:(lockset:{m}, multiplicity:{}),
+         race:(),
+         mhp:(),
+         assert:(),
+         pthreadMutexType:()], widen-context:{}),
+       ([expRelation:(),
+         mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+         base:({
+                 Global {
+                   m ->   mutex
+                 }
+                 Local {
+                   r ->   0
+                 }
+               }, {}, {}, {}),
+         threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+         threadflag:Singlethreaded,
+         threadreturn:true,
+         escape:{},
+         mutexEvents:(),
+         access:(),
+         mutex:(lockset:{}, multiplicity:{}),
+         race:(),
+         mhp:(),
+         assert:(),
+         pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:7:1-34:1(main) ->
-      {(MCP.D:[expRelation:(),
-               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-               base:({
-                       Global {
-                         m ->   mutex
-                       }
-                     }, {}, {}, {}),
-               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-               threadflag:Singlethreaded,
-               threadreturn:true,
-               escape:{},
-               mutexEvents:(),
-               access:(),
-               mutex:(lockset:{}, multiplicity:{}),
-               race:(),
-               mhp:(),
-               assert:(),
-               pthreadMutexType:()], widen-context:{})}
+      {([expRelation:(),
+         mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+         base:({
+                 Global {
+                   m ->   mutex
+                 }
+               }, {}, {}, {}),
+         threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+         threadflag:Singlethreaded,
+         threadreturn:true,
+         escape:{},
+         mutexEvents:(),
+         access:(),
+         mutex:(lockset:{}, multiplicity:{}),
+         race:(),
+         mhp:(),
+         assert:(),
+         pthreadMutexType:()], widen-context:{})}
     33-hoare-over-paths.c:7:1-34:1(main) ->
-      {(MCP.D:[expRelation:(),
-               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-               base:({
-                       Global {
-                         m ->   mutex
-                       }
-                       Temp {
-                         RETURN ->   0
-                       }
-                     }, {}, {}, {}),
-               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-               threadflag:Singlethreaded,
-               threadreturn:true,
-               escape:{},
-               mutexEvents:(),
-               access:(),
-               mutex:(lockset:{m}, multiplicity:{}),
-               race:(),
-               mhp:(),
-               assert:(),
-               pthreadMutexType:()], widen-context:{}),
-       (MCP.D:[expRelation:(),
-               mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
-               base:({
-                       Global {
-                         m ->   mutex
-                       }
-                       Temp {
-                         RETURN ->   0
-                       }
-                     }, {}, {}, {}),
-               threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
-               threadflag:Singlethreaded,
-               threadreturn:true,
-               escape:{},
-               mutexEvents:(),
-               access:(),
-               mutex:(lockset:{}, multiplicity:{}),
-               race:(),
-               mhp:(),
-               assert:(),
-               pthreadMutexType:()], widen-context:{})}
+      {([expRelation:(),
+         mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+         base:({
+                 Global {
+                   m ->   mutex
+                 }
+                 Temp {
+                   RETURN ->   0
+                 }
+               }, {}, {}, {}),
+         threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+         threadflag:Singlethreaded,
+         threadreturn:true,
+         escape:{},
+         mutexEvents:(),
+         access:(),
+         mutex:(lockset:{m}, multiplicity:{}),
+         race:(),
+         mhp:(),
+         assert:(),
+         pthreadMutexType:()], widen-context:{}),
+       ([expRelation:(),
+         mallocWrapper:(wrapper call:Unknown node, unique calls:{}),
+         base:({
+                 Global {
+                   m ->   mutex
+                 }
+                 Temp {
+                   RETURN ->   0
+                 }
+               }, {}, {}, {}),
+         threadid:(wrapper call:unknown node, Thread:[main], created:(current function:bot, callees:bot)),
+         threadflag:Singlethreaded,
+         threadreturn:true,
+         escape:{},
+         mutexEvents:(),
+         access:(),
+         mutex:(lockset:{}, multiplicity:{}),
+         race:(),
+         mhp:(),
+         assert:(),
+         pthreadMutexType:()], widen-context:{})}
     OTHERS -> Not available
   }


### PR DESCRIPTION
This continues with some TODOs from #2118.

This changes the meaning of `Conf` for `ProdConf` and `Prod3Conf` to match the behavior from #1294 for `EitherConf`, etc.
Notably, the `expand*` booleans don't choose whether to output `show` or `pretty` (which should be the same), but rather whether to add the inner domain name prefix.
This allows the prefix to be omitted in `Spec` lifters for the `MCP.D` side, which is self-explanatory by construction (see changed cram test).

While doing so, this finally cleans up `Printable.ProdConf` and `Printable.Prod3Conf` to not use pointless `ref`s.