### PR TITLE
Find widening thresholds from reset conditions

### DIFF
--- a/src/cdomain/value/util/wideningThresholds.ml
+++ b/src/cdomain/value/util/wideningThresholds.ml
@@ -25,25 +25,31 @@ class extractThresholdsFromConditionsVisitor(upper_thresholds,lower_thresholds, 
     (* Comparisons of type: expr < 10, 10 > expr *)
     | BinOp (Lt, _, (Const (CInt(i,_,_))), _)
     | BinOp (Gt, (Const (CInt(i,_,_))), _, _) ->
-      self#addUpper i;
+      self#addUpper i; (* if used as loop condition *)
+      self#addLower i; (* if used as reset condition inside loop *)
       DoChildren
 
     (* Comparisons of type: 10 <= expr, expr >= 10 *)
     | BinOp (Le, (Const (CInt(i,_,_))), _, _)
     | BinOp (Ge, _, (Const (CInt(i,_,_))), _) ->
-      self#addLower (Z.pred i);
+      self#addUpper (Z.pred i); (* if used as reset condition inside loop *)
+      self#addLower (Z.pred i); (* if used as loop condition *)
       DoChildren
 
     (* Comparisons of type: expr <= 10, 10 >= expr *)
     | BinOp (Le, _, (Const (CInt(i,_,_))), _)
     | BinOp (Ge, (Const (CInt(i,_,_))), _, _) ->
-      self#addUpper (Z.succ i); (* The same as above with i+1 because for integers expr <= 10 <=> expr < 11 *)
+      (* The same as above with i+1 because for integers expr <= 10 <=> expr < 11 *)
+      self#addUpper (Z.succ i); (* if used as loop condition *)
+      self#addLower (Z.succ i); (* if used as reset condition inside loop *)
       DoChildren
 
     (* Comparisons of type: 10 < expr, expr > 10 *)
     | BinOp (Lt, (Const (CInt(i,_,_))), _, _)
     | BinOp (Gt, _, (Const (CInt(i,_,_))), _) ->
-      self#addLower i; (* The same as above with i+1 because for integers expr <= 10 <=> expr < 11 *)
+      (* The same as above with i+1 because for integers expr > 10 <=> expr >= 11 *)
+      self#addUpper i; (* if used as reset condition inside loop *)
+      self#addLower i; (* if used as loop condition *)
       DoChildren
 
     (* Comparisons of type: 10 == expr, expr == 10, expr != 10, 10 != expr *)

--- a/tests/regression/03-practical/38-mine-tutorial-ex4.7-threshold.c
+++ b/tests/regression/03-practical/38-mine-tutorial-ex4.7-threshold.c
@@ -1,0 +1,17 @@
+// PARAM: --enable ana.int.interval --enable ana.sv-comp.functions --enable ana.int.interval_threshold_widening --set ana.int.interval_threshold_widening_constants comparisons
+// Copy of 56-witness/27-mine-tutorial-ex4.7 without witness.
+#include <goblint.h>
+extern _Bool __VERIFIER_nondet_bool();
+int main() {
+  int x = 0;
+  while (__VERIFIER_nondet_bool() == 0) {
+    __goblint_check(0 <= x);
+    __goblint_check(x <= 40); // TODO
+    if (__VERIFIER_nondet_bool() == 0) {
+      x++;
+      if (x > 40)
+        x = 0;
+    }
+  }
+  return 0;
+}

--- a/tests/regression/03-practical/38-mine-tutorial-ex4.7-threshold.c
+++ b/tests/regression/03-practical/38-mine-tutorial-ex4.7-threshold.c
@@ -6,7 +6,7 @@ int main() {
   int x = 0;
   while (__VERIFIER_nondet_bool() == 0) {
     __goblint_check(0 <= x);
-    __goblint_check(x <= 40); // TODO
+    __goblint_check(x <= 40);
     if (__VERIFIER_nondet_bool() == 0) {
       x++;
       if (x > 40)


### PR DESCRIPTION
The existing logic for widening thresholds considers the case where the expression is used as the loop condition.
However, there are other examples like the second one in #2135 or an existing Miné one copies here as a test, where the condition is inside the loop and used to reset a counter to be back in bounds.
This essentially means that the same expression is used in the opposite role w.r.t. widening thresholds, so this adds both upper and lower thresholds in all cases.

I've intentionally not added a helper to do both (even though all cases now do) because the reasons in each case are different and worth documenting.
Moreover, this doesn't undo the splitting/refactoring of #2146 (the test didn't work before it either). Prior to #2146 the opposite bound added from the reset condition was off by one and, thus, didn't help.