### PR TITLE
Uses modulo constants as extra widening thresholds

### DIFF
--- a/src/cdomain/value/util/wideningThresholds.ml
+++ b/src/cdomain/value/util/wideningThresholds.ml
@@ -56,6 +56,20 @@ class extractThresholdsFromConditionsVisitor(upper_thresholds,lower_thresholds, 
       addThreshold octagon_thresholds @@ doubleI;
       addThreshold octagon_thresholds @@ Z.neg doubleI;
       DoChildren
+
+    (* Modulo by a constant: expr % 10 *)
+    (* The result of expr % c is contained in [-(|c|-1), |c|-1], so |c|-1 is the tightest bound *)
+    | BinOp (Mod, _, (Const (CInt(i,_,_))), _) when not (Z.equal i Z.zero) ->
+      let i = Z.pred @@ Z.abs i in
+      addThreshold upper_thresholds @@ i;
+      addThreshold lower_thresholds @@ Z.neg i;
+
+      addThreshold octagon_thresholds @@ i;
+      addThreshold octagon_thresholds @@ Z.neg i;
+      let doubleI = Z.add i i in
+      addThreshold octagon_thresholds @@ doubleI;
+      addThreshold octagon_thresholds @@ Z.neg doubleI;
+      DoChildren
     | _ -> DoChildren
 end
 

--- a/tests/regression/03-practical/37-threshold-modulo.c
+++ b/tests/regression/03-practical/37-threshold-modulo.c
@@ -1,0 +1,25 @@
+// PARAM: --enable ana.int.interval --enable ana.int.interval_threshold_widening --set ana.int.interval_threshold_widening_constants comparisons --enable exp.no-narrow
+#include <goblint.h>
+
+int nondet();
+
+int main() {
+  int x = 0;
+
+  while (nondet()) {
+    x = (x + 1) % 10;
+  }
+
+  __goblint_check(x >= 0);
+  __goblint_check(x <= 9);
+
+  int y = 0;
+
+  while (nondet()) {
+    y = (y - 1) % 10;
+  }
+
+  __goblint_check(y >= -9);
+
+  return 0;
+}


### PR DESCRIPTION
In wideningThresholds.ml, extractThresholdsFromConditionsVisitor now matches BinOp (Mod, _, Const (CInt c), _) and contributes |c|-1 as an upper threshold and -(|c|-1) as a lower one, matching C semantics where the result takes the dividend's sign, plus the four octagon thresholds following the existing cases. 

Zero divisors are guarded, negative ones normalised with Z.abs.

autoTune.ml needs no change: wideningOption derives value and cost from upper_thresholds' cardinality, so modulo constants feed the heuristic already.

Closes #2135.