### PR TITLE
Remove default `ptrdiff_t` ikind from gStoreWidening tutorial intervals

### DIFF
--- a/src/analyses/tutorials/gStoreWideningHelper.ml
+++ b/src/analyses/tutorials/gStoreWideningHelper.ml
@@ -2,7 +2,7 @@
 open GoblintCil
 
 (* Complicated definition for technical reasons relating to different int types *)
-module Intervals = IntDomain.IntDomWithDefaultIkind(IntDomain.IntDomLifter (IntDomain.SOverflowUnlifter (IntDomain.Interval))) (IntDomain.PtrDiffIkind)
+module Intervals = IntDomain.IntDomLifter (IntDomain.SOverflowUnlifter (IntDomain.Interval))
 
 let is_tracked_var v =
   Cil.isIntegralType v.vtype && not v.vaddrof


### PR DESCRIPTION
I noticed this in #2138.

I thought there was some subtle reason relating to all the messy `IntDomain` interfaces that we have that this default was necessary.
But no, just removing the wrapper still compiles and passes the tests for the tutorial.