### PR TITLE
Add used assumptions declarations

### DIFF
--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -1237,8 +1237,7 @@ struct
     let tids = ask.f (Q.EvalThread exp) in
     if force then (
       if ConcDomain.ThreadSet.is_top tids then (
-        (* TODO: assume *)
-        M.info ~category:Unsound "Unknown thread ID assume-joined, relation privatization unsound"; (* TODO: something more sound *)
+        Assumptions.add "Unknown thread ID assume-joined, relation privatization unsound"; (* TODO: something more sound *)
         st (* cannot find all thread IDs to join them all *)
       )
       else (

--- a/src/analyses/apron/relationPriv.apron.ml
+++ b/src/analyses/apron/relationPriv.apron.ml
@@ -1237,6 +1237,7 @@ struct
     let tids = ask.f (Q.EvalThread exp) in
     if force then (
       if ConcDomain.ThreadSet.is_top tids then (
+        (* TODO: assume *)
         M.info ~category:Unsound "Unknown thread ID assume-joined, relation privatization unsound"; (* TODO: something more sound *)
         st (* cannot find all thread IDs to join them all *)
       )

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1033,7 +1033,7 @@ struct
                 if contains_vla t || contains_vla (Addr.Mval.type_of (x, o)) then
                   begin
                     (* TODO: Is this ok? *)
-                    M.info ~category:Unsound "Casting involving a VLA is assumed to work";
+                    M.info ~category:Unsound "Casting involving a VLA is assumed to work"; (* TODO: assume *)
                     true
                   end
                 else
@@ -1521,7 +1521,7 @@ struct
     | Q.EvalMutexAttr e -> begin
         match eval_rv_address ~man man.local e with
         | Address a ->
-          let default = `Lifted MutexAttrDomain.MutexKind.NonRec in (* Goblint assumption *)
+          let default = `Lifted MutexAttrDomain.MutexKind.NonRec in (* Goblint assumption *) (* TODO: assume *)
           begin match get ~man ~top:(MutexAttr default) man.local a None with (* ~top corresponds to default NULL with assume_top *)
             | MutexAttr a -> a
             | Bot -> default (* corresponds to default NULL with assume_none *)
@@ -1857,7 +1857,7 @@ struct
     (* If any of the addresses are unknown, we ignore it!?! *)
     | SetDomain.Unsupported x ->
       (* if M.tracing then M.tracel "set" "set got an exception '%s'" x; *)
-      M.info ~category:Unsound "Assignment to unknown address, assuming no write happened."; st
+      M.info ~category:Unsound "Assignment to unknown address, assuming no write happened."; st (* TODO: assume *)
 
   let set_many ~man (st: store) lval_value_list: store =
     (* Maybe this can be done with a simple fold *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1032,8 +1032,7 @@ struct
               | exception (SizeOfError _) ->
                 if contains_vla t || contains_vla (Addr.Mval.type_of (x, o)) then
                   begin
-                    (* TODO: Is this ok? *)
-                    M.info ~category:Unsound "Casting involving a VLA is assumed to work"; (* TODO: assume *)
+                    Assumptions.add "Casting involving a VLA is assumed to work";
                     true
                   end
                 else
@@ -1857,7 +1856,8 @@ struct
     (* If any of the addresses are unknown, we ignore it!?! *)
     | SetDomain.Unsupported x ->
       (* if M.tracing then M.tracel "set" "set got an exception '%s'" x; *)
-      M.info ~category:Unsound "Assignment to unknown address, assuming no write happened."; st (* TODO: assume *)
+      Assumptions.add "Assignment to unknown address, assuming no write happened.";
+      st
 
   let set_many ~man (st: store) lval_value_list: store =
     (* Maybe this can be done with a simple fold *)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1520,7 +1520,8 @@ struct
     | Q.EvalMutexAttr e -> begin
         match eval_rv_address ~man man.local e with
         | Address a ->
-          let default = `Lifted MutexAttrDomain.MutexKind.NonRec in (* Goblint assumption *) (* TODO: assume *)
+          let default = `Lifted MutexAttrDomain.MutexKind.NonRec in
+          Assumptions.add "Mutexes are non-recursive by default";
           begin match get ~man ~top:(MutexAttr default) man.local a None with (* ~top corresponds to default NULL with assume_top *)
             | MutexAttr a -> a
             | Bot -> default (* corresponds to default NULL with assume_none *)

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -631,7 +631,7 @@ struct
     let tids = ask.f (Q.EvalThread exp) in
     if force then (
       if ConcDomain.ThreadSet.is_top tids then (
-        M.info ~category:Unsound "Unknown thread ID assume-joined, privatization unsound"; (* TODO: something more sound *) (* TODO: assume *)
+        Assumptions.add "Unknown thread ID assume-joined, privatization unsound"; (* TODO: something more sound *)
         st (* cannot find all thread IDs to join them all *)
       )
       else (

--- a/src/analyses/basePriv.ml
+++ b/src/analyses/basePriv.ml
@@ -631,7 +631,7 @@ struct
     let tids = ask.f (Q.EvalThread exp) in
     if force then (
       if ConcDomain.ThreadSet.is_top tids then (
-        M.info ~category:Unsound "Unknown thread ID assume-joined, privatization unsound"; (* TODO: something more sound *)
+        M.info ~category:Unsound "Unknown thread ID assume-joined, privatization unsound"; (* TODO: something more sound *) (* TODO: assume *)
         st (* cannot find all thread IDs to join them all *)
       )
       else (

--- a/src/analyses/extractPthread.ml
+++ b/src/analyses/extractPthread.ml
@@ -769,7 +769,7 @@ module Codegen = struct
       in
       let init =
         let run_threads =
-          (* NOTE: assumes no args are passed to the thread func *) (* TODO: assume *)
+          Assumptions.add "No arguments are passed to the thread function";
           List.map
             (fun t ->
                let tid = Action.(t.tid) in

--- a/src/analyses/extractPthread.ml
+++ b/src/analyses/extractPthread.ml
@@ -769,7 +769,7 @@ module Codegen = struct
       in
       let init =
         let run_threads =
-          (* NOTE: assumes no args are passed to the thread func *)
+          (* NOTE: assumes no args are passed to the thread func *) (* TODO: assume *)
           List.map
             (fun t ->
                let tid = Action.(t.tid) in

--- a/src/analyses/tutorials/solution/taintSol.ml
+++ b/src/analyses/tutorials/solution/taintSol.ml
@@ -58,9 +58,9 @@ struct
       (* TODO: Check whether variable v is tainted *)
       D.mem v state
     | _ ->
-      (* We assume using a tainted offset does not taint the expression, and that our language has no pointers *)
-      (* TODO: assume? *)
-      false
+      Assumptions.add "Tainted offset does not taint the expression";
+      Assumptions.add "Language has no pointers";
+      false (* Nothing more needs to be done *)
 
   (* transfer functions *)
 

--- a/src/analyses/tutorials/solution/taintSol.ml
+++ b/src/analyses/tutorials/solution/taintSol.ml
@@ -59,6 +59,7 @@ struct
       D.mem v state
     | _ ->
       (* We assume using a tainted offset does not taint the expression, and that our language has no pointers *)
+      (* TODO: assume? *)
       false
 
   (* transfer functions *)

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -59,6 +59,7 @@ struct
       false
     | _ ->
       (* We assume using a tainted offset does not taint the expression, and that our language has no pointers *)
+      (* TODO: assume? *)
       false
 
   (* transfer functions *)

--- a/src/analyses/tutorials/taint.ml
+++ b/src/analyses/tutorials/taint.ml
@@ -58,9 +58,9 @@ struct
       (* TODO: Check whether variable v is tainted *)
       false
     | _ ->
-      (* We assume using a tainted offset does not taint the expression, and that our language has no pointers *)
-      (* TODO: assume? *)
-      false
+      Assumptions.add "Tainted offset does not taint the expression";
+      Assumptions.add "Language has no pointers";
+      false (* Nothing more needs to be done *)
 
   (* transfer functions *)
 

--- a/src/common/util/assumptions.ml
+++ b/src/common/util/assumptions.ml
@@ -1,10 +1,14 @@
 (** Assumptions used by the analysis. *)
 
 (** Declare used assumption at current (or provided) location. *)
-let add ?loc ?tags fmt =
+let add ?loc ?tags ?final fmt =
   GoblintCil.Pretty.gprintf (fun doc ->
       Messages.info ?loc ~category:Assumption ?tags "%a" GoblintCil.Pretty.insert doc;
-      Messages.msg_final Info ~category:Assumption ?tags "%a" GoblintCil.Pretty.insert doc;
+      match final with
+      | None -> (* use name message for final *)
+        Messages.msg_final Info ~category:Assumption ?tags "%a" GoblintCil.Pretty.insert doc
+      | Some final -> (* use different unformatted message for final *)
+        Messages.msg_final Info ~category:Assumption ?tags "%s" final
     ) fmt
 
 (** Declare used assumption without location. *)

--- a/src/common/util/assumptions.ml
+++ b/src/common/util/assumptions.ml
@@ -14,3 +14,24 @@ let add ?loc ?tags ?final fmt =
 (** Declare used assumption without location. *)
 let add_noloc ?tags fmt =
   Messages.msg_final Info ~category:Assumption ?tags fmt
+
+
+let message_to_dashboard_yojson (m: Messages.Message.t): Yojson.Safe.t =
+  match m.multipiece with
+  | Single piece ->
+    `Assoc ([
+        ("message", `String piece.text);
+      ] @ match piece.loc with
+      | Some loc ->
+        [("range", Checks.Check.range_to_yojson (Messages.Location.to_cil loc))]
+      | None -> [])
+  | Group _ -> failwith "Assumptions.message_to_dashboard_yojson: Group" (* TODO: implement when actually needed *)
+
+let message_is_assumption (m: Messages.Message.t) =
+  BatList.mem_cmp Messages.Tag.compare (Category Assumption) m.tags
+
+let to_dashboard_yojson (): Yojson.Safe.t =
+  Messages.Table.to_list ()
+  |> List.filter message_is_assumption
+  |> List.map message_to_dashboard_yojson
+  |> fun l -> `List l

--- a/src/common/util/assumptions.ml
+++ b/src/common/util/assumptions.ml
@@ -1,0 +1,8 @@
+let add ?loc ?tags fmt =
+  GoblintCil.Pretty.gprintf (fun doc ->
+      Messages.info ?loc ~category:Assumption ?tags "%a" GoblintCil.Pretty.insert doc;
+      Messages.msg_final Info ~category:Assumption ?tags "%a" GoblintCil.Pretty.insert doc;
+    ) fmt
+
+let add_noloc ?tags fmt =
+  Messages.msg_final Info ~category:Assumption ?tags fmt

--- a/src/common/util/assumptions.ml
+++ b/src/common/util/assumptions.ml
@@ -1,8 +1,12 @@
+(** Assumptions used by the analysis. *)
+
+(** Declare used assumption at current (or provided) location. *)
 let add ?loc ?tags fmt =
   GoblintCil.Pretty.gprintf (fun doc ->
       Messages.info ?loc ~category:Assumption ?tags "%a" GoblintCil.Pretty.insert doc;
       Messages.msg_final Info ~category:Assumption ?tags "%a" GoblintCil.Pretty.insert doc;
     ) fmt
 
+(** Declare used assumption without location. *)
 let add_noloc ?tags fmt =
   Messages.msg_final Info ~category:Assumption ?tags fmt

--- a/src/common/util/checks.ml
+++ b/src/common/util/checks.ml
@@ -92,23 +92,26 @@ module Check = struct
     messages: string;
   } [@@deriving make, hash, eq]
 
+  let range_to_yojson (loc: CilType.Location.t) =
+    `Assoc [
+      ("start", `Assoc [
+          ("file", `String loc.file);
+          ("line", `Int loc.line);
+          ("column", `Int (loc.column - 1))
+        ]);
+      ("end", `Assoc [
+          ("file", `String loc.file);
+          ("line", `Int loc.endLine);
+          ("column", `Int (loc.endColumn - 1))
+        ])
+    ]
+
   let to_yojson check =
     `Assoc [
       ("kind", Kind.to_yojson check.kind);
       ("title", Category.to_yojson check.title);
       ("range", match check.range with
-        | Some loc -> `Assoc [
-            ("start", `Assoc [
-                ("file", `String loc.file);
-                ("line", `Int loc.line);
-                ("column", `Int (loc.column - 1))
-              ]);
-            ("end", `Assoc [
-                ("file", `String loc.file);
-                ("line", `Int loc.endLine);
-                ("column", `Int (loc.endColumn - 1))
-              ])
-          ]
+        | Some loc -> range_to_yojson loc
         | None -> `Null);
       ("messages", `String check.messages)
     ]

