### PR TITLE
SV-COMP 2027 development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ native :
 .PHONY: sv-comp-tag sv-comp-build sv-comp-smoketest-ubuntu sv-comp-smoketest-competition sv-comp-smoketest sv-comp
 
 sv-comp-tag:
-	git tag -m "SV-COMP 2026" svcomp26
+	git tag -m "SV-COMP 2027" svcomp27
 
 sv-comp-build: sv-comp-tag
 	docker build . -f scripts/sv-comp/Dockerfile --output=scripts/sv-comp/

--- a/conf/svcomp27/common.json
+++ b/conf/svcomp27/common.json
@@ -1,0 +1,56 @@
+{
+  "ana": {
+    "sv-comp": {
+      "enabled": true,
+      "functions": true
+    },
+    "int": {
+      "def_exc": true
+    },
+    "context": {
+      "widen": false
+    },
+    "race": {
+      "free": false,
+      "call": false
+    },
+    "autotune": {
+      "enabled": true
+    }
+  },
+  "exp": {
+    "region-offsets": true
+  },
+  "solver": "td3",
+  "solvers": {
+    "td3": {
+      "weak-deps": "lazy"
+    }
+  },
+  "sem": {
+    "unknown_function": {
+      "spawn": false
+    },
+    "int": {
+      "signed_overflow": "assume_none"
+    },
+    "null-pointer": {
+      "dereference": "assume_none"
+    },
+    "malloc": {
+      "fail": false,
+      "zero": "either"
+    }
+  },
+  "witness": {
+    "yaml": {
+      "format-version": "2.1"
+    },
+    "invariant": {
+      "loop-head": true
+    }
+  },
+  "pre": {
+    "transform-paths": false
+  }
+}

--- a/conf/svcomp27/common.json
+++ b/conf/svcomp27/common.json
@@ -38,7 +38,7 @@
       "dereference": "assume_none"
     },
     "malloc": {
-      "fail": false,
+      "fail": true,
       "zero": "either"
     }
   },

