### PR TITLE
Remove ikind argument from `IndexDomain` functions

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -979,7 +979,7 @@ struct
       (* CIL's very nice implicit conversion of an array name [a] to a pointer
         * to its first element [&a[0]]. *)
       | StartOf lval ->
-        let array_ofs = `Index (IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) Z.zero, `NoOffset) in
+        let array_ofs = `Index (IdxDom.of_int Z.zero, `NoOffset) in
         let array_start = add_offset_varinfo array_ofs in
         Address (AD.map array_start (eval_lv ~man st lval))
       | CastE (_, t, Const (CStr (x,e))) -> (* VD.top () *) eval_rv ~man st (Const (CStr (x,e))) (* TODO safe? *)
@@ -1563,7 +1563,7 @@ struct
             (match r with
              | Array a ->
                (* unroll into array for Calloc calls *)
-               (match ValueDomain.CArrays.get (Queries.to_value_domain_ask (Analyses.ask_of_man man)) a (None, (IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) Z.zero)) with
+               (match ValueDomain.CArrays.get (Queries.to_value_domain_ask (Analyses.ask_of_man man)) a (None, (IdxDom.of_int Z.zero)) with
                 | Blob (_,s,_) -> `Lifted (ID.cast_to ~kind:Internal (Cilfacade.ptrdiff_ikind ()) s) (* TODO: should be size_t *) (* TODO: should really be casted on creation *)
                 | _ -> Queries.Result.top q
                )
@@ -2774,11 +2774,11 @@ struct
               let@ () = GobRef.wrap AnalysisState.executing_speculative_computations true in
               ID.mul (ID.cast_to ~kind:Internal ik @@ sizeval) (ID.cast_to ~kind:Internal ik @@ countval) (* TODO: proper castkind *)
             in
-            let offset = `Index (IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) Z.zero, `NoOffset) in
+            let offset = `Index (IdxDom.of_int Z.zero, `NoOffset) in
             (* the heap_var is the base address of the allocated memory, but we need to keep track of the offset for the blob *)
             let addr_offset = AD.map (fun a -> Addr.add_offset a offset) addr in
             (* the memory that was allocated by calloc is set to bottom, but we keep track that it originated from calloc, so when bottom is read from memory allocated by calloc it is turned to zero *)
-            let blob_set = Option.map_default (fun heap_var -> [heap_var, TVoid [], VD.Array (CArrays.make (IdxDom.of_int (Cilfacade.ptrdiff_ikind ()) Z.one) (Blob (VD.bot (), blobsize, ZeroInit.calloc)))]) [] heap_var in
+            let blob_set = Option.map_default (fun heap_var -> [heap_var, TVoid [], VD.Array (CArrays.make (IdxDom.of_int Z.one) (Blob (VD.bot (), blobsize, ZeroInit.calloc)))]) [] heap_var in
             set_many ~man st ((eval_lv ~man st lv, (Cilfacade.typeOfLval lv), Address addr_offset) :: blob_set)
         | _ -> st
       end

--- a/src/cdomain/value/cdomains/arrayDomain.ml
+++ b/src/cdomain/value/cdomains/arrayDomain.ml
@@ -1182,7 +1182,7 @@ struct
         Checks.safe Checks.Category.NegativeArraySize;
         Z.zero, None
     in
-    let size = BatOption.map_default (fun max -> Idx.of_interval ILong (min_i, max)) (Idx.starting ILong min_i) max_i in
+    let size = BatOption.map_default (fun max -> Idx.of_interval (min_i, max)) (Idx.starting ILong min_i) max_i in (* TODO: used ILong *)
     match Val.is_null v with
     | Null -> (Nulls.make_all_must (), size)
     | NotNull -> (Nulls.empty (), size)
@@ -1338,7 +1338,7 @@ struct
       (* else return interval [minimal may null, minimal must null] *)
     else (
       Checks.safe Checks.Category.InvalidMemoryAccess;
-      Idx.of_interval !Cil.kindOfSizeOf (Nulls.min_elem Possibly nulls, Nulls.min_elem Definitely nulls))
+      Idx.of_interval (Nulls.min_elem Possibly nulls, Nulls.min_elem Definitely nulls)) (* TODO: used !Cil.kindOfSizeOf *)
 
   let string_copy (dstnulls, dstsize) ((srcnulls, srcsize) as src) n =
     let must_nulls_set1, may_nulls_set1 = dstnulls in

--- a/src/cdomain/value/cdomains/arrayDomain.ml
+++ b/src/cdomain/value/cdomains/arrayDomain.ml
@@ -1182,7 +1182,7 @@ struct
         Checks.safe Checks.Category.NegativeArraySize;
         Z.zero, None
     in
-    let size = BatOption.map_default (fun max -> Idx.of_interval (min_i, max)) (Idx.starting ILong min_i) max_i in (* TODO: used ILong *)
+    let size = BatOption.map_default (fun max -> Idx.of_interval (min_i, max)) (Idx.starting min_i) max_i in (* TODO: used ILong *)
     match Val.is_null v with
     | Null -> (Nulls.make_all_must (), size)
     | NotNull -> (Nulls.empty (), size)
@@ -1329,12 +1329,12 @@ struct
     (* if must_nulls_set and min_nulls_set empty, definitely no null byte in array => return interval [size, inf) and warn *)
     if Nulls.is_empty Definitely nulls then
       (warn_past_end "Array doesn't contain a null byte: buffer overflow";
-       Idx.starting !Cil.kindOfSizeOf (BatOption.default Z.zero (Idx.minimal size))
+       Idx.starting (BatOption.default Z.zero (Idx.minimal size)) (* TODO: used !Cil.kindOfSizeOf *)
       )
       (* if only must_nulls_set empty, no guarantee that null ever encountered in array => return interval [minimal may null, inf) and *)
     else if Nulls.is_empty Possibly nulls then
       (warn_past_end "Array might not contain a null byte: potential buffer overflow";
-       Idx.starting !Cil.kindOfSizeOf (Nulls.min_elem Possibly nulls))
+       Idx.starting (Nulls.min_elem Possibly nulls)) (* TODO: used !Cil.kindOfSizeOf *)
       (* else return interval [minimal may null, minimal must null] *)
     else (
       Checks.safe Checks.Category.InvalidMemoryAccess;

--- a/src/cdomain/value/cdomains/arrayDomain.ml
+++ b/src/cdomain/value/cdomains/arrayDomain.ml
@@ -1248,7 +1248,7 @@ struct
     * an n bytes string. *)
   let to_n_string (nulls, size) n:t =
     if n < 0 then
-      (Nulls.top (), Idx.top_of ILong)
+      (Nulls.top (), Idx.top ()) (* TODO: used ILong *)
     else
       let n = Z.of_int n in
       let warn_no_null min_must_null min_may_null =
@@ -1896,14 +1896,14 @@ struct
 
   let to_null_byte_domain s =
     if get_bool "ana.base.arrays.nullbytes" then
-      (A.make (Idx.top_of ILong) (Val.meet (Val.not_zero_of_ikind IChar) (Val.zero_of_ikind IChar)), N.to_null_byte_domain s)
+      (A.make (Idx.top ()) (* TODO: used ILong *) (Val.meet (Val.not_zero_of_ikind IChar) (Val.zero_of_ikind IChar)), N.to_null_byte_domain s)
     else
       (A.top (), N.top ())
   let to_string_length (_, t_n) =
     if get_bool "ana.base.arrays.nullbytes" then
       N.to_string_length t_n
     else
-      Idx.top_of !Cil.kindOfSizeOf
+      Idx.top () (* TODO: used !Cil.kindOfSizeOf *)
 
   let project ?(varAttr=[]) ?(typAttr=[]) ask (t_f, t_n) = (A.project ~varAttr ~typAttr ask t_f, t_n)
   let invariant ~value_invariant ~offset ~lval (t_f, _) = A.invariant ~value_invariant ~offset ~lval t_f

--- a/src/cdomain/value/cdomains/arrayDomain.ml
+++ b/src/cdomain/value/cdomains/arrayDomain.ml
@@ -183,7 +183,7 @@ let factor () =
   | 0 -> failwith "ArrayDomain: ana.base.arrays.unrolling-factor needs to be set when using the unroll domain"
   | x -> x
 
-module Unroll (Val: LatticeWithInvalidate) (Idx:IntDomain.Z): S with type value = Val.t and type idx = Idx.t =
+module Unroll (Val: LatticeWithInvalidate) (Idx:IntDomain.ZDefault): S with type value = Val.t and type idx = Idx.t =
 struct
   module Factor = struct let x () = (get_int "ana.base.arrays.unrolling-factor") end
   module Base = Lattice.ProdList (Val) (Factor)
@@ -309,7 +309,7 @@ sig
   val move_if_affected_with_length: ?replace_with_const:bool -> idx option -> VDQ.t -> t -> Cil.varinfo -> (Cil.exp -> int option) -> t
 end
 
-module Partitioned (Val: LatticeWithSmartOps) (Idx:IntDomain.Z): SPartitioned with type value = Val.t and type idx = Idx.t =
+module Partitioned (Val: LatticeWithSmartOps) (Idx:IntDomain.ZDefault): SPartitioned with type value = Val.t and type idx = Idx.t =
 struct
   include Printable.Std
 
@@ -812,12 +812,12 @@ struct
 end
 
 (* This is the main array out of bounds check *)
-let array_oob_check ( type a ) (module Idx: IntDomain.Z with type t = a) (x, l) (e, v) =
+let array_oob_check ( type a ) (module Idx: IntDomain.ZDefault with type t = a) (x, l) (e, v) =
   if !AnalysisState.executing_speculative_computations then
     ()
   else if GobConfig.get_bool "ana.arrayoob" then (* The purpose of the following 2 lines is to give the user extra info about the array oob *)
     let idx_before_end = Idx.lt v l in (* check whether index is before the end of the array *)
-    let idx_after_start = Idx.ge v (Idx.of_int (Cilfacade.ptrdiff_ikind ()) Z.zero) in (* check whether the index is non-negative *)
+    let idx_after_start = Idx.ge v (Idx.of_int Z.zero) in (* check whether the index is non-negative *)
     (* For an explanation of the warning types check the Pull Request #255 *)
     match idx_after_start, idx_before_end with
     | Some true, Some true -> (* Certainly in bounds on both sides.*)
@@ -844,7 +844,7 @@ let array_oob_check ( type a ) (module Idx: IntDomain.Z with type t = a) (x, l) 
       Checks.warn Checks.Category.InvalidMemoryAccess "Invalid array access: May access out of bounds"
 
 
-module TrivialWithLength (Val: LatticeWithInvalidate) (Idx: IntDomain.Z): S with type value = Val.t and type idx = Idx.t =
+module TrivialWithLength (Val: LatticeWithInvalidate) (Idx: IntDomain.ZDefault): S with type value = Val.t and type idx = Idx.t =
 struct
   module Base = Trivial (Val) (Idx)
   include Lattice.Prod (Base) (Idx)
@@ -888,7 +888,7 @@ struct
 end
 
 
-module PartitionedWithLength (Val: LatticeWithSmartOps) (Idx: IntDomain.Z): S with type value = Val.t and type idx = Idx.t =
+module PartitionedWithLength (Val: LatticeWithSmartOps) (Idx: IntDomain.ZDefault): S with type value = Val.t and type idx = Idx.t =
 struct
   module Base = Partitioned (Val) (Idx)
   include Lattice.Prod (Base) (Idx)
@@ -942,7 +942,7 @@ struct
   let to_yojson (x, y) = `Assoc [ (Base.name (), Base.to_yojson x); ("length", Idx.to_yojson y) ]
 end
 
-module UnrollWithLength (Val: LatticeWithInvalidate) (Idx: IntDomain.Z): S with type value = Val.t and type idx = Idx.t =
+module UnrollWithLength (Val: LatticeWithInvalidate) (Idx: IntDomain.ZDefault): S with type value = Val.t and type idx = Idx.t =
 struct
   module Base = Unroll (Val) (Idx)
   include Lattice.Prod (Base) (Idx)
@@ -986,7 +986,7 @@ struct
   let to_yojson (x, y) = `Assoc [ (Base.name (), Base.to_yojson x); ("length", Idx.to_yojson y) ]
 end
 
-module NullByte (Val: LatticeWithNull) (Idx: IntDomain.Z): Str with type value = Val.t and type idx = Idx.t =
+module NullByte (Val: LatticeWithNull) (Idx: IntDomain.ZDefault): Str with type value = Val.t and type idx = Idx.t =
 struct
   module MustSet = NullByteSet.MustSet
   module MaySet = NullByteSet.MaySet
@@ -1210,7 +1210,7 @@ struct
         | Some i -> build_set (i + 1) (Nulls.Set.add (Z.of_int i) set)
         | None -> Nulls.Set.add last_null set in
     let set = build_set 0 (Nulls.Set.empty ()) in
-    (Nulls.precise_set set, Idx.of_int ILong (Z.succ last_null))
+    (Nulls.precise_set set, Idx.of_int (Z.succ last_null)) (* TODO: used ILong *)
 
   (** Returns an abstract value with at most one null byte marking the end of the string *)
   let to_string ((nulls, size) as x:t):t =
@@ -1223,7 +1223,7 @@ struct
     else
       (Checks.safe Checks.Category.InvalidMemoryAccess;
       let min_must_null = Nulls.min_elem Definitely nulls in
-      let new_size = Idx.of_int ILong (Z.succ min_must_null) in
+      let new_size = Idx.of_int (Z.succ min_must_null) in (* TODO: used ILong *)
       let min_may_null = Nulls.min_elem Possibly nulls in
       (* if smallest index in sets coincides, only this null byte is kept in both sets *)
       let nulls =
@@ -1323,7 +1323,7 @@ struct
             let nulls = Nulls.add_interval Possibly (min_may_null, Z.pred n) nulls in
             Nulls.filter (fun x -> x <. n) nulls)
       in
-      (nulls,  Idx.of_int ILong n)
+      (nulls,  Idx.of_int n) (* TODO: used ILong *)
 
   let to_string_length (nulls, size) =
     (* if must_nulls_set and min_nulls_set empty, definitely no null byte in array => return interval [size, inf) and warn *)
@@ -1454,9 +1454,9 @@ struct
       update_sets truncated (to_string_length src)
     (* strncpy = exactly n bytes from src are copied to dest *)
     | Some n when n >= 0 ->
-      sizes_warning (Idx.of_int ILong (Z.of_int n));
+      sizes_warning (Idx.of_int (Z.of_int n)); (* TODO: used ILong *)
       let truncated = to_n_string src n in
-      update_sets truncated (Idx.of_int !Cil.kindOfSizeOf (Z.of_int n))
+      update_sets truncated (Idx.of_int (Z.of_int n)) (* TODO: used !Cil.kindOfSizeOf *)
     | _ -> (Nulls.top (), dstsize)
 
   let string_concat (nulls1, size1) (nulls2, size2) n =
@@ -1688,7 +1688,7 @@ struct
   let update_length new_size (nulls, size) = (nulls, new_size)
 end
 
-module AttributeConfiguredArrayDomain(Val: LatticeWithSmartOps) (Idx:IntDomain.Z):S with type value = Val.t and type idx = Idx.t =
+module AttributeConfiguredArrayDomain(Val: LatticeWithSmartOps) (Idx:IntDomain.ZDefault):S with type value = Val.t and type idx = Idx.t =
 struct
   module P = PartitionedWithLength(Val)(Idx)
   module T = TrivialWithLength(Val)(Idx)
@@ -1759,7 +1759,7 @@ struct
     | UnrolledDomain -> (None, None, Some (U.make i v))
 
   (* convert to another domain *)
-  let index_as_expression i = (Some (Cil.integer i), Idx.of_int IInt (Z.of_int i))
+  let index_as_expression i = (Some (Cil.integer i), Idx.of_int (Z.of_int i)) (* TODO: used IInt *)
 
   let partitioned_of_trivial ask t = P.make (Option.value (T.length t) ~default:(Idx.top ())) (T.get ~checkBounds:false ask t (index_as_expression 0))
 
@@ -1810,7 +1810,7 @@ struct
       (U.invariant ~value_invariant ~offset ~lval)
 end
 
-module AttributeConfiguredAndNullByteArrayDomain (Val: LatticeWithNull) (Idx: IntDomain.Z): StrWithDomain with type value = Val.t and type idx = Idx.t =
+module AttributeConfiguredAndNullByteArrayDomain (Val: LatticeWithNull) (Idx: IntDomain.ZDefault): StrWithDomain with type value = Val.t and type idx = Idx.t =
 struct
   module A = AttributeConfiguredArrayDomain (Val) (Idx)
   module N = NullByte (Val) (Idx)

--- a/src/cdomain/value/cdomains/arrayDomain.mli
+++ b/src/cdomain/value/cdomains/arrayDomain.mli
@@ -148,11 +148,11 @@ module Trivial (Val: LatticeWithInvalidate) (Idx: Lattice.S): S with type value 
   * indexing type is taken as a parameter to satisfy the type system, it is not
   * used in the implementation. *)
 
-module TrivialWithLength (Val: LatticeWithInvalidate) (Idx: IntDomain.Z): S with type value = Val.t and type idx = Idx.t
+module TrivialWithLength (Val: LatticeWithInvalidate) (Idx: IntDomain.ZDefault): S with type value = Val.t and type idx = Idx.t
 (** This functor creates a trivial single cell representation of an array. The
   * indexing type is also used to manage the length. *)
 
-module Partitioned (Val: LatticeWithSmartOps) (Idx: IntDomain.Z): S with type value = Val.t and type idx = Idx.t
+module Partitioned (Val: LatticeWithSmartOps) (Idx: IntDomain.ZDefault): S with type value = Val.t and type idx = Idx.t
 (** This functor creates an array representation that allows for partitioned arrays
   * Such an array can be partitioned according to an expression in which case it
   * uses three values from Val to represent the elements of the array to the left,
@@ -160,10 +160,10 @@ module Partitioned (Val: LatticeWithSmartOps) (Idx: IntDomain.Z): S with type va
   * have a signature that allows for choosing an array representation at runtime.
 *)
 
-module PartitionedWithLength (Val: LatticeWithSmartOps) (Idx:IntDomain.Z): S with type value = Val.t and type idx = Idx.t
+module PartitionedWithLength (Val: LatticeWithSmartOps) (Idx:IntDomain.ZDefault): S with type value = Val.t and type idx = Idx.t
 (** Like partitioned but additionally manages the length of the array. *)
 
-module NullByte (Val: LatticeWithNull) (Idx: IntDomain.Z): Str with type value = Val.t and type idx = Idx.t
+module NullByte (Val: LatticeWithNull) (Idx: IntDomain.ZDefault): Str with type value = Val.t and type idx = Idx.t
 (** This functor creates an array representation by the indexes of all null bytes
   * the array must and may contain. This is useful to analyze strings, i.e. null-
   * terminated char arrays, and particularly to determine if operations on strings
@@ -171,10 +171,10 @@ module NullByte (Val: LatticeWithNull) (Idx: IntDomain.Z): Str with type value =
   * for this domain. It additionally tracks the array size.
 *)
 
-module AttributeConfiguredArrayDomain (Val: LatticeWithSmartOps) (Idx: IntDomain.Z): S with type value = Val.t and type idx = Idx.t
+module AttributeConfiguredArrayDomain (Val: LatticeWithSmartOps) (Idx: IntDomain.ZDefault): S with type value = Val.t and type idx = Idx.t
 (** Switches between PartitionedWithLength, TrivialWithLength and Unroll based on variable, type, and flag. *)
 
-module AttributeConfiguredAndNullByteArrayDomain (Val: LatticeWithNull) (Idx: IntDomain.Z): StrWithDomain with type value = Val.t and type idx = Idx.t
+module AttributeConfiguredAndNullByteArrayDomain (Val: LatticeWithNull) (Idx: IntDomain.ZDefault): StrWithDomain with type value = Val.t and type idx = Idx.t
 (** Like FlagHelperAttributeConfiguredArrayDomain but additionally runs NullByte
   * in parallel if flag "ana.base.arrays.nullbytes" is set.
 *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -286,6 +286,7 @@ struct
   let of_bitfield x = I.of_bitfield (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let starting ?suppress_ovwarn x = I.starting ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let ending ?suppress_ovwarn x = I.ending ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
+  let of_excl_list x = I.of_excl_list (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
 end
 
 module Size = struct (* size in bits as int, range as int64 *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -279,6 +279,7 @@ struct
   let top () = I.top_of (Ik.ikind ())
   let is_top x = I.is_top_of (Ik.ikind ()) x
   let bot () = I.bot_of (Ik.ikind ())
+  (* let is_bot x = I.is_bot_of (Ik.ikind ()) x *) (* TODO: add this? *)
   let of_int ?suppress_ovwarn x = I.of_int ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_bool x = I.of_bool (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_interval ?suppress_ovwarn x = I.of_interval ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
@@ -287,6 +288,12 @@ struct
   let starting ?suppress_ovwarn x = I.starting ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let ending ?suppress_ovwarn x = I.ending ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_excl_list x = I.of_excl_list (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
+
+  let bot_of = Printable.Empty.show
+  let top_of = Printable.Empty.show
+  let is_bot_of = Printable.Empty.show
+  let is_top_of = Printable.Empty.show
+  let cast_to = Printable.Empty.show
 end
 
 module Size = struct (* size in bits as int, range as int64 *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -288,12 +288,6 @@ struct
   let starting ?suppress_ovwarn x = I.starting ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let ending ?suppress_ovwarn x = I.ending ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_excl_list x = I.of_excl_list (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
-
-  let bot_of = Printable.Empty.show
-  let top_of = Printable.Empty.show
-  let is_bot_of = Printable.Empty.show
-  let is_top_of = Printable.Empty.show
-  let cast_to = Printable.Empty.show
 end
 
 module Size = struct (* size in bits as int, range as int64 *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -280,6 +280,7 @@ struct
   let is_top x = I.is_top_of (Ik.ikind ()) x
   let bot () = I.bot_of (Ik.ikind ())
   let of_int ?suppress_ovwarn x = I.of_int ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
+  let of_bool x = I.of_bool (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
 end
 
 module Size = struct (* size in bits as int, range as int64 *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -280,14 +280,14 @@ struct
   let is_top x = I.is_top_of (Ik.ikind ()) x
   let bot () = I.bot_of (Ik.ikind ())
   (* let is_bot x = I.is_bot_of (Ik.ikind ()) x *) (* TODO: add this? *)
-  let of_int ?suppress_ovwarn x = I.of_int ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
-  let of_bool x = I.of_bool (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
-  let of_interval ?suppress_ovwarn x = I.of_interval ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
-  let of_congruence x = I.of_congruence (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
-  let of_bitfield x = I.of_bitfield (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
-  let starting ?suppress_ovwarn x = I.starting ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
-  let ending ?suppress_ovwarn x = I.ending ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
-  let of_excl_list x = I.of_excl_list (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
+  let of_int ?suppress_ovwarn x = I.of_int ?suppress_ovwarn (Ik.ikind ()) x
+  let of_bool x = I.of_bool (Ik.ikind ()) x
+  let of_interval ?suppress_ovwarn x = I.of_interval ?suppress_ovwarn (Ik.ikind ()) x
+  let of_congruence x = I.of_congruence (Ik.ikind ()) x
+  let of_bitfield x = I.of_bitfield (Ik.ikind ()) x
+  let starting ?suppress_ovwarn x = I.starting ?suppress_ovwarn (Ik.ikind ()) x
+  let ending ?suppress_ovwarn x = I.ending ?suppress_ovwarn (Ik.ikind ()) x
+  let of_excl_list x = I.of_excl_list (Ik.ikind ()) x
 end
 
 module Size = struct (* size in bits as int, range as int64 *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -273,12 +273,13 @@ struct
   let ikind = Cilfacade.ptrdiff_ikind
 end
 
-module IntDomWithDefaultIkind (I: Y) (Ik: Ikind) : Y with type t = I.t and type int_t = I.int_t =
+module IntDomWithDefaultIkind (I: Y) (Ik: Ikind) : YDefault with type t = I.t and type int_t = I.int_t =
 struct
   include I
   let top () = I.top_of (Ik.ikind ())
   let is_top x = I.is_top_of (Ik.ikind ()) x
   let bot () = I.bot_of (Ik.ikind ())
+  let of_int ?suppress_ovwarn x = I.of_int ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
 end
 
 module Size = struct (* size in bits as int, range as int64 *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -283,6 +283,7 @@ struct
   let of_bool x = I.of_bool (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_interval ?suppress_ovwarn x = I.of_interval ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_congruence x = I.of_congruence (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
+  let of_bitfield x = I.of_bitfield (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
 end
 
 module Size = struct (* size in bits as int, range as int64 *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -284,6 +284,8 @@ struct
   let of_interval ?suppress_ovwarn x = I.of_interval ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_congruence x = I.of_congruence (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_bitfield x = I.of_bitfield (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
+  let starting ?suppress_ovwarn x = I.starting ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
+  let ending ?suppress_ovwarn x = I.ending ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
 end
 
 module Size = struct (* size in bits as int, range as int64 *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -281,6 +281,7 @@ struct
   let bot () = I.bot_of (Ik.ikind ())
   let of_int ?suppress_ovwarn x = I.of_int ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_bool x = I.of_bool (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
+  let of_interval ?suppress_ovwarn x = I.of_interval ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
 end
 
 module Size = struct (* size in bits as int, range as int64 *)

--- a/src/cdomain/value/cdomains/intDomain0.ml
+++ b/src/cdomain/value/cdomains/intDomain0.ml
@@ -282,6 +282,7 @@ struct
   let of_int ?suppress_ovwarn x = I.of_int ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_bool x = I.of_bool (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
   let of_interval ?suppress_ovwarn x = I.of_interval ?suppress_ovwarn (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
+  let of_congruence x = I.of_congruence (Ik.ikind ()) x (* TODO: add cast? (somewhere) *)
 end
 
 module Size = struct (* size in bits as int, range as int64 *)

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -334,7 +334,7 @@ sig
   val of_int: ?suppress_ovwarn:bool -> int_t -> t
   (** Transform an integer literal to your internal domain representation with the specified ikind. *)
 
-  val of_bool: Cil.ikind -> bool -> t
+  val of_bool: bool -> t
   (** Transform a known boolean value to the default internal representation of the specified ikind. It
     * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
 

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -354,10 +354,12 @@ sig
 
   val project: PrecisionUtil.int_precision -> t -> t
   val invariant: Cil.exp -> t -> Invariant.t
-  (* TODO: no bot_of *)
-  (* TODO: no top_of *)
-  (* TODO: no is_bot_of *)
-  (* TODO: no is_top_of *)
+
+  val bot_of: Printable.Empty.t -> string (* TODO: properly remove *)
+  val top_of: Printable.Empty.t -> string (* TODO: properly remove *)
+  val is_bot_of: Printable.Empty.t -> string (* TODO: properly remove *)
+  val is_top_of: Printable.Empty.t -> string (* TODO: properly remove *)
+  val cast_to: Printable.Empty.t -> string (* TODO: properly remove *)
 end
 (** The signature of integral value domains keeping track of ikind information *)
 

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -348,10 +348,16 @@ sig
   val starting   : ?suppress_ovwarn:bool -> int_t -> t
   val ending     : ?suppress_ovwarn:bool -> int_t -> t
 
+  val of_excl_list: int_t list -> t
+
   val is_top_of: Cil.ikind -> t -> bool
 
   val project: PrecisionUtil.int_precision -> t -> t
   val invariant: Cil.exp -> t -> Invariant.t
+  (* TODO: no bot_of *)
+  (* TODO: no top_of *)
+  (* TODO: no is_bot_of *)
+  (* TODO: no is_top_of *)
 end
 (** The signature of integral value domains keeping track of ikind information *)
 

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -342,7 +342,7 @@ sig
 
   val of_congruence: int_t * int_t -> t
 
-  val of_bitfield: Cil.ikind -> int_t * int_t -> t
+  val of_bitfield: int_t * int_t -> t
   val to_bitfield: Cil.ikind -> t -> int_t * int_t
 
   val starting   : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -345,8 +345,8 @@ sig
   val of_bitfield: int_t * int_t -> t
   val to_bitfield: Cil.ikind -> t -> int_t * int_t
 
-  val starting   : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
-  val ending     : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
+  val starting   : ?suppress_ovwarn:bool -> int_t -> t
+  val ending     : ?suppress_ovwarn:bool -> int_t -> t
 
   val is_top_of: Cil.ikind -> t -> bool
 

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -325,7 +325,38 @@ sig
 end
 (** The signature of integral value domains keeping track of ikind information *)
 
+module type YDefault =
+sig
+  include B
+  include Lattice.Top with type t := t
+  include Arith with type t:=t
+
+  val of_int: ?suppress_ovwarn:bool -> int_t -> t
+  (** Transform an integer literal to your internal domain representation with the specified ikind. *)
+
+  val of_bool: Cil.ikind -> bool -> t
+  (** Transform a known boolean value to the default internal representation of the specified ikind. It
+    * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
+
+  val of_interval: ?suppress_ovwarn:bool -> Cil.ikind -> int_t * int_t -> t
+
+  val of_congruence: Cil.ikind -> int_t * int_t -> t
+
+  val of_bitfield: Cil.ikind -> int_t * int_t -> t
+  val to_bitfield: Cil.ikind -> t -> int_t * int_t
+
+  val starting   : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
+  val ending     : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t
+
+  val is_top_of: Cil.ikind -> t -> bool
+
+  val project: PrecisionUtil.int_precision -> t -> t
+  val invariant: Cil.exp -> t -> Invariant.t
+end
+(** The signature of integral value domains keeping track of ikind information *)
+
 module type Z = Y with type int_t = Z.t
+module type ZDefault = YDefault with type int_t = Z.t
 
 module type Ikind =
 sig
@@ -353,7 +384,9 @@ sig
   module SOverflowUnlifter (D : SOverflow) : S2 with type int_t = D.int_t and type t = D.t
 
   module type Y = Y
+  module type YDefault = YDefault
   module type Z = Z
+  module type ZDefault = ZDefault
 
   module IntDomLifter (I: S2): Y with type int_t = I.int_t
 
@@ -361,7 +394,7 @@ sig
 
   module PtrDiffIkind : Ikind
 
-  module IntDomWithDefaultIkind (I: Y) (Ik: Ikind) : Y with type t = I.t and type int_t = I.int_t
+  module IntDomWithDefaultIkind (I: Y) (Ik: Ikind) : YDefault with type t = I.t and type int_t = I.int_t
 
   (* module ManyInts : S *)
   (* module IntDomList : S *)

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -136,15 +136,12 @@ sig
 end
 
 (* Shared signature of IntDomain implementations and the lifted IntDomains *)
-module type B =
+module type BDefault =
 sig
   include Lattice.PO
   include Lattice.Bot with type t := t
   type int_t
   (** {b Accessing values of the ADT} *)
-
-  val bot_of: Cil.ikind -> t
-  val top_of: ?bitfield:int -> Cil.ikind -> t
 
   val to_int: t -> int_t option
   (** Return a single integer value if the value is a known constant, otherwise
@@ -159,9 +156,6 @@ sig
   val to_excl_list: t -> (int_t list * (int * int)) option
   (** Gives a list representation of the excluded values from included range of bits if possible. *)
 
-  val of_excl_list: Cil.ikind -> int_t list -> t
-  (** Creates an exclusion set from a given list of integers. *)
-
   val is_excl_list: t -> bool
   (** Checks if the element is an exclusion set. *)
 
@@ -170,6 +164,18 @@ sig
 
   val maximal    : t -> int_t option
   val minimal    : t -> int_t option
+end
+
+(* Shared signature of IntDomain implementations and the lifted IntDomains *)
+module type B =
+sig
+  include BDefault
+
+  val bot_of: Cil.ikind -> t
+  val top_of: ?bitfield:int -> Cil.ikind -> t
+
+  val of_excl_list: Cil.ikind -> int_t list -> t
+  (** Creates an exclusion set from a given list of integers. *)
 
   (** {b Cast} *)
 
@@ -327,7 +333,7 @@ end
 
 module type YDefault =
 sig
-  include B
+  include BDefault
   include Lattice.Top with type t := t
   include Arith with type t:=t
 
@@ -350,16 +356,8 @@ sig
 
   val of_excl_list: int_t list -> t
 
-  val is_top_of: Cil.ikind -> t -> bool
-
   val project: PrecisionUtil.int_precision -> t -> t
   val invariant: Cil.exp -> t -> Invariant.t
-
-  val bot_of: Printable.Empty.t -> string (* TODO: properly remove *)
-  val top_of: Printable.Empty.t -> string (* TODO: properly remove *)
-  val is_bot_of: Printable.Empty.t -> string (* TODO: properly remove *)
-  val is_top_of: Printable.Empty.t -> string (* TODO: properly remove *)
-  val cast_to: Printable.Empty.t -> string (* TODO: properly remove *)
 end
 (** The signature of integral value domains keeping track of ikind information *)
 

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -340,7 +340,7 @@ sig
 
   val of_interval: ?suppress_ovwarn:bool -> int_t * int_t -> t
 
-  val of_congruence: Cil.ikind -> int_t * int_t -> t
+  val of_congruence: int_t * int_t -> t
 
   val of_bitfield: Cil.ikind -> int_t * int_t -> t
   val to_bitfield: Cil.ikind -> t -> int_t * int_t

--- a/src/cdomain/value/cdomains/intDomain_intf.ml
+++ b/src/cdomain/value/cdomains/intDomain_intf.ml
@@ -338,7 +338,7 @@ sig
   (** Transform a known boolean value to the default internal representation of the specified ikind. It
     * should follow C: [of_bool true = of_int 1] and [of_bool false = of_int 0]. *)
 
-  val of_interval: ?suppress_ovwarn:bool -> Cil.ikind -> int_t * int_t -> t
+  val of_interval: ?suppress_ovwarn:bool -> int_t * int_t -> t
 
   val of_congruence: Cil.ikind -> int_t * int_t -> t
 

--- a/src/cdomain/value/cdomains/offset.ml
+++ b/src/cdomain/value/cdomains/offset.ml
@@ -221,7 +221,7 @@ struct
         let bits_offset = Cilfacade.fieldBitsOffsetOnly field in
         let bits_offset = Z.of_int bits_offset in
         (* Interval of floor and ceil division in case bitfield offset. *)
-        let bytes_offset = Idx.of_interval (Cilfacade.ptrdiff_ikind ()) Z.(fdiv bits_offset eight, cdiv bits_offset eight) in
+        let bytes_offset = Idx.of_interval Z.(fdiv bits_offset eight, cdiv bits_offset eight) in
         let remaining_offset = offset_to_index_offset ~typ:field.ftype o in
         let@ () = GobRef.wrap AnalysisState.executing_speculative_computations true in
         Idx.add bytes_offset remaining_offset

--- a/src/cdomain/value/cdomains/offset.ml
+++ b/src/cdomain/value/cdomains/offset.ml
@@ -205,7 +205,7 @@ struct
      element) answers with any_index_exp on all non-concrete cases. *)
   let rec of_exp: exp offs -> t = function (* TODO: Poly.map_indices *)
     | `NoOffset    -> `NoOffset
-    | `Index (Const (CInt (i,ik,s)),o) -> `Index (Idx.of_int ik i, of_exp o)
+    | `Index (Const (CInt (i,ik,s)),o) -> `Index (Idx.of_int i, of_exp o)
     | `Index (_,o) -> `Index (Idx.top (), of_exp o)
     | `Field (f,o) -> `Field (f, of_exp o)
 
@@ -213,7 +213,7 @@ struct
 
   let to_index ?typ (offs: t): Idx.t =
     let idx_of_int x =
-      Idx.of_int (Cilfacade.ptrdiff_ikind ()) (Z.of_int x)
+      Idx.of_int (Z.of_int x)
     in
     let rec offset_to_index_offset ?typ offs = match offs with
       | `NoOffset -> idx_of_int 0

--- a/src/cdomain/value/cdomains/offset_intf.ml
+++ b/src/cdomain/value/cdomains/offset_intf.ml
@@ -24,7 +24,7 @@ struct
     (** Convert to definite integer if possible. *)
   end
 
-  module type Lattice = IntDomain.Z
+  module type Lattice = IntDomain.ZDefault
 end
 
 exception Type_of_error of GoblintCil.typ * string

--- a/src/cdomain/value/cdomains/valueDomain.ml
+++ b/src/cdomain/value/cdomains/valueDomain.ml
@@ -157,7 +157,7 @@ struct
 
   let array_length_idx default length =
     let l = BatOption.bind length (fun e -> Cil.getInteger (Cil.constFold true e)) in
-    BatOption.map_default (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) default l
+    BatOption.map_default IndexDomain.of_int default l
 
   let rec bot_value ?(varAttr=[]) (t: typ): t =
     match t with
@@ -447,7 +447,7 @@ struct
             (* array to its first element *)
             | TArray _, _ ->
               if M.tracing then M.tracel "casta" "cast array to its first element";
-              adjust_offs v (Addr.Offs.add_offset o (`Index (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ()) Z.zero, `NoOffset))) (Some false)
+              adjust_offs v (Addr.Offs.add_offset o (`Index (IndexDomain.of_int Z.zero, `NoOffset))) (Some false)
             | _ -> err @@ Format.sprintf "Cast to neither array index nor struct field. is_zero_offset: %b" (Addr.Offs.cmp_zero_offset o = `MustZero)
           end
     in
@@ -1134,10 +1134,10 @@ struct
                           match Cil.unrollType fld.ftype with
                           | TArray(_, l, _) ->
                             let len = Cil.lenOfArray l in (* LenOfArray exception will not happen, VLA not allowed in union and struct *)
-                            Array(CArrays.make (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ()) (Z.of_int len)) Top), offs
+                            Array(CArrays.make (IndexDomain.of_int (Z.of_int len)) Top), offs
                           | _ -> top (), offs (* will not happen*)
                         end
-                      | `Index (idx, _) when IndexDomain.equal idx (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ()) Z.zero) ->
+                      | `Index (idx, _) when IndexDomain.equal idx (IndexDomain.of_int Z.zero) ->
                         (* Why does cil index unions? We'll just pick the first field. *)
                         top (), `Field (List.nth fld.fcomp.cfields 0,`NoOffset)
                       | _ -> M.warn ~category:Analyzer ~tags:[Category Unsound] "Indexing on a union is unusual, and unsupported by the analyzer";
@@ -1166,7 +1166,7 @@ struct
                   let new_value_at_index = do_update_offset Bot offs l' o' in
                   let new_array_value =  CArrays.set ask x' (e, idx) new_value_at_index in
                   let len_ci = BatOption.bind len (fun e -> Cil.getInteger @@ Cil.constFold true e) in
-                  let len_id = BatOption.map (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) len_ci in
+                  let len_id = BatOption.map IndexDomain.of_int len_ci in
                   let newl = BatOption.default (ID.starting (Cilfacade.ptrdiff_ikind ()) Z.zero) len_id in
                   let new_array_value = CArrays.update_length newl new_array_value in
                   Array new_array_value

--- a/src/cdomains/lockDomain.ml
+++ b/src/cdomains/lockDomain.ml
@@ -35,7 +35,7 @@ struct
     | _ -> None
 
   let to_mval ((v, o): t): Mval.t =
-    (v, Offset.Poly.map_indices (IndexDomain.of_int (Cilfacade.ptrdiff_ikind ())) o)
+    (v, Offset.Poly.map_indices IndexDomain.of_int o)
 end
 
 module MustLockset =

--- a/tests/unit/cdomains/lvalTest.ml
+++ b/tests/unit/cdomains/lvalTest.ml
@@ -12,13 +12,13 @@ let ikind = IntDomain.PtrDiffIkind.ikind ()
 
 let a_var = Cil.makeGlobalVar "a" Cil.intPtrType
 let a_lv = LV.of_var a_var
-let i_0 = ID.of_int ikind Z.zero
+let i_0 = ID.of_int Z.zero
 let a_lv_0 = LV.of_mval (a_var, `Index (i_0, `NoOffset))
-let i_1 = ID.of_int ikind Z.one
+let i_1 = ID.of_int Z.one
 let a_lv_1 = LV.of_mval (a_var, `Index (i_1, `NoOffset))
 let i_top = ID.join i_0 i_1
 let a_lv_top = LV.of_mval (a_var, `Index (i_top, `NoOffset))
-let i_not_0 = ID.join i_1 (ID.of_int ikind (Z.of_int 2))
+let i_not_0 = ID.join i_1 (ID.of_int (Z.of_int 2))
 let a_lv_not_0 = LV.of_mval (a_var, `Index (i_not_0, `NoOffset))
 
 


### PR DESCRIPTION
`IndexDomain` defaults the ikind to `ptrdiff_t`: https://github.com/goblint/analyzer/blob/1ed379e2db8f8df4df204f46a989a761be644110/src/cdomain/value/cdomains/preValueDomain.ml#L3

However, currently `IntDomWithDefaultIkind` doesn't pass the default ikind to all functions, but only some.
This means that it's possible to misuse `IndexDomain`, e.g. `IndexDomain.of_int IInt Z.zero`, which is fine on its own but can lead to `IncompatibleIKinds` down the line, when operations on `IndexDomain` try to use `ptrdiff_t` on it instead.
So the default ikind should really be used across the entire interface, preventing such misuses altogether.

In most cases `(Cilfacade.ptrdiff_ikind ())` was passed anyway, so this just simplifies code.
There are two major misuses though:
- [x] For some reason the gStoreWidening tutorial defaults intervals to `ptrdiff_t` as well: https://github.com/goblint/analyzer/blob/1ed379e2db8f8df4df204f46a989a761be644110/src/analyses/tutorials/gStoreWideningHelper.ml#L4-L5
    However, later it still creates values with other ikinds. Fixed by #2139.
- [ ] `ArrayDomain.NullByte` uses a wild mix of `IInt`, `ILong` and `!Cil.kindOfSizeOf`.
- [x] ~~The latter probably causes~~ 73/07 larger_example and 73/10 char_arrays to fail now. Fixed by #2140.
- [ ] Do casts in `IntDomWithDefaultIkind`? Shouldn't be needed for `of_*` operations. But `IndexDomain` should have abstract type and conversion to-from `ID` cast.

This came up in https://github.com/goblint/analyzer/pull/1987#discussion_r3915030799.