--- a/src/common/util/messageCategory.ml
+++ b/src/common/util/messageCategory.ml
@@ -46,6 +46,7 @@ type category =
   | Witness
   | Program
   | Termination
+  | Assumption
 [@@deriving eq, ord, hash]
 
 type t = category [@@deriving eq, ord, hash]
@@ -205,6 +206,7 @@ let should_warn e =
     | Witness -> "witness"
     | Program -> "program"
     | Termination -> "termination"
+    | Assumption -> "assumption"
     (* Don't forget to add option to schema! *)
   in get_bool ("warn." ^ (to_string e))
 
@@ -226,6 +228,7 @@ let path_show e =
   | Witness -> ["Witness"]
   | Program -> ["Program"]
   | Termination -> ["Termination"]
+  | Assumption -> ["Assumption"]
 
 let show x = String.concat " > " (path_show x)
 
@@ -266,6 +269,7 @@ let categoryName = function
       | DivByZero -> "DivByZero")
   | Float -> "Float"
   | Termination -> "Termination"
+  | Assumption -> "Assumption"
 
 
 let from_string_list (s: string list) =
@@ -287,6 +291,7 @@ let from_string_list (s: string list) =
     | "witness" -> Witness
     | "program" -> Program
     | "termination" -> Termination
+    | "assumption" -> Assumption
     | _ -> Unknown
 
 let to_yojson x = `List (List.map (fun x -> `String x) (path_show x))

