### PR TITLE
Remove unnecessary code from region analysis

### DIFF
--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -14,7 +14,7 @@ module Spec =
 struct
   include Analyses.DefaultSpec
 
-  module D = RegionDomain.RegionDom
+  module D = RegMap
   module G = RegPart
   include Analyses.ValueContexts(D)
 
@@ -26,21 +26,17 @@ struct
 
   let regions exp part st : Mval.Exp.t list =
     match st with
-    | `Lifted reg ->
+    | reg ->
       let ev = Reg.eval_exp exp in
       Reg.related_globals ev (part,reg)
-    | `Top -> Messages.info ~category:Unsound "Region state is broken :("; []
-    | `Bot -> []
 
   let is_bullet exp part st : bool =
     match st with
-    | `Lifted reg ->
+    | reg ->
       begin match Reg.eval_exp exp with
         | Some (_,v,_) -> (try RegionDomain.RS.is_single_bullet (RegMap.find v reg) with Not_found -> false)
         | _ -> false
       end
-    | `Top -> false
-    | `Bot -> true
 
   let get_region man e =
     let regpart = man.global () in
@@ -89,13 +85,12 @@ struct
   (* transfer functions *)
   let assign man (lval:lval) (rval:exp) : D.t =
     match man.local with
-    | `Lifted reg ->
+    | reg ->
       let old_regpart = man.global () in
       let regpart, reg = Reg.assign lval rval (old_regpart, reg) in
       if not (RegPart.leq regpart old_regpart) then
         man.sideg () regpart;
-      `Lifted reg
-    | x -> x
+      reg
 
   let branch man (exp:exp) (tv:bool) : D.t =
     man.local
@@ -106,7 +101,7 @@ struct
   let return man (exp:exp option) (f:fundec) : D.t =
     let locals = f.sformals @ f.slocals in
     match man.local with
-    | `Lifted reg ->
+    | reg ->
       let old_regpart = man.global () in
       let regpart, reg = match exp with
         | Some exp ->
@@ -116,8 +111,7 @@ struct
       let regpart, reg = Reg.kill_vars locals (Reg.remove_vars locals (regpart, reg)) in
       if not (RegPart.leq regpart old_regpart) then
         man.sideg () regpart;
-      `Lifted reg
-    | x -> x
+      reg
 
 
   let enter man (lval: lval option) (fundec:fundec) (args:exp list) : (D.t * D.t) list =
@@ -127,21 +121,20 @@ struct
       | _ -> r
     in
     match man.local with
