### PR TITLE
Fix `eval_offset` on unknown union field with known value

### DIFF
--- a/tests/regression/01-cpa/61-union-top-field-known-value.c
+++ b/tests/regression/01-cpa/61-union-top-field-known-value.c
@@ -1,0 +1,40 @@
+#include <goblint.h>
+
+union U {
+  int x;
+  int y;
+};
+
+int main() {
+  union U u;
+
+  int r, r2; // rand
+
+  switch (r) {
+    case 0:
+      u.x = 0;
+      __goblint_check(u.x == 0);
+      __goblint_check(u.y == 0);
+      break;
+
+    case 1:
+      u.y = 0;
+      __goblint_check(u.x == 0);
+      __goblint_check(u.y == 0);
+      break;
+
+    case 2:
+      if (r2)
+        u.x = 0;
+      else
+        u.y = 0;
+
+      __goblint_check(u.x == 0); // TODO
+      __goblint_check(u.y == 0); // TODO
+      break;
+
+    default:
+      break;
+  }
+  return 0;
+}


### PR DESCRIPTION
This came out of #2127 in a somewhat involved way.
This is an independent fix using a simpler test.

Namely, for
```c
union U {
  int x;
  int y;
};
```
both
```c
u.x = 0;
__goblint_check(u.x == 0);
__goblint_check(u.y == 0);
```
and
```c
u.y = 0;
__goblint_check(u.x == 0);
__goblint_check(u.y == 0);
```
succeed in both checks.

But
```c
if (r2)
  u.x = 0;
else
  u.y = 0;

__goblint_check(u.x == 0);
__goblint_check(u.y == 0);
```
doesn't (in either check).

If we already allow cross-field reads, then there's no reason to not allow it with when the union field is not known.