### PR TITLE
Introduce `Var` abstraction

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -51,13 +51,13 @@ struct
 
   (* Functions for manipulating globals as temporary locals. *)
 
-  let read_global ask getg st g x =
+  let read_global ask getg st (Var.Cil vi as g) x =
     if ThreadFlag.has_ever_been_multi ask then
       Priv.read_global ask getg st g x
     else (
       let rel = st.rel in
       (* If it has escaped and we have never been multi-threaded, we can still refer to the local *)
-      let g_var = if g.vglob then RV.global g else RV.local g in
+      let g_var = if vi.vglob then RV.global g else RV.local g in
       let x_var = RV.local x in
       let rel' = RD.add_vars rel [g_var] in
       let rel' = RD.assign_var rel' x_var g_var in
@@ -87,10 +87,10 @@ struct
     end
     in
     let e' = visitCilExpr visitor e in
-    let rel = RD.add_vars st.rel (List.map RV.local (VH.to_seq_values v_ins |> List.of_seq)) in (* add temporary g#in-s *)
+    let rel = RD.add_vars st.rel (List.map RV.local (VH.to_seq_values v_ins |> Seq.map (fun v_in -> Var.Cil v_in) |> List.of_seq)) in (* add temporary g#in-s *)
     let rel' = VH.fold (fun v v_in rel ->
         if M.tracing then M.trace "relation" "read_global %a %a" CilType.Varinfo.pretty v CilType.Varinfo.pretty v_in;
-        read_global ask getg {st with rel} v v_in (* g#in = g; *)
+        read_global ask getg {st with rel} (Cil v) (Cil v_in) (* g#in = g; *)
       ) v_ins rel
     in
     (rel', e', v_ins)
@@ -102,9 +102,9 @@ struct
         v_in.vattr <- v.vattr; (* preserve goblint_relation_track attribute *)
         VH.replace v_ins_inv v_in v;
       ) vs;
-    let rel = RD.add_vars st.rel (List.map RV.local (VH.to_seq_keys v_ins_inv |> List.of_seq)) in (* add temporary g#in-s *)
+    let rel = RD.add_vars st.rel (List.map RV.local (VH.to_seq_keys v_ins_inv |> Seq.map (fun v_in -> Var.Cil v_in) |> List.of_seq)) in (* add temporary g#in-s *)
     let rel' = VH.fold (fun v_in v rel ->
-        read_global ask getg {st with rel} v v_in (* g#in = g; *)
+        read_global ask getg {st with rel} (Cil v) (Cil v_in) (* g#in = g; *)
       ) v_ins_inv rel
     in
     let visitor_inv = object
@@ -126,7 +126,7 @@ struct
     let (rel', e', v_ins) = read_globals_to_locals ask getg st e in
     if M.tracing then M.trace "relation" "assign_from_globals_wrapper %a" d_exp e';
     let rel' = f rel' e' in (* x = e; *)
-    let rel'' = RD.remove_vars rel' (List.map RV.local (VH.to_seq_values v_ins |> List.of_seq)) in (* remove temporary g#in-s *)
+    let rel'' = RD.remove_vars rel' (List.map RV.local (VH.to_seq_values v_ins |> Seq.map (fun v_in -> Var.Cil v_in) |> List.of_seq)) in (* remove temporary g#in-s *)
     rel''
 
   let write_global ask getg sideg st g x =
@@ -153,11 +153,11 @@ struct
       else (
         let v_out = Cilfacade.create_var @@ makeVarinfo false (v.vname ^ "#out") v.vtype in (* temporary local g#out for global g *)
         v_out.vattr <- v.vattr; (*copy the attributes because the tracking may depend on them. Otherwise an assertion fails *)
-        let st = {st with rel = RD.add_vars st.rel [RV.local v_out]} in (* add temporary g#out *)
+        let st = {st with rel = RD.add_vars st.rel [RV.local (Cil v_out)]} in (* add temporary g#out *)
         let st' = {st with rel = f st v_out} in (* g#out = e; *)
         if M.tracing then M.trace "relation" "write_global %a %a" CilType.Varinfo.pretty v CilType.Varinfo.pretty v_out;
-        let st' = write_global ask getg sideg st' v v_out in (* g = g#out; *)
-        let rel'' = RD.remove_vars st'.rel [RV.local v_out] in (* remove temporary g#out *)
+        let st' = write_global ask getg sideg st' (Cil v) (Cil v_out) in (* g = g#out; *)
+        let rel'' = RD.remove_vars st'.rel [RV.local (Cil v_out)] in (* remove temporary g#out *)
         {st' with rel = rel''}
       )
     | (Mem v, NoOffset) ->
@@ -255,7 +255,7 @@ struct
         assign_from_globals_wrapper ask man.global st simplified_e (fun apr' e' ->
             if M.tracing then M.traceli "relation" "assign inner %a = %a (%a)" CilType.Varinfo.pretty v d_exp e' d_plainexp e';
             if M.tracing then M.trace "relation" "st: %a" RD.pretty apr';
-            let r = RD.assign_exp ask apr' (RV.local v) e' (no_overflow ask simplified_e) in
+            let r = RD.assign_exp ask apr' (RV.local (Cil v)) e' (no_overflow ask simplified_e) in
             let r' = assert_type_bounds ask r v in
             if M.tracing then M.traceu "relation" "-> %a" RD.pretty r';
             r'
@@ -306,7 +306,7 @@ struct
     let st = man.local in
     let arg_assigns =
       GobList.combine_short f.sformals args (* TODO: is it right to ignore missing formals/args? *)
-      |> List.filter_map (fun (x, e) ->  if RD.Tracked.varinfo_tracked x then Some (RV.arg x, e) else None)
+      |> List.filter_map (fun (x, e) ->  if RD.Tracked.varinfo_tracked x then Some (RV.arg (Cil x), e) else None)
     in
     let arg_vars = List.map fst arg_assigns in
     let new_rel = RD.add_vars st.rel arg_vars in
@@ -343,13 +343,13 @@ struct
     let ask = Analyses.ask_of_man man in
     let formals = List.filter RD.Tracked.varinfo_tracked f.sformals in
     let locals = List.filter RD.Tracked.varinfo_tracked f.slocals in
-    let new_rel = RD.add_vars st.rel (List.map RV.local (formals @ locals)) in
+    let new_rel = RD.add_vars st.rel (List.map (fun x -> RV.local (Cil x)) (formals @ locals)) in
     (* TODO: do this after local_assigns? *)
     let new_rel = List.fold_left (fun new_rel x ->
         assert_type_bounds ask new_rel x
       ) new_rel (formals @ locals)
     in
-    let local_assigns = List.map (fun x -> (RV.local x, RV.arg x)) formals in
+    let local_assigns = List.map (fun x -> (RV.local (Cil x), RV.arg (Cil x))) formals in
     RD.assign_var_parallel_with new_rel local_assigns; (* doesn't need to be parallel since arg vars aren't local vars *)
     {st with rel = new_rel}
 
@@ -371,7 +371,7 @@ struct
     let local_vars =
       f.sformals @ f.slocals
       |> List.filter RD.Tracked.varinfo_tracked
-      |> List.map RV.local
+      |> List.map (fun x -> RV.local (Cil x))
     in
     RD.remove_vars_with new_rel local_vars;
     let st' = {st with rel = new_rel} in
@@ -400,7 +400,7 @@ struct
       GobList.combine_short f.sformals args (* TODO: is it right to ignore missing formals/args? *)
       (* Do not do replacement for actuals whose value may be modified after the call *)
       |> List.filter filter_actuals
-      |> List.map (Tuple2.map1 RV.arg)
+      |> List.map (Tuple2.map1 (fun x -> RV.arg (Cil x)))
     in
     (* RD.substitute_exp_parallel_with new_fun_rel arg_substitutes; (* doesn't need to be parallel since exps aren't arg vars directly *) *)
     (* TODO: parallel version of assign_from_globals_wrapper? *)
@@ -415,7 +415,7 @@ struct
       ) new_fun_rel arg_substitutes
     in
     let any_local_reachable = any_local_reachable fundec reachable_from_args in
-    let arg_vars = f.sformals |> List.filter (RD.Tracked.varinfo_tracked) |> List.map RV.arg in
+    let arg_vars = f.sformals |> List.filter (RD.Tracked.varinfo_tracked) |> List.map (fun x -> RV.arg (Cil x)) in
     if M.tracing then M.tracel "combine-rel" "relation remove vars: %a" (docList (GobApron.Var.pretty ())) arg_vars;
     RD.remove_vars_with new_fun_rel arg_vars; (* fine to remove arg vars that also exist in caller because unify from new_rel adds them back with proper constraints *)
     let tainted = f_ask.f Queries.MayBeTainted in
@@ -443,7 +443,7 @@ struct
       let unify_st' = Option.map_default (fun lv ->
           let ask = Analyses.ask_of_man man in
           assign_to_global_wrapper ask man.global man.sideg unify_st lv (fun st v ->
-              let rel = RD.assign_var st.rel (RV.local v) RV.return in
+              let rel = RD.assign_var st.rel (RV.local (Cil v)) RV.return in
               assert_type_bounds ask rel v (* TODO: should be done in return instead *)
             )
         ) unify_st r
@@ -456,7 +456,7 @@ struct
 
   let invalidate_one ask man st lv =
     assign_to_global_wrapper ask man.global man.sideg st lv (fun st v ->
-        let rel' = RD.forget_vars st.rel [RV.local v] in
+        let rel' = RD.forget_vars st.rel [RV.local (Cil v)] in
         assert_type_bounds ask rel' v (* re-establish type bounds after forget *) (* TODO: no_overflow on wrapped *)
       )
 
@@ -581,6 +581,7 @@ struct
           else
             [] (* avoid pointless queries *)
         in
+        let priv_vars = List.map (fun (Var.Cil g) -> g) priv_vars in
         let (rel, e_inv, v_ins_inv) = read_globals_to_locals_inv ask man.global man.local priv_vars in
         (* filter variables *)
         let var_filter v = match RV.find_metadata v with
@@ -707,7 +708,7 @@ struct
       let (rel, e, v_ins) = read_globals_to_locals ask man.global man.local e in
 
       let vars = Basetype.CilExp.get_vars e |> List.unique ~eq:CilType.Varinfo.equal |> List.filter RD.Tracked.varinfo_tracked in
-      let rel = RD.forget_vars rel (List.map RV.local vars) in (* havoc *)
+      let rel = RD.forget_vars rel (List.map (fun x -> RV.local (Cil x)) vars) in (* havoc *)
       let rel = List.fold_left (assert_type_bounds ask) rel vars in (* add type bounds to avoid overflow in top state *)
       let rec dummyask =
         (* assert_inv calls texpr1_expr_of_cil_exp, which simplifies the constraint based on the pre-state of the transition;
@@ -734,7 +735,7 @@ struct
       let rel = RD.assert_inv dummyask rel e false (no_overflow ask e_orig) in (* assume *)
       let rel =
         if GobConfig.get_bool "ana.apron.strengthening" then
-          RD.keep_vars rel (List.map RV.local vars) (* restrict *)
+          RD.keep_vars rel (List.map (fun x -> RV.local (Cil x)) vars) (* restrict *)
         else
           rel (* naive unassume: will be homogeneous join below *)
       in
@@ -744,11 +745,11 @@ struct
         WideningTokenLifter.with_side_tokens (WideningTokenLifter.TS.of_list tokens) (fun () ->
             VH.fold (fun v v_in st ->
                 (* TODO: is this sideg fine? *)
-                write_global ask man.global man.sideg st v v_in
+                write_global ask man.global man.sideg st (Cil v) (Cil v_in)
               ) v_ins {man.local with rel}
           )
       in
-      let rel = RD.remove_vars st.rel (List.map RV.local (VH.to_seq_values v_ins |> List.of_seq)) in (* remove temporary g#in-s *)
+      let rel = RD.remove_vars st.rel (List.map (fun x -> RV.local (Cil x)) (VH.to_seq_values v_ins |> List.of_seq)) in (* remove temporary g#in-s *)
 
       if M.tracing then M.traceli "apron" "unassume join";
       let st = D.join man.local {st with rel} in (* (strengthening) join *)

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -29,11 +29,11 @@ module type S =
     val name: unit -> string
     val startstate: unit -> D.t
 
-    val read_global: Q.ask -> (V.t -> G.t) -> relation_components_t -> varinfo -> varinfo -> RD.t
+    val read_global: Q.ask -> (V.t -> G.t) -> relation_components_t -> Var.t -> Var.t -> RD.t
 
     (* [invariant]: Check if we should avoid producing a side-effect, such as updates to
        the state when following conditional guards. *)
-    val write_global: ?invariant:bool -> Q.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> relation_components_t -> varinfo -> varinfo -> relation_components_t
+    val write_global: ?invariant:bool -> Q.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> relation_components_t -> Var.t -> Var.t -> relation_components_t
 
     val lock: Q.ask -> (V.t -> G.t) -> relation_components_t -> LockDomain.MustLock.t -> relation_components_t
     val unlock: Q.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> relation_components_t -> LockDomain.MustLock.t -> relation_components_t
@@ -51,7 +51,7 @@ module type S =
     val invariant_global: Q.ask -> (V.t -> G.t) -> V.t -> Invariant.t
     (** Returns flow-insensitive invariant for global unknown. *)
 
-    val invariant_vars: Q.ask -> (V.t -> G.t) -> relation_components_t -> varinfo list
+    val invariant_vars: Q.ask -> (V.t -> G.t) -> relation_components_t -> Var.t list
     (** Returns global variables which are privatized. *)
 
     val init: unit -> unit
@@ -210,9 +210,9 @@ struct
   struct
     include RelationDomain.VarMetadataTbl (VM)
 
-    let local g = make_var (Local g)
-    let unprot g = make_var (Unprot g)
-    let prot g = make_var (Prot g)
+    let local (Var.Cil g) = make_var (Local g)
+    let unprot (Var.Cil g) = make_var (Unprot g)
+    let prot (Var.Cil g) = make_var (Prot g)
   end
 
   let name () = "ProtectionBasedPriv"
@@ -227,12 +227,12 @@ struct
 
   (** Restrict environment to local variables and still-protected global variables. *)
   let restrict_local is_unprot rel w_remove =
-    let remove_local_vars = List.map AV.local (List.map (fun (Var.Cil v) -> v) (W.elements w_remove)) in
+    let remove_local_vars = List.map AV.local (W.elements w_remove) in
     let rel' = RD.remove_vars rel remove_local_vars in
     (* remove global vars *)
     RD.remove_filter rel' (fun var ->
         match AV.find_metadata var with
-        | Some (Unprot g | Prot g) -> is_unprot g
+        | Some (Unprot g | Prot g) -> is_unprot (Var.Cil g)
         | _ -> false
       )
 
@@ -244,15 +244,15 @@ struct
     let g_local_var = AV.local g in
     let x_var = AV.local x in
     let rel_local =
-      if W.mem (Cil g) w then
+      if W.mem g w then
         RD.assign_var rel x_var g_local_var
       else
         RD.bot ()
     in
     let rel_local' =
-      if P.mem (Cil g) p then
+      if P.mem g p then
         rel_local
-      else if is_unprotected ask (Cil g) then (
+      else if is_unprotected ask g then (
         let g_unprot_var = AV.unprot g in
         let rel_unprot = RD.add_vars rel [g_unprot_var] in
         let rel_unprot = RD.assign_var rel_unprot x_var g_unprot_var in
@@ -271,7 +271,7 @@ struct
         RD.join rel_local rel_prot
       )
     in
-    let rel_local' = restrict_local (fun g -> is_unprotected ask (Cil g)) rel_local' (W.empty ()) in
+    let rel_local' = restrict_local (is_unprotected ask) rel_local' (W.empty ()) in
     let rel_local' = RD.meet rel_local' (getg ()) in
     rel_local'
 
@@ -294,12 +294,12 @@ struct
          else
          (* restricting g#unprot-s out from oct' gives oct_local *)
          {oct = oct_local; priv = (P.add g p, W.add g w)} *)
-      if is_unprotected ask (Cil g) then
-        {st with rel = restrict_local (fun g -> is_unprotected ask (Cil g)) rel' (W.singleton (Cil g))}
+      if is_unprotected ask g then
+        {st with rel = restrict_local (is_unprotected ask) rel' (W.singleton g)}
       else (
-        let p' = P.add (Cil g) p in
-        let w' = W.add (Cil g) w in
-        {rel = restrict_local (fun g -> is_unprotected ask (Cil g)) rel' (W.empty ()); priv = (p', w')}
+        let p' = P.add g p in
+        let w' = W.add g w in
+        {rel = restrict_local (is_unprotected ask) rel' (W.empty ()); priv = (p', w')}
       )
     in
     let rel_local' = RD.meet st'.rel (getg ()) in
@@ -331,7 +331,6 @@ struct
         )
     in
     let rel_side = List.fold_left (fun acc omega ->
-        let omega = List.map (fun (Var.Cil g) -> g) omega in
         let g_prot_vars = List.map AV.prot omega in
         let g_local_vars = List.map AV.local omega in
         let rel_side1 = RD.add_vars rel g_prot_vars in
@@ -342,7 +341,7 @@ struct
     let rel' = rel_side in
     let rel_side = restrict_global rel_side in
     sideg () rel_side;
-    let rel_local = restrict_local (fun g -> is_unprotected_without ask (Cil g) m) rel' w_remove in
+    let rel_local = restrict_local (fun g -> is_unprotected_without ask g m) rel' w_remove in
     let rel_local' = RD.meet rel_local (getg ()) in
     {rel = rel_local'; priv = (p', w')}
 
@@ -362,7 +361,7 @@ struct
           |> List.to_seq
           |> Seq.filter_map (fun var ->
               match RD.V.find_metadata var with
-              | Some (Global g) -> Some (var, g)
+              | Some (Global g) -> Some (var, Var.Cil g)
               | _ -> None
             )
           |> Seq.unzip
@@ -410,7 +409,7 @@ struct
       |> List.to_seq
       |> Seq.filter_map (fun var ->
           match RD.V.find_metadata var with
-          | Some (Global g) -> Some (var, g)
+          | Some (Global g) -> Some (var, Var.Cil g)
           | _ -> None
         )
       |> Seq.unzip
@@ -432,7 +431,7 @@ struct
 
   let iter_sys_vars getg vq vf = () (* TODO: or report singleton global for any Global query? *)
   let invariant_global ask getg g = Invariant.none
-  let invariant_vars ask getg st = List.map (fun (Var.Cil g) -> g) @@ protected_vars ask ~kind:Write (* TODO: is this right? *)
+  let invariant_vars ask getg st = protected_vars ask ~kind:Write (* TODO: is this right? *)
 
   let finalize () = ()
 
@@ -467,7 +466,7 @@ struct
     RD.vars st.rel
     |> List.filter_map (fun var ->
         match RD.V.find_metadata var with
-        | Some (Global g) -> Some g
+        | Some (Global g) -> Some (Var.Cil g)
         | _ -> None
       )
 end
@@ -507,7 +506,7 @@ struct
         RD.keep_vars (getg (V.mutex atomic_mutex)) [g_var]
       )
       else
-        getg (V.global (Cil g))
+        getg (V.global g)
     in
     let get_mutex_inits = getg V.mutex_inits in
     let get_mutex_inits' = RD.keep_vars get_mutex_inits [g_var] in
@@ -543,7 +542,7 @@ struct
     (* unlock *)
     if not atomic then (
       let rel_local' =
-        if is_unprotected ask (Cil g) then
+        if is_unprotected ask g then
           RD.remove_vars rel_local [g_var]
         else
           rel_local
@@ -579,9 +578,9 @@ struct
       if Param.handle_atomic then
         sideg (V.mutex atomic_mutex) rel_side (* Unprotected invariant is one big relation. *)
       else
-        sideg (V.global (Cil g)) rel_side;
+        sideg (V.global g) rel_side;
       let rel_local' =
-        if is_unprotected ask (Cil g) then
+        if is_unprotected ask g then
           RD.remove_vars rel_local [g_var]
         else
           rel_local
@@ -707,8 +706,8 @@ struct
 
   let escape node ask getg sideg (st:relation_components_t) escaped : relation_components_t =
     let esc_vars = EscapeDomain.EscapedVars.elements escaped in
-    let esc_vars = List.filter (fun v -> not v.vglob && RD.Tracked.varinfo_tracked v && RD.mem_var st.rel (AV.local v)) esc_vars in
-    let escape_one (x:varinfo) st = write_escape ask getg sideg st x x in
+    let esc_vars = List.filter (fun v -> not v.vglob && RD.Tracked.varinfo_tracked v && RD.mem_var st.rel (AV.local (Cil v))) esc_vars in
+    let escape_one (x:varinfo) st = write_escape ask getg sideg st (Cil x) (Cil x) in
     List.fold_left (fun st v -> escape_one v st) st esc_vars
 
   let threadenter ask getg (st: relation_components_t): relation_components_t =
@@ -767,7 +766,7 @@ sig
   module Cluster: Printable.S
 
   val keep_only_protected_globals: Q.ask -> LockDomain.MustLock.t -> LRD.t -> LRD.t
-  val keep_global: varinfo -> LRD.t -> LRD.t
+  val keep_global: Var.t -> LRD.t -> LRD.t
 
   val lock: RD.t -> LRD.t -> LRD.t -> RD.t
   val unlock: W.t -> RD.t -> LRD.t * (Cluster.t list)
@@ -807,7 +806,7 @@ end
 
 module type ClusteringArg =
 sig
-  val generate: varinfo list -> varinfo list list
+  val generate: Var.t list -> Var.t list list
   val name: unit -> string
 end
 
@@ -816,7 +815,7 @@ module Clustering12: ClusteringArg =
 struct
   let generate gs =
     List.cartesian_product gs gs
-    |> List.filter (fun (g1, g2) -> CilType.Varinfo.compare g1 g2 <= 0) (* filter flipped ordering, keep equals for next step *)
+    |> List.filter (fun (g1, g2) -> Var.compare g1 g2 <= 0) (* filter flipped ordering, keep equals for next step *)
     |> List.map (fun (g1, g2) -> [g1; g2]) (* if g1 = g2, then we get a singleton cluster *)
 
   let name () = "cluster12"
@@ -830,7 +829,7 @@ struct
     | [_] -> [gs] (* use clusters of size 1 if only 1 variable *)
     | _ ->
       List.cartesian_product gs gs
-      |> List.filter (fun (g1, g2) -> CilType.Varinfo.compare g1 g2 < 0) (* filter flipped ordering, forbid equals for just clusters of size 2 *)
+      |> List.filter (fun (g1, g2) -> Var.compare g1 g2 < 0) (* filter flipped ordering, forbid equals for just clusters of size 2 *)
       |> List.map (fun (g1, g2) -> [g1; g2])
 
   let name () = "cluster2"
@@ -871,7 +870,7 @@ module DownwardClosedCluster (ClusteringArg: ClusteringArg) =  functor (RD: Rela
 struct
   open CommonPerMutex(RD)
 
-  module VS = SetDomain.Make (CilType.Varinfo)
+  module VS = SetDomain.Make (Var)
   module LRD = MapDomain.MapBot (VS) (RD)
 
   module Cluster = VS
@@ -880,7 +879,7 @@ struct
     (* normal (strong) mapping: contains only still fully protected *)
     (* must filter by protection to avoid later meeting with non-protecting *)
     LRD.filter (fun gs _ ->
-        VS.for_all (fun g -> is_protected_by ask m (Cil g)) gs
+        VS.for_all (is_protected_by ask m) gs
       ) octs
 
   let keep_global g octs =
@@ -913,14 +912,14 @@ struct
   let unlock w oct_side =
     let vars = RD.vars oct_side in
     let gs = List.map (fun var -> match V.find_metadata var with
-        | Some (Global g) -> g
+        | Some (Global g) -> Var.Cil g
         | _ -> assert false (* oct_side should only contain (protected) globals *)
       ) vars
     in
     let clusters =
       ClusteringArg.generate gs
       |> List.map VS.of_list
-      |> List.filter (VS.exists (fun g -> W.mem (Cil g) w)) (* cluster intersection w is non-empty *)
+      |> List.filter (VS.exists (fun g -> W.mem g w)) (* cluster intersection w is non-empty *)
     in
     let oct_side_cluster gs =
       RD.keep_vars oct_side (gs |> VS.elements |> List.map V.global)
@@ -963,7 +962,7 @@ struct
       (* backup (weak) mapping: contains any still intersecting with protected, needed for decreasing protecting locksets *)
       filter_map' (fun gs oct ->
           (* must filter by protection to avoid later meeting with non-protecting *)
-          let gs' = VS.filter (fun g -> is_protected_by ask m (Cil g)) gs in
+          let gs' = VS.filter (is_protected_by ask m) gs in
           if VS.is_empty gs' then
             None
           else
@@ -1066,9 +1065,9 @@ struct
         |> Cluster.keep_global g
       )
       else
-        get_relevant_writes_nofilter ask @@ G.mutex @@ getg (V.global (Cil g))
+        get_relevant_writes_nofilter ask @@ G.mutex @@ getg (V.global g)
     in
-    if M.tracing then M.traceli "relationpriv" "get_mutex_global_g_with_mutex_inits %a\n  get=%a" CilType.Varinfo.pretty g LRD.pretty get_mutex_global_g;
+    if M.tracing then M.traceli "relationpriv" "get_mutex_global_g_with_mutex_inits %a\n  get=%a" Var.pretty g LRD.pretty get_mutex_global_g;
     let r =
       let get_mutex_inits = merge_all @@ G.mutex @@ getg V.mutex_inits in
       let get_mutex_inits' = Cluster.keep_global g get_mutex_inits in
@@ -1090,7 +1089,7 @@ struct
     let atomic = Param.handle_atomic && ask.f MustBeAtomic in
     let _,lmust,l = st.priv in
     let rel = st.rel in
-    let lm = LLock.global (Var.Cil g) in
+    let lm = LLock.global g in
     (* lock *)
     let local_m = BatOption.default (LRD.bot ()) (L.find_opt lm l) in
     (* Additionally filter get_m in case it contains variables it no longer protects. E.g. in 36/22. *)
@@ -1110,7 +1109,7 @@ struct
     (* unlock *)
     if not atomic then (
       let rel_local' =
-        if is_unprotected ask (Cil g) then
+        if is_unprotected ask g then
           RD.remove_vars rel_local [g_var]
         else
           rel_local
@@ -1123,7 +1122,7 @@ struct
   let write_global ?(invariant=false) (ask:Q.ask) getg sideg (st: relation_components_t) g x: relation_components_t =
     let atomic = Param.handle_atomic && ask.f MustBeAtomic in
     let w,lmust,l = st.priv in
-    let lm = LLock.global (Var.Cil g) in
+    let lm = LLock.global g in
     let rel = st.rel in
     (* lock *)
     let local_m = BatOption.default (LRD.bot ()) (L.find_opt lm l) in
@@ -1144,26 +1143,26 @@ struct
     (* unlock *)
     if not atomic then (
       let rel_side = RD.keep_vars rel_local [g_var] in
-      let rel_side, clusters = Cluster.unlock (W.singleton (Cil g)) rel_side in
+      let rel_side, clusters = Cluster.unlock (W.singleton g) rel_side in
       let digest = Digest.current ask in
       let sidev = GMutex.singleton digest rel_side in
       if Param.handle_atomic then
         sideg (V.mutex atomic_mutex) (G.create_global sidev) (* Unprotected invariant is one big relation. *)
       else
-        sideg (V.global (Cil g)) (G.create_global sidev);
+        sideg (V.global g) (G.create_global sidev);
       let l' = L.add lm rel_side l in
       let rel_local' =
-        if is_unprotected ask (Cil g) then
+        if is_unprotected ask g then
           RD.remove_vars rel_local [g_var]
         else
           rel_local
       in
       let lmust' = List.fold (fun a c -> LMust.add (lm,c) a) lmust clusters in
-      {rel = rel_local'; priv = (W.add (Cil g) w,lmust',l')}
+      {rel = rel_local'; priv = (W.add g w,lmust',l')}
     )
     else
       (* Delay publishing unprotected write in the atomic section. *)
-      {rel = rel_local; priv = (W.add (Cil g) w,lmust,l)} (* Keep write local as if it were protected by the atomic section. *)
+      {rel = rel_local; priv = (W.add g w,lmust,l)} (* Keep write local as if it were protected by the atomic section. *)
 
   let lock ask getg (st: relation_components_t) m =
     let atomic = Param.handle_atomic && LockDomain.MustLock.equal m atomic_mutex in
@@ -1303,8 +1302,8 @@ struct
 
   let escape node ask getg sideg (st: relation_components_t) escaped: relation_components_t =
     let esc_vars = EscapeDomain.EscapedVars.elements escaped in
-    let esc_vars = List.filter (fun v -> not v.vglob && RD.Tracked.varinfo_tracked v && RD.mem_var st.rel (AV.local v)) esc_vars in
-    let escape_one (x:varinfo) st = write_global ask getg sideg st x x in
+    let esc_vars = List.filter (fun v -> not v.vglob && RD.Tracked.varinfo_tracked v && RD.mem_var st.rel (AV.local (Cil v))) esc_vars in
+    let escape_one (x:varinfo) st = write_global ask getg sideg st (Cil x) (Cil x) in
     List.fold_left (fun st v -> escape_one v st) st esc_vars
 
   let enter_multithreaded (ask:Q.ask) getg sideg (st: relation_components_t): relation_components_t =
@@ -1350,7 +1349,7 @@ struct
   module RelComponents = RelationDomain.RelComponents (RD) (D)
 
   let read_global ask getg st g x =
-    if M.tracing then M.traceli "relationpriv" "read_global %a %a" CilType.Varinfo.pretty g CilType.Varinfo.pretty x;
+    if M.tracing then M.traceli "relationpriv" "read_global %a %a" Var.pretty g Var.pretty x;
     if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in
@@ -1362,7 +1361,7 @@ struct
     r
 
   let write_global ?invariant ask getg sideg st g x =
-    if M.tracing then M.traceli "relationpriv" "write_global %a %a" CilType.Varinfo.pretty g CilType.Varinfo.pretty x;
+    if M.tracing then M.traceli "relationpriv" "write_global %a %a" Var.pretty g Var.pretty x;
     if M.tracing then M.trace "relationpriv" "st: %a" RelComponents.pretty st;
     let getg x =
       let r = getg x in

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -227,7 +227,7 @@ struct
 
   (** Restrict environment to local variables and still-protected global variables. *)
   let restrict_local is_unprot rel w_remove =
-    let remove_local_vars = List.map AV.local (W.elements w_remove) in
+    let remove_local_vars = List.map AV.local (List.map (fun (Var.Cil v) -> v) (W.elements w_remove)) in
     let rel' = RD.remove_vars rel remove_local_vars in
     (* remove global vars *)
     RD.remove_filter rel' (fun var ->
@@ -244,15 +244,15 @@ struct
     let g_local_var = AV.local g in
     let x_var = AV.local x in
     let rel_local =
-      if W.mem g w then
+      if W.mem (Cil g) w then
         RD.assign_var rel x_var g_local_var
       else
         RD.bot ()
     in
     let rel_local' =
-      if P.mem g p then
+      if P.mem (Cil g) p then
         rel_local
-      else if is_unprotected ask g then (
+      else if is_unprotected ask (Cil g) then (
         let g_unprot_var = AV.unprot g in
         let rel_unprot = RD.add_vars rel [g_unprot_var] in
         let rel_unprot = RD.assign_var rel_unprot x_var g_unprot_var in
@@ -271,7 +271,7 @@ struct
         RD.join rel_local rel_prot
       )
     in
-    let rel_local' = restrict_local (is_unprotected ask) rel_local' (W.empty ()) in
+    let rel_local' = restrict_local (fun g -> is_unprotected ask (Cil g)) rel_local' (W.empty ()) in
     let rel_local' = RD.meet rel_local' (getg ()) in
     rel_local'
 
@@ -294,12 +294,12 @@ struct
          else
          (* restricting g#unprot-s out from oct' gives oct_local *)
          {oct = oct_local; priv = (P.add g p, W.add g w)} *)
-      if is_unprotected ask g then
-        {st with rel = restrict_local (is_unprotected ask) rel' (W.singleton g)}
+      if is_unprotected ask (Cil g) then
+        {st with rel = restrict_local (fun g -> is_unprotected ask (Cil g)) rel' (W.singleton (Cil g))}
       else (
-        let p' = P.add g p in
-        let w' = W.add g w in
-        {rel = restrict_local (is_unprotected ask) rel' (W.empty ()); priv = (p', w')}
+        let p' = P.add (Cil g) p in
+        let w' = W.add (Cil g) w in
+        {rel = restrict_local (fun g -> is_unprotected ask (Cil g)) rel' (W.empty ()); priv = (p', w')}
       )
     in
     let rel_local' = RD.meet st'.rel (getg ()) in
@@ -331,6 +331,7 @@ struct
         )
     in
     let rel_side = List.fold_left (fun acc omega ->
+        let omega = List.map (fun (Var.Cil g) -> g) omega in
         let g_prot_vars = List.map AV.prot omega in
         let g_local_vars = List.map AV.local omega in
         let rel_side1 = RD.add_vars rel g_prot_vars in
@@ -341,7 +342,7 @@ struct
     let rel' = rel_side in
     let rel_side = restrict_global rel_side in
     sideg () rel_side;
-    let rel_local = restrict_local (fun g -> is_unprotected_without ask g m) rel' w_remove in
+    let rel_local = restrict_local (fun g -> is_unprotected_without ask (Cil g) m) rel' w_remove in
     let rel_local' = RD.meet rel_local (getg ()) in
     {rel = rel_local'; priv = (p', w')}
 
@@ -431,7 +432,7 @@ struct
 
   let iter_sys_vars getg vq vf = () (* TODO: or report singleton global for any Global query? *)
   let invariant_global ask getg g = Invariant.none
-  let invariant_vars ask getg st = protected_vars ask ~kind:Write (* TODO: is this right? *)
+  let invariant_vars ask getg st = List.map (fun (Var.Cil g) -> g) @@ protected_vars ask ~kind:Write (* TODO: is this right? *)
 
   let finalize () = ()
 
@@ -445,14 +446,14 @@ struct
 
   let remove_globals_unprotected_after_unlock ask m oct =
     let newly_unprot var = match V.find_metadata var with
-      | Some (Global g) -> is_protected_by ask m g && is_unprotected_without ask g m
+      | Some (Global g) -> is_protected_by ask m (Cil g) && is_unprotected_without ask (Cil g) m
       | _ -> false
     in
     RD.remove_filter oct newly_unprot
 
   let keep_only_protected_globals ask m oct =
     let protected var = match V.find_metadata var with
-      | Some (Global g) -> is_protected_by ask m g
+      | Some (Global g) -> is_protected_by ask m (Cil g)
       | _ -> false
     in
     RD.keep_filter oct protected
@@ -506,7 +507,7 @@ struct
         RD.keep_vars (getg (V.mutex atomic_mutex)) [g_var]
       )
       else
-        getg (V.global g)
+        getg (V.global (Cil g))
     in
     let get_mutex_inits = getg V.mutex_inits in
     let get_mutex_inits' = RD.keep_vars get_mutex_inits [g_var] in
@@ -542,7 +543,7 @@ struct
     (* unlock *)
     if not atomic then (
       let rel_local' =
-        if is_unprotected ask g then
+        if is_unprotected ask (Cil g) then
           RD.remove_vars rel_local [g_var]
         else
           rel_local
@@ -578,9 +579,9 @@ struct
       if Param.handle_atomic then
         sideg (V.mutex atomic_mutex) rel_side (* Unprotected invariant is one big relation. *)
       else
-        sideg (V.global g) rel_side;
+        sideg (V.global (Cil g)) rel_side;
       let rel_local' =
-        if is_unprotected ask g then
+        if is_unprotected ask (Cil g) then
           RD.remove_vars rel_local [g_var]
         else
           rel_local
@@ -634,7 +635,7 @@ struct
         sideg (V.mutex atomic_mutex) rel_side;
       let rel_local =
         let newly_unprot var = match AV.find_metadata var with
-          | Some (Global g) -> is_unprotected_without ask g atomic_mutex
+          | Some (Global g) -> is_unprotected_without ask (Cil g) atomic_mutex
           | _ -> false
         in
         RD.remove_filter rel newly_unprot
@@ -664,7 +665,7 @@ struct
         if g_vars <> [] then sideg V.mutex_inits rel_side;
         let rel_local = RD.remove_filter rel (fun var ->
             match AV.find_metadata var with
-            | Some (Global g) -> is_unprotected ask g
+            | Some (Global g) -> is_unprotected ask (Cil g)
             | _ -> false
           )
         in
@@ -879,7 +880,7 @@ struct
     (* normal (strong) mapping: contains only still fully protected *)
     (* must filter by protection to avoid later meeting with non-protecting *)
     LRD.filter (fun gs _ ->
-        VS.for_all (is_protected_by ask m) gs
+        VS.for_all (fun g -> is_protected_by ask m (Cil g)) gs
       ) octs
 
   let keep_global g octs =
@@ -919,7 +920,7 @@ struct
     let clusters =
       ClusteringArg.generate gs
       |> List.map VS.of_list
-      |> List.filter (VS.exists (fun g -> W.mem g w)) (* cluster intersection w is non-empty *)
+      |> List.filter (VS.exists (fun g -> W.mem (Cil g) w)) (* cluster intersection w is non-empty *)
     in
     let oct_side_cluster gs =
       RD.keep_vars oct_side (gs |> VS.elements |> List.map V.global)
@@ -962,7 +963,7 @@ struct
       (* backup (weak) mapping: contains any still intersecting with protected, needed for decreasing protecting locksets *)
       filter_map' (fun gs oct ->
           (* must filter by protection to avoid later meeting with non-protecting *)
-          let gs' = VS.filter (is_protected_by ask m) gs in
+          let gs' = VS.filter (fun g -> is_protected_by ask m (Cil g)) gs in
           if VS.is_empty gs' then
             None
           else
@@ -1065,7 +1066,7 @@ struct
         |> Cluster.keep_global g
       )
       else
-        get_relevant_writes_nofilter ask @@ G.mutex @@ getg (V.global g)
+        get_relevant_writes_nofilter ask @@ G.mutex @@ getg (V.global (Cil g))
     in
     if M.tracing then M.traceli "relationpriv" "get_mutex_global_g_with_mutex_inits %a\n  get=%a" CilType.Varinfo.pretty g LRD.pretty get_mutex_global_g;
     let r =
@@ -1089,7 +1090,7 @@ struct
     let atomic = Param.handle_atomic && ask.f MustBeAtomic in
     let _,lmust,l = st.priv in
     let rel = st.rel in
-    let lm = LLock.global g in
+    let lm = LLock.global (Var.Cil g) in
     (* lock *)
     let local_m = BatOption.default (LRD.bot ()) (L.find_opt lm l) in
     (* Additionally filter get_m in case it contains variables it no longer protects. E.g. in 36/22. *)
@@ -1109,7 +1110,7 @@ struct
     (* unlock *)
     if not atomic then (
       let rel_local' =
-        if is_unprotected ask g then
+        if is_unprotected ask (Cil g) then
           RD.remove_vars rel_local [g_var]
         else
           rel_local
@@ -1122,7 +1123,7 @@ struct
   let write_global ?(invariant=false) (ask:Q.ask) getg sideg (st: relation_components_t) g x: relation_components_t =
     let atomic = Param.handle_atomic && ask.f MustBeAtomic in
     let w,lmust,l = st.priv in
-    let lm = LLock.global g in
+    let lm = LLock.global (Var.Cil g) in
     let rel = st.rel in
     (* lock *)
     let local_m = BatOption.default (LRD.bot ()) (L.find_opt lm l) in
@@ -1143,26 +1144,26 @@ struct
     (* unlock *)
     if not atomic then (
       let rel_side = RD.keep_vars rel_local [g_var] in
-      let rel_side, clusters = Cluster.unlock (W.singleton g) rel_side in
+      let rel_side, clusters = Cluster.unlock (W.singleton (Cil g)) rel_side in
       let digest = Digest.current ask in
       let sidev = GMutex.singleton digest rel_side in
       if Param.handle_atomic then
         sideg (V.mutex atomic_mutex) (G.create_global sidev) (* Unprotected invariant is one big relation. *)
       else
-        sideg (V.global g) (G.create_global sidev);
+        sideg (V.global (Cil g)) (G.create_global sidev);
       let l' = L.add lm rel_side l in
       let rel_local' =
-        if is_unprotected ask g then
+        if is_unprotected ask (Cil g) then
           RD.remove_vars rel_local [g_var]
         else
           rel_local
       in
       let lmust' = List.fold (fun a c -> LMust.add (lm,c) a) lmust clusters in
-      {rel = rel_local'; priv = (W.add g w,lmust',l')}
+      {rel = rel_local'; priv = (W.add (Cil g) w,lmust',l')}
     )
     else
       (* Delay publishing unprotected write in the atomic section. *)
-      {rel = rel_local; priv = (W.add g w,lmust,l)} (* Keep write local as if it were protected by the atomic section. *)
+      {rel = rel_local; priv = (W.add (Cil g) w,lmust,l)} (* Keep write local as if it were protected by the atomic section. *)
 
   let lock ask getg (st: relation_components_t) m =
     let atomic = Param.handle_atomic && LockDomain.MustLock.equal m atomic_mutex in
@@ -1281,7 +1282,7 @@ struct
         (* TODO: Is not potentially even unsound to do so?! *)
         let rel_local = RD.remove_filter rel (fun var ->
             match AV.find_metadata var with
-            | Some (Global g) -> is_unprotected ask g
+            | Some (Global g) -> is_unprotected ask (Cil g)
             | _ -> false
           )
         in
@@ -1332,7 +1333,7 @@ struct
 
   let iter_sys_vars getg vq vf =
     match vq with
-    | VarQuery.Global g -> vf (V.global g)
+    | VarQuery.Global g -> vf (V.global (Cil g))
     | _ -> ()
 
   let finalize () = ()

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -137,7 +137,7 @@ struct
     VD.project ask p a value
 
   let project ask p_opt cpa fundec =
-    CPA.mapi (fun varinfo value -> project_val ask (attributes_varinfo varinfo fundec) p_opt value (is_privglob varinfo)) cpa
+    CPA.mapi (fun (Cil varinfo) value -> project_val ask (attributes_varinfo varinfo fundec) p_opt value (is_privglob varinfo)) cpa
 
 
   (**************************************************************************
@@ -536,7 +536,7 @@ struct
     ignore (sync' reason man)
 
   (* TODO: This isn't a simpler version of get_mval, it doesn't do some Blob handling that get_mval does with `NoOffset, so use that instead if in doubt. *)
-  let get_var ~man (st: store) (x: varinfo): value =
+  let get_var ~man (st: store) (x: Var.t): value =
     let ask = Analyses.ask_of_man man in
     if (!earlyglobs || ThreadFlag.has_ever_been_multi ask) && is_global ask x then
       Priv.read_global ask (priv_getg man.global) st x
@@ -547,7 +547,7 @@ struct
 
   let rec get_mval ~man ?(full=false) (st: store) ((x, offs): Addr.Mval.t) (exp:exp option) =
     (* get hold of the variable value, either from local or global state *)
-    let var = get_var ~man st x in
+    let var = get_var ~man st (Cil x) in (* TODO: move Var into Mval *)
     let v = VD.eval_offset (Queries.to_value_domain_ask (Analyses.ask_of_man man)) var offs exp (Some (Var x, Offs.to_cil_offset offs)) x.vtype in
     if M.tracing then M.tracec "get" "var = %a, %a = %a" VD.pretty var AD.pretty (AD.of_mval (x, offs)) VD.pretty v;
     if full then var else match v with
@@ -714,7 +714,7 @@ struct
     st |>
     (* Here earlyglobs only drops syntactic globals from the context and does not consider e.g. escaped globals. *)
     (* This is equivalent to having escaped globals excluded from earlyglobs for contexts *)
-    f (not !earlyglobs) (CPA.filter (fun k v -> (not k.vglob) || is_excluded_from_earlyglobs k))
+    f (not !earlyglobs) (CPA.filter (fun (Cil vi as k) v -> (not vi.vglob) || is_excluded_from_earlyglobs k))
     %> f (ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.base.context.non-ptr" ~removeAttr:"base.no-non-ptr" ~keepAttr:"base.non-ptr" fd) drop_non_ptrs
     %> f (ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.base.context.int" ~removeAttr:"base.no-int" ~keepAttr:"base.int" fd) drop_ints
     %> f (ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.base.context.interval" ~removeAttr:"base.no-interval" ~keepAttr:"base.interval" fd) drop_interval
@@ -1161,7 +1161,7 @@ struct
             );
             (* Warn if any of the addresses contains a non-local and non-global variable *)
             if AD.exists (function
-                | AD.Addr.Addr (v, _) -> not (CPA.mem v st.cpa) && not (is_global (Analyses.ask_of_man man) v)
+                | AD.Addr.Addr (v, _) -> not (CPA.mem (Cil v) st.cpa) && not (is_global (Analyses.ask_of_man man) (Cil v))
                 | _ -> false
               ) adr then (
               AnalysisStateUtil.set_mem_safety_flag InvalidDeref;
@@ -1287,8 +1287,8 @@ struct
         keep_local
     in
 
-    let var_invariant ?offset v =
-      if not (InvariantCil.var_is_heap v) then
+    let var_invariant ?offset (Var.Cil vi as v) =
+      if not (InvariantCil.var_is_heap vi) then (* TODO: move var_is_heap natively into Var *)
         I.key_invariant v ?offset (Arg.find v)
       else
         Invariant.none
@@ -1334,8 +1334,8 @@ struct
       Lval.Set.fold (fun k a ->
           let i =
             match k with
-            | (Var v, offset) when var_filter v && not (InvariantCil.var_is_heap v) ->
-              (try I.key_invariant_lval v ~offset ~lval:k (Arg.find v) with Not_found -> Invariant.none)
+            | (Var v, offset) when var_filter (Cil v) && not (InvariantCil.var_is_heap v) ->
+              (try I.key_invariant_lval v ~offset ~lval:k (Arg.find (Cil v)) with Not_found -> Invariant.none)
             | _ -> Invariant.none
           in
           Invariant.(a && i)
@@ -1657,9 +1657,9 @@ struct
                                )
     | _ -> Q.Result.top q
 
-  let update_variable variable typ value cpa =
+  let update_variable (Var.Cil vi as variable) typ value cpa =
     if ((get_bool "exp.volatiles_are_top") && (is_always_unknown variable)) then
-      CPA.add variable (VD.top_value ~varAttr:variable.vattr typ) cpa
+      CPA.add variable (VD.top_value ~varAttr:vi.vattr typ) cpa
     else
       CPA.add variable value cpa
 
@@ -1682,10 +1682,10 @@ struct
     (* Blob cannot contain arrays *)
     | _ ->  st
 
-  let update_variable x t y z =
-    if M.tracing then M.tracel "set" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a" x.vname VD.pretty y CPA.pretty z;
+  let update_variable (Var.Cil vi as x) t y z =
+    if M.tracing then M.tracel "set" ~var:vi.vname "update_variable: start '%a' '%a'\nto\n%a" Var.pretty x VD.pretty y CPA.pretty z;
     let r = update_variable x t y z in (* refers to definition above *)
-    if M.tracing then M.tracel "set" ~var:x.vname "update_variable: start '%s' '%a'\nto\n%a\nresults in\n%a" x.vname VD.pretty y CPA.pretty z CPA.pretty r;
+    if M.tracing then M.tracel "set" ~var:vi.vname "update_variable: start '%a' '%a'\nto\n%a\nresults in\n%a" Var.pretty x VD.pretty y CPA.pretty z CPA.pretty r;
     r
 
   (* Updating a single varinfo*offset pair. NB! This function's type does
@@ -1711,7 +1711,7 @@ struct
     in
     let update_offset old_value =
       (* Projection globals to highest Precision *)
-      let projected_value = project_val (Queries.to_value_domain_ask ask) None None value (is_global ask x) in
+      let projected_value = project_val (Queries.to_value_domain_ask ask) None None value (is_global ask (Cil x)) in
       let new_value = VD.update_offset ~blob_destructive (Queries.to_value_domain_ask ask) old_value offs projected_value lval_raw ((Var x), cil_offset) t in
       if WeakUpdates.mem x st.weak then
         VD.join old_value new_value
@@ -1732,11 +1732,11 @@ struct
     end else
     if get_bool "exp.globs_are_top" then begin
       if M.tracing then M.tracel "set" "update_one_addr: BAD? exp.globs_are_top is set ";
-      { st with cpa = CPA.add x Top st.cpa }
+      { st with cpa = CPA.add (Cil x) Top st.cpa }
     end else
       (* Check if we need to side-effect this one. We no longer generate
        * side-effects here, but the code still distinguishes these cases. *)
-    if (!earlyglobs || ThreadFlag.has_ever_been_multi ask) && is_global ask x then begin
+    if (!earlyglobs || ThreadFlag.has_ever_been_multi ask) && is_global ask (Cil x) then begin
       if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: update a global var '%s' ..." x.vname;
       let priv_getg = priv_getg man.global in
       (* Optimization to avoid evaluating integer values when setting them.
@@ -1745,17 +1745,17 @@ struct
       let old_value = if not invariant && Cil.isIntegralType x.vtype && not (man.ask (IsAllocVar x)) && offs = `NoOffset then begin
           VD.bot_value ~varAttr:x.vattr lval_type
         end else
-          Priv.read_global ask priv_getg st x
+          Priv.read_global ask priv_getg st (Cil x)
       in
       let new_value = update_offset old_value in
       if M.tracing then M.tracel "set" "update_offset %a -> %a" VD.pretty old_value VD.pretty new_value;
-      let r = Priv.write_global ~invariant ask priv_getg (priv_sideg man.sideg) st x new_value in
+      let r = Priv.write_global ~invariant ask priv_getg (priv_sideg man.sideg) st (Cil x) new_value in
       if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: updated a global var '%s' \nstate:%a" x.vname D.pretty r;
       r
     end else begin
       if M.tracing then M.tracel "set" ~var:x.vname "update_one_addr: update a local var '%s' ..." x.vname;
       (* Normal update of the local state *)
-      let new_value = update_offset (CPA.find x st.cpa) in
+      let new_value = update_offset (CPA.find (Cil x) st.cpa) in
       (* what effect does changing this local variable have on arrays -
          we only need to do this here since globals are not allowed in the
          expressions for partitioning *)
@@ -1780,7 +1780,7 @@ struct
               None
         in
         let effect_on_array actually_moved arr (st: store):store =
-          let v = CPA.find arr st.cpa in
+          let v = CPA.find (Cil arr) st.cpa in
           let nval =
             if actually_moved then
               match lval_raw, rval_raw with
@@ -1816,15 +1816,15 @@ struct
               (* TODO: why does affect_move need general ask (of any query) instead of to_value_domain_ask? *)
               VD.affect_move (Queries.to_value_domain_ask patched_ask) v x moved_by     (* was a set call caused e.g. by a guard *)
           in
-          { st with cpa = update_variable arr arr.vtype nval st.cpa }
+          { st with cpa = update_variable (Cil arr) arr.vtype nval st.cpa }
         in
         (* within invariant, a change to the way arrays are partitioned is not necessary *)
         List.fold_left (fun x y -> effect_on_array (not invariant) y x) st affected_arrays
       in
-      if VD.is_bot new_value && invariant && not (CPA.mem x st.cpa) then
+      if VD.is_bot new_value && invariant && not (CPA.mem (Cil x) st.cpa) then
         st
       else
-        let x_updated = update_variable x t new_value st.cpa in
+        let x_updated = update_variable (Cil x) t new_value st.cpa in
         let with_dep = add_partitioning_dependencies x new_value {st with cpa = x_updated } in
         effect_on_arrays ask with_dep
       end
@@ -1868,7 +1868,7 @@ struct
     List.fold_left f st lval_value_list
 
   let rem_many a (st: store) (v_list: varinfo list): store =
-    let f acc v = CPA.remove v acc in
+    let f acc v = CPA.remove (Cil v) acc in
     let g dep v = Dep.remove v dep in
     { st with cpa = List.fold_left f st.cpa v_list; deps = List.fold_left g st.deps v_list }
 
@@ -1881,9 +1881,9 @@ struct
         Dep.VarSet.elements set
       in
       let effect_on_array arr st =
-        let v = CPA.find arr st in
+        let v = CPA.find (Cil arr) st in
         let nval = VD.affect_move ~replace_with_const:(get_bool ("ana.base.partition-arrays.partition-by-const-on-return")) a v x (fun _ -> None) in (* Having the function for movement return None here is equivalent to forcing the partitioning to be dropped *)
-        update_variable arr arr.vtype nval st
+        update_variable (Cil arr) arr.vtype nval st
       in
       { st with cpa = List.fold_left (fun x y -> effect_on_array y x) st.cpa affected_arrays }
     in
@@ -1980,7 +1980,7 @@ struct
     let not_local xs =
       let not_local x =
         match Addr.to_var_may x with
-        | Some x -> is_global (Analyses.ask_of_man man) x
+        | Some x -> is_global (Analyses.ask_of_man man) (Cil x)
         | None -> x = Addr.UnknownPtr
       in
       AD.is_top xs || AD.exists not_local xs
@@ -2193,11 +2193,11 @@ struct
     (* Assign parameters to arguments *)
     let pa = GobList.combine_short fundec.sformals vals in (* TODO: is it right to ignore missing formals/args? *)
     add_to_array_map fundec pa;
-    let new_cpa = CPA.add_list pa st'.cpa in
+    let new_cpa = CPA.add_list (List.map (Tuple2.map1 (fun x -> Var.Cil x)) pa) st'.cpa in
     (* List of reachable variables *)
     let reachable = AD.to_var_may (reachable_vars ~man st (get_ptrs vals)) in
-    let reachable = List.filter (fun v -> CPA.mem v st.cpa) reachable in
-    let new_cpa = CPA.add_list_fun reachable (fun v -> CPA.find v st.cpa) new_cpa in
+    let reachable = List.filter (fun v -> CPA.mem (Cil v) st.cpa) reachable in
+    let new_cpa = CPA.add_list_fun (List.map (fun x -> Var.Cil x) reachable) (fun v -> CPA.find v st.cpa) new_cpa in
 
     (* Projection to Precision of the Callee *)
     let p = PU.int_precision_from_fundec fundec in
@@ -2860,16 +2860,16 @@ struct
   let combine_st man (local_st : store) (fun_st : store) (tainted_lvs : AD.t) : store =
     AD.fold (fun addr (st: store) ->
         match addr with
-        | Addr.Addr ((v,o) as mval) when CPA.mem v fun_st.cpa ->
+        | Addr.Addr ((v,o) as mval) when CPA.mem (Cil v) fun_st.cpa ->
           begin
             let lval_type = Addr.type_of addr in
             if M.tracing then M.trace "taintPC" "updating %a; type: %a" Addr.Mval.pretty (v,o) d_type lval_type;
-            match CPA.find_opt v (fun_st.cpa) with
+            match CPA.find_opt (Cil v) (fun_st.cpa) with
             | None -> st
             (* partitioned arrays cannot be copied by individual lvalues, so if tainted just copy the whole callee value for the array variable *)
-            | Some (Array a) when CArrays.domain_of_t a = PartitionedDomain -> {st with cpa = CPA.add v (Array a) st.cpa}
+            | Some (Array a) when CArrays.domain_of_t a = PartitionedDomain -> {st with cpa = CPA.add (Cil v) (Array a) st.cpa}
             (* "get" returned "unknown" when applied to a void type, so special case void types. This caused problems with some sv-comps (e.g. regtest 64 11) *)
-            | Some voidVal when Addr.type_of addr = voidType -> {st with cpa = CPA.add v voidVal st.cpa}
+            | Some voidVal when Addr.type_of addr = voidType -> {st with cpa = CPA.add (Cil v) voidVal st.cpa}
             | _ ->
               let address = AD.singleton addr in
               let new_val = get_mval ~man fun_st mval None in
@@ -2879,8 +2879,8 @@ struct
               Option.map_default (fun deps ->
                   {st' with cpa = (Dep.VarSet.fold
                                      (fun v accCPA ->
-                                        let val_opt = CPA.find_opt v fun_st.cpa in
-                                        Option.map_default (fun new_val -> CPA.add v new_val accCPA) accCPA val_opt
+                                        let val_opt = CPA.find_opt (Cil v) fun_st.cpa in
+                                        Option.map_default (fun new_val -> CPA.add (Cil v) new_val accCPA) accCPA val_opt
                                      ) deps st'.cpa)}
                 ) st' (Dep.find_opt v fun_st.deps)
           end
@@ -2897,7 +2897,7 @@ struct
        * variables of the called function from cpa_s. *)
       let add_globals (st: store) (fun_st: store) =
         (* Remove the return value as this is dealt with separately. *)
-        let cpa_noreturn = CPA.remove (return_varinfo ()) fun_st.cpa in
+        let cpa_noreturn = CPA.remove (Cil (return_varinfo ())) fun_st.cpa in (* TODO: add Return to Var.t *)
         let ask = Analyses.ask_of_man man in
         let tainted = f_ask.f Q.MayBeTainted in
         if M.tracing then M.trace "taintPC" "combine for %s in base: tainted: %a" f.svar.vname AD.pretty tainted;
@@ -2918,7 +2918,7 @@ struct
           if M.tracing then M.trace "taintPC" "cpa_caller': %a" CPA.pretty cpa_caller';
           (* remove lvals from the tainted set that correspond to variables for which we just added a new mapping from the callee*)
           let tainted = AD.filter (function
-              | Addr.Addr (v,_) -> not (CPA.mem v cpa_new)
+              | Addr.Addr (v,_) -> not (CPA.mem (Cil v) cpa_new)
               | _ -> false
             ) tainted in
           let st_combined = combine_st man {st with cpa = cpa_caller'} fun_st tainted in
@@ -2942,7 +2942,7 @@ struct
     let combine_one (st: D.t) (fun_st: D.t) =
       let return_var = return_varinfo () in
       let return_val =
-        if CPA.mem return_var fun_st.cpa
+        if CPA.mem (Cil return_var) fun_st.cpa
         then get_mval ~man fun_st (return_var, `NoOffset) None
         else VD.top ()
       in
@@ -3111,7 +3111,7 @@ struct
        This invokes [Priv.write_global], which was suppressed above. *)
     let e_d' =
       WideningTokenLifter.with_side_tokens (WideningTokenLifter.TS.of_list uuids) (fun () ->
-          CPA.fold (fun x v acc ->
+          CPA.fold (fun (Cil x) v acc ->
               set_var ~man ~invariant:false acc x x.vtype v
             ) e_d.cpa man.local
         )
@@ -3147,7 +3147,7 @@ struct
     | Events.Longjmped {lval} ->
       Option.map_default (fun lval ->
           let st' = assign man lval (Lval (Cil.var !longjmp_return)) in
-          {st' with cpa = CPA.remove !longjmp_return st'.cpa}
+          {st' with cpa = CPA.remove (Cil !longjmp_return) st'.cpa} (* TODO: add longjmp_return to Var.t *)
         ) man.local lval
     | _ ->
       man.local

--- a/src/analyses/baseInvariant.ml
+++ b/src/analyses/baseInvariant.ml
@@ -22,7 +22,7 @@ sig
   val eval_lv: man:(D.t, G.t, _, V.t) Analyses.man -> D.t -> lval -> AD.t
   val convert_offset: man:(D.t, G.t, _, V.t) Analyses.man -> D.t -> offset -> ID.t Offset.t
 
-  val get_var: man:(D.t, G.t, _, V.t) Analyses.man -> D.t -> varinfo -> VD.t
+  val get_var: man:(D.t, G.t, _, V.t) Analyses.man -> D.t -> Var.t -> VD.t
   val get_mval: man:(D.t, G.t, _, V.t) Analyses.man -> D.t -> PreValueDomain.Addr.Mval.t -> exp option -> VD.t
   val get: man:(D.t, G.t, _, V.t) Analyses.man -> D.t -> AD.t -> exp option -> VD.t
   val set: man:(D.t, G.t, _, V.t) Analyses.man -> D.t -> AD.t -> typ -> ?lval_raw:lval -> VD.t -> D.t
@@ -100,7 +100,7 @@ struct
     match x with
     | Var var, o when refine_entire_var ->
       (* For variables, this is done at to the level of entire variables to benefit e.g. from disjunctive struct domains *)
-      let old_val = get_var ~man st var in
+      let old_val = get_var ~man st (Cil var) in
       let old_val = map_oldval old_val var.vtype in
       let offs = convert_offset ~man st o in
       let new_val = VD.update_offset (Queries.to_value_domain_ask (Analyses.ask_of_man man)) old_val offs c' (Some exp) x (Cilfacade.typeOfLval x) in

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -24,11 +24,11 @@ sig
 
   val startstate: unit -> D.t
 
-  val read_global: Q.ask -> (V.t -> G.t) -> BaseComponents (D).t -> varinfo -> VD.t
+  val read_global: Q.ask -> (V.t -> G.t) -> BaseComponents (D).t -> Var.t -> VD.t
 
   (* [invariant]: Check if we should avoid producing a side-effect, such as updates to
    * the state when following conditional guards. *)
-  val write_global: ?invariant:bool -> Q.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseComponents (D).t -> varinfo -> VD.t -> BaseComponents (D).t
+  val write_global: ?invariant:bool -> Q.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseComponents (D).t -> Var.t -> VD.t -> BaseComponents (D).t
 
   val lock: Q.ask -> (V.t -> G.t) -> BaseComponents (D).t -> LockDomain.MustLock.t -> BaseComponents (D).t
   val unlock: Q.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseComponents (D).t -> LockDomain.MustLock.t -> BaseComponents (D).t
@@ -45,7 +45,7 @@ sig
   val thread_return: Q.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> ThreadIdDomain.Thread.t -> BaseComponents (D).t -> BaseComponents (D).t
 
   val invariant_global: Q.ask -> (V.t -> G.t) -> V.t -> Invariant.t
-  val invariant_vars: Q.ask -> (V.t -> G.t) -> BaseComponents (D).t -> varinfo list
+  val invariant_vars: Q.ask -> (V.t -> G.t) -> BaseComponents (D).t -> Var.t list
 
   val init: unit -> unit
   val finalize: unit -> unit
@@ -109,7 +109,7 @@ struct
   include NoFinalize
 
   module G = VD
-  module V = VarinfoV
+  module V = VarV
   module D = Lattice.Unit
 
   let init () = ()
@@ -159,8 +159,8 @@ struct
       st
 
   let escape ask getg sideg (st: BaseComponents (D).t) escaped =
-    let cpa' = CPA.fold (fun x v acc ->
-        if EscapeDomain.EscapedVars.mem x escaped then (
+    let cpa' = CPA.fold (fun (Cil vi as x) v acc ->
+        if EscapeDomain.EscapedVars.mem vi escaped then (
           sideg x v;
           CPA.remove x acc
         )
@@ -189,7 +189,7 @@ struct
   let iter_sys_vars getg vq vf =
     match vq with
     | VarQuery.Global g ->
-      vf g;
+      vf (Var.Cil g);
     | _ -> ()
 
   let invariant_global ask getg g =
@@ -235,12 +235,12 @@ struct
     get_mutex_global_x |? VD.bot ()
 
   let escape ask getg sideg (st: BaseComponents (D).t) escaped =
-    let escaped_cpa = CPA.filter (fun x _ -> EscapeDomain.EscapedVars.mem x escaped) st.cpa in
+    let escaped_cpa = CPA.filter (fun (Var.Cil x) _ -> EscapeDomain.EscapedVars.mem x escaped) st.cpa in
     sideg V.mutex_inits escaped_cpa;
 
-    let cpa' = CPA.fold (fun x v acc ->
-        if EscapeDomain.EscapedVars.mem x escaped (* && is_unprotected ask x *) then (
-          if M.tracing then M.tracel "priv" "ESCAPE SIDE %a = %a" CilType.Varinfo.pretty x VD.pretty v;
+    let cpa' = CPA.fold (fun (Cil vi as x) v acc ->
+        if EscapeDomain.EscapedVars.mem vi escaped (* && is_unprotected ask x *) then (
+          if M.tracing then M.tracel "priv" "ESCAPE SIDE %a = %a" Var.pretty x VD.pretty v;
           sideg (V.global x) (CPA.singleton x v);
           CPA.remove x acc
         )
@@ -256,8 +256,8 @@ struct
 
     let cpa' = CPA.fold (fun x v acc ->
         if is_global ask x (* && is_unprotected ask x *) then (
-          if M.tracing then M.tracel "priv" "enter_multithreaded remove %a" CilType.Varinfo.pretty x;
-          if M.tracing then M.tracel "priv" "ENTER MULTITHREADED SIDE %a = %a" CilType.Varinfo.pretty x VD.pretty v;
+          if M.tracing then M.tracel "priv" "enter_multithreaded remove %a" Var.pretty x;
+          if M.tracing then M.tracel "priv" "ENTER MULTITHREADED SIDE %a = %a" Var.pretty x VD.pretty v;
           sideg (V.global x) (CPA.singleton x v);
           CPA.remove x acc
         )
@@ -369,8 +369,8 @@ struct
       let atomic = LockDomain.MustLock.equal m' (LockDomain.MustLock.of_var LibraryFunctions.verifier_atomic_var) in
       if atomic || ask.f (GhostVarAvailable (Locked m')) then (
         let cpa = get_m_with_mutex_inits ask getg m' in (* Could be more precise if mutex_inits invariant is added by disjunction instead of joining abstract values. *)
-        let inv = CPA.fold (fun v _ acc ->
-            if ask.f (MustBeProtectedBy {mutex = m'; global = v; kind = Write; protection = Strong}) then
+        let inv = CPA.fold (fun (Cil vi as v) _ acc ->
+            if ask.f (MustBeProtectedBy {mutex = m'; global = vi; kind = Write; protection = Strong}) then
               let inv = ValueDomain.invariant_global (fun g -> CPA.find g cpa) v in
               Invariant.(acc && inv)
             else
@@ -413,7 +413,7 @@ struct
       CPA.find x st.cpa
   let read_global ask getg st x =
     let v = read_global ask getg st x in
-    if M.tracing then M.tracel "priv" "READ GLOBAL %a %B %a = %a" CilType.Varinfo.pretty x (is_unprotected ask x) CPA.pretty st.cpa VD.pretty v;
+    if M.tracing then M.tracel "priv" "READ GLOBAL %a %B %a = %a" Var.pretty x (is_unprotected ask x) CPA.pretty st.cpa VD.pretty v;
     v
   let write_global ?(invariant=false) ask getg sideg (st: BaseComponents (D).t) x v =
     let cpa' =
@@ -423,7 +423,7 @@ struct
         CPA.add x v st.cpa
     in
     if not invariant then (
-      if M.tracing then M.tracel "priv" "WRITE GLOBAL SIDE %a = %a" CilType.Varinfo.pretty x VD.pretty v;
+      if M.tracing then M.tracel "priv" "WRITE GLOBAL SIDE %a = %a" Var.pretty x VD.pretty v;
       let side_cpa = CPA.singleton x v in
       sideg (V.global x) side_cpa;
       if !earlyglobs && not (ThreadFlag.is_currently_multi ask) then
@@ -471,12 +471,12 @@ struct
 
       let cpa' = CPA.fold (fun x v cpa ->
           if is_global ask x && is_unprotected ask x (* && not (VD.is_top v) *) then (
-            if M.tracing then M.tracel "priv" "SYNC SIDE %a = %a" CilType.Varinfo.pretty x VD.pretty v;
+            if M.tracing then M.tracel "priv" "SYNC SIDE %a = %a" Var.pretty x VD.pretty v;
             sideg (V.global x) (CPA.singleton x v);
             CPA.remove x cpa
           )
           else (
-            if M.tracing then M.tracel "priv" "SYNC NOSIDE %a = %a" CilType.Varinfo.pretty x VD.pretty v;
+            if M.tracing then M.tracel "priv" "SYNC NOSIDE %a = %a" Var.pretty x VD.pretty v;
             cpa
           )
         ) st.cpa st.cpa
@@ -505,7 +505,7 @@ struct
 
   let iter_sys_vars getg vq vf =
     match vq with
-    | VarQuery.Global g -> vf (V.global g)
+    | VarQuery.Global g -> vf (V.global (Cil g))
     | _ -> ()
 
   let long_meet m1 m2 = CPA.nonidempotent_union VD.meet m1 m2 (* TODO: idempotent_union if not using int domain refinement *)
@@ -563,7 +563,7 @@ struct
 
   let read_global ask getg st x =
     let v = read_global ask getg st x in
-    if M.tracing then M.tracel "priv" "READ GLOBAL %a %B %a = %a" CilType.Varinfo.pretty x (is_unprotected ~protection:Weak ask x) CPA.pretty st.cpa VD.pretty v;
+    if M.tracing then M.tracel "priv" "READ GLOBAL %a %B %a = %a" Var.pretty x (is_unprotected ~protection:Weak ask x) CPA.pretty st.cpa VD.pretty v;
     v
 
   let write_global ?(invariant=false) ask getg sideg (st: BaseComponents (D).t) x v =
@@ -575,7 +575,7 @@ struct
       else
         CPA.add x v st.cpa
     in
-    if M.tracing then M.tracel "priv" "WRITE GLOBAL SIDE %a = %a" CilType.Varinfo.pretty x VD.pretty v;
+    if M.tracing then M.tracel "priv" "WRITE GLOBAL SIDE %a = %a" Var.pretty x VD.pretty v;
     let digest = Digest.current ask in
     let sidev = GMutex.singleton digest (CPA.singleton x v) in
     let l' = L.add lm (CPA.singleton x v) l in
@@ -669,13 +669,13 @@ struct
     st
 
   let escape ask getg sideg (st: BaseComponents (D).t) escaped =
-    let escaped_cpa = CPA.filter (fun x _ -> EscapeDomain.EscapedVars.mem x escaped) st.cpa in
+    let escaped_cpa = CPA.filter (fun (Cil x) _ -> EscapeDomain.EscapedVars.mem x escaped) st.cpa in
     let digest = Digest.current ask in
     let sidev = GMutex.singleton digest escaped_cpa in
     sideg V.mutex_inits (G.create_mutex sidev);
-    let cpa' = CPA.fold (fun x v acc ->
-        if EscapeDomain.EscapedVars.mem x escaped (* && is_unprotected ask x *) then (
-          if M.tracing then M.tracel "priv" "ESCAPE SIDE %a = %a" CilType.Varinfo.pretty x VD.pretty v;
+    let cpa' = CPA.fold (fun (Cil vi as x) v acc ->
+        if EscapeDomain.EscapedVars.mem vi escaped (* && is_unprotected ask x *) then (
+          if M.tracing then M.tracel "priv" "ESCAPE SIDE %a = %a" Var.pretty x VD.pretty v;
           let sidev = GMutex.singleton digest (CPA.singleton x v) in
           sideg (V.global x) (G.create_global sidev);
           CPA.remove x acc
@@ -706,7 +706,7 @@ struct
 
   let threadspawn (ask:Queries.ask) get set (st: BaseComponents (D).t) =
     let is_recovered_st = ThreadFlag.has_ever_been_multi ask && not @@ ThreadFlag.is_currently_multi ask in
-    let unprotected_after x = ask.f (Q.MayBePublic {global=x; kind=Write; protection=Weak}) in
+    let unprotected_after (Var.Cil x) = ask.f (Q.MayBePublic {global=x; kind=Write; protection=Weak}) in
     if is_recovered_st then
       (* Remove all things that are now unprotected *)
       let cpa' = CPA.fold (fun x v cpa ->
@@ -745,7 +745,7 @@ struct
 
   module D = Lattice.Unit
   module G = VD
-  module V = VarinfoV
+  module V = VarV
 
   let startstate () = ()
 
@@ -806,8 +806,8 @@ struct
       st
 
   let escape ask getg sideg (st: BaseComponents (D).t) escaped =
-    CPA.iter (fun x v ->
-        if EscapeDomain.EscapedVars.mem x escaped then
+    CPA.iter (fun (Var.Cil vi as x) v ->
+        if EscapeDomain.EscapedVars.mem vi escaped then
           sideg x v
       ) st.cpa;
     st
@@ -828,17 +828,17 @@ struct
   let iter_sys_vars getg vq vf =
     match vq with
     | VarQuery.Global g ->
-      vf g;
+      vf (Var.Cil g);
     | _ -> ()
 
-  let invariant_global (ask: Q.ask) getg g =
-    let locks = ask.f (Q.MustProtectingLocks {global = g; kind = ReadWrite}) in
+  let invariant_global (ask: Q.ask) getg (Var.Cil vi as g) =
+    let locks = ask.f (Q.MustProtectingLocks {global = vi; kind = ReadWrite}) in
     if LockDomain.MustLockset.is_all locks then
       Invariant.none
     else (
       (* Only read g as protected, everything else (e.g. pointed to variables) may be unprotected.
          See 56-witness/69-ghost-ptr-protection and https://github.com/goblint/analyzer/pull/1394#discussion_r1698136411. *)
-      let read_global g' = if CilType.Varinfo.equal g' g then getg g' else VD.top () in (* TODO: Could be more precise for at least those which might not have all same protecting locks? *)
+      let read_global g' = if Var.equal g' g then getg g' else VD.top () in (* TODO: Could be more precise for at least those which might not have all same protecting locks? *)
       let inv = ValueDomain.invariant_global read_global g in
       (* Very conservative about multiple protecting mutexes: invariant is not claimed when any of them is held.
          It should be possible to be more precise because writes only happen with all of them held,
@@ -883,9 +883,9 @@ end
 module type ProtectionDom =
 sig
   include Lattice.S
-  val add: bool -> varinfo -> VD.t -> t -> t
-  val remove: varinfo -> t -> t
-  val precise_side: varinfo -> VD.t -> t -> VD.t option
+  val add: bool -> Var.t -> VD.t -> t -> t
+  val remove: Var.t -> t -> t
+  val precise_side: Var.t -> VD.t -> t -> VD.t option
   val empty: unit -> t
   val getP: t -> P.t
 end
@@ -913,12 +913,12 @@ end
 module ProtectionBasedV = struct
   module VUnprot =
   struct
-    include VarinfoV (* [g]' *)
+    include VarV (* [g]' *)
     let name () = "unprotected"
   end
   module VProt =
   struct
-    include VarinfoV (* [g] *)
+    include VarV (* [g] *)
     let name () = "protected"
   end
   module V =
@@ -980,7 +980,7 @@ struct
     let atomic = Param.handle_atomic && LockDomain.MustLock.equal m (LockDomain.MustLock.of_var LibraryFunctions.verifier_atomic_var) in
     (* TODO: what about G_m globals in cpa that weren't actually written? *)
     CPA.fold (fun x v (st: BaseComponents (D).t) ->
-        if (atomic && is_global ask x && not (VD.is_immediate_type x.vtype)) || is_protected_by ask m x then ( (* is_in_Gm *)
+        if (atomic && is_global ask x && not (VD.is_immediate_type (Var.typ x))) || is_protected_by ask m x then ( (* is_in_Gm *)
           (* Only apply sides for values that were actually written to globals!
              This excludes invariants inferred through guards. *)
           begin match D.precise_side x v st.priv with
@@ -1033,8 +1033,8 @@ struct
 
   let escape ask getg sideg (st: BaseComponents (D).t) escaped =
     let sideg = Wrapper.sideg ask sideg in
-    let cpa' = CPA.fold (fun x v acc ->
-        if EscapeDomain.EscapedVars.mem x escaped then (
+    let cpa' = CPA.fold (fun (Cil vi as x) v acc ->
+        if EscapeDomain.EscapedVars.mem vi escaped then (
           sideg (V.unprotected x) v;
           sideg (V.protected x) v;
           CPA.remove x acc
@@ -1066,8 +1066,8 @@ struct
   let iter_sys_vars getg vq vf =
     match vq with
     | VarQuery.Global g ->
-      vf (V.unprotected g);
-      vf (V.protected g);
+      vf (V.unprotected (Var.Cil g));
+      vf (V.protected (Var.Cil g));
     | _ -> ()
 
   let invariant_global (ask: Q.ask) getg g =
@@ -1075,8 +1075,8 @@ struct
     match g with
     | `Left g' -> (* unprotected *)
       ValueDomain.invariant_global (fun g -> getg (V.unprotected g)) g'
-    | `Right g' -> (* protected *)
-      let locks = ask.f (Q.MustProtectingLocks {global = g'; kind = Write}) in
+    | `Right (Var.Cil vi as g') -> (* protected *)
+      let locks = ask.f (Q.MustProtectingLocks {global = vi; kind = Write}) in
       if LockDomain.MustLockset.is_all locks || LockDomain.MustLockset.is_empty locks then
         Invariant.none
       else if VD.equal (getg (V.protected g')) (getg (V.unprotected g')) then
@@ -1084,7 +1084,7 @@ struct
       else (
         (* Only read g' as protected, everything else (e.g. pointed to variables) may be unprotected.
            See 56-witness/69-ghost-ptr-protection and https://github.com/goblint/analyzer/pull/1394#discussion_r1698136411. *)
-        let read_global g = getg (if CilType.Varinfo.equal g g' then V.protected g else V.unprotected g) in
+        let read_global g = getg (if Var.equal g g' then V.protected g else V.unprotected g) in
         let inv = ValueDomain.invariant_global read_global g' in
         (* Very conservative about multiple (write-)protecting mutexes: invariant is not claimed when any of them is held.
            It should be possible to be more precise because writes only happen with all of them held,
@@ -1148,7 +1148,7 @@ end
 module type SyncRangeS =
 sig
   include Lattice.S
-  val fold_sync_vars: (varinfo -> 'a -> 'a) -> t -> 'a -> 'a
+  val fold_sync_vars: (Var.t -> 'a -> 'a) -> t -> 'a -> 'a
   (** Fold over all variables represented by sync range. *)
 end
 
@@ -1170,7 +1170,7 @@ struct
       Invariant.none
 
   let invariant_vars ask getg st =
-    let module VS = Set.Make (CilType.Varinfo) in
+    let module VS = Set.Make (Var) in
     let s = current_lockset ask in
     MustLockset.fold (fun m acc ->
         GSync.fold (fun s' cpa' acc ->
@@ -1375,7 +1375,7 @@ struct
 
   module W =
   struct
-    include SetDomain.ToppedSet (Basetype.Variables) (struct let topname = "All variables" end)
+    include SetDomain.ToppedSet (Var) (struct let topname = "All variables" end)
     let name () = "W"
   end
   module D = W
@@ -1592,8 +1592,8 @@ struct
 
   let escape ask getg sideg (st: BaseComponents (D).t) escaped =
     let sideg = Wrapper.sideg ask sideg in
-    let cpa' = CPA.fold (fun x v acc ->
-        if EscapeDomain.EscapedVars.mem x escaped then (
+    let cpa' = CPA.fold (fun (Cil vi as x) v acc ->
+        if EscapeDomain.EscapedVars.mem vi escaped then (
           sideg (V.global x) (UnwrappedG.create_weak (GWeak.singleton lockset_init v));
           CPA.remove x acc
         )
@@ -1746,7 +1746,7 @@ struct
     let side_gsyncw = CPA.fold (fun x v acc ->
         if is_global ask x then (
           let w_x = W.find x w in
-          if M.tracing then M.trace "priv" "gsyncw %a %a %a" CilType.Varinfo.pretty x VD.pretty v MinLocksets.pretty w_x;
+          if M.tracing then M.trace "priv" "gsyncw %a %a %a" Var.pretty x VD.pretty v MinLocksets.pretty w_x;
           MinLocksets.fold (fun w acc ->
               let v = distr_init getg x v in
               GSyncW.add w (CPA.add x v (GSyncW.find w acc)) acc
@@ -1772,8 +1772,8 @@ struct
   let escape ask getg sideg (st: BaseComponents (D).t) escaped =
     let sideg = Wrapper.sideg ask sideg in
     let s = current_lockset ask in
-    CPA.fold (fun x v acc ->
-        if EscapeDomain.EscapedVars.mem x escaped then (
+    CPA.fold (fun (Cil vi as x) v acc ->
+        if EscapeDomain.EscapedVars.mem vi escaped then (
           let (w, p) = st.priv in
           let p' = P.add x (MinLocksets.singleton s) p in
           sideg (V.global x) (UnwrappedG.create_weak (GWeak.singleton (MustLockset.empty ()) (GWeakW.singleton lockset_init v)));
@@ -1955,8 +1955,8 @@ struct
   let escape ask getg sideg (st: BaseComponents (D).t) escaped =
     let sideg = Wrapper.sideg ask sideg in
     let s = current_lockset ask in
-    CPA.fold (fun x v acc ->
-        if EscapeDomain.EscapedVars.mem x escaped then (
+    CPA.fold (fun (Cil vi as x) v acc ->
+        if EscapeDomain.EscapedVars.mem vi escaped then (
           let ((w, p), (vv, l)) = st.priv in
           let p' = P.add x (MinLocksets.singleton s) p in
           sideg (V.global x) (UnwrappedG.create_weak (GWeak.singleton (MustLockset.empty ()) (GWeakW.singleton lockset_init v)));
@@ -2050,7 +2050,7 @@ struct
   module BaseComponents = BaseComponents (D)
 
   let read_global ask getg st x =
-    if M.tracing then M.traceli "priv" "read_global %a" CilType.Varinfo.pretty x;
+    if M.tracing then M.traceli "priv" "read_global %a" Var.pretty x;
     if M.tracing then M.trace "priv" "st: %a" BaseComponents.pretty st;
     let getg x =
       let r = getg x in
@@ -2062,7 +2062,7 @@ struct
     v
 
   let write_global ?invariant ask getg sideg st x v =
-    if M.tracing then M.traceli "priv" "write_global %a %a" CilType.Varinfo.pretty x VD.pretty v;
+    if M.tracing then M.traceli "priv" "write_global %a %a" Var.pretty x VD.pretty v;
     if M.tracing then M.trace "priv" "st: %a" BaseComponents.pretty st;
     let getg x =
       let r = getg x in

--- a/src/analyses/basePriv.mli
+++ b/src/analyses/basePriv.mli
@@ -16,8 +16,8 @@ sig
 
   val startstate: unit -> D.t
 
-  val read_global: Queries.ask -> (V.t -> G.t) -> BaseDomain.BaseComponents (D).t -> varinfo -> BaseDomain.VD.t
-  val write_global: ?invariant:bool -> Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> varinfo -> BaseDomain.VD.t -> BaseDomain.BaseComponents (D).t
+  val read_global: Queries.ask -> (V.t -> G.t) -> BaseDomain.BaseComponents (D).t -> Var.t -> BaseDomain.VD.t
+  val write_global: ?invariant:bool -> Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> Var.t -> BaseDomain.VD.t -> BaseDomain.BaseComponents (D).t
 
   val lock: Queries.ask -> (V.t -> G.t) -> BaseDomain.BaseComponents (D).t -> LockDomain.MustLock.t -> BaseDomain.BaseComponents (D).t
   val unlock: Queries.ask -> (V.t -> G.t) -> (V.t -> G.t -> unit) -> BaseDomain.BaseComponents (D).t -> LockDomain.MustLock.t -> BaseDomain.BaseComponents (D).t
@@ -38,7 +38,7 @@ sig
 
       Should account for all unprotected/weak values of global variables. *)
 
-  val invariant_vars: Queries.ask -> (V.t -> G.t) -> BaseDomain.BaseComponents (D).t -> varinfo list
+  val invariant_vars: Queries.ask -> (V.t -> G.t) -> BaseDomain.BaseComponents (D).t -> Var.t list
   (** Returns global variables which are privatized. *)
 
   val init: unit -> unit

--- a/src/analyses/baseUtil.ml
+++ b/src/analyses/baseUtil.ml
@@ -2,13 +2,13 @@ open GoblintCil
 open GobConfig
 module Q = Queries
 
-let is_global (a: Q.ask) (v: varinfo): bool =
+let is_global (a: Q.ask) (Cil v: Var.t): bool =
   v.vglob || ThreadEscape.has_escaped a v
 
 let is_static (v:varinfo): bool = v.vstorage = Static
 let is_volatile variable = Ciltools.is_volatile_tp variable.vtype
 
-let is_always_unknown variable = variable.vstorage = Extern || Ciltools.is_volatile_tp variable.vtype
+let is_always_unknown (Cil variable: Var.t) = variable.vstorage = Extern || Ciltools.is_volatile_tp variable.vtype
 
-let is_excluded_from_earlyglobs v = List.mem v.vname (get_string_list "exp.exclude_from_earlyglobs")
+let is_excluded_from_earlyglobs (Cil v: Var.t) = List.mem v.vname (get_string_list "exp.exclude_from_earlyglobs")
 let is_excluded_from_invalidation v =  List.mem v.vname (get_string_list "exp.exclude_from_invalidation")

--- a/src/analyses/baseUtil.mli
+++ b/src/analyses/baseUtil.mli
@@ -2,9 +2,9 @@
 
 open GoblintCil
 
-val is_global: Queries.ask -> varinfo -> bool
+val is_global: Queries.ask -> Var.t -> bool
 val is_static: varinfo -> bool
 val is_volatile: varinfo -> bool
-val is_always_unknown: varinfo -> bool
-val is_excluded_from_earlyglobs: varinfo -> bool
+val is_always_unknown: Var.t -> bool
+val is_excluded_from_earlyglobs: Var.t -> bool
 val is_excluded_from_invalidation: varinfo -> bool

--- a/src/analyses/commonPriv.ml
+++ b/src/analyses/commonPriv.ml
@@ -84,28 +84,29 @@ struct
   open Q.Protection
   open Q.ProtectionKind
 
-  let is_unprotected ask ?(kind=Write) ?(protection=Strong) x: bool =
+  let is_unprotected ask ?(kind=Write) ?(protection=Strong) (Var.Cil vi as x): bool =
     let multi = if protection = Weak then ThreadFlag.is_currently_multi ask else ThreadFlag.has_ever_been_multi ask in
     (!GobConfig.earlyglobs && not multi && not (is_excluded_from_earlyglobs x)) ||
     (
       multi &&
-      ask.f (Q.MayBePublic {global=x; kind; protection})
+      ask.f (Q.MayBePublic {global=vi; kind; protection})
     )
 
-  let is_unprotected_without ask ?(kind=Write) ?(protection=Strong) x m: bool =
+  let is_unprotected_without ask ?(kind=Write) ?(protection=Strong) (Var.Cil x) m: bool =
     (if protection = Weak then ThreadFlag.is_currently_multi ask else ThreadFlag.has_ever_been_multi ask) &&
     ask.f (Q.MayBePublicWithout {global=x; kind; without_mutex=m; protection})
 
-  let is_protected_by ask ?(kind=Write) ?(protection=Strong) m x: bool =
+  let is_protected_by ask ?(kind=Write) ?(protection=Strong) m (Var.Cil vi as x): bool =
     is_global ask x &&
-    not (VD.is_immediate_type x.vtype) &&
-    ask.f (Q.MustBeProtectedBy {mutex=m; global=x; kind; protection})
+    not (VD.is_immediate_type (Var.typ x)) &&
+    ask.f (Q.MustBeProtectedBy {mutex=m; global=vi; kind; protection})
 
-  let protected_vars (ask: Q.ask) ~(kind): varinfo list =
+  let protected_vars (ask: Q.ask) ~(kind): Var.t list =
     LockDomain.MustLockset.fold (fun ml acc ->
         Q.VS.join (ask.f (Q.MustProtectedVars {mutex = ml; kind})) acc
       ) (ask.f Q.MustLockset) (Q.VS.empty ())
     |> Q.VS.elements
+    |> List.map (fun x -> Var.Cil x)
 end
 
 module MutexGlobals =
@@ -118,7 +119,7 @@ struct
   module VMutexInits = Printable.UnitConf (struct let name = "MUTEX_INITS" end)
   module VGlobal =
   struct
-    include VarinfoV
+    include VarV
     let name () = "global"
   end
   module V =
@@ -132,13 +133,13 @@ struct
 
   let iter_sys_vars getg vq vf =
     match vq with
-    | Goblint_constraint.VarQuery.Global g -> vf (V.global g)
+    | Goblint_constraint.VarQuery.Global g -> vf (V.global (Cil g))
     | _ -> ()
 end
 
 module MayVars =
 struct
-  include SetDomain.ToppedSet (Basetype.Variables) (struct let topname = "All Variables" end)
+  include SetDomain.ToppedSet (Var) (struct let topname = "All Variables" end)
   let name () = "may variables"
 end
 
@@ -169,7 +170,7 @@ struct
 
   module W =
   struct
-    include MapDomain.PatriciaMapBot_LiftTop (Basetype.Variables) (MinLocksets)
+    include MapDomain.PatriciaMapBot_LiftTop (Var) (MinLocksets)
     let name () = "W"
   end
 
@@ -178,7 +179,7 @@ struct
     (* Note different Map order! *)
     (* MapTop because default value in P must be top of MinLocksets,
        as opposed to bottom in W. *)
-    include MapDomain.PatriciaMapTop_LiftBot (Basetype.Variables) (MinLocksets)
+    include MapDomain.PatriciaMapTop_LiftBot (Var) (MinLocksets)
     let name () = "P"
 
     (* TODO: change MinLocksets.exists/top instead? *)
@@ -263,7 +264,7 @@ struct
 
   module LLock =
   struct
-    include Printable.Either (LockDomain.MustLock) (struct include CilType.Varinfo let name () = "global" end)
+    include Printable.Either (LockDomain.MustLock) (struct include Var let name () = "global" end)
     let mutex m = `Left m
     let global x = `Right x
   end

--- a/src/analyses/varEq.ml
+++ b/src/analyses/varEq.ml
@@ -351,7 +351,7 @@ struct
     | Imag _ -> None
     | Const _ -> Some false
     | Lval (Var v,_) ->
-      Some (v.vglob || (ask.f (Queries.IsMultiple v) || BaseUtil.is_global ask v))
+      Some (v.vglob || (ask.f (Queries.IsMultiple v) || BaseUtil.is_global ask (Cil v)))
     | Lval (Mem e, _) ->
       begin match ask.f (Queries.MayPointTo e) with
         | ad when not (Queries.AD.is_top ad) ->

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -1346,7 +1346,7 @@ module type InvariantArg =
 sig
   val context: Invariant.context
   val scope: fundec
-  val find: varinfo -> Compound.t
+  val find: Var.t -> Compound.t
 end
 
 module ValueInvariant (Arg: InvariantArg) =
@@ -1443,7 +1443,7 @@ struct
     | _ -> Invariant.none (* TODO *)
 
   and deref_invariant ~vs vi ~offset ~lval =
-    let v = find vi in
+    let v = find (Cil vi) in
     key_invariant_lval ~vs vi ~offset ~lval v
 
   and key_invariant_lval ?(vs=VS.empty) k ~offset ~lval v =
@@ -1453,7 +1453,7 @@ struct
     else
       Invariant.none
 
-  let key_invariant k ?(offset=NoOffset) v = key_invariant_lval k ~offset ~lval:(var k) v
+  let key_invariant (Var.Cil k) ?(offset=NoOffset) v = key_invariant_lval k ~offset ~lval:(var k) v
 end
 
 let invariant_global find g =

--- a/src/cdomains/apron/relationDomain.apron.ml
+++ b/src/cdomains/apron/relationDomain.apron.ml
@@ -2,6 +2,8 @@
 
     See {!ApronDomain} and {!AffineEqualityDomain}. *)
 
+module GVar = Var (** Goblint {!Var}, not {!Apron.Var}. *)
+
 open GobApron
 open Batteries
 open GoblintCil
@@ -53,10 +55,10 @@ sig
   val vh: vartable
   val make_var: ?name:string -> VM.t -> t
   val find_metadata: t -> VM.t Option.t
-  val local: varinfo -> t
-  val arg: varinfo -> t
+  val local: GVar.t -> t
+  val arg: GVar.t -> t
   val return: t
-  val global: varinfo -> t
+  val global: GVar.t -> t
   val to_cil_varinfo: t -> varinfo Option.t
 end
 
@@ -70,10 +72,10 @@ struct
 
   type vartable = VM.t VMT.VH.t
 
-  let local x = make_var (Local x)
-  let arg x = make_var (Arg x)
+  let local (GVar.Cil x) = make_var (Local x)
+  let arg (GVar.Cil x) = make_var (Arg x)
   let return = make_var Return
-  let global g = make_var (Global g)
+  let global (GVar.Cil g) = make_var (Global g)
 
   let to_cil_varinfo v =
     match find_metadata v with

--- a/src/cdomains/apron/sharedFunctions.apron.ml
+++ b/src/cdomains/apron/sharedFunctions.apron.ml
@@ -131,9 +131,9 @@ struct
           if not v.vglob || Arg.allow_global then
             let var =
               if v.vglob then
-                V.global v
+                V.global (Cil v)
               else
-                V.local v
+                V.local (Cil v)
             in
             if Environment.mem_var env var then
               Var var

--- a/src/cdomains/baseDomain.ml
+++ b/src/cdomains/baseDomain.ml
@@ -5,11 +5,11 @@ module VD = ValueDomain.Compound
 
 module CPA =
 struct
-  module M0 = MapDomain.PatriciaMapBot (Basetype.Variables) (VD)
+  module M0 = MapDomain.PatriciaMapBot (Var) (VD)
   module M =
   struct
     include M0
-    include MapDomain.PrintGroupable (Basetype.Variables) (VD) (M0)
+    include MapDomain.PrintGroupable (Var) (VD) (M0)
   end
   include MapDomain.LiftTop (VD) (MapDomain.HashCached (M))
   let name () = "value domain"

--- a/src/common/cdomains/var.ml
+++ b/src/common/cdomains/var.ml
@@ -1,0 +1,21 @@
+type t =
+  | Cil of Basetype.Variables.t (* Basetype not CilType because of custom printing *)
+[@@deriving eq, ord, hash, show]
+
+let name () = "var"
+
+include Printable.Std
+
+let show (Cil x) = Basetype.Variables.show x
+let pretty () (Cil x) = Basetype.Variables.pretty () x
+let printXml f (Cil x) = Basetype.Variables.printXml f x
+let to_yojson (Cil x) = Basetype.Variables.to_yojson x
+
+let tag (Cil x) = Basetype.Variables.tag x (* for Patricia maps *)
+let relift (Cil x) = Cil (Basetype.Variables.relift x)
+
+let typ (Cil x) = x.vtype
+
+
+type group = Basetype.Variables.group [@@deriving ord, show { with_path = false }]
+let to_group (Cil x) = Basetype.Variables.to_group x

--- a/src/common/cdomains/var.mli
+++ b/src/common/cdomains/var.mli
@@ -1,0 +1,12 @@
+type t = Cil of GoblintCil.varinfo
+
+include Printable.S with type t := t
+
+val typ: t -> GoblintCil.typ
+
+(* include MapDomain.Groupable *)
+(* TODO: don't duplicate *)
+type group (* use [@@deriving show { with_path = false }] *)
+val compare_group: group -> group -> int
+val show_group: group -> string
+val to_group: t -> group

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -11,7 +11,7 @@ module M  = Messages
 type fundecs = fundec list * fundec list * fundec list
 
 
-module Var =
+module VarNode =
 struct
   type t = Node.t [@@deriving eq, ord, hash, relift]
 
@@ -36,12 +36,12 @@ struct
     else dprintf "%a on %a" Node.pretty_trace n CilType.Location.pretty (getLocation x)
 
   let printXml f (n,c) =
-    Var.printXml f n;
+    VarNode.printXml f n;
     BatPrintf.fprintf f "<context>\n";
     LD.printXml f c;
     BatPrintf.fprintf f "</context>\n"
 
-  let var_id (n,_) = Var.var_id n
+  let var_id (n,_) = VarNode.var_id n
   let node (n,_) = n
   let is_write_only _ = false
 end

--- a/src/framework/analyses.ml
+++ b/src/framework/analyses.ml
@@ -307,6 +307,12 @@ struct
   include StdV
 end
 
+module VarV =
+struct
+  include Var (* TODO: or Basetype.Variables? *)
+  include StdV
+end
+
 module TIDV =
 struct
   include ThreadIdDomain.Thread

--- a/src/util/privPrecCompareUtil.ml
+++ b/src/util/privPrecCompareUtil.ml
@@ -5,10 +5,10 @@ open PrecCompareUtil
 
 module LV =
 struct
-  include Printable.Prod (CilType.Location) (Basetype.Variables)
+  include Printable.Prod (CilType.Location) (Var)
   let name () = "location variables"
   type marshal = t
-  let pretty () (l, v) = Pretty.dprintf "%a %a" CilType.Location.pretty l Basetype.Variables.pretty v
+  let pretty () (l, v) = Pretty.dprintf "%a %a" CilType.Location.pretty l Var.pretty v
   let to_location = fst
 end
 


### PR DESCRIPTION
The idea would be to replace uses of `Cil.varinfo` with our own `Var.t` in domains, etc., such that we could avoid abusing `varinfo` for all of our non-CIL variables, e.g., `(alloc@...)`, `RETURN`, `g#in`, `g#out`, etc.
Then we could easily associate arbitrary interesting information with them (e.g. in allocated variables) and _maybe_ be able to fix things like #1025.
This might also make it easier to introduce ghost variables without trying to cram everything into `varinfo`.

This is currently just the tip of the iceberg: it simply wraps a `varinfo` in a variant type with a single constructor. And then it changes a few domains and does a lot of (un)wrapping at the interface with the rest.
The hope would be that by doing this across the board, these conversions would more-or-less disappear because everything is `Var.t`.

And the conversions would largely have to disappear because once we'd introduce another case to `Var.t` (like `Return` or `Alloc of ...`), then each one of these conversions would suddenly need pattern matching. So there should be a minimal amount of back-and-forth conversion before even attempting that.

I'm not entirely sure if this would actually succeed though. The relational analyses already have a bunch of different things like this:
https://github.com/goblint/analyzer/blob/5665ee1a39c59c267424a0c0cf2c53af10325a3f/src/cdomains/apron/relationDomain.apron.ml#L17-L21
https://github.com/goblint/analyzer/blob/5665ee1a39c59c267424a0c0cf2c53af10325a3f/src/analyses/apron/relationPriv.apron.ml#L199-L202
But they're all subtly different and I don't know if they could reasonably be crammed into a single `Var.t` type.
Perhaps the proper way would require parametrizing everything over different `Var` modules (as functors), rather than a single global one, but that's yet another layer of complexity on top of this.

### TODO
- [ ] `Mval`
- [ ] `Queries`
- [ ] Other analyses