--- a/src/config/options.schema.json
+++ b/src/config/options.schema.json
@@ -2412,6 +2412,12 @@
           "type": "boolean",
           "default": true
         },
+        "assumption": {
+          "title": "warn.assumption",
+          "description": "Assumption messages",
+          "type": "boolean",
+          "default": true
+        },
         "imprecise": {
           "title": "warn.imprecise",
           "description": "Imprecision messages",

--- a/src/framework/analysisResultOutput.ml
+++ b/src/framework/analysisResultOutput.ml
@@ -98,6 +98,7 @@ struct
           ("files", Preprocessor.dependencies_to_yojson ());
           ("time", `Float (if get_bool "dbg.timing.enabled" then timings.cputime else -1.));
           ("checks", Checks.export ());
+          ("assumptions", Assumptions.to_dashboard_yojson ());
         ] in
       Yojson.Safe.to_channel ~std:true out json
     | "none" -> ()

--- a/src/goblint_lib.ml
+++ b/src/goblint_lib.ml
@@ -346,6 +346,7 @@ module CilMaps = CilMaps
 module Messages = Messages
 module Logs = Logs
 module Checks = Checks
+module Assumptions = Assumptions
 
 (** {2 Front-end}
 

--- a/tests/regression/06-symbeq/14-list_entry_rc.t
+++ b/tests/regression/06-symbeq/14-list_entry_rc.t
@@ -1,5 +1,6 @@
   $ goblint --enable ana.race.direct-arithmetic --set ana.activated[+] "'var_eq'"  --set ana.activated[+] "'symb_locks'" 14-list_entry_rc.c 2>&1 | sed -r 's/sid:[0-9]+/sid:$SID/' | tee default-output.txt
   [Info][Imprecise] Invalidating expressions: & mutexattr (14-list_entry_rc.c:37:3-37:37)
+  [Info][Assumption] Mutexes are non-recursive by default (14-list_entry_rc.c:19:3-19:44)
   [Warning][Unknown] unlocking mutex (((alloc@sid:$SID@tid:[main]), 14-list_entry_rc.c:41:3-41:35)[1].mutex) which may not be held (14-list_entry_rc.c:28:3-28:34)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 23
@@ -15,15 +16,16 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 2
+  [Info][Assumption] Mutexes are non-recursive by default
 
   $ goblint --enable ana.race.direct-arithmetic --set ana.activated[+] "'var_eq'" --set ana.activated[+] "'symb_locks'" --enable dbg.full-output 14-list_entry_rc.c 2>&1 | sed -r 's/sid:[0-9]+/sid:$SID/' > full-output.txt
 
   $ diff default-output.txt full-output.txt
-  2c2
+  3c3
   < [Warning][Unknown] unlocking mutex (((alloc@sid:$SID@tid:[main]), 14-list_entry_rc.c:41:3-41:35)[1].mutex) which may not be held (14-list_entry_rc.c:28:3-28:34)
   ---
   > [Warning][Unknown] unlocking mutex (((alloc@sid:$SID@tid:[main](#top)), 14-list_entry_rc.c:41:3-41:35)[def_exc:1].mutex) which may not be held (14-list_entry_rc.c:28:3-28:34)
-  7,11c7,11
+  8,12c8,12
   < [Warning][Race] Memory location (alloc@sid:$SID@tid:[main])[?].datum (race with conf. 110): (14-list_entry_rc.c:41:3-41:35)
   <   write with thread:[main, t_fun@14-list_entry_rc.c:45:3-45:40] (conf. 110)  (exp: & s->datum) (14-list_entry_rc.c:27:3-27:13)
   <   write with [mhp:{created={[main, t_fun@14-list_entry_rc.c:45:3-45:40]}}, thread:[main]] (conf. 110)  (exp: & s->datum) (14-list_entry_rc.c:27:3-27:13)

--- a/tests/regression/13-privatized/74-mutex.t
+++ b/tests/regression/13-privatized/74-mutex.t
@@ -1,4 +1,5 @@
   $ goblint --enable ana.sv-comp.functions --set ana.base.privatization protection --enable witness.yaml.enabled --set ana.activated[+] mutexGhosts --set witness.yaml.entry-types[+] ghost_instrumentation --set witness.yaml.invariant-types[*] flow_insensitive_invariant --set witness.yaml.format-version 2.1-goblint 74-mutex.c
+  [Info][Assumption] Mutexes are non-recursive by default (74-mutex.c:33:3-33:28)
   [Success][Assert] Assertion "used == 0" will succeed (74-mutex.c:37:3-37:29)
   [Warning][Deadcode] Function 'producer' has dead code:
     on line 26 (74-mutex.c:26-26)
@@ -17,6 +18,7 @@
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
+  [Info][Assumption] Mutexes are non-recursive by default
 
   $ grep format_version witness.yml
       format_version: "2.1"
@@ -98,6 +100,7 @@
 Flow-insensitive invariants as location invariants.
 
   $ goblint --enable ana.sv-comp.functions --set ana.base.privatization protection --enable witness.yaml.enabled --set ana.activated[+] mutexGhosts --set witness.yaml.entry-types[+] ghost_instrumentation --set witness.yaml.invariant-types[*] flow_insensitive_invariant --set witness.invariant.flow_insensitive-as invariant_set-location_invariant 74-mutex.c
+  [Info][Assumption] Mutexes are non-recursive by default (74-mutex.c:33:3-33:28)
   [Success][Assert] Assertion "used == 0" will succeed (74-mutex.c:37:3-37:29)
   [Warning][Deadcode] Function 'producer' has dead code:
     on line 26 (74-mutex.c:26-26)
@@ -116,6 +119,7 @@ Flow-insensitive invariants as location invariants.
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
+  [Info][Assumption] Mutexes are non-recursive by default
 
 TODO: should invariant_set-s which use ghosts also be 2.1?
   $ grep format_version witness.yml
@@ -149,6 +153,7 @@ Should also work with earlyglobs.
 Earlyglobs shouldn't cause protected writes in multithreaded mode from being immediately published to protected invariant.
 
   $ goblint --enable ana.sv-comp.functions --set ana.base.privatization protection --enable exp.earlyglobs 74-mutex.c
+  [Info][Assumption] Mutexes are non-recursive by default (74-mutex.c:33:3-33:28)
   [Success][Assert] Assertion "used == 0" will succeed (74-mutex.c:37:3-37:29)
   [Warning][Deadcode] Function 'producer' has dead code:
     on line 26 (74-mutex.c:26-26)
@@ -162,10 +167,12 @@ Earlyglobs shouldn't cause protected writes in multithreaded mode from being imm
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
+  [Info][Assumption] Mutexes are non-recursive by default
 
 Same with ghost_instrumentation and invariant_set entries.
 
   $ goblint --enable ana.sv-comp.functions --set ana.base.privatization protection --enable witness.yaml.enabled --set ana.activated[+] mutexGhosts --set witness.yaml.entry-types[+] ghost_instrumentation --set witness.yaml.invariant-types[*] flow_insensitive_invariant --set witness.invariant.flow_insensitive-as invariant_set-location_invariant 74-mutex.c
+  [Info][Assumption] Mutexes are non-recursive by default (74-mutex.c:33:3-33:28)
   [Success][Assert] Assertion "used == 0" will succeed (74-mutex.c:37:3-37:29)
   [Warning][Deadcode] Function 'producer' has dead code:
     on line 26 (74-mutex.c:26-26)
@@ -184,6 +191,7 @@ Same with ghost_instrumentation and invariant_set entries.
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
+  [Info][Assumption] Mutexes are non-recursive by default
 
   $ yamlWitnessStrip < witness.yml
   - entry_type: ghost_instrumentation
@@ -271,6 +279,7 @@ Same with ghost_instrumentation and invariant_set entries.
 Same protected invariant with vojdani but no unprotected invariant.
 
   $ goblint --enable ana.sv-comp.functions --set ana.base.privatization vojdani --enable witness.yaml.enabled --set ana.activated[+] mutexGhosts --set witness.yaml.entry-types[+] ghost_instrumentation --set witness.yaml.invariant-types[*] flow_insensitive_invariant --set witness.yaml.format-version 2.1-goblint 74-mutex.c
+  [Info][Assumption] Mutexes are non-recursive by default (74-mutex.c:33:3-33:28)
   [Success][Assert] Assertion "used == 0" will succeed (74-mutex.c:37:3-37:29)
   [Warning][Deadcode] Function 'producer' has dead code:
     on line 26 (74-mutex.c:26-26)
@@ -289,6 +298,7 @@ Same protected invariant with vojdani but no unprotected invariant.
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
+  [Info][Assumption] Mutexes are non-recursive by default
 
   $ yamlWitnessStrip < witness.yml
   - entry_type: ghost_instrumentation
@@ -362,6 +372,7 @@ Same protected invariant with vojdani but no unprotected invariant.
 Same as protection with mutex-meet.
 
   $ goblint --enable ana.sv-comp.functions --set ana.base.privatization mutex-meet --enable witness.yaml.enabled --set ana.activated[+] mutexGhosts --set witness.yaml.entry-types[+] ghost_instrumentation --set witness.yaml.invariant-types[*] flow_insensitive_invariant --set witness.yaml.format-version 2.1-goblint 74-mutex.c
+  [Info][Assumption] Mutexes are non-recursive by default (74-mutex.c:33:3-33:28)
   [Success][Assert] Assertion "used == 0" will succeed (74-mutex.c:37:3-37:29)
   [Warning][Deadcode] Function 'producer' has dead code:
     on line 26 (74-mutex.c:26-26)
@@ -380,6 +391,7 @@ Same as protection with mutex-meet.
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
+  [Info][Assumption] Mutexes are non-recursive by default
 
   $ yamlWitnessStrip < witness.yml
   - entry_type: ghost_instrumentation
@@ -457,6 +469,7 @@ Same as protection with mutex-meet.
 Should also work with earlyglobs.
 
   $ goblint --enable ana.sv-comp.functions --set ana.base.privatization mutex-meet --enable exp.earlyglobs 74-mutex.c
+  [Info][Assumption] Mutexes are non-recursive by default (74-mutex.c:33:3-33:28)
   [Success][Assert] Assertion "used == 0" will succeed (74-mutex.c:37:3-37:29)
   [Warning][Deadcode] Function 'producer' has dead code:
     on line 26 (74-mutex.c:26-26)
@@ -470,3 +483,4 @@ Should also work with earlyglobs.
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
+  [Info][Assumption] Mutexes are non-recursive by default

--- a/tests/regression/13-privatized/92-idx_priv.t
+++ b/tests/regression/13-privatized/92-idx_priv.t
@@ -1,4 +1,5 @@
   $ goblint --set ana.base.privatization protection --enable witness.yaml.enabled --set ana.activated[+] mutexGhosts --set witness.yaml.entry-types[+] ghost_instrumentation --set witness.yaml.invariant-types[*] flow_insensitive_invariant --set witness.yaml.format-version 2.1-goblint 92-idx_priv.c
+  [Info][Assumption] Mutexes are non-recursive by default (92-idx_priv.c:17:5-17:35)
   [Success][Assert] Assertion "data == 0" will succeed (92-idx_priv.c:22:3-22:29)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
     live: 14
@@ -14,6 +15,7 @@
     vulnerable: 0
     unsafe: 0
     total memory locations: 1
+  [Info][Assumption] Mutexes are non-recursive by default
 
   $ yamlWitnessStrip < witness.yml
   - entry_type: ghost_instrumentation

--- a/tests/regression/56-witness/66-ghost-alloc-lock.t
+++ b/tests/regression/56-witness/66-ghost-alloc-lock.t
@@ -1,4 +1,6 @@
   $ goblint --set ana.base.privatization protection --enable witness.yaml.enabled --set ana.activated[+] mutexGhosts  --set ana.malloc.unique_address_count 1 --set witness.yaml.entry-types[+] ghost_instrumentation --set witness.yaml.invariant-types[*] flow_insensitive_invariant --set witness.yaml.format-version 2.1-goblint 66-ghost-alloc-lock.c
+  [Info][Assumption] Mutexes are non-recursive by default (66-ghost-alloc-lock.c:23:3-23:30)
+  [Info][Assumption] Mutexes are non-recursive by default (66-ghost-alloc-lock.c:25:3-25:30)
   [Success][Assert] Assertion "g1 == 0" will succeed (66-ghost-alloc-lock.c:31:3-31:27)
   [Success][Assert] Assertion "g2 == 0" will succeed (66-ghost-alloc-lock.c:34:3-34:27)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
@@ -15,6 +17,7 @@
     vulnerable: 0
     unsafe: 0
     total memory locations: 4
+  [Info][Assumption] Mutexes are non-recursive by default
 
   $ ./66-ghost-alloc-lock-strip.sh witness.yml > stripped.yml
   $ yamlWitnessStrip < stripped.yml

--- a/tests/regression/56-witness/68-ghost-ambiguous-idx.t
+++ b/tests/regression/56-witness/68-ghost-ambiguous-idx.t
@@ -1,4 +1,5 @@
   $ goblint --set ana.base.privatization protection --enable witness.yaml.enabled --set ana.activated[+] mutexGhosts --set witness.yaml.entry-types[+] ghost_instrumentation --set witness.yaml.invariant-types[*] flow_insensitive_invariant --set witness.yaml.format-version 2.1-goblint 68-ghost-ambiguous-idx.c
+  [Info][Assumption] Mutexes are non-recursive by default (68-ghost-ambiguous-idx.c:17:5-17:35)
   [Warning][Assert] Assertion "data == 0" is unknown. (68-ghost-ambiguous-idx.c:24:3-24:29)
   [Warning][Unknown] unlocking mutex (m[4]) which may not be held (68-ghost-ambiguous-idx.c:25:3-25:30)
   [Info][Deadcode] Logical lines of code (LLoC) summary:
@@ -19,6 +20,7 @@
     vulnerable: 0
     unsafe: 1
     total memory locations: 1
+  [Info][Assumption] Mutexes are non-recursive by default
 
   $ yamlWitnessStrip < witness.yml
   - entry_type: ghost_instrumentation

--- a/tests/regression/71-doublelocking/17-default-null-dyn.c
+++ b/tests/regression/71-doublelocking/17-default-null-dyn.c
@@ -1,4 +1,5 @@
-// PARAM: --set ana.activated[+] 'maylocks' --set ana.activated[+] 'pthreadMutexType'
+// PARAM: --set ana.activated[+] 'maylocks' --set ana.activated[+] 'pthreadMutexType' --disable warn.assumption
+// Disabled assumptions for NOWARN (no null pointer error) below
 #define _GNU_SOURCE
 #include<pthread.h>
 #include<stdio.h>


### PR DESCRIPTION
This is a very simple implementation of `Assumptions.add` for declaring which assumptions have been used by the analysis.

Unlike the vibed version for effects, this doesn't implement a system for dynamically registering assumption types (separately from their message). That seems overengineering given that we don't have a standard numeration of all warning types even.

### TODO
- [x] Output assumptions to checks file like Mopsa.
- [x] Add possibility of specifying separate final assumption message (for cases where location-message has analysis-specific details).