### PR TITLE
Remove polymorphic `BatSet` usage in old solvers and `MCP`

### DIFF
--- a/src/analyses/mCP.ml
+++ b/src/analyses/mCP.ml
@@ -36,7 +36,7 @@ struct
   let name () = "MCP2"
 
   let path_sens = ref []
-  let act_cont_sens = ref Set.empty
+  let act_cont_sens = ref Set.Int.empty
   let base_id   = ref (-1)
 
 
@@ -91,7 +91,7 @@ struct
         let cont_sens = map' find_id @@ sens in
         activated_context_sens := List.filter (fun (n, _) -> List.mem n cont_sens) !activated;
     end;
-    act_cont_sens := Set.of_list (List.map (fun (n,p) -> n) !activated_context_sens);
+    act_cont_sens := Set.Int.of_list (List.map (fun (n,p) -> n) !activated_context_sens);
     activated_path_sens := List.filter (fun (n, _) -> List.mem n !path_sens) !activated;
     match marshal with
     | Some marshal ->
@@ -119,7 +119,7 @@ struct
 
   let startcontext () =
     filter_map (fun (n,{spec=(module S:MCPSpec); _}) ->
-        if Set.is_empty !act_cont_sens || not (Set.mem n !act_cont_sens) then (*n is insensitive*)
+        if Set.Int.is_empty !act_cont_sens || not (Set.Int.mem n !act_cont_sens) then (*n is insensitive*)
           None
         else
           Some (n, Obj.repr @@ S.startcontext ())
@@ -236,7 +236,7 @@ struct
     let man'' = outer_man "context_computation" man in
     let x = spec_list x in
     filter_map (fun (n,(module S:MCPSpec),d) ->
-        if Set.is_empty !act_cont_sens || not (Set.mem n !act_cont_sens) then (*n is insensitive*)
+        if Set.Int.is_empty !act_cont_sens || not (Set.Int.mem n !act_cont_sens) then (*n is insensitive*)
           None
         else
           let man' : (S.D.t, S.G.t, S.C.t, S.V.t) man = inner_man "context_computation" man'' n d in

--- a/src/solver/sLR.ml
+++ b/src/solver/sLR.ml
@@ -90,11 +90,11 @@ module SLR3 =
         match S.system x with
         | None -> S.Dom.bot ()
         | Some f ->
-          let effects = ref Set.empty in
+          let effects = ref VS.empty in
           let sidef y d =
-            if not (Set.mem y !effects) then (
+            if not (VS.mem y !effects) then (
               HPM.replace rho' (x,y) (S.Dom.bot ());
-              effects := Set.add y !effects
+              effects := VS.add y !effects
             );
             set y d
           in

--- a/src/solver/sLRphased.ml
+++ b/src/solver/sLRphased.ml
@@ -69,12 +69,12 @@ module Make =
           HM.replace infl y (VS.add x (HM.find infl y));
           HM.find rho y
         in
-        let effects = ref Set.empty in
+        let effects = ref VS.empty in
         let side y d =
           assert (not (S.Dom.is_bot d));
           if tracing then trace "sol" "SIDE: Var: %a\nVal: %a" S.Var.pretty_trace y S.Dom.pretty d;
-          let first = not (Set.mem y !effects) in
-          effects := Set.add y !effects;
+          let first = not (VS.mem y !effects) in
+          effects := VS.add y !effects;
           if first then (
             (* let old = try HPM.find rho' (x,y) with _ -> S.Dom.bot () in *)
             (* let d = S.Dom.join old d in *)

--- a/src/solver/sLRterm.ml
+++ b/src/solver/sLRterm.ml
@@ -103,7 +103,7 @@ module SLR3term =
           HM.replace infl y (VS.add x (try HM.find infl y with Not_found -> VS.empty));
           HM.find rho y
         in
-        let effects = ref Set.empty in
+        let effects = ref VS.empty in
         let side y d =
           assert (not (S.Dom.is_bot d));
           (*
@@ -122,8 +122,8 @@ module SLR3term =
           *)
           (* if S.Dom.is_bot d then print_endline "BOT" else *)
           if tracing then trace "sol" "SIDE: Var: %a\nVal: %a" S.Var.pretty_trace y S.Dom.pretty d;
-          let first = not (Set.mem y !effects) in
-          effects := Set.add y !effects;
+          let first = not (VS.mem y !effects) in
+          effects := VS.add y !effects;
           if first then (
             HPM.replace rho' (x,y) d;
             HM.replace set y (VS.add x (try HM.find set y with Not_found -> VS.empty));

--- a/src/solver/topDown.ml
+++ b/src/solver/topDown.ml
@@ -79,11 +79,11 @@ module WP =
         match S.system x with
         | None -> S.Dom.bot ()
         | Some f ->
-          let effects = ref Set.empty in
+          let effects = ref VS.empty in
           let sidef y d =
-            if not (Set.mem y !effects) then (
+            if not (VS.mem y !effects) then (
               HPM.replace rho' (x,y) (S.Dom.bot ()); (* TODO needed? tests also work without this... *)
-              effects := Set.add y !effects
+              effects := VS.add y !effects
             );
             set y d
           in

--- a/src/solver/topDown_deprecated.ml
+++ b/src/solver/topDown_deprecated.ml
@@ -73,11 +73,11 @@ module TD3 =
         match S.system x with
         | None -> S.Dom.bot ()
         | Some f ->
-          let effects = ref Set.empty in
+          let effects = ref VS.empty in
           let sidef y d =
-            if not (Set.mem y !effects) then (
+            if not (VS.mem y !effects) then (
               HPM.replace rho' (x,y) (S.Dom.bot ());
-              effects := Set.add y !effects
+              effects := VS.add y !effects
             );
             set y d
           in


### PR DESCRIPTION
@kalmera used the `slr3` solver for some evaluations and it sometimes crashed with
```
Fatal error: exception Invalid_argument("compare: abstract value")
```
For example:
```
./goblint --conf conf/svcomp26/common.json --conf conf/svcomp26/verify.json --conf conf/svcomp26/level01.json --set solver slr3 -v --sets ana.specification ../sv-benchmarks/c/properties/termination.prp --sets exp.architecture 64bit ../sv-benchmarks/c/termination-memory-alloca/Urban-alloca-2.i
```

This exception is caused by using polymorphic comparison on some abstract values (in the OCaml sense), possibly Apron elements.
This PR removes usages of the polymorphic `BatSet` in the old solvers and `MCP` (where it was actually fine due to `int` elements).