### PR TITLE
Improve `invariant` `set` for weak updates

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1713,8 +1713,12 @@ struct
       (* Projection globals to highest Precision *)
       let projected_value = project_val (Queries.to_value_domain_ask ask) None None value (is_global ask x) in
       let new_value = VD.update_offset ~blob_destructive (Queries.to_value_domain_ask ask) old_value offs projected_value lval_raw ((Var x), cil_offset) t in
-      if WeakUpdates.mem x st.weak then
-        VD.join old_value new_value
+      if WeakUpdates.mem x st.weak then (
+        if invariant then
+          old_value (* without this, invariant for ambiguous pointer might worsen precision for each individual weakly updatable address to their join *)
+        else
+          VD.join old_value new_value
+      )
       else if invariant then (
         (* without this, invariant for ambiguous pointer might worsen precision for each individual address to their join *)
         try

--- a/tests/regression/01-cpa/62-weak-branch.c
+++ b/tests/regression/01-cpa/62-weak-branch.c
@@ -16,7 +16,7 @@ void foo(int i, int *p) { // p is actually unused - only used to make x weakly u
     int r; // rand
     int *q = r ? &x : &y;
 
-    // Spurious branching, which makes x[0] less precise!
+    // Spurious branching, which used to make x[0] less precise!
     if (*q != 42); // NB! Semicolon - no body for if branches.
     // *q evaluates to [0,1]
     // In true branch:

--- a/tests/regression/01-cpa/62-weak-branch.c
+++ b/tests/regression/01-cpa/62-weak-branch.c
@@ -1,0 +1,35 @@
+#include <stdlib.h>
+#include <goblint.h>
+
+void foo(int i, int *p) { // p is actually unused - only used to make x weakly updatable.
+  int x[1] = {0};
+  // x is an array because in the recursive call initialization is by weak update.
+  // If x were just int, then it starts out as top and even the initialization cannot improve it.
+  // Arrays start out with bottom contents, so the issue isn't covered up by extreme imprecision.
+
+  if (i == 0) { // initial call from main
+    foo(1, &x); // recursive call to just make x weakly updatable.
+  }
+  else { // recursive call from foo
+    int y = 1;
+
+    int r; // rand
+    int *q = r ? &x : &y;
+
+    // Spurious branching, which makes x[0] less precise!
+    if (*q != 42); // NB! Semicolon - no body for if branches.
+    // *q evaluates to [0,1]
+    // In true branch:
+    //   *q refined to Not{42}
+    //   Two cases (joined):
+    //     1. x[0] refined to Not{42} - weak update should not make x[0] less precise than 0.
+    //     2. y refined to Not{42}
+
+    __goblint_check(x[0] == 0);
+  }
+}
+
+int main() {
+  foo(0, NULL);
+  return 0;
+}


### PR DESCRIPTION
This came out of #2127 in a somewhat involved way.
This is an independent fix using ~~a simpler test~~ an arguably more involved test because currently base only does weak updates to recursively escaped variables and non-array recursively escaped variables are inherently top.

The test is more complicated than the issue and its fix. Basically, without this, spurious branching can make the analysis less precise.