### PR TITLE
Port recent ppx deriving improvements to vendored ppx_easy_deriving

### DIFF
--- a/src/vendor/ppx_easy_deriving/deriver.ml
+++ b/src/vendor/ppx_easy_deriving/deriver.ml
@@ -68,8 +68,9 @@ struct
     let vbs = List.map (fun td ->
         let quoter = Expansion_helpers.Quoter.create () in
         let expr = expr_declaration ~loc ~quoter td in
-        let expr = Expansion_helpers.Quoter.sanitize quoter expr in
         let expr = Ppx_deriving.poly_fun_of_type_decl td expr in
+        (* TODO: eta-expansion *)
+        let expr = Expansion_helpers.Quoter.sanitize quoter expr in
         let ct = typ ~loc td in
         let pat = ppat_var ~loc {loc; txt = Expansion_helpers.mangle_type_decl (Prefix Arg.name) td} in
         let pat = ppat_constraint ~loc pat ct in

--- a/src/vendor/ppx_easy_deriving/deriver.ml
+++ b/src/vendor/ppx_easy_deriving/deriver.ml
@@ -64,6 +64,7 @@ struct
 
   let generate_impl ~ctxt (_rec_flag, type_declarations) =
     let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+    Ast_helper.with_default_loc loc @@ fun () -> (* ppx_easy_deriving shouldn't be using default_loc, but some of the Ppx_deriving API calls might *)
     let vbs = List.map (fun td ->
         let quoter = Expansion_helpers.Quoter.create () in
         let expr = expr_declaration ~loc ~quoter td in
@@ -79,6 +80,7 @@ struct
 
   let generate_intf ~ctxt (_rec_flag, type_declarations) =
     let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+    Ast_helper.with_default_loc loc @@ fun () -> (* ppx_easy_deriving shouldn't be using default_loc, but some of the Ppx_deriving API calls might *)
     List.map (fun td ->
         let ct = typ ~loc td in
         let val_ = Ast_helper.Val.mk ~loc {loc; txt = Expansion_helpers.mangle_type_decl (Prefix Arg.name) td} ct in

--- a/src/vendor/ppx_easy_deriving/deriver.ml
+++ b/src/vendor/ppx_easy_deriving/deriver.ml
@@ -62,7 +62,7 @@ struct
       td
       (Arg.typ ~loc ct)
 
-  let generate_impl ~ctxt (_rec_flag, type_declarations) =
+  let generate_impl ~ctxt (rec_flag, type_declarations) =
     let loc = Expansion_context.Deriver.derived_item_loc ctxt in
     Ast_helper.with_default_loc loc @@ fun () -> (* ppx_easy_deriving shouldn't be using default_loc, but some of the Ppx_deriving API calls might *)
     let vbs = List.map (fun td ->
@@ -77,7 +77,7 @@ struct
         Ast_helper.Vb.mk ~loc ~attrs:[Ppx_deriving.attr_warning [%expr "-39"]] pat expr
       ) type_declarations
     in
-    [Ast_helper.Str.value ~loc Recursive vbs]
+    [Ast_helper.Str.value ~loc (really_recursive rec_flag type_declarations) vbs]
 
   let generate_intf ~ctxt (_rec_flag, type_declarations) =
     let loc = Expansion_context.Deriver.derived_item_loc ctxt in


### PR DESCRIPTION
[ppx_deriving_hash 0.1.4](https://github.com/sim642/ppx_deriving_hash/releases/tag/0.1.4), [ppx_deriving 6.1.3](https://github.com/ocaml-ppx/ppx_deriving/releases/tag/6.1.3) and [ppx_deriving 6.2.0](https://github.com/ocaml-ppx/ppx_deriving/releases/tag/6.2.0) include some improvements to performance on OCaml >= 5.2.
Couple of months ago when I made those changes, I also made them in the vendored ppx_easy_deriving (used for `[@@deriving lattice]`).

I also benchmarked these on OCaml 5.6.0+trunk on top of the other changes at the time, but this on its own didn't seem to make a difference in sv-benchmarks: https://goblint.cs.ut.ee/results/372-all-level01-ocaml-5.6-really_recursive-easy/table-generator-cmp.table.html#/scatter?toolX=0&columnX=2&toolY=1&columnY=2&results=All&regression=Linear&scaling=Linear&filter=0(0*status*(status(notIn()),category(notIn(error)))),1(0*status*(status(notIn()),category(notIn(error))))&line=2.
Still, it would be good to stay in sync with upstream ppx deriving code patterns.

### TODO
- [ ] Eta-expansion TODO