-    | `Lifted reg ->
+    | reg ->
       let f x r reg = Reg.assign (var x) r reg in
       let old_regpart = man.global () in
       let regpart, reg = fold_right2 f fundec.sformals args (old_regpart,reg) in
       if not (RegPart.leq regpart old_regpart) then
         man.sideg () regpart;
-      [man.local, `Lifted reg]
-    | x -> [x,x]
+      [man.local, reg]
 
   let combine_env man lval fexp f args fc au f_ask =
     man.local
 
   let combine_assign man (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
     match au with
-    | `Lifted reg -> begin
+    | reg -> begin
         let old_regpart = man.global () in
         let regpart, reg = match lval with
           | None -> (old_regpart, reg)
@@ -150,43 +143,41 @@ struct
         let regpart, reg = Reg.remove_vars [ReturnUtil.return_varinfo ()] (regpart, reg) in
         if not (RegPart.leq regpart old_regpart) then
           man.sideg () regpart;
-        `Lifted reg
+        reg
       end
-    | _ -> au
 
   let special man (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     let desc = LibraryFunctions.find f in
     match desc.special arglist with
     | Malloc _ | Calloc _ | Realloc _ | Alloca _ -> begin
         match man.local, lval with
-        | `Lifted reg, Some lv ->
+        | reg, Some lv ->
           let old_regpart = man.global () in
           (* TODO: should realloc use arg region if failed/in-place? *)
           let regpart, reg = Reg.assign_bullet lv (old_regpart, reg) in
           if not (RegPart.leq regpart old_regpart) then
             man.sideg () regpart;
-          `Lifted reg
+          reg
         | _ -> man.local
       end
     | _ ->
       man.local
 
   let startstate v =
-    `Lifted (RegMap.bot ())
+    RegMap.bot ()
 
   let threadenter man ~multiple lval f args =
-    [`Lifted (RegMap.bot ())]
+    [RegMap.bot ()]
   let threadspawn man ~multiple lval f args fman =
     match man.local with
-    | `Lifted reg ->
+    | reg ->
       let old_regpart = man.global () in
       let regpart, reg = List.fold_right Reg.assign_escape args (old_regpart, reg) in
       if not (RegPart.leq regpart old_regpart) then
         man.sideg () regpart;
-      `Lifted reg
-    | x -> x
+      reg
 
-  let exitstate v = `Lifted (RegMap.bot ())
+  let exitstate v = RegMap.bot ()
 
   let name () = "region"
 end

--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -24,19 +24,14 @@ struct
     include StdV
   end
 
-  let regions exp part st : Mval.Exp.t list =
-    match st with
-    | reg ->
-      let ev = Reg.eval_exp exp in
-      Reg.related_globals ev (part,reg)
+  let regions exp part reg : Mval.Exp.t list =
+    let ev = Reg.eval_exp exp in
+    Reg.related_globals ev (part,reg)
 
-  let is_bullet exp part st : bool =
-    match st with
-    | reg ->
-      begin match Reg.eval_exp exp with
-        | Some (_,v,_) -> (try RegionDomain.RS.is_single_bullet (RegMap.find v reg) with Not_found -> false)
-        | _ -> false
-      end
+  let is_bullet exp part reg : bool =
+    match Reg.eval_exp exp with
+    | Some (_,v,_) -> (try RegionDomain.RS.is_single_bullet (RegMap.find v reg) with Not_found -> false)
+    | _ -> false
 
   let get_region man e =
     let regpart = man.global () in
@@ -84,13 +79,12 @@ struct
 
   (* transfer functions *)
   let assign man (lval:lval) (rval:exp) : D.t =
-    match man.local with
-    | reg ->
-      let old_regpart = man.global () in
-      let regpart, reg = Reg.assign lval rval (old_regpart, reg) in
-      if not (RegPart.leq regpart old_regpart) then
-        man.sideg () regpart;
-      reg
+    let reg = man.local in
+    let old_regpart = man.global () in
+    let regpart, reg = Reg.assign lval rval (old_regpart, reg) in
+    if not (RegPart.leq regpart old_regpart) then
+      man.sideg () regpart;
+    reg
 
   let branch man (exp:exp) (tv:bool) : D.t =
     man.local
@@ -100,18 +94,17 @@ struct
 
   let return man (exp:exp option) (f:fundec) : D.t =
     let locals = f.sformals @ f.slocals in
-    match man.local with
-    | reg ->
-      let old_regpart = man.global () in
-      let regpart, reg = match exp with
-        | Some exp ->
-          Reg.assign (ReturnUtil.return_lval ()) exp (old_regpart, reg)
-        | None -> (old_regpart, reg)
-      in
-      let regpart, reg = Reg.kill_vars locals (Reg.remove_vars locals (regpart, reg)) in
-      if not (RegPart.leq regpart old_regpart) then
-        man.sideg () regpart;
-      reg
+    let reg = man.local in
+    let old_regpart = man.global () in
+    let regpart, reg = match exp with
+      | Some exp ->
+        Reg.assign (ReturnUtil.return_lval ()) exp (old_regpart, reg)
+      | None -> (old_regpart, reg)
+    in
+    let regpart, reg = Reg.kill_vars locals (Reg.remove_vars locals (regpart, reg)) in
+    if not (RegPart.leq regpart old_regpart) then
+      man.sideg () regpart;
+    reg
 
 
   let enter man (lval: lval option) (fundec:fundec) (args:exp list) : (D.t * D.t) list =
@@ -120,38 +113,36 @@ struct
       | x::xs, y::ys -> f x y (fold_right2 f xs ys r)
       | _ -> r
     in
-    match man.local with
-    | reg ->
-      let f x r reg = Reg.assign (var x) r reg in
-      let old_regpart = man.global () in
-      let regpart, reg = fold_right2 f fundec.sformals args (old_regpart,reg) in
-      if not (RegPart.leq regpart old_regpart) then
-        man.sideg () regpart;
-      [man.local, reg]
+    let reg = man.local in
+    let f x r reg = Reg.assign (var x) r reg in
+    let old_regpart = man.global () in
+    let regpart, reg = fold_right2 f fundec.sformals args (old_regpart,reg) in
+    if not (RegPart.leq regpart old_regpart) then
+      man.sideg () regpart;
+    [man.local, reg]
 
   let combine_env man lval fexp f args fc au f_ask =
     man.local
 
   let combine_assign man (lval:lval option) fexp (f:fundec) (args:exp list) fc (au:D.t) (f_ask: Queries.ask) : D.t =
-    match au with
-    | reg -> begin
-        let old_regpart = man.global () in
-        let regpart, reg = match lval with
-          | None -> (old_regpart, reg)
-          | Some lval -> Reg.assign lval (AddrOf (ReturnUtil.return_lval ())) (old_regpart, reg)
-        in
-        let regpart, reg = Reg.remove_vars [ReturnUtil.return_varinfo ()] (regpart, reg) in
-        if not (RegPart.leq regpart old_regpart) then
-          man.sideg () regpart;
-        reg
-      end
+    let reg = au in
+    let old_regpart = man.global () in
+    let regpart, reg = match lval with
+      | None -> (old_regpart, reg)
+      | Some lval -> Reg.assign lval (AddrOf (ReturnUtil.return_lval ())) (old_regpart, reg)
+    in
+    let regpart, reg = Reg.remove_vars [ReturnUtil.return_varinfo ()] (regpart, reg) in
+    if not (RegPart.leq regpart old_regpart) then
+      man.sideg () regpart;
+    reg
 
   let special man (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
     let desc = LibraryFunctions.find f in
     match desc.special arglist with
     | Malloc _ | Calloc _ | Realloc _ | Alloca _ -> begin
-        match man.local, lval with
-        | reg, Some lv ->
+        match lval with
+        | Some lv ->
+          let reg = man.local in
           let old_regpart = man.global () in
           (* TODO: should realloc use arg region if failed/in-place? *)
           let regpart, reg = Reg.assign_bullet lv (old_regpart, reg) in
@@ -169,13 +160,12 @@ struct
   let threadenter man ~multiple lval f args =
     [RegMap.bot ()]
   let threadspawn man ~multiple lval f args fman =
-    match man.local with
-    | reg ->
-      let old_regpart = man.global () in
-      let regpart, reg = List.fold_right Reg.assign_escape args (old_regpart, reg) in
-      if not (RegPart.leq regpart old_regpart) then
-        man.sideg () regpart;
-      reg
+    let reg = man.local in
+    let old_regpart = man.global () in
+    let regpart, reg = List.fold_right Reg.assign_escape args (old_regpart, reg) in
+    if not (RegPart.leq regpart old_regpart) then
+      man.sideg () regpart;
+    reg
 
   let exitstate v = RegMap.bot ()
 

--- a/src/analyses/region.ml
+++ b/src/analyses/region.ml
@@ -82,8 +82,7 @@ struct
     let reg = man.local in
     let old_regpart = man.global () in
     let regpart, reg = Reg.assign lval rval (old_regpart, reg) in
-    if not (RegPart.leq regpart old_regpart) then
-      man.sideg () regpart;
+    man.sideg () regpart;
     reg
 
   let branch man (exp:exp) (tv:bool) : D.t =
@@ -102,8 +101,7 @@ struct
       | None -> (old_regpart, reg)
     in
     let regpart, reg = Reg.kill_vars locals (Reg.remove_vars locals (regpart, reg)) in
-    if not (RegPart.leq regpart old_regpart) then
-      man.sideg () regpart;
+    man.sideg () regpart;
     reg
 
 
@@ -117,8 +115,7 @@ struct
     let f x r reg = Reg.assign (var x) r reg in
     let old_regpart = man.global () in
     let regpart, reg = fold_right2 f fundec.sformals args (old_regpart,reg) in
-    if not (RegPart.leq regpart old_regpart) then
-      man.sideg () regpart;
+    man.sideg () regpart;
     [man.local, reg]
 
   let combine_env man lval fexp f args fc au f_ask =
@@ -132,8 +129,7 @@ struct
       | Some lval -> Reg.assign lval (AddrOf (ReturnUtil.return_lval ())) (old_regpart, reg)
     in
     let regpart, reg = Reg.remove_vars [ReturnUtil.return_varinfo ()] (regpart, reg) in
-    if not (RegPart.leq regpart old_regpart) then
-      man.sideg () regpart;
+    man.sideg () regpart;
     reg
 
   let special man (lval: lval option) (f:varinfo) (arglist:exp list) : D.t =
@@ -146,8 +142,7 @@ struct
           let old_regpart = man.global () in
           (* TODO: should realloc use arg region if failed/in-place? *)
           let regpart, reg = Reg.assign_bullet lv (old_regpart, reg) in
-          if not (RegPart.leq regpart old_regpart) then
-            man.sideg () regpart;
+          man.sideg () regpart;
           reg
         | _ -> man.local
       end
@@ -163,8 +158,7 @@ struct
     let reg = man.local in
     let old_regpart = man.global () in
     let regpart, reg = List.fold_right Reg.assign_escape args (old_regpart, reg) in
-    if not (RegPart.leq regpart old_regpart) then
-      man.sideg () regpart;
+    man.sideg () regpart;
     reg
 
   let exitstate v = RegMap.bot ()

--- a/src/cdomains/regionDomain.ml
+++ b/src/cdomains/regionDomain.ml
@@ -235,6 +235,3 @@ struct
       if is_global vfd then [vfd] else []
     | None -> Messages.info ~category:Unsound "Access to unknown address could be global"; []
 end
-
-(* TODO: remove Lift *)
-module RegionDom = Lattice.LiftConf (struct include Printable.DefaultConf let top_name = "Unknown" let bot_name = "Error" end) (RegMap)


### PR DESCRIPTION
Due to https://github.com/goblint/analyzer/issues/118#issuecomment-5614353021 I had a quick look at the region analysis.
I don't have a solution for that issue but I did some very obvious cleanup while at it:

1. Remove unnecessary `Lift` wrapper on the domain. The `` `Bot `` and `` `Top`` values weren't constructed anywhere.
2. Remove unnecessary `leq` checks before `sideg`. No other analysis does this and the solvers should optimally handle the subsumed case anyway. I think this is a leftover from #124.

This PR is probably best viewed with whitespace ignored.