--- a/conf/svcomp27/common.json
+++ b/conf/svcomp27/common.json
@@ -40,6 +40,10 @@
     "malloc": {
       "fail": true,
       "zero": "either"
+    },
+    "alloca": {
+      "fail": false,
+      "zero": "pointer"
     }
   },
   "witness": {

--- a/conf/svcomp27/level00.json
+++ b/conf/svcomp27/level00.json
@@ -1,0 +1,63 @@
+{
+  "ana": {
+    "int": {
+      "enums": false
+    },
+    "float": {
+      "interval": false,
+      "evaluate_math_functions": false
+    },
+    "activated": [
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "mallocWrapper",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "race",
+      "escape",
+      "expRelation",
+      "mhp",
+      "assert",
+      "symb_locks",
+      "region",
+      "thread",
+      "threadJoins",
+      "abortUnless",
+      "mutexGhosts",
+      "pthreadMutexType"
+    ],
+    "path_sens": [
+      "mutex",
+      "malloc_null",
+      "uninit",
+      "expsplit",
+      "activeSetjmp",
+      "memLeak",
+      "threadflag"
+    ],
+    "context": {
+      "gas_value": 30
+    },
+    "base": {
+      "arrays": {
+        "domain": "partitioned"
+      }
+    },
+    "autotune": {
+      "activated": [
+        "reduceAnalyses",
+        "mallocWrappers",
+        "noRecursiveIntervals",
+        "wideningThresholds",
+        "loopUnrollHeuristic",
+        "memsafetySpecification",
+        "noOverflows",
+        "termination",
+        "tmpSpecialAnalysis"
+      ]
+    }
+  }
+}

--- a/conf/svcomp27/level01.json
+++ b/conf/svcomp27/level01.json
@@ -1,0 +1,68 @@
+{
+  "ana": {
+    "int": {
+      "enums": false,
+      "interval": true
+    },
+    "float": {
+      "interval": true,
+      "evaluate_math_functions": true
+    },
+    "activated": [
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "mallocWrapper",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "race",
+      "escape",
+      "expRelation",
+      "mhp",
+      "assert",
+      "var_eq",
+      "symb_locks",
+      "region",
+      "thread",
+      "threadJoins",
+      "abortUnless",
+      "mutexGhosts",
+      "pthreadMutexType"
+    ],
+    "path_sens": [
+      "mutex",
+      "malloc_null",
+      "uninit",
+      "expsplit",
+      "activeSetjmp",
+      "memLeak",
+      "threadflag"
+    ],
+    "context": {
+      "gas_value": 30
+    },
+    "base": {
+      "arrays": {
+        "domain": "partitioned"
+      }
+    },
+    "autotune": {
+      "activated": [
+        "reduceAnalyses",
+        "mallocWrappers",
+        "noRecursiveIntervals",
+        "enums",
+        "congruence",
+        "octagon",
+        "wideningThresholds",
+        "loopUnrollHeuristic",
+        "memsafetySpecification",
+        "noOverflows",
+        "termination",
+        "tmpSpecialAnalysis"
+      ]
+    }
+  }
+}

--- a/conf/svcomp27/level02.json
+++ b/conf/svcomp27/level02.json
@@ -1,0 +1,80 @@
+{
+  "ana": {
+    "int": {
+      "enums": true,
+      "congruence": true,
+      "bitfield":true,
+      "interval": true
+    },
+    "float": {
+      "interval": true,
+      "evaluate_math_functions": true
+    },
+    "activated": [
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "mallocWrapper",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "race",
+      "escape",
+      "expRelation",
+      "mhp",
+      "assert",
+      "var_eq",
+      "symb_locks",
+      "region",
+      "thread",
+      "threadJoins",
+      "abortUnless",
+      "mutexGhosts",
+      "pthreadMutexType",
+      "affeq",
+      "apron"
+    ],
+    "apron": {
+      "domain": "octagon"
+    },
+    "path_sens": [
+      "mutex",
+      "malloc_null",
+      "uninit",
+      "expsplit",
+      "activeSetjmp",
+      "memLeak",
+      "threadflag"
+    ],
+    "base": {
+      "arrays": {
+        "domain": "partitioned"
+      },
+      "structs": {
+        "domain": "sets"
+      }
+    },
+    "autotune": {
+      "activated": [
+        "reduceAnalyses",
+        "mallocWrappers",
+        "noRecursiveIntervals",
+        "enums",
+        "congruence",
+        "wideningThresholds",
+        "loopUnrollHeuristic",
+        "memsafetySpecification",
+        "noOverflows",
+        "termination",
+        "tmpSpecialAnalysis"
+      ]
+    }
+  },
+  "solvers": {
+    "td3": {
+      "widen_gas": 30,
+      "side_widen_gas": 30
+    }
+  }
+}

--- a/conf/svcomp27/level03.json
+++ b/conf/svcomp27/level03.json
@@ -1,0 +1,82 @@
+{
+  "ana": {
+    "int": {
+      "enums": true,
+      "congruence": true,
+      "bitfield":true,
+      "interval": true
+    },
+    "float": {
+      "interval": true,
+      "evaluate_math_functions": true
+    },
+    "activated": [
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "mallocWrapper",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "race",
+      "escape",
+      "expRelation",
+      "mhp",
+      "assert",
+      "var_eq",
+      "symb_locks",
+      "region",
+      "thread",
+      "threadJoins",
+      "abortUnless",
+      "mutexGhosts",
+      "pthreadMutexType",
+      "affeq",
+      "apron",
+      "branchSet"
+    ],
+    "apron": {
+      "domain": "octagon"
+    },
+    "path_sens": [
+      "mutex",
+      "malloc_null",
+      "uninit",
+      "expsplit",
+      "activeSetjmp",
+      "memLeak",
+      "threadflag",
+      "branchSet"
+    ],
+    "base": {
+      "arrays": {
+        "domain": "partitioned"
+      },
+      "structs": {
+        "domain": "sets"
+      }
+    },
+    "autotune": {
+      "activated": [
+        "reduceAnalyses",
+        "mallocWrappers",
+        "noRecursiveIntervals",
+        "enums",
+        "congruence",
+        "wideningThresholds",
+        "loopUnrollHeuristic",
+        "memsafetySpecification",
+        "noOverflows",
+        "termination",
+        "tmpSpecialAnalysis"
+      ]
+    }
+  },
+  "solvers": {
+    "td3": {
+      "widen_gas": 30,
+      "side_widen_gas": 30
+    }
+  }
+}

--- a/conf/svcomp27/level04-validate.json
+++ b/conf/svcomp27/level04-validate.json
@@ -1,0 +1,76 @@
+{
+  "ana": {
+    "int": {
+      "congruence": true,
+      "bitfield":true,
+      "enums": true,
+      "interval": true,
+      "interval_threshold_widening": true
+    },
+    "float": {
+      "interval": true,
+      "evaluate_math_functions": true
+    },
+    "activated": [
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "mallocWrapper",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "race",
+      "escape",
+      "expRelation",
+      "mhp",
+      "assert",
+      "var_eq",
+      "symb_locks",
+      "region",
+      "thread",
+      "threadJoins",
+      "abortUnless",
+      "mutexGhosts",
+      "pthreadMutexType"
+    ],
+    "path_sens": [
+      "mutex",
+      "malloc_null",
+      "uninit",
+      "expsplit",
+      "activeSetjmp",
+      "memLeak",
+      "threadflag",
+      "base"
+    ],
+    "base": {
+      "arrays": {
+        "domain": "unroll",
+        "unrolling-factor": 16
+      },
+      "structs": {
+        "domain": "sets"
+      }
+    },
+    "autotune": {
+      "activated": [
+        "reduceAnalyses",
+        "mallocWrappers",
+        "noRecursiveIntervals",
+        "enums",
+        "congruence",
+        "octagon",
+        "wideningThresholds",
+        "loopUnrollHeuristic",
+        "memsafetySpecification",
+        "noOverflows",
+        "termination",
+        "tmpSpecialAnalysis"
+      ]
+    }
+  },
+  "exp": {
+    "unrolling-factor": 4
+  }
+}

--- a/conf/svcomp27/level04.json
+++ b/conf/svcomp27/level04.json
@@ -1,0 +1,84 @@
+{
+  "ana": {
+    "int": {
+      "congruence": true,
+      "bitfield":true,
+      "enums": true,
+      "interval": true,
+      "interval_threshold_widening": true
+    },
+    "float": {
+      "interval": true,
+      "evaluate_math_functions": true
+    },
+    "activated": [
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "mallocWrapper",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "race",
+      "escape",
+      "expRelation",
+      "mhp",
+      "assert",
+      "var_eq",
+      "symb_locks",
+      "region",
+      "thread",
+      "threadJoins",
+      "abortUnless",
+      "mutexGhosts",
+      "pthreadMutexType"
+    ],
+    "path_sens": [
+      "mutex",
+      "malloc_null",
+      "uninit",
+      "expsplit",
+      "activeSetjmp",
+      "memLeak",
+      "threadflag",
+      "base"
+    ],
+    "base": {
+      "arrays": {
+        "domain": "unroll",
+        "unrolling-factor": 16
+      },
+      "structs": {
+        "domain": "sets"
+      }
+    },
+    "autotune": {
+      "activated": [
+        "reduceAnalyses",
+        "mallocWrappers",
+        "noRecursiveIntervals",
+        "enums",
+        "congruence",
+        "octagon",
+        "wideningThresholds",
+        "loopUnrollHeuristic",
+        "memsafetySpecification",
+        "noOverflows",
+        "termination",
+        "tmpSpecialAnalysis"
+      ]
+    }
+  },
+  "exp": {
+    "unrolling-factor": 4
+  },
+  "witness": {
+    "yaml": {
+      "entry-types": [
+        "invariant_set"
+      ],
+      "invariant-types": []
+    }
+  }
+}

--- a/conf/svcomp27/level05.json
+++ b/conf/svcomp27/level05.json
@@ -1,0 +1,84 @@
+{
+  "ana": {
+    "int": {
+      "enums": true,
+      "congruence": true,
+      "bitfield":true,
+      "interval": true
+    },
+    "float": {
+      "interval": true,
+      "evaluate_math_functions": true
+    },
+    "activated": [
+      "base",
+      "threadid",
+      "threadflag",
+      "threadreturn",
+      "mallocWrapper",
+      "mutexEvents",
+      "mutex",
+      "access",
+      "race",
+      "escape",
+      "expRelation",
+      "mhp",
+      "assert",
+      "var_eq",
+      "symb_locks",
+      "region",
+      "thread",
+      "threadJoins",
+      "abortUnless",
+      "mutexGhosts",
+      "pthreadMutexType",
+      "apron"
+    ],
+    "apron": {
+      "domain": "polyhedra"
+    },
+    "path_sens": [
+      "mutex",
+      "malloc_null",
+      "uninit",
+      "expsplit",
+      "activeSetjmp",
+      "memLeak",
+      "threadflag"
+    ],
+    "base": {
+      "arrays": {
+        "domain": "unroll",
+        "unrolling-factor": 4
+      },
+      "structs": {
+        "domain": "sets"
+      }
+    },
+    "autotune": {
+      "activated": [
+        "reduceAnalyses",
+        "mallocWrappers",
+        "noRecursiveIntervals",
+        "wideningThresholds",
+        "loopUnrollHeuristic",
+        "memsafetySpecification",
+        "noOverflows",
+        "termination",
+        "tmpSpecialAnalysis"
+      ]
+    }
+  },
+  "exp": {
+    "unrolling-factor": 4
+  },
+  "solvers": {
+    "td3": {
+      "narrow-globs": {
+        "enabled": true
+      },
+      "widen_gas": 60,
+      "side_widen_gas": 60
+    }
+  }
+}

--- a/conf/svcomp27/seq-validate.txt
+++ b/conf/svcomp27/seq-validate.txt
@@ -1,0 +1,15 @@
+# Portfolio Configuration Sequence
+# paths are relative to analyzer base directory
+#
+# minimalist run, basically only constants/def_exc, but with context gas
+--conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level00.json --set ana.activated[+] unassume
+# standard run based on svcomp 25 settings, but with context gas
+--conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level01.json --set ana.activated[+] unassume
+# apron/affeq run with enums,congruence, bitfield and sets for structs, sporting (side_)widen_gas 30, no autotuner for apron
+--conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level02.json --set ana.activated[+] unassume
+# apron/affeq run with enums,congruence, bitfield and sets for structs, sporting (side_)widen_gas 30, no autotuner for apron, branchset-sensitive
+--conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level03.json --set ana.activated[+] unassume
+# base-pathsensitive run
+--conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level04-validate.json --set ana.activated[+] unassume
+# polyhedra analysis
+--conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level05.json --set ana.activated[+] unassume

--- a/conf/svcomp27/seq-validate.txt
+++ b/conf/svcomp27/seq-validate.txt
@@ -2,14 +2,14 @@
 # paths are relative to analyzer base directory
 #
 # minimalist run, basically only constants/def_exc, but with context gas
---conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level00.json --set ana.activated[+] unassume
+--conf conf/svcomp27/common.json --conf conf/svcomp27/validate.json --conf conf/svcomp27/level00.json --set ana.activated[+] unassume
 # standard run based on svcomp 25 settings, but with context gas
---conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level01.json --set ana.activated[+] unassume
+--conf conf/svcomp27/common.json --conf conf/svcomp27/validate.json --conf conf/svcomp27/level01.json --set ana.activated[+] unassume
 # apron/affeq run with enums,congruence, bitfield and sets for structs, sporting (side_)widen_gas 30, no autotuner for apron
---conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level02.json --set ana.activated[+] unassume
+--conf conf/svcomp27/common.json --conf conf/svcomp27/validate.json --conf conf/svcomp27/level02.json --set ana.activated[+] unassume
 # apron/affeq run with enums,congruence, bitfield and sets for structs, sporting (side_)widen_gas 30, no autotuner for apron, branchset-sensitive
---conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level03.json --set ana.activated[+] unassume
+--conf conf/svcomp27/common.json --conf conf/svcomp27/validate.json --conf conf/svcomp27/level03.json --set ana.activated[+] unassume
 # base-pathsensitive run
---conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level04-validate.json --set ana.activated[+] unassume
+--conf conf/svcomp27/common.json --conf conf/svcomp27/validate.json --conf conf/svcomp27/level04-validate.json --set ana.activated[+] unassume
 # polyhedra analysis
---conf conf/svcomp26/common.json --conf conf/svcomp26/validate.json --conf conf/svcomp26/level05.json --set ana.activated[+] unassume
+--conf conf/svcomp27/common.json --conf conf/svcomp27/validate.json --conf conf/svcomp27/level05.json --set ana.activated[+] unassume

--- a/conf/svcomp27/seq.txt
+++ b/conf/svcomp27/seq.txt
@@ -1,0 +1,15 @@
+# Portfolio Configuration Sequence
+# paths are relative to analyzer base directory
+#
+# minimalist run, basically only constants/def_exc, but with context gas
+--conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level00.json
+# standard run based on svcomp 25 settings, but with context gas
+--conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level01.json
+# apron/affeq run with enums,congruence, bitfield and sets for structs, sporting (side_)widen_gas 30, no autotuner for apron
+--conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level02.json
+# apron/affeq run with enums,congruence, bitfield and sets for structs, sporting (side_)widen_gas 30, no autotuner for apron, branchset-sensitive
+--conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level03.json
+# base-pathsensitive run
+--conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level04.json
+# polyhedra analysis
+--conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level05.json

--- a/conf/svcomp27/seq.txt
+++ b/conf/svcomp27/seq.txt
@@ -2,14 +2,14 @@
 # paths are relative to analyzer base directory
 #
 # minimalist run, basically only constants/def_exc, but with context gas
---conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level00.json
+--conf conf/svcomp27/common.json --conf conf/svcomp27/verify.json --conf conf/svcomp27/level00.json
 # standard run based on svcomp 25 settings, but with context gas
---conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level01.json
+--conf conf/svcomp27/common.json --conf conf/svcomp27/verify.json --conf conf/svcomp27/level01.json
 # apron/affeq run with enums,congruence, bitfield and sets for structs, sporting (side_)widen_gas 30, no autotuner for apron
---conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level02.json
+--conf conf/svcomp27/common.json --conf conf/svcomp27/verify.json --conf conf/svcomp27/level02.json
 # apron/affeq run with enums,congruence, bitfield and sets for structs, sporting (side_)widen_gas 30, no autotuner for apron, branchset-sensitive
---conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level03.json
+--conf conf/svcomp27/common.json --conf conf/svcomp27/verify.json --conf conf/svcomp27/level03.json
 # base-pathsensitive run
---conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level04.json
+--conf conf/svcomp27/common.json --conf conf/svcomp27/verify.json --conf conf/svcomp27/level04.json
 # polyhedra analysis
---conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level05.json
+--conf conf/svcomp27/common.json --conf conf/svcomp27/verify.json --conf conf/svcomp27/level05.json

--- a/conf/svcomp27/validate.json
+++ b/conf/svcomp27/validate.json
@@ -1,0 +1,25 @@
+{
+  "ana": {
+    "widen": {
+      "tokens": true
+    }
+  },
+  "witness": {
+    "yaml": {
+      "enabled": false,
+      "strict": true,
+      "entry-types": [
+        "invariant_set",
+        "violation_sequence"
+      ],
+      "invariant-types": [
+        "location_invariant",
+        "loop_invariant"
+      ]
+    },
+    "invariant": {
+      "after-lock": true,
+      "other": true
+    }
+  }
+}

--- a/conf/svcomp27/verify.json
+++ b/conf/svcomp27/verify.json
@@ -1,0 +1,30 @@
+{
+  "ana": {
+    "apron": {
+      "invariant": {
+        "diff-box": true
+      }
+    }
+  },
+  "witness": {
+    "yaml": {
+      "enabled": true,
+      "sv-comp-true-only": false,
+      "entry-types": [
+        "invariant_set",
+        "ghost_instrumentation"
+      ],
+      "invariant-types": [
+        "loop_invariant",
+        "flow_insensitive_invariant"
+      ]
+    },
+    "invariant": {
+      "after-lock": false,
+      "other": true,
+      "accessed": false,
+      "exact": true,
+      "flow_insensitive-as": "invariant_set-location_invariant"
+    }
+  }
+}

--- a/scripts/sv-comp/Dockerfile
+++ b/scripts/sv-comp/Dockerfile
@@ -36,6 +36,7 @@ WORKDIR /root/goblint
 RUN ./smoketest.sh
 
 FROM registry.gitlab.com/sosy-lab/benchmarking/competition-scripts/user:2026 AS smoketest-competition
+# TODO: FROM :2027
 
 RUN apt-get update \
     && apt-get install -y unzip \

--- a/scripts/sv-comp/archive.sh
+++ b/scripts/sv-comp/archive.sh
@@ -38,7 +38,7 @@ zip -r goblint/scripts/sv-comp/goblint.zip \
     goblint/lib/libboxD.so \
     goblint/lib/libpolkaMPQ.so \
     goblint/lib/LICENSE.APRON \
-    goblint/conf/svcomp26/ \
+    goblint/conf/svcomp27/ \
     goblint/lib/libc/stub/include/assert.h \
     goblint/lib/goblint/runtime/include/goblint.h \
     goblint/lib/libc/stub/src/stdlib.c \

--- a/scripts/sv-comp/smoketest.sh
+++ b/scripts/sv-comp/smoketest.sh
@@ -13,7 +13,7 @@ set -o pipefail # Make pipes fail if any command in pipe fails.
 
 # Run smoke tests in subdirectory for convenience.
 cd smoketests/
-GOBLINT="../goblint_runner.py --portfolio-conf conf/svcomp26/seq.txt"
+GOBLINT="../goblint_runner.py --portfolio-conf conf/svcomp27/seq.txt"
 # This will also check if Goblint works when executed from different directory (finds Apron libs, conf, lib stubs), crashes otherwise.
 
 
@@ -32,7 +32,7 @@ $GOBLINT --set ana.specification no-data-race.prp --set exp.architecture 32bit 0
 
 
 # Check if witness validation returns correct results.
-GOBLINT_VALIDATOR="../goblint_runner.py --portfolio-conf conf/svcomp26/seq-validate.txt"
+GOBLINT_VALIDATOR="../goblint_runner.py --portfolio-conf conf/svcomp27/seq-validate.txt"
 
 # From scratch verification actually succeeds for a variety of reasons (abortUnless analysis, wideningThresholds autotuner):
 # This is not intentional.


### PR DESCRIPTION
This branch contains development and integration for SV-COMP 2027. This branch is used for creating verifier archives for preruns.

Closes #1888.

### TODO
- [ ] Merge `master` in (regularly).
- [ ] Add autotuners from #2152.