### PR TITLE
Mod bounds unsoundness

### DIFF
--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -342,19 +342,24 @@ struct
         let a' = ID.add (ID.mul (ID.div a b) b) c in
         let b' = ID.div (ID.sub a c) (ID.div a b) in
         (* However, for [2,4]%2 == 1 this only gives [3,4].
-         * If the upper bound of a is divisible by b, we can also meet with the result of a/b*b - c to get the precise [3,3].
-         * If b is negative we have to look at the lower bound. *)
-        let is_divisible bound =
-          (* TODO: could check divisibility directly, instead of via ID? *)
-          GobOption.exists (fun ba -> ID.equal_to Z.zero (ID.rem (ID.of_int ikind ba) b) = `Eq) (bound a)
-        in
-        let max_pos = match ID.maximal b with None -> true | Some x -> Z.compare x Z.zero >= 0 in
-        let min_neg = match ID.minimal b with None -> true | Some x -> Z.compare x Z.zero < 0 in
-        let implies a b = not a || b in
+         * Since [a % b == c] implies that [a] is congruent to [c] modulo [b], every known
+         * bound of [a] can be moved inwards to the closest value congruent to [c] modulo [b].
+         * Here the upper bound 4 moves to 3, which gives the precise [3,3]. *)
         let a'' =
-          if implies max_pos (is_divisible ID.maximal) && implies min_neg (is_divisible ID.minimal) then
-            ID.meet a' (ID.sub (ID.mul (ID.div a b) b) c)
-          else a'
+          match ID.to_int b, ID.to_int c with
+          | Some b, Some c when not (Z.equal b Z.zero) ->
+            (* To handle signs uniformly, we tighten the upper bound m by subtracting the
+             * always positive Euclidean remainder of (m - c) modulo b, which is the precise
+             * amount that m is too high. And symmetrically for the lower bound. *)
+            let a' = match ID.maximal a with
+              | Some m -> ID.meet a' (ID.ending ~suppress_ovwarn:true ikind (Z.sub m (Z.erem (Z.sub m c) b)))
+              | None -> a'
+            in
+            begin match ID.minimal a with
+              | Some m -> ID.meet a' (ID.starting ~suppress_ovwarn:true ikind (Z.add m (Z.erem (Z.sub c m) b)))
+              | None -> a'
+            end
+          | _, _ -> a'
         in
         let a''' =
           (* if both b and c are definite, we can get a precise value in the congruence domain *)

--- a/tests/regression/27-inv_invariants/26-mod-bounds.c
+++ b/tests/regression/27-inv_invariants/26-mod-bounds.c
@@ -1,0 +1,47 @@
+// PARAM: --enable ana.int.interval
+// Refining the interval of a in "a % b == c" must only move the bounds of a to values
+// that are congruent to c modulo b, otherwise satisfying values are cut away.
+#include <goblint.h>
+
+int main() {
+  int x;
+  if (x > 1 && x < 5 && x % 2 == 1) // x = [2,4] && x % 2 == 1 => x = 3
+    __goblint_check(x == 3);
+
+  int y;
+  if (y >= -4 && y <= -2 && y % 2 == -1) // y = [-4,-2] && y % 2 == -1 => y = -3
+    __goblint_check(y == -3);
+
+  // The upper bound 3 is divisible by 3, so it cannot be attained, but 2 still can.
+  // Used to be considered dead because the bound was moved to 3-2=1 instead of 3-(3-2)=2.
+  int z;
+  if (z >= 0 && z <= 3 && z % 3 == 2)
+    __goblint_check(z == 2); // TODO
+
+  // Same for a negative divisor, where only the magnitude of b matters.
+  int n;
+  if (n >= -28 && n <= -22 && n % -7 == -5)
+    __goblint_check(n == -26); // TODO
+
+  // Test to show both refinements are needed. The congruence shift accepts 1,
+  // but the original mod refinement restricts the sign to negative, so <= -2.
+  int s;
+  if (s >= -12 && s <= 1 && s % 3 == -2) { // s = -11, -8, -5, -2
+    __goblint_check(s >= -11); // TODO
+    __goblint_check(s <= -2);
+  }
+
+  int w;
+  if (w >= 0 && w <= 48 && w % 3 == 1) { // w = 1, 4, ..., 46
+    __goblint_check(w >= 1);
+    __goblint_check(w <= 46); // TODO
+  }
+
+  int v;
+  if (v >= 0 && v <= 48 && v % 3 == 0) { // bounds are already congruent, must not move
+    __goblint_check(v >= 0);
+    __goblint_check(v <= 48);
+  }
+
+  return 0;
+}

--- a/tests/regression/27-inv_invariants/26-mod-bounds.c
+++ b/tests/regression/27-inv_invariants/26-mod-bounds.c
@@ -16,25 +16,25 @@ int main() {
   // Used to be considered dead because the bound was moved to 3-2=1 instead of 3-(3-2)=2.
   int z;
   if (z >= 0 && z <= 3 && z % 3 == 2)
-    __goblint_check(z == 2); // TODO
+    __goblint_check(z == 2);
 
   // Same for a negative divisor, where only the magnitude of b matters.
   int n;
   if (n >= -28 && n <= -22 && n % -7 == -5)
-    __goblint_check(n == -26); // TODO
+    __goblint_check(n == -26);
 
   // Test to show both refinements are needed. The congruence shift accepts 1,
   // but the original mod refinement restricts the sign to negative, so <= -2.
   int s;
   if (s >= -12 && s <= 1 && s % 3 == -2) { // s = -11, -8, -5, -2
-    __goblint_check(s >= -11); // TODO
+    __goblint_check(s >= -11);
     __goblint_check(s <= -2);
   }
 
   int w;
   if (w >= 0 && w <= 48 && w % 3 == 1) { // w = 1, 4, ..., 46
     __goblint_check(w >= 1);
-    __goblint_check(w <= 46); // TODO
+    __goblint_check(w <= 46);
   }
 
   int v;

--- a/tests/regression/27-inv_invariants/27-mod-bounds-congruence.c
+++ b/tests/regression/27-inv_invariants/27-mod-bounds-congruence.c
@@ -1,0 +1,20 @@
+// PARAM: --enable ana.int.interval --enable ana.int.congruence
+// The interval refinement for "a % b == c" also constrains the congruence domain, so it
+// must not meet with a value that is incongruent to c modulo b: that made the branch below
+// bot with interval and congruence enabled together, while either domain alone got it right.
+#include <goblint.h>
+
+int main() {
+  int t;
+  if (t >= 0 && t <= 48 && t % 3 == 1) // e.g. t = 4
+    __goblint_check(1); // TODO reachable
+
+  int p;
+  if (p >= 0 && p <= 24) {
+    int u = 2 * p;
+    if (u % 3 == 1) // e.g. p = 2 gives u = 4 and 4 % 3 == 1
+      __goblint_check(1); // TODO reachable
+  }
+
+  return 0;
+}

--- a/tests/regression/27-inv_invariants/27-mod-bounds-congruence.c
+++ b/tests/regression/27-inv_invariants/27-mod-bounds-congruence.c
@@ -7,13 +7,13 @@
 int main() {
   int t;
   if (t >= 0 && t <= 48 && t % 3 == 1) // e.g. t = 4
-    __goblint_check(1); // TODO reachable
+    __goblint_check(1); // reachable
 
   int p;
   if (p >= 0 && p <= 24) {
     int u = 2 * p;
     if (u % 3 == 1) // e.g. p = 2 gives u = 4 and 4 % 3 == 1
-      __goblint_check(1); // TODO reachable
+      __goblint_check(1); // reachable
   }
 
   return 0;


### PR DESCRIPTION
This fixes unsound invariant refinement for the mod operation. The issue I ran into was when having intervals and congruences enabled, there was some weird unsoundness that Claude had to debug. I don't even remember what I was doing... But the code it isolated and rewrote is so clearly an improvement that I think it's worth taking. The previous code is very confusing, even to understand what the intention was, and it's also very wrong.

So the main unsoundness was actually that it would just brutally meet with a refined bound, which is very destructive for the congruence domain itself, since it just results in bot. This now relies on meeting with the half-planes ID.starting/ending, so that it is up to the domain to give its best sound representation of that, which is top for congruences. This fixes the unsoundness in 27/27 (mod-bounds-congruence).

The other things were discovered by accident, but is almost more important since it's pure interval unsoundness where some values are refined too aggressively; tests in 27/26 (mod-bounds) also show precision